### PR TITLE
feat: Add guided tours system with Joyride across all main sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,11 @@
         "react-hook-form": "^7.56.3",
         "react-i18next": "^15.6.0",
         "react-imask": "^7.6.1",
+        "react-joyride": "^3.0.2",
         "react-phone-number-input": "^3.4.14",
         "react-router-dom": "^7.6.0",
         "recharts": "^3.6.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.11",
         "uuid": "^11.1.0",
@@ -140,6 +142,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -506,6 +509,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -529,6 +533,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1175,32 +1180,48 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz",
+      "integrity": "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1208,10 +1229,37 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@gilbarbara/deep-equal": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz",
+      "integrity": "sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==",
+      "license": "MIT"
+    },
+    "node_modules/@gilbarbara/hooks": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz",
+      "integrity": "sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@gilbarbara/deep-equal": "^0.4.1"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19"
+      }
+    },
+    "node_modules/@gilbarbara/types": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz",
+      "integrity": "sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.1.0"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.1",
@@ -3630,6 +3678,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3867,6 +3916,7 @@
       "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3875,8 +3925,8 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
       "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
-      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3887,6 +3937,7 @@
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3943,6 +3994,7 @@
       "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.0",
         "@typescript-eslint/types": "8.39.0",
@@ -4341,6 +4393,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4527,6 +4580,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -4808,7 +4862,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -4914,6 +4967,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5142,7 +5196,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5339,6 +5394,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5964,6 +6020,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -6016,6 +6073,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -6121,6 +6179,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz",
+      "integrity": "sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==",
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6179,6 +6243,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -7145,6 +7210,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7175,6 +7241,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7233,6 +7300,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
       "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7286,12 +7354,44 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/react-innertext": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
+      "integrity": "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": ">=0.0.0 <=99",
+        "react": ">=0.0.0 <=99"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz",
       "integrity": "sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-joyride": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz",
+      "integrity": "sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/deepmerge": "^3.2.1",
+        "@floating-ui/react-dom": "^2.1.8",
+        "@gilbarbara/deep-equal": "^0.4.1",
+        "@gilbarbara/hooks": "^0.11.0",
+        "@gilbarbara/types": "^0.2.2",
+        "is-lite": "^2.0.0",
+        "react-innertext": "^1.1.5",
+        "scroll": "^3.0.1",
+        "scrollparent": "^2.1.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "16.8 - 19",
+        "react-dom": "16.8 - 19"
+      }
     },
     "node_modules/react-phone-number-input": {
       "version": "3.4.14",
@@ -7315,6 +7415,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7508,7 +7609,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7647,6 +7749,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/scroll": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz",
+      "integrity": "sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==",
+      "license": "MIT"
+    },
+    "node_modules/scrollparent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz",
+      "integrity": "sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7787,7 +7901,8 @@
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
       "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.2.2",
@@ -7882,6 +7997,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8019,12 +8135,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8155,9 +8284,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
-      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8216,6 +8345,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8817,6 +8947,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9353,6 +9484,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-hook-form": "^7.56.3",
     "react-i18next": "^15.6.0",
     "react-imask": "^7.6.1",
+    "react-joyride": "^3.0.2",
     "react-phone-number-input": "^3.4.14",
     "react-router-dom": "^7.6.0",
     "recharts": "^3.6.0",

--- a/src/components/TourFab.tsx
+++ b/src/components/TourFab.tsx
@@ -1,0 +1,35 @@
+import { useSyncExternalStore } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Navigation } from 'lucide-react';
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@evoapi/design-system';
+import { tourRegistry, matchTourRoute } from '@/tours/tourRegistry';
+
+export function TourFab() {
+  const snapshot = useSyncExternalStore(
+    tourRegistry.subscribe,
+    tourRegistry.getSnapshot,
+  );
+  const { pathname } = useLocation();
+  const matchedRoute = matchTourRoute(pathname, snapshot);
+
+  if (!matchedRoute) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => tourRegistry.start(matchedRoute)}
+          aria-label="Ver tour desta página"
+          className="h-10 w-10 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground cursor-pointer"
+        >
+          <Navigation className="h-5 w-5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Ver tour desta página</p>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/WelcomeTourModal.tsx
+++ b/src/components/WelcomeTourModal.tsx
@@ -1,0 +1,81 @@
+import { useState, useEffect, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Map } from 'lucide-react';
+import { Button } from '@evoapi/design-system/button';
+import { tourRegistry } from '@/tours/tourRegistry';
+import { useTranslation } from '@/hooks/useTranslation';
+
+const STORAGE_KEY = 'onboarding:welcome-seen';
+const TOUR_ROUTE = '/channels';
+
+export function WelcomeTourModal() {
+  const { t } = useTranslation('tours');
+  const [dismissed, setDismissed] = useState(
+    () => !!localStorage.getItem(STORAGE_KEY),
+  );
+  const [pendingTour, setPendingTour] = useState(false);
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Only start the tour after we have navigated to TOUR_ROUTE
+  useEffect(() => {
+    if (!pendingTour) return;
+    if (pathname !== TOUR_ROUTE) return;
+
+    timerRef.current = setTimeout(() => {
+      tourRegistry.start(TOUR_ROUTE);
+      setPendingTour(false);
+    }, 400);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [pendingTour, pathname]);
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setDismissed(true);
+  };
+
+  const handleStartTour = () => {
+    handleDismiss();
+    navigate(TOUR_ROUTE);
+    setPendingTour(true);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-background rounded-2xl shadow-2xl p-8 max-w-md w-full mx-4 flex flex-col items-center gap-6 text-center">
+        <div
+          className="flex items-center justify-center rounded-full w-16 h-16"
+          style={{ backgroundColor: '#00C48C' }}
+        >
+          <Map className="h-8 w-8 text-white" />
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">{t('welcome.title')}</h2>
+          <p className="text-muted-foreground text-sm">
+            {t('welcome.description')}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 w-full">
+          <Button
+            onClick={handleStartTour}
+            className="w-full"
+            style={{ backgroundColor: '#00C48C', color: '#fff' }}
+          >
+            {t('welcome.startButton')}
+          </Button>
+          <Button variant="ghost" onClick={handleDismiss} className="w-full text-muted-foreground">
+            {t('welcome.skipButton')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/agents/AgentsHeader.tsx
+++ b/src/components/agents/AgentsHeader.tsx
@@ -42,6 +42,7 @@ export default function AgentsHeader({
     label: t('createAgent'),
     icon: <Plus className="h-4 w-4" />,
     onClick: onNewAgent,
+    dataTour: 'agents-new-button',
   } : undefined;
 
   const secondaryActions: HeaderAction[] = [
@@ -50,6 +51,7 @@ export default function AgentsHeader({
       icon: <Key className="h-4 w-4" />,
       onClick: onManageApiKeys,
       variant: 'outline' as const,
+      dataTour: 'agents-api-keys',
     },
     {
       label: t('export.all'),

--- a/src/components/base/BaseHeader.tsx
+++ b/src/components/base/BaseHeader.tsx
@@ -26,6 +26,7 @@ export interface HeaderAction {
   className?: string;
   disabled?: boolean;
   tooltip?: string;
+  dataTour?: string;
 }
 
 export interface HeaderFilter {
@@ -46,6 +47,8 @@ export interface BaseHeaderProps {
   filters?: HeaderFilter[];
   onFilterClick?: () => void;
   showFilters?: boolean;
+  filterButtonDataTour?: string;
+  searchDataTour?: string;
   totalCount?: number;
   selectedCount?: number;
   onClearSelection?: () => void;
@@ -66,6 +69,8 @@ export default function BaseHeader({
   filters = [],
   onFilterClick,
   showFilters = false,
+  filterButtonDataTour,
+  searchDataTour,
   selectedCount = 0,
   onClearSelection,
   bulkActions = [],
@@ -91,7 +96,7 @@ export default function BaseHeader({
 
         {/* Primary Action */}
         {primaryAction && primaryAction.show !== false && (
-          <div className="flex-shrink-0">
+          <div className="flex-shrink-0" data-tour={primaryAction.dataTour}>
             <PrimaryActionButton
               label={primaryAction.label}
               icon={primaryAction.icon}
@@ -111,7 +116,7 @@ export default function BaseHeader({
         <div className="flex items-center gap-3 flex-1">
           {/* Search */}
           {onSearchChange && (
-            <div className="relative flex-1 max-w-md">
+            <div className="relative flex-1 max-w-md" data-tour={searchDataTour}>
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-sidebar-foreground/60" />
               <Input
                 type="search"
@@ -130,6 +135,7 @@ export default function BaseHeader({
               size="sm"
               onClick={onFilterClick}
               className="bg-sidebar border-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent whitespace-nowrap"
+              data-tour={filterButtonDataTour}
             >
               <Filter className="h-4 w-4 mr-2" />
               {t('base.header.filters')}
@@ -170,6 +176,7 @@ export default function BaseHeader({
                 size="sm"
                 onClick={action.onClick}
                 className="bg-sidebar border-sidebar-border text-sidebar-foreground hover:bg-sidebar-accent"
+                data-tour={action.dataTour}
               >
                 {renderIcon()}
                 {action.label}

--- a/src/components/channels/ChannelsHeader.tsx
+++ b/src/components/channels/ChannelsHeader.tsx
@@ -27,6 +27,7 @@ export default function ChannelsHeader({
     label: t('actions.newChannel'),
     icon: <Plus className="h-4 w-4" />,
     onClick: onNewChannel,
+    dataTour: 'channels-new-button',
   } : undefined;
 
   return (

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -506,6 +506,7 @@ const ChatSidebar = ({
 
   return (
     <div
+      data-tour="chat-sidebar"
       className={`
         ${mobileView === 'list' ? 'flex' : 'hidden'} md:flex
         w-full md:w-80 border-r bg-card/50 flex-col h-full
@@ -514,7 +515,7 @@ const ChatSidebar = ({
       {/* Search and Filter Header */}
       <div className="p-4 border-b space-y-3">
         {/* Search */}
-        <div className="relative">
+        <div className="relative" data-tour="chat-search">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground z-10" />
           <Input
             type="text"
@@ -567,13 +568,14 @@ const ChatSidebar = ({
               </Badge>
             )}
 
-            {/* BotÃ£o de filtros */}
+            {/* Botão de filtros */}
             <Button
               variant="ghost"
               size="sm"
               onClick={() => setFilterModalOpen(true)}
               disabled={filters.state.isApplyingFilters}
               className="h-8 px-2 cursor-pointer"
+              data-tour="chat-filter-button"
             >
               <Filter className="h-4 w-4" />
               {t('chatSidebar.filtersButton')}
@@ -590,6 +592,7 @@ const ChatSidebar = ({
         ref={sidebarScrollRef}
         className="flex-1 overflow-y-auto"
         onScroll={handleSidebarScroll}
+        data-tour="chat-conversations-list"
       >
         {!conversations ? (
           <ConversationSkeleton count={8} />

--- a/src/components/contacts/ContactsHeader.tsx
+++ b/src/components/contacts/ContactsHeader.tsx
@@ -47,6 +47,7 @@ export default function ContactsHeader({
     label: t('header.newContact'),
     icon: <Plus className="h-4 w-4" />,
     onClick: onNewContact,
+    dataTour: 'contacts-new-button',
   } : undefined;
 
   const secondaryActions: HeaderAction[] = [
@@ -98,6 +99,7 @@ export default function ContactsHeader({
       filters={activeFilters}
       onFilterClick={onFilter}
       showFilters={showFilters}
+      filterButtonDataTour="contacts-filter-button"
       onClearSelection={onClearSelection}
     />
   );

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -23,6 +23,7 @@ import { usePermissions } from '@/contexts/PermissionsContext';
 import { useMenuState } from '@/hooks/useMenuState';
 import { useDashboardApps } from '@/hooks/useDashboardApps';
 import { injectDashboardAppsIntoMenu } from '@/utils/injectDashboardApps';
+import { WelcomeTourModal } from '@/components/WelcomeTourModal';
 
 interface MainLayoutProps {
   children: React.ReactNode;
@@ -145,6 +146,9 @@ export default function MainLayout({ children }: MainLayoutProps) {
         </main>
 
       </div>
+
+      {/* Tour */}
+      <WelcomeTourModal />
 
       {/* Logout Dialog */}
       <Dialog open={logoutDialogOpen} onOpenChange={setLogoutDialogOpen}>

--- a/src/components/layout/components/Header.tsx
+++ b/src/components/layout/components/Header.tsx
@@ -23,6 +23,7 @@ import { useLanguage } from '../../../hooks/useLanguage';
 import { useWhitelabelConfig } from '../../../hooks/useWhitelabelConfig';
 import NotificationBell from '../NotificationBell';
 import ProfileMenu from './ProfileMenu';
+import { TourFab } from '@/components/TourFab';
 import MenuItem from './MenuItem';
 import { MenuItem as MenuItemType } from '../config/menuItems';
 
@@ -212,6 +213,7 @@ export default function Header({
 
         {/* Right: Notifications and User Menu */}
         <div className="flex-1 flex justify-end items-center gap-2">
+          <TourFab />
           <NotificationBell />
           <ProfileMenu
             user={user}
@@ -272,6 +274,7 @@ export default function Header({
 
         {/* Right side */}
         <div className="flex items-center gap-2 px-4">
+          <TourFab />
           {/* Notifications */}
           <NotificationBell />
           {/* User Menu */}

--- a/src/components/pipelines/PipelinesHeader.tsx
+++ b/src/components/pipelines/PipelinesHeader.tsx
@@ -41,7 +41,7 @@ export default function PipelinesHeader({
           />
         </div>
 
-        <Button onClick={onNewPipeline}>
+        <Button onClick={onNewPipeline} data-tour="pipelines-new-button">
           <Plus className="h-4 w-4 mr-2" />
           {t('pipelinesHeader.newPipeline')}
         </Button>

--- a/src/components/scheduledActions/ScheduledActionsHeader.tsx
+++ b/src/components/scheduledActions/ScheduledActionsHeader.tsx
@@ -32,6 +32,7 @@ export default function ScheduledActionsHeader({
     label: t('scheduledActions.newAction'),
     icon: <Plus className="h-4 w-4" />,
     onClick: onNewAction,
+    dataTour: 'scheduled-actions-new-button',
   } : undefined;
 
   const bulkActions: HeaderAction[] = isReady && can('contacts', 'update') ? [
@@ -52,6 +53,7 @@ export default function ScheduledActionsHeader({
       searchValue={searchValue}
       onSearchChange={onSearchChange}
       searchPlaceholder={t('scheduledActions.searchPlaceholder')}
+      searchDataTour="scheduled-actions-search"
       primaryAction={primaryAction}
       bulkActions={bulkActions}
       onClearSelection={onClearSelection}

--- a/src/hooks/useJoyride.ts
+++ b/src/hooks/useJoyride.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import { useJoyride as useJoyrideLib, EVENTS } from 'react-joyride';
+import type { Step } from 'react-joyride';
+import { JoyrideTooltip } from '@/tours/JoyrideTooltip';
+
+interface UseJoyrideOptions {
+  tourKey: string;
+  steps: Step[];
+  autoStart?: boolean;
+}
+
+export function useJoyride({ tourKey, steps, autoStart = true }: UseJoyrideOptions) {
+  const storageKey = `tour:${tourKey}`;
+
+  const { Tour, controls, on } = useJoyrideLib({
+    steps,
+    continuous: true,
+    showSkipButton: false,
+    scrollToFirstStep: true,
+    portalElement: 'main.overflow-auto',
+    tooltipComponent: JoyrideTooltip,
+    options: {
+      skipBeacon: true,
+      zIndex: 10000,
+      arrowColor: '#252836',
+      scrollOffset: 80,
+      skipScroll: false,
+    },
+    locale: {
+      back: 'Voltar',
+      close: 'Fechar',
+      last: 'Concluir',
+      next: 'Próximo',
+      open: 'Abrir tour',
+      skip: 'Pular',
+    },
+  });
+
+  // Persist completion to localStorage when tour ends or is skipped
+  useEffect(() => {
+    const unsubscribe = on(EVENTS.TOUR_END, () => {
+      localStorage.setItem(storageKey, 'true');
+    });
+    return unsubscribe;
+  }, [on, storageKey]);
+
+  // Auto-start on first visit (only after the welcome modal has been dismissed)
+  useEffect(() => {
+    if (!autoStart) return;
+
+    const welcomeSeen = localStorage.getItem('onboarding:welcome-seen');
+    if (!welcomeSeen) return;
+
+    const completed = localStorage.getItem(storageKey);
+    if (!completed) {
+      const timer = setTimeout(() => controls.start(), 600);
+      return () => clearTimeout(timer);
+    }
+  }, [storageKey, autoStart, controls]);
+
+  const resetTour = () => {
+    localStorage.removeItem(storageKey);
+    controls.reset(true);
+  };
+
+  return {
+    Tour,
+    controls,
+    resetTour,
+    isCompleted: !!localStorage.getItem(storageKey),
+  };
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -261,6 +261,12 @@ import itApi from './locales/it/api.json';
 import itInstagram from './locales/it/instagram.json';
 import itMessenger from './locales/it/messenger.json';
 import itCustomerDashboard from './locales/it/customerDashboard.json';
+import ptBRTours from './locales/pt-BR/tours.json';
+import ptTours from './locales/pt/tours.json';
+import enTours from './locales/en/tours.json';
+import esTours from './locales/es/tours.json';
+import frTours from './locales/fr/tours.json';
+import itTours from './locales/it/tours.json';
 export const locales = ['en', 'pt-BR', 'pt', 'fr', 'it', 'es'] as const;
 export const defaultLocale = 'en' as const;
 
@@ -341,6 +347,7 @@ const resources = {
     instagram: ptBRInstagram,
     messenger: ptBRMessenger,
     customerDashboard: ptBRCustomerDashboard,
+    tours: ptBRTours,
   },
   pt: {
     auth: ptAuth,
@@ -386,6 +393,7 @@ const resources = {
     instagram: ptInstagram,
     messenger: ptMessenger,
     customerDashboard: ptCustomerDashboard,
+    tours: ptTours,
   },
   en: {
     auth: enAuth,
@@ -432,6 +440,7 @@ const resources = {
     instagram: enInstagram,
     messenger: enMessenger,
     customerDashboard: enCustomerDashboard,
+    tours: enTours,
   },
   es: {
     auth: esAuth,
@@ -477,6 +486,7 @@ const resources = {
     instagram: esInstagram,
     messenger: esMessenger,
     customerDashboard: esCustomerDashboard,
+    tours: esTours,
   },
   fr: {
     auth: frAuth,
@@ -522,6 +532,7 @@ const resources = {
     instagram: frInstagram,
     messenger: frMessenger,
     customerDashboard: frCustomerDashboard,
+    tours: frTours,
   },
   it: {
     auth: itAuth,
@@ -567,6 +578,7 @@ const resources = {
     instagram: itInstagram,
     messenger: itMessenger,
     customerDashboard: itCustomerDashboard,
+    tours: itTours,
   },
 };
 

--- a/src/i18n/locales/en/tours.json
+++ b/src/i18n/locales/en/tours.json
@@ -1,0 +1,203 @@
+{
+  "welcome": {
+    "title": "Welcome to EvoAI!",
+    "description": "Would you like a guided tour to discover the platform's features?",
+    "startButton": "Start guided tour",
+    "skipButton": "I prefer to explore on my own"
+  },
+  "stepOf": "{{current}} of {{total}}",
+  "next": "Next",
+  "back": "Back",
+  "finish": "Finish",
+  "close": "Close",
+  "dashboard": {
+    "step1": {
+      "title": "Welcome to the Dashboard!",
+      "content": "This is the main panel of the platform. Here you can track the most important metrics of your business in real time."
+    },
+    "step2": {
+      "title": "Filters",
+      "content": "Use filters to segment data by channel, agent, team, or other criteria."
+    },
+    "step3": {
+      "title": "Analysis Period",
+      "content": "Select the period you want to analyze: today, last 7 days, 30 days, or a custom range."
+    },
+    "step4": {
+      "title": "Key Metrics",
+      "content": "View key indicators: total conversations, messages sent, resolution rate, and average response time."
+    },
+    "step5": {
+      "title": "Trends",
+      "content": "Trend charts show the evolution of metrics over time to help you identify patterns."
+    },
+    "step6": {
+      "title": "Performance",
+      "content": "Track your team's performance with rankings, satisfaction rates, and service distribution."
+    }
+  },
+  "conversations": {
+    "step1": {
+      "title": "Your Conversations",
+      "content": "All your team's conversations are here. Select one to start responding."
+    },
+    "step2": {
+      "title": "Search Conversations",
+      "content": "Search conversations by contact name or message content."
+    },
+    "step3": {
+      "title": "Conversation Filters",
+      "content": "Filter conversations by status (open, resolved, pending), assigned agent, team, or service channel."
+    },
+    "step4": {
+      "title": "Conversation List",
+      "content": "Click any conversation to open it. The blue dot indicates unread messages. Right-click for quick actions."
+    },
+    "step5": {
+      "title": "Service Area",
+      "content": "When you select a conversation, the message history appears here. At the top you'll find contact info and actions like resolve, pause, and transfer."
+    }
+  },
+  "contacts": {
+    "step1": {
+      "title": "Contact Management",
+      "content": "Here you manage all contacts in your database. Use search to find a contact quickly."
+    },
+    "step2": {
+      "title": "Create Contact",
+      "content": "Click here to manually add a new contact. You can also import a CSV list or export your database."
+    },
+    "step3": {
+      "title": "Advanced Filters",
+      "content": "Filter your database by attributes such as email, phone, tag, pipeline, or any custom field."
+    },
+    "step4": {
+      "title": "View Mode",
+      "content": "Switch between card (grid) and table view according to your preference."
+    },
+    "step5": {
+      "title": "Contact List",
+      "content": "Click a contact to view details, start a conversation, edit, or delete. Select multiple for bulk actions."
+    },
+    "step6": {
+      "title": "Page Navigation",
+      "content": "Navigate between pages of your contact database and adjust how many records are displayed per page."
+    }
+  },
+  "agents": {
+    "step1": {
+      "title": "Agent Management",
+      "content": "Here you manage all your AI agents. Use search to find an agent quickly."
+    },
+    "step2": {
+      "title": "Create Agent",
+      "content": "Click here to create a new AI agent. The wizard will guide you step by step through the configuration."
+    },
+    "step3": {
+      "title": "API Keys",
+      "content": "Manage API keys to integrate your agents with other systems and platforms."
+    },
+    "step4": {
+      "title": "View Mode",
+      "content": "Switch between card (grid) and table view according to your preference."
+    },
+    "step5": {
+      "title": "Agent List",
+      "content": "See all your agents here. Click edit to configure behaviors, integrations, and the agent's personality."
+    }
+  },
+  "channels": {
+    "step1": {
+      "title": "Channel Management",
+      "content": "Here you manage all connected communication channels. Use search to find a channel quickly."
+    },
+    "step2": {
+      "title": "Create Channel",
+      "content": "Click here to connect a new channel. We support WhatsApp, email, Instagram, and other communication channels."
+    },
+    "step3": {
+      "title": "View Mode",
+      "content": "Switch between card (grid) and table view according to your preference."
+    },
+    "step4": {
+      "title": "Channel List",
+      "content": "See all connected channels here. Click settings to adjust each channel individually or delete channels that are no longer needed."
+    },
+    "step5": {
+      "title": "Page Navigation",
+      "content": "Navigate between pages of your channels and adjust how many records are displayed per page."
+    }
+  },
+  "pipelines": {
+    "step1": {
+      "title": "Pipeline Management",
+      "content": "Here you organize the service flow of your contacts in stages. Use search to find a pipeline quickly."
+    },
+    "step2": {
+      "title": "Create Pipeline",
+      "content": "Click here to create a new pipeline. Define custom stages to organize your team's service funnel."
+    },
+    "step3": {
+      "title": "View Mode",
+      "content": "Switch between card (grid) and table view according to your preference."
+    },
+    "step4": {
+      "title": "Pipeline List",
+      "content": "See all your pipelines here. Click a pipeline to open the kanban with stages and contacts. You can also edit, duplicate, or delete pipelines via the actions menu."
+    }
+  },
+  "settings": {
+    "step1": {
+      "title": "Account Settings",
+      "content": "Here you manage all your account settings, such as name, language, users, teams, and integrations. Use the side menu to navigate between sections."
+    },
+    "step2": {
+      "title": "General Settings",
+      "content": "Set your account name, default interface language, and other basic preferences. Remember to save after making changes."
+    },
+    "step3": {
+      "title": "Auto Resolution",
+      "content": "Set the time for inactive conversations to be automatically resolved. You can define a closing message and apply a label when finishing."
+    },
+    "step4": {
+      "title": "Account ID",
+      "content": "This is your account's unique identifier. You may need it when contacting support or configuring external integrations."
+    }
+  },
+  "campaigns": {
+    "step1": {
+      "title": "Campaign Management",
+      "content": "Here you create and track all communication campaigns. Use search to find a campaign quickly."
+    },
+    "step2": {
+      "title": "Create Campaign",
+      "content": "Click here to create a new campaign. The wizard will guide you through the steps of configuring audience, content, and scheduling."
+    },
+    "step3": {
+      "title": "Filters",
+      "content": "Filter your campaigns by status, type, channel, and other criteria to find exactly what you need."
+    },
+    "step4": {
+      "title": "Campaign List",
+      "content": "See all your campaigns here. Track status in real time, start, pause, resume, or delete campaigns as needed."
+    },
+    "step5": {
+      "title": "Page Navigation",
+      "content": "Navigate between pages of your campaigns and adjust how many records are displayed per page."
+    }
+  },
+  "journey": {
+    "step1": {
+      "title": "Journey Automations",
+      "content": "Here you create and manage automated journeys to engage your contacts with intelligent message flows."
+    },
+    "step2": {
+      "title": "Create Journey",
+      "content": "Click here to create a new journey. Set the name, description, and then configure the triggers and actions in the flow editor."
+    },
+    "step3": {
+      "title": "Journey List",
+      "content": "See all your journeys here. Enable or disable each journey via the status toggle, open the flow editor to customize the steps, or duplicate existing journeys to speed up creation."
+    }
+  }
+}

--- a/src/i18n/locales/es/tours.json
+++ b/src/i18n/locales/es/tours.json
@@ -1,0 +1,203 @@
+{
+  "welcome": {
+    "title": "¡Bienvenido a EvoAI!",
+    "description": "¿Te gustaría hacer un tour guiado para conocer las funcionalidades de la plataforma?",
+    "startButton": "Iniciar tour guiado",
+    "skipButton": "Prefiero explorar por mi cuenta"
+  },
+  "stepOf": "{{current}} de {{total}}",
+  "next": "Siguiente",
+  "back": "Anterior",
+  "finish": "Finalizar",
+  "close": "Cerrar",
+  "dashboard": {
+    "step1": {
+      "title": "¡Bienvenido al Dashboard!",
+      "content": "Este es el panel principal de la plataforma. Aquí puedes seguir las métricas más importantes de tu negocio en tiempo real."
+    },
+    "step2": {
+      "title": "Filtros",
+      "content": "Usa los filtros para segmentar los datos por canal, agente, equipo u otros criterios."
+    },
+    "step3": {
+      "title": "Período de Análisis",
+      "content": "Selecciona el período que deseas analizar: hoy, últimos 7 días, 30 días o un intervalo personalizado."
+    },
+    "step4": {
+      "title": "Métricas Principales",
+      "content": "Ve los indicadores clave: total de conversaciones, mensajes enviados, tasa de resolución y tiempo promedio de respuesta."
+    },
+    "step5": {
+      "title": "Tendencias",
+      "content": "Los gráficos de tendencia muestran la evolución de las métricas a lo largo del tiempo para identificar patrones."
+    },
+    "step6": {
+      "title": "Rendimiento",
+      "content": "Sigue el rendimiento de tu equipo con clasificaciones, tasas de satisfacción y distribución de atenciones."
+    }
+  },
+  "conversations": {
+    "step1": {
+      "title": "Tus Conversaciones",
+      "content": "Aquí están todas las conversaciones de tu equipo. Selecciona una para comenzar a atender."
+    },
+    "step2": {
+      "title": "Buscar Conversaciones",
+      "content": "Busca conversaciones por el nombre del contacto o por el contenido del mensaje."
+    },
+    "step3": {
+      "title": "Filtros de Conversación",
+      "content": "Filtra las conversaciones por estado (abierta, resuelta, pendiente), agente asignado, equipo o canal de atención."
+    },
+    "step4": {
+      "title": "Lista de Conversaciones",
+      "content": "Haz clic en cualquier conversación para abrirla. El punto azul indica mensajes no leídos. Haz clic derecho para acciones rápidas."
+    },
+    "step5": {
+      "title": "Área de Atención",
+      "content": "Al seleccionar una conversación, el historial de mensajes aparece aquí. En la parte superior encontrarás información del contacto y acciones como resolver, pausar y transferir."
+    }
+  },
+  "contacts": {
+    "step1": {
+      "title": "Gestión de Contactos",
+      "content": "Aquí gestionas todos los contactos de tu base de datos. Usa la búsqueda para encontrar un contacto rápidamente."
+    },
+    "step2": {
+      "title": "Crear Contacto",
+      "content": "Haz clic aquí para agregar un nuevo contacto manualmente. También puedes importar una lista en CSV o exportar tu base de datos."
+    },
+    "step3": {
+      "title": "Filtros Avanzados",
+      "content": "Filtra tu base por atributos como correo electrónico, teléfono, etiqueta, pipeline o cualquier campo personalizado."
+    },
+    "step4": {
+      "title": "Modo de Visualización",
+      "content": "Alterna entre visualización en tarjetas (cuadrícula) o tabla según tu preferencia."
+    },
+    "step5": {
+      "title": "Lista de Contactos",
+      "content": "Haz clic en un contacto para ver detalles, iniciar una conversación, editar o eliminar. Selecciona múltiples para acciones en lote."
+    },
+    "step6": {
+      "title": "Navegación entre Páginas",
+      "content": "Navega entre las páginas de tu base de contactos y ajusta cuántos registros se muestran por página."
+    }
+  },
+  "agents": {
+    "step1": {
+      "title": "Gestión de Agentes",
+      "content": "Aquí gestionas todos tus agentes de IA. Usa la búsqueda para encontrar un agente rápidamente."
+    },
+    "step2": {
+      "title": "Crear Agente",
+      "content": "Haz clic aquí para crear un nuevo agente de IA. El asistente te guiará paso a paso en la configuración."
+    },
+    "step3": {
+      "title": "Claves de API",
+      "content": "Gestiona las claves de API para integrar tus agentes con otros sistemas y plataformas."
+    },
+    "step4": {
+      "title": "Modo de Visualización",
+      "content": "Alterna entre visualización en tarjetas (cuadrícula) o tabla según tu preferencia."
+    },
+    "step5": {
+      "title": "Lista de Agentes",
+      "content": "Ve todos tus agentes aquí. Haz clic en editar para configurar comportamientos, integraciones y la personalidad del agente."
+    }
+  },
+  "channels": {
+    "step1": {
+      "title": "Gestión de Canales",
+      "content": "Aquí gestionas todos los canales de comunicación conectados. Usa la búsqueda para encontrar un canal rápidamente."
+    },
+    "step2": {
+      "title": "Crear Canal",
+      "content": "Haz clic aquí para conectar un nuevo canal. Soportamos WhatsApp, correo electrónico, Instagram y otros medios de comunicación."
+    },
+    "step3": {
+      "title": "Modo de Visualización",
+      "content": "Alterna entre visualización en tarjetas (cuadrícula) o tabla según tu preferencia."
+    },
+    "step4": {
+      "title": "Lista de Canales",
+      "content": "Ve todos los canales conectados aquí. Haz clic en configuración para ajustar cada canal individualmente o elimina canales que ya no son necesarios."
+    },
+    "step5": {
+      "title": "Navegación entre Páginas",
+      "content": "Navega entre las páginas de tus canales y ajusta cuántos registros se muestran por página."
+    }
+  },
+  "pipelines": {
+    "step1": {
+      "title": "Gestión de Pipelines",
+      "content": "Aquí organizas el flujo de atención de tus contactos en etapas. Usa la búsqueda para encontrar un pipeline rápidamente."
+    },
+    "step2": {
+      "title": "Crear Pipeline",
+      "content": "Haz clic aquí para crear un nuevo pipeline. Define etapas personalizadas para organizar el embudo de atención de tu equipo."
+    },
+    "step3": {
+      "title": "Modo de Visualización",
+      "content": "Alterna entre visualización en tarjetas (cuadrícula) o tabla según tu preferencia."
+    },
+    "step4": {
+      "title": "Lista de Pipelines",
+      "content": "Ve todos tus pipelines aquí. Haz clic en un pipeline para abrir el kanban con las etapas y contactos. También puedes editar, duplicar o eliminar pipelines desde el menú de acciones."
+    }
+  },
+  "settings": {
+    "step1": {
+      "title": "Configuración de la Cuenta",
+      "content": "Aquí gestionas toda la configuración de tu cuenta, como nombre, idioma, usuarios, equipos e integraciones. Usa el menú lateral para navegar entre las secciones."
+    },
+    "step2": {
+      "title": "Configuración General",
+      "content": "Define el nombre de tu cuenta, el idioma predeterminado de la interfaz y otras preferencias básicas. Recuerda guardar después de hacer cambios."
+    },
+    "step3": {
+      "title": "Resolución Automática",
+      "content": "Configura el tiempo para que las conversaciones inactivas se resuelvan automáticamente. Puedes definir un mensaje de cierre y aplicar una etiqueta al finalizar."
+    },
+    "step4": {
+      "title": "ID de la Cuenta",
+      "content": "Este es el identificador único de tu cuenta. Puede que lo necesites al contactar con el soporte o al configurar integraciones externas."
+    }
+  },
+  "campaigns": {
+    "step1": {
+      "title": "Gestión de Campañas",
+      "content": "Aquí creas y haces seguimiento de todas las campañas de comunicación. Usa la búsqueda para encontrar una campaña rápidamente."
+    },
+    "step2": {
+      "title": "Crear Campaña",
+      "content": "Haz clic aquí para crear una nueva campaña. El asistente te guiará por los pasos de configuración de audiencia, contenido y programación."
+    },
+    "step3": {
+      "title": "Filtros",
+      "content": "Filtra tus campañas por estado, tipo, canal y otros criterios para encontrar exactamente lo que necesitas."
+    },
+    "step4": {
+      "title": "Lista de Campañas",
+      "content": "Ve todas tus campañas aquí. Sigue el estado en tiempo real, inicia, pausa, reanuda o elimina campañas según sea necesario."
+    },
+    "step5": {
+      "title": "Navegación entre Páginas",
+      "content": "Navega entre las páginas de tus campañas y ajusta cuántos registros se muestran por página."
+    }
+  },
+  "journey": {
+    "step1": {
+      "title": "Automatizaciones de Journey",
+      "content": "Aquí creas y gestionas journeys automatizados para involucrar a tus contactos con flujos de mensajes inteligentes."
+    },
+    "step2": {
+      "title": "Crear Journey",
+      "content": "Haz clic aquí para crear un nuevo journey. Define el nombre, descripción y luego configura los disparadores y acciones en el editor de flujo."
+    },
+    "step3": {
+      "title": "Lista de Journeys",
+      "content": "Ve todos tus journeys aquí. Activa o desactiva cada journey con el interruptor de estado, abre el editor de flujo para personalizar los pasos o duplica journeys existentes para agilizar la creación."
+    }
+  }
+}

--- a/src/i18n/locales/fr/tours.json
+++ b/src/i18n/locales/fr/tours.json
@@ -1,0 +1,203 @@
+{
+  "welcome": {
+    "title": "Bienvenue sur EvoAI !",
+    "description": "Souhaitez-vous faire une visite guidée pour découvrir les fonctionnalités de la plateforme ?",
+    "startButton": "Démarrer la visite guidée",
+    "skipButton": "Je préfère explorer par moi-même"
+  },
+  "stepOf": "{{current}} sur {{total}}",
+  "next": "Suivant",
+  "back": "Précédent",
+  "finish": "Terminer",
+  "close": "Fermer",
+  "dashboard": {
+    "step1": {
+      "title": "Bienvenue sur le Tableau de Bord !",
+      "content": "Voici le panneau principal de la plateforme. Ici, vous suivez les métriques les plus importantes de votre activité en temps réel."
+    },
+    "step2": {
+      "title": "Filtres",
+      "content": "Utilisez les filtres pour segmenter les données par canal, agent, équipe ou d'autres critères."
+    },
+    "step3": {
+      "title": "Période d'Analyse",
+      "content": "Sélectionnez la période à analyser : aujourd'hui, 7 derniers jours, 30 jours ou une plage personnalisée."
+    },
+    "step4": {
+      "title": "Métriques Principales",
+      "content": "Consultez les indicateurs clés : total des conversations, messages envoyés, taux de résolution et temps de réponse moyen."
+    },
+    "step5": {
+      "title": "Tendances",
+      "content": "Les graphiques de tendance montrent l'évolution des métriques dans le temps pour identifier les patterns."
+    },
+    "step6": {
+      "title": "Performance",
+      "content": "Suivez la performance de votre équipe avec les classements, les taux de satisfaction et la distribution des prises en charge."
+    }
+  },
+  "conversations": {
+    "step1": {
+      "title": "Vos Conversations",
+      "content": "Toutes les conversations de votre équipe sont ici. Sélectionnez-en une pour commencer à répondre."
+    },
+    "step2": {
+      "title": "Recherche de Conversations",
+      "content": "Recherchez des conversations par le nom du contact ou par le contenu du message."
+    },
+    "step3": {
+      "title": "Filtres de Conversation",
+      "content": "Filtrez les conversations par statut (ouverte, résolue, en attente), agent assigné, équipe ou canal de service."
+    },
+    "step4": {
+      "title": "Liste des Conversations",
+      "content": "Cliquez sur n'importe quelle conversation pour l'ouvrir. Le point bleu indique les messages non lus. Cliquez avec le bouton droit pour des actions rapides."
+    },
+    "step5": {
+      "title": "Zone de Service",
+      "content": "Lorsque vous sélectionnez une conversation, l'historique des messages apparaît ici. En haut, vous trouverez les informations du contact et les actions comme résoudre, mettre en pause et transférer."
+    }
+  },
+  "contacts": {
+    "step1": {
+      "title": "Gestion des Contacts",
+      "content": "Ici, vous gérez tous les contacts de votre base de données. Utilisez la recherche pour trouver un contact rapidement."
+    },
+    "step2": {
+      "title": "Créer un Contact",
+      "content": "Cliquez ici pour ajouter manuellement un nouveau contact. Vous pouvez également importer une liste CSV ou exporter votre base de données."
+    },
+    "step3": {
+      "title": "Filtres Avancés",
+      "content": "Filtrez votre base par attributs tels que l'e-mail, le téléphone, le tag, le pipeline ou tout champ personnalisé."
+    },
+    "step4": {
+      "title": "Mode d'Affichage",
+      "content": "Basculez entre l'affichage en cartes (grille) et en tableau selon vos préférences."
+    },
+    "step5": {
+      "title": "Liste des Contacts",
+      "content": "Cliquez sur un contact pour voir les détails, démarrer une conversation, modifier ou supprimer. Sélectionnez plusieurs pour des actions en lot."
+    },
+    "step6": {
+      "title": "Navigation entre Pages",
+      "content": "Naviguez entre les pages de votre base de contacts et ajustez le nombre d'enregistrements affichés par page."
+    }
+  },
+  "agents": {
+    "step1": {
+      "title": "Gestion des Agents",
+      "content": "Ici, vous gérez tous vos agents IA. Utilisez la recherche pour trouver un agent rapidement."
+    },
+    "step2": {
+      "title": "Créer un Agent",
+      "content": "Cliquez ici pour créer un nouvel agent IA. L'assistant vous guidera étape par étape dans la configuration."
+    },
+    "step3": {
+      "title": "Clés API",
+      "content": "Gérez les clés API pour intégrer vos agents avec d'autres systèmes et plateformes."
+    },
+    "step4": {
+      "title": "Mode d'Affichage",
+      "content": "Basculez entre l'affichage en cartes (grille) et en tableau selon vos préférences."
+    },
+    "step5": {
+      "title": "Liste des Agents",
+      "content": "Voyez tous vos agents ici. Cliquez sur modifier pour configurer les comportements, les intégrations et la personnalité de l'agent."
+    }
+  },
+  "channels": {
+    "step1": {
+      "title": "Gestion des Canaux",
+      "content": "Ici, vous gérez tous les canaux de communication connectés. Utilisez la recherche pour trouver un canal rapidement."
+    },
+    "step2": {
+      "title": "Créer un Canal",
+      "content": "Cliquez ici pour connecter un nouveau canal. Nous prenons en charge WhatsApp, l'e-mail, Instagram et d'autres canaux de communication."
+    },
+    "step3": {
+      "title": "Mode d'Affichage",
+      "content": "Basculez entre l'affichage en cartes (grille) et en tableau selon vos préférences."
+    },
+    "step4": {
+      "title": "Liste des Canaux",
+      "content": "Voyez tous les canaux connectés ici. Cliquez sur les paramètres pour ajuster chaque canal individuellement ou supprimez les canaux qui ne sont plus nécessaires."
+    },
+    "step5": {
+      "title": "Navigation entre Pages",
+      "content": "Naviguez entre les pages de vos canaux et ajustez le nombre d'enregistrements affichés par page."
+    }
+  },
+  "pipelines": {
+    "step1": {
+      "title": "Gestion des Pipelines",
+      "content": "Ici, vous organisez le flux de service de vos contacts en étapes. Utilisez la recherche pour trouver un pipeline rapidement."
+    },
+    "step2": {
+      "title": "Créer un Pipeline",
+      "content": "Cliquez ici pour créer un nouveau pipeline. Définissez des étapes personnalisées pour organiser l'entonnoir de service de votre équipe."
+    },
+    "step3": {
+      "title": "Mode d'Affichage",
+      "content": "Basculez entre l'affichage en cartes (grille) et en tableau selon vos préférences."
+    },
+    "step4": {
+      "title": "Liste des Pipelines",
+      "content": "Voyez tous vos pipelines ici. Cliquez sur un pipeline pour ouvrir le kanban avec les étapes et contacts. Vous pouvez également modifier, dupliquer ou supprimer des pipelines via le menu d'actions."
+    }
+  },
+  "settings": {
+    "step1": {
+      "title": "Paramètres du Compte",
+      "content": "Ici, vous gérez tous les paramètres de votre compte, tels que le nom, la langue, les utilisateurs, les équipes et les intégrations. Utilisez le menu latéral pour naviguer entre les sections."
+    },
+    "step2": {
+      "title": "Paramètres Généraux",
+      "content": "Définissez le nom de votre compte, la langue par défaut de l'interface et d'autres préférences de base. N'oubliez pas de sauvegarder après avoir effectué des modifications."
+    },
+    "step3": {
+      "title": "Résolution Automatique",
+      "content": "Configurez le délai pour que les conversations inactives soient résolues automatiquement. Vous pouvez définir un message de clôture et appliquer une étiquette à la fin."
+    },
+    "step4": {
+      "title": "ID du Compte",
+      "content": "Voici l'identifiant unique de votre compte. Vous pourriez en avoir besoin pour contacter le support ou configurer des intégrations externes."
+    }
+  },
+  "campaigns": {
+    "step1": {
+      "title": "Gestion des Campagnes",
+      "content": "Ici, vous créez et suivez toutes les campagnes de communication. Utilisez la recherche pour trouver une campagne rapidement."
+    },
+    "step2": {
+      "title": "Créer une Campagne",
+      "content": "Cliquez ici pour créer une nouvelle campagne. L'assistant vous guidera à travers les étapes de configuration de l'audience, du contenu et de la planification."
+    },
+    "step3": {
+      "title": "Filtres",
+      "content": "Filtrez vos campagnes par statut, type, canal et d'autres critères pour trouver exactement ce dont vous avez besoin."
+    },
+    "step4": {
+      "title": "Liste des Campagnes",
+      "content": "Voyez toutes vos campagnes ici. Suivez le statut en temps réel, démarrez, mettez en pause, reprenez ou supprimez des campagnes selon les besoins."
+    },
+    "step5": {
+      "title": "Navigation entre Pages",
+      "content": "Naviguez entre les pages de vos campagnes et ajustez le nombre d'enregistrements affichés par page."
+    }
+  },
+  "journey": {
+    "step1": {
+      "title": "Automatisations de Parcours",
+      "content": "Ici, vous créez et gérez des parcours automatisés pour engager vos contacts avec des flux de messages intelligents."
+    },
+    "step2": {
+      "title": "Créer un Parcours",
+      "content": "Cliquez ici pour créer un nouveau parcours. Définissez le nom, la description, puis configurez les déclencheurs et actions dans l'éditeur de flux."
+    },
+    "step3": {
+      "title": "Liste des Parcours",
+      "content": "Voyez tous vos parcours ici. Activez ou désactivez chaque parcours via le bouton de statut, ouvrez l'éditeur de flux pour personnaliser les étapes ou dupliquez des parcours existants pour accélérer la création."
+    }
+  }
+}

--- a/src/i18n/locales/it/tours.json
+++ b/src/i18n/locales/it/tours.json
@@ -1,0 +1,203 @@
+{
+  "welcome": {
+    "title": "Benvenuto su EvoAI!",
+    "description": "Vorresti fare un tour guidato per scoprire le funzionalità della piattaforma?",
+    "startButton": "Avvia il tour guidato",
+    "skipButton": "Preferisco esplorare da solo"
+  },
+  "stepOf": "{{current}} di {{total}}",
+  "next": "Avanti",
+  "back": "Indietro",
+  "finish": "Termina",
+  "close": "Chiudi",
+  "dashboard": {
+    "step1": {
+      "title": "Benvenuto nella Dashboard!",
+      "content": "Questo è il pannello principale della piattaforma. Qui puoi monitorare le metriche più importanti della tua attività in tempo reale."
+    },
+    "step2": {
+      "title": "Filtri",
+      "content": "Usa i filtri per segmentare i dati per canale, agente, team o altri criteri."
+    },
+    "step3": {
+      "title": "Periodo di Analisi",
+      "content": "Seleziona il periodo da analizzare: oggi, ultimi 7 giorni, 30 giorni o un intervallo personalizzato."
+    },
+    "step4": {
+      "title": "Metriche Principali",
+      "content": "Visualizza gli indicatori chiave: totale conversazioni, messaggi inviati, tasso di risoluzione e tempo medio di risposta."
+    },
+    "step5": {
+      "title": "Tendenze",
+      "content": "I grafici delle tendenze mostrano l'evoluzione delle metriche nel tempo per identificare i pattern."
+    },
+    "step6": {
+      "title": "Prestazioni",
+      "content": "Monitora le prestazioni del tuo team con classifiche, tassi di soddisfazione e distribuzione delle assistenze."
+    }
+  },
+  "conversations": {
+    "step1": {
+      "title": "Le tue Conversazioni",
+      "content": "Qui si trovano tutte le conversazioni del tuo team. Selezionane una per iniziare a rispondere."
+    },
+    "step2": {
+      "title": "Cerca Conversazioni",
+      "content": "Cerca conversazioni per nome del contatto o per contenuto del messaggio."
+    },
+    "step3": {
+      "title": "Filtri Conversazione",
+      "content": "Filtra le conversazioni per stato (aperta, risolta, in attesa), agente assegnato, team o canale di assistenza."
+    },
+    "step4": {
+      "title": "Lista Conversazioni",
+      "content": "Clicca su qualsiasi conversazione per aprirla. Il punto blu indica i messaggi non letti. Clicca con il tasto destro per azioni rapide."
+    },
+    "step5": {
+      "title": "Area di Assistenza",
+      "content": "Quando selezioni una conversazione, la cronologia dei messaggi appare qui. In alto troverai le informazioni sul contatto e le azioni come risolvere, mettere in pausa e trasferire."
+    }
+  },
+  "contacts": {
+    "step1": {
+      "title": "Gestione Contatti",
+      "content": "Qui gestisci tutti i contatti del tuo database. Usa la ricerca per trovare un contatto rapidamente."
+    },
+    "step2": {
+      "title": "Crea Contatto",
+      "content": "Clicca qui per aggiungere manualmente un nuovo contatto. Puoi anche importare un elenco CSV o esportare il tuo database."
+    },
+    "step3": {
+      "title": "Filtri Avanzati",
+      "content": "Filtra il tuo database per attributi come email, telefono, tag, pipeline o qualsiasi campo personalizzato."
+    },
+    "step4": {
+      "title": "Modalità di Visualizzazione",
+      "content": "Passa dalla visualizzazione a schede (griglia) a quella a tabella secondo le tue preferenze."
+    },
+    "step5": {
+      "title": "Lista Contatti",
+      "content": "Clicca su un contatto per visualizzare i dettagli, avviare una conversazione, modificare o eliminare. Seleziona più contatti per azioni in blocco."
+    },
+    "step6": {
+      "title": "Navigazione tra Pagine",
+      "content": "Naviga tra le pagine del tuo database di contatti e regola quanti record vengono visualizzati per pagina."
+    }
+  },
+  "agents": {
+    "step1": {
+      "title": "Gestione Agenti",
+      "content": "Qui gestisci tutti i tuoi agenti IA. Usa la ricerca per trovare un agente rapidamente."
+    },
+    "step2": {
+      "title": "Crea Agente",
+      "content": "Clicca qui per creare un nuovo agente IA. La procedura guidata ti guiderà passo dopo passo nella configurazione."
+    },
+    "step3": {
+      "title": "Chiavi API",
+      "content": "Gestisci le chiavi API per integrare i tuoi agenti con altri sistemi e piattaforme."
+    },
+    "step4": {
+      "title": "Modalità di Visualizzazione",
+      "content": "Passa dalla visualizzazione a schede (griglia) a quella a tabella secondo le tue preferenze."
+    },
+    "step5": {
+      "title": "Lista Agenti",
+      "content": "Vedi tutti i tuoi agenti qui. Clicca su modifica per configurare comportamenti, integrazioni e la personalità dell'agente."
+    }
+  },
+  "channels": {
+    "step1": {
+      "title": "Gestione Canali",
+      "content": "Qui gestisci tutti i canali di comunicazione connessi. Usa la ricerca per trovare un canale rapidamente."
+    },
+    "step2": {
+      "title": "Crea Canale",
+      "content": "Clicca qui per connettere un nuovo canale. Supportiamo WhatsApp, email, Instagram e altri canali di comunicazione."
+    },
+    "step3": {
+      "title": "Modalità di Visualizzazione",
+      "content": "Passa dalla visualizzazione a schede (griglia) a quella a tabella secondo le tue preferenze."
+    },
+    "step4": {
+      "title": "Lista Canali",
+      "content": "Vedi tutti i canali connessi qui. Clicca su impostazioni per regolare ogni canale individualmente o elimina i canali non più necessari."
+    },
+    "step5": {
+      "title": "Navigazione tra Pagine",
+      "content": "Naviga tra le pagine dei tuoi canali e regola quanti record vengono visualizzati per pagina."
+    }
+  },
+  "pipelines": {
+    "step1": {
+      "title": "Gestione Pipeline",
+      "content": "Qui organizzi il flusso di assistenza dei tuoi contatti in fasi. Usa la ricerca per trovare una pipeline rapidamente."
+    },
+    "step2": {
+      "title": "Crea Pipeline",
+      "content": "Clicca qui per creare una nuova pipeline. Definisci fasi personalizzate per organizzare il funnel di assistenza del tuo team."
+    },
+    "step3": {
+      "title": "Modalità di Visualizzazione",
+      "content": "Passa dalla visualizzazione a schede (griglia) a quella a tabella secondo le tue preferenze."
+    },
+    "step4": {
+      "title": "Lista Pipeline",
+      "content": "Vedi tutte le tue pipeline qui. Clicca su una pipeline per aprire il kanban con le fasi e i contatti. Puoi anche modificare, duplicare o eliminare pipeline dal menu delle azioni."
+    }
+  },
+  "settings": {
+    "step1": {
+      "title": "Impostazioni Account",
+      "content": "Qui gestisci tutte le impostazioni del tuo account, come nome, lingua, utenti, team e integrazioni. Usa il menu laterale per navigare tra le sezioni."
+    },
+    "step2": {
+      "title": "Impostazioni Generali",
+      "content": "Imposta il nome del tuo account, la lingua predefinita dell'interfaccia e altre preferenze di base. Ricorda di salvare dopo aver apportato le modifiche."
+    },
+    "step3": {
+      "title": "Risoluzione Automatica",
+      "content": "Configura il tempo per cui le conversazioni inattive vengono risolte automaticamente. Puoi definire un messaggio di chiusura e applicare un'etichetta al termine."
+    },
+    "step4": {
+      "title": "ID Account",
+      "content": "Questo è l'identificatore univoco del tuo account. Potresti averne bisogno quando contatti il supporto o configuri integrazioni esterne."
+    }
+  },
+  "campaigns": {
+    "step1": {
+      "title": "Gestione Campagne",
+      "content": "Qui crei e monitori tutte le campagne di comunicazione. Usa la ricerca per trovare una campagna rapidamente."
+    },
+    "step2": {
+      "title": "Crea Campagna",
+      "content": "Clicca qui per creare una nuova campagna. La procedura guidata ti guiderà attraverso i passaggi di configurazione del pubblico, del contenuto e della pianificazione."
+    },
+    "step3": {
+      "title": "Filtri",
+      "content": "Filtra le tue campagne per stato, tipo, canale e altri criteri per trovare esattamente ciò di cui hai bisogno."
+    },
+    "step4": {
+      "title": "Lista Campagne",
+      "content": "Vedi tutte le tue campagne qui. Monitora lo stato in tempo reale, avvia, metti in pausa, riprendi o elimina le campagne secondo necessità."
+    },
+    "step5": {
+      "title": "Navigazione tra Pagine",
+      "content": "Naviga tra le pagine delle tue campagne e regola quanti record vengono visualizzati per pagina."
+    }
+  },
+  "journey": {
+    "step1": {
+      "title": "Automazioni Journey",
+      "content": "Qui crei e gestisci journey automatizzati per coinvolgere i tuoi contatti con flussi di messaggi intelligenti."
+    },
+    "step2": {
+      "title": "Crea Journey",
+      "content": "Clicca qui per creare un nuovo journey. Definisci nome e descrizione, poi configura i trigger e le azioni nell'editor di flusso."
+    },
+    "step3": {
+      "title": "Lista Journey",
+      "content": "Vedi tutti i tuoi journey qui. Attiva o disattiva ogni journey tramite l'interruttore di stato, apri l'editor di flusso per personalizzare i passaggi o duplica journey esistenti per velocizzare la creazione."
+    }
+  }
+}

--- a/src/i18n/locales/pt-BR/tours.json
+++ b/src/i18n/locales/pt-BR/tours.json
@@ -1,0 +1,203 @@
+{
+  "welcome": {
+    "title": "Bem-vindo ao EvoAI!",
+    "description": "Quer fazer um tour guiado para conhecer as funcionalidades da plataforma?",
+    "startButton": "Iniciar tour guiado",
+    "skipButton": "Prefiro explorar sozinho"
+  },
+  "stepOf": "{{current}} de {{total}}",
+  "next": "Próximo",
+  "back": "Voltar",
+  "finish": "Concluir",
+  "close": "Fechar",
+  "dashboard": {
+    "step1": {
+      "title": "Bem-vindo ao Dashboard!",
+      "content": "Este é o painel principal da plataforma. Aqui você acompanha as métricas mais importantes do seu negócio em tempo real."
+    },
+    "step2": {
+      "title": "Filtros",
+      "content": "Use os filtros para segmentar os dados por canal, agente, equipe ou outros critérios."
+    },
+    "step3": {
+      "title": "Período de Análise",
+      "content": "Selecione o período que deseja analisar: hoje, últimos 7 dias, 30 dias ou um intervalo personalizado."
+    },
+    "step4": {
+      "title": "Métricas Principais",
+      "content": "Veja os indicadores-chave: total de conversas, mensagens enviadas, taxa de resolução e tempo médio de resposta."
+    },
+    "step5": {
+      "title": "Tendências",
+      "content": "Gráficos de tendência mostram a evolução das métricas ao longo do tempo para identificar padrões."
+    },
+    "step6": {
+      "title": "Performance",
+      "content": "Acompanhe a performance da sua equipe com rankings, taxas de satisfação e distribuição de atendimentos."
+    }
+  },
+  "conversations": {
+    "step1": {
+      "title": "Suas Conversas",
+      "content": "Aqui ficam todas as conversas do seu time. Selecione uma para começar a atender."
+    },
+    "step2": {
+      "title": "Busca de Conversas",
+      "content": "Pesquise conversas pelo nome do contato ou pelo conteúdo da mensagem."
+    },
+    "step3": {
+      "title": "Filtros de Conversa",
+      "content": "Filtre as conversas por status (aberta, resolvida, pendente), agente responsável, equipe ou canal de atendimento."
+    },
+    "step4": {
+      "title": "Lista de Conversas",
+      "content": "Clique em qualquer conversa para abri-la. O ponto azul indica mensagens não lidas. Clique com o botão direito para ações rápidas."
+    },
+    "step5": {
+      "title": "Área de Atendimento",
+      "content": "Ao selecionar uma conversa, o histórico de mensagens aparece aqui. No topo você encontra informações do contato e ações como resolver, pausar e transferir."
+    }
+  },
+  "contacts": {
+    "step1": {
+      "title": "Gerenciamento de Contatos",
+      "content": "Aqui você gerencia todos os contatos da sua base. Use a busca para encontrar um contato rapidamente."
+    },
+    "step2": {
+      "title": "Criar Contato",
+      "content": "Clique aqui para adicionar um novo contato manualmente. Você também pode importar uma lista em CSV ou exportar sua base."
+    },
+    "step3": {
+      "title": "Filtros Avançados",
+      "content": "Filtre sua base por atributos como e-mail, telefone, tag, pipeline ou qualquer campo customizado."
+    },
+    "step4": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cards (grade) ou tabela conforme sua preferência."
+    },
+    "step5": {
+      "title": "Lista de Contatos",
+      "content": "Clique em um contato para ver detalhes, iniciar uma conversa, editar ou excluir. Selecione múltiplos para ações em lote."
+    },
+    "step6": {
+      "title": "Navegação entre Páginas",
+      "content": "Navegue entre as páginas da sua base de contatos e ajuste quantos registros são exibidos por página."
+    }
+  },
+  "agents": {
+    "step1": {
+      "title": "Gerenciamento de Agentes",
+      "content": "Aqui você gerencia todos os seus agentes de IA. Use a busca para encontrar um agente rapidamente."
+    },
+    "step2": {
+      "title": "Criar Agente",
+      "content": "Clique aqui para criar um novo agente de IA. O assistente irá guiá-lo passo a passo na configuração."
+    },
+    "step3": {
+      "title": "Chaves de API",
+      "content": "Gerencie as chaves de API para integrar seus agentes com outros sistemas e plataformas."
+    },
+    "step4": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cards (grade) ou tabela conforme sua preferência."
+    },
+    "step5": {
+      "title": "Lista de Agentes",
+      "content": "Veja todos os seus agentes aqui. Clique em editar para configurar comportamentos, integrações e personalidade do agente."
+    }
+  },
+  "channels": {
+    "step1": {
+      "title": "Gerenciamento de Canais",
+      "content": "Aqui você gerencia todos os canais de comunicação conectados. Use a busca para encontrar um canal rapidamente."
+    },
+    "step2": {
+      "title": "Criar Canal",
+      "content": "Clique aqui para conectar um novo canal. Suportamos WhatsApp, e-mail, Instagram e outros meios de comunicação."
+    },
+    "step3": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cards (grade) ou tabela conforme sua preferência."
+    },
+    "step4": {
+      "title": "Lista de Canais",
+      "content": "Veja todos os canais conectados aqui. Clique em configurações para ajustar cada canal individualmente ou exclua canais que não são mais necessários."
+    },
+    "step5": {
+      "title": "Navegação entre Páginas",
+      "content": "Navegue entre as páginas dos seus canais e ajuste quantos registros são exibidos por página."
+    }
+  },
+  "pipelines": {
+    "step1": {
+      "title": "Gerenciamento de Pipelines",
+      "content": "Aqui você organiza o fluxo de atendimento dos seus contatos em etapas. Use a busca para encontrar um pipeline rapidamente."
+    },
+    "step2": {
+      "title": "Criar Pipeline",
+      "content": "Clique aqui para criar um novo pipeline. Defina etapas personalizadas para organizar o funil de atendimento da sua equipe."
+    },
+    "step3": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cards (grade) ou tabela conforme sua preferência."
+    },
+    "step4": {
+      "title": "Lista de Pipelines",
+      "content": "Veja todos os seus pipelines aqui. Clique em um pipeline para abrir o kanban com as etapas e contatos. Você também pode editar, duplicar ou excluir pipelines pelo menu de ações."
+    }
+  },
+  "settings": {
+    "step1": {
+      "title": "Configurações da Conta",
+      "content": "Aqui você gerencia todas as configurações da sua conta, como nome, idioma, usuários, times e integrações. Use o menu lateral para navegar entre as seções."
+    },
+    "step2": {
+      "title": "Configurações Gerais",
+      "content": "Defina o nome da sua conta, o idioma padrão da interface e outras preferências básicas. Lembre-se de salvar após fazer alterações."
+    },
+    "step3": {
+      "title": "Resolução Automática",
+      "content": "Configure o tempo para que conversas inativas sejam resolvidas automaticamente. Você pode definir uma mensagem de encerramento e aplicar uma etiqueta ao finalizar."
+    },
+    "step4": {
+      "title": "ID da Conta",
+      "content": "Este é o identificador único da sua conta. Você pode precisar dele ao entrar em contato com o suporte ou ao configurar integrações externas."
+    }
+  },
+  "campaigns": {
+    "step1": {
+      "title": "Gerenciamento de Campanhas",
+      "content": "Aqui você cria e acompanha todas as campanhas de comunicação. Use a busca para encontrar uma campanha rapidamente."
+    },
+    "step2": {
+      "title": "Criar Campanha",
+      "content": "Clique aqui para criar uma nova campanha. O assistente irá guiá-lo pelas etapas de configuração de audiência, conteúdo e agendamento."
+    },
+    "step3": {
+      "title": "Filtros",
+      "content": "Filtre suas campanhas por status, tipo, canal e outros critérios para encontrar exatamente o que você precisa."
+    },
+    "step4": {
+      "title": "Lista de Campanhas",
+      "content": "Veja todas as suas campanhas aqui. Acompanhe o status em tempo real, inicie, pause, retome ou exclua campanhas conforme necessário."
+    },
+    "step5": {
+      "title": "Navegação entre Páginas",
+      "content": "Navegue entre as páginas das suas campanhas e ajuste quantos registros são exibidos por página."
+    }
+  },
+  "journey": {
+    "step1": {
+      "title": "Automações de Jornada",
+      "content": "Aqui você cria e gerencia jornadas automatizadas para engajar seus contatos com fluxos de mensagens inteligentes."
+    },
+    "step2": {
+      "title": "Criar Jornada",
+      "content": "Clique aqui para criar uma nova jornada. Defina o nome, descrição e depois configure os gatilhos e ações no editor de fluxo."
+    },
+    "step3": {
+      "title": "Lista de Jornadas",
+      "content": "Veja todas as suas jornadas aqui. Ative ou desative cada jornada pelo toggle de status, abra o editor de fluxo para personalizar os passos ou duplique jornadas existentes para agilizar a criação."
+    }
+  }
+}

--- a/src/i18n/locales/pt/tours.json
+++ b/src/i18n/locales/pt/tours.json
@@ -1,0 +1,203 @@
+{
+  "welcome": {
+    "title": "Bem-vindo ao EvoAI!",
+    "description": "Quer fazer uma visita guiada para conhecer as funcionalidades da plataforma?",
+    "startButton": "Iniciar visita guiada",
+    "skipButton": "Prefiro explorar por conta própria"
+  },
+  "stepOf": "{{current}} de {{total}}",
+  "next": "Seguinte",
+  "back": "Anterior",
+  "finish": "Concluir",
+  "close": "Fechar",
+  "dashboard": {
+    "step1": {
+      "title": "Bem-vindo ao Dashboard!",
+      "content": "Este é o painel principal da plataforma. Aqui acompanha as métricas mais importantes do seu negócio em tempo real."
+    },
+    "step2": {
+      "title": "Filtros",
+      "content": "Utilize os filtros para segmentar os dados por canal, agente, equipa ou outros critérios."
+    },
+    "step3": {
+      "title": "Período de Análise",
+      "content": "Selecione o período que pretende analisar: hoje, últimos 7 dias, 30 dias ou um intervalo personalizado."
+    },
+    "step4": {
+      "title": "Métricas Principais",
+      "content": "Veja os indicadores-chave: total de conversas, mensagens enviadas, taxa de resolução e tempo médio de resposta."
+    },
+    "step5": {
+      "title": "Tendências",
+      "content": "Gráficos de tendência mostram a evolução das métricas ao longo do tempo para identificar padrões."
+    },
+    "step6": {
+      "title": "Desempenho",
+      "content": "Acompanhe o desempenho da sua equipa com classificações, taxas de satisfação e distribuição de atendimentos."
+    }
+  },
+  "conversations": {
+    "step1": {
+      "title": "As suas Conversas",
+      "content": "Aqui ficam todas as conversas da sua equipa. Selecione uma para começar a atender."
+    },
+    "step2": {
+      "title": "Pesquisa de Conversas",
+      "content": "Pesquise conversas pelo nome do contacto ou pelo conteúdo da mensagem."
+    },
+    "step3": {
+      "title": "Filtros de Conversa",
+      "content": "Filtre as conversas por estado (aberta, resolvida, pendente), agente responsável, equipa ou canal de atendimento."
+    },
+    "step4": {
+      "title": "Lista de Conversas",
+      "content": "Clique em qualquer conversa para a abrir. O ponto azul indica mensagens não lidas. Clique com o botão direito para ações rápidas."
+    },
+    "step5": {
+      "title": "Área de Atendimento",
+      "content": "Ao selecionar uma conversa, o histórico de mensagens aparece aqui. No topo encontra informações do contacto e ações como resolver, pausar e transferir."
+    }
+  },
+  "contacts": {
+    "step1": {
+      "title": "Gestão de Contactos",
+      "content": "Aqui gere todos os contactos da sua base de dados. Utilize a pesquisa para encontrar um contacto rapidamente."
+    },
+    "step2": {
+      "title": "Criar Contacto",
+      "content": "Clique aqui para adicionar um novo contacto manualmente. Também pode importar uma lista em CSV ou exportar a sua base de dados."
+    },
+    "step3": {
+      "title": "Filtros Avançados",
+      "content": "Filtre a sua base por atributos como e-mail, telefone, etiqueta, pipeline ou qualquer campo personalizado."
+    },
+    "step4": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cartões (grelha) ou tabela conforme a sua preferência."
+    },
+    "step5": {
+      "title": "Lista de Contactos",
+      "content": "Clique num contacto para ver detalhes, iniciar uma conversa, editar ou eliminar. Selecione múltiplos para ações em lote."
+    },
+    "step6": {
+      "title": "Navegação entre Páginas",
+      "content": "Navegue entre as páginas da sua base de contactos e ajuste quantos registos são apresentados por página."
+    }
+  },
+  "agents": {
+    "step1": {
+      "title": "Gestão de Agentes",
+      "content": "Aqui gere todos os seus agentes de IA. Utilize a pesquisa para encontrar um agente rapidamente."
+    },
+    "step2": {
+      "title": "Criar Agente",
+      "content": "Clique aqui para criar um novo agente de IA. O assistente irá guiá-lo passo a passo na configuração."
+    },
+    "step3": {
+      "title": "Chaves de API",
+      "content": "Gira as chaves de API para integrar os seus agentes com outros sistemas e plataformas."
+    },
+    "step4": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cartões (grelha) ou tabela conforme a sua preferência."
+    },
+    "step5": {
+      "title": "Lista de Agentes",
+      "content": "Veja todos os seus agentes aqui. Clique em editar para configurar comportamentos, integrações e personalidade do agente."
+    }
+  },
+  "channels": {
+    "step1": {
+      "title": "Gestão de Canais",
+      "content": "Aqui gere todos os canais de comunicação ligados. Utilize a pesquisa para encontrar um canal rapidamente."
+    },
+    "step2": {
+      "title": "Criar Canal",
+      "content": "Clique aqui para ligar um novo canal. Suportamos WhatsApp, e-mail, Instagram e outros meios de comunicação."
+    },
+    "step3": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cartões (grelha) ou tabela conforme a sua preferência."
+    },
+    "step4": {
+      "title": "Lista de Canais",
+      "content": "Veja todos os canais ligados aqui. Clique em definições para ajustar cada canal individualmente ou elimine canais que já não são necessários."
+    },
+    "step5": {
+      "title": "Navegação entre Páginas",
+      "content": "Navegue entre as páginas dos seus canais e ajuste quantos registos são apresentados por página."
+    }
+  },
+  "pipelines": {
+    "step1": {
+      "title": "Gestão de Pipelines",
+      "content": "Aqui organiza o fluxo de atendimento dos seus contactos em etapas. Utilize a pesquisa para encontrar um pipeline rapidamente."
+    },
+    "step2": {
+      "title": "Criar Pipeline",
+      "content": "Clique aqui para criar um novo pipeline. Defina etapas personalizadas para organizar o funil de atendimento da sua equipa."
+    },
+    "step3": {
+      "title": "Modo de Visualização",
+      "content": "Alterne entre visualização em cartões (grelha) ou tabela conforme a sua preferência."
+    },
+    "step4": {
+      "title": "Lista de Pipelines",
+      "content": "Veja todos os seus pipelines aqui. Clique num pipeline para abrir o kanban com as etapas e contactos. Também pode editar, duplicar ou eliminar pipelines pelo menu de ações."
+    }
+  },
+  "settings": {
+    "step1": {
+      "title": "Definições da Conta",
+      "content": "Aqui gere todas as definições da sua conta, como nome, idioma, utilizadores, equipas e integrações. Utilize o menu lateral para navegar entre as secções."
+    },
+    "step2": {
+      "title": "Definições Gerais",
+      "content": "Defina o nome da sua conta, o idioma predefinido da interface e outras preferências básicas. Lembre-se de guardar após fazer alterações."
+    },
+    "step3": {
+      "title": "Resolução Automática",
+      "content": "Configure o tempo para que conversas inativas sejam resolvidas automaticamente. Pode definir uma mensagem de encerramento e aplicar uma etiqueta ao finalizar."
+    },
+    "step4": {
+      "title": "ID da Conta",
+      "content": "Este é o identificador único da sua conta. Pode precisar dele ao contactar o suporte ou ao configurar integrações externas."
+    }
+  },
+  "campaigns": {
+    "step1": {
+      "title": "Gestão de Campanhas",
+      "content": "Aqui cria e acompanha todas as campanhas de comunicação. Utilize a pesquisa para encontrar uma campanha rapidamente."
+    },
+    "step2": {
+      "title": "Criar Campanha",
+      "content": "Clique aqui para criar uma nova campanha. O assistente irá guiá-lo pelas etapas de configuração de audiência, conteúdo e agendamento."
+    },
+    "step3": {
+      "title": "Filtros",
+      "content": "Filtre as suas campanhas por estado, tipo, canal e outros critérios para encontrar exatamente o que precisa."
+    },
+    "step4": {
+      "title": "Lista de Campanhas",
+      "content": "Veja todas as suas campanhas aqui. Acompanhe o estado em tempo real, inicie, pause, retome ou elimine campanhas conforme necessário."
+    },
+    "step5": {
+      "title": "Navegação entre Páginas",
+      "content": "Navegue entre as páginas das suas campanhas e ajuste quantos registos são apresentados por página."
+    }
+  },
+  "journey": {
+    "step1": {
+      "title": "Automações de Jornada",
+      "content": "Aqui cria e gere jornadas automatizadas para envolver os seus contactos com fluxos de mensagens inteligentes."
+    },
+    "step2": {
+      "title": "Criar Jornada",
+      "content": "Clique aqui para criar uma nova jornada. Defina o nome, descrição e depois configure os gatilhos e ações no editor de fluxo."
+    },
+    "step3": {
+      "title": "Lista de Jornadas",
+      "content": "Veja todas as suas jornadas aqui. Ative ou desative cada jornada pelo botão de estado, abra o editor de fluxo para personalizar os passos ou duplique jornadas existentes para agilizar a criação."
+    }
+  }
+}

--- a/src/pages/Customer/Agents/Agents.tsx
+++ b/src/pages/Customer/Agents/Agents.tsx
@@ -10,6 +10,7 @@ import { getAccessibleAgents, deleteAgent } from '@/services/agents';
 import { Agent } from '@/types/agents';
 import { useLanguage } from '@/hooks/useLanguage';
 import { ApiKeysModal } from '@/components/ApiKeysModal';
+import { AgentsTour } from '@/tours';
 import { exportAsJson, generateExportFilename } from '@/utils/exportUtils';
 import { useDarkMode } from '@/hooks/useDarkMode';
 import type { PaginationMeta } from '@/types/core';
@@ -265,7 +266,9 @@ const Agentes = () => {
         </div>
       ) : (
         <div className="animate-fadeIn h-full flex flex-col">
+          <AgentsTour />
           <div className="flex-1 space-y-6 p-6">
+            <div data-tour="agents-header">
             <AgentsHeader
               totalCount={state.meta.pagination.total}
               selectedCount={state.selectedAgents.length}
@@ -279,8 +282,9 @@ const Agentes = () => {
               activeFilters={[]}
               showFilters={true}
             />
+            </div>
 
-            <div className="flex items-center justify-end">
+            <div className="flex items-center justify-end" data-tour="agents-view-toggle">
               <div className="flex items-center border rounded-lg">
                 <Button
                   variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -301,6 +305,7 @@ const Agentes = () => {
               </div>
             </div>
 
+            <div data-tour="agents-list">
             {state.loading ? (
               <div className="flex items-center justify-center h-48">
                 <Bot className="h-8 w-8 animate-pulse" />
@@ -356,6 +361,7 @@ const Agentes = () => {
                 onSort={handleSort}
               />
             )}
+            </div>
           </div>
 
           <div className="p-6 pt-0">

--- a/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
+++ b/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { useLanguage } from '@/hooks/useLanguage';
+import { AgentsCustomMCPsTour } from '@/tours';
 import {
   Dialog,
   DialogContent,
@@ -354,21 +355,24 @@ export default function CustomMCPServers() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <CustomMCPServersHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedServerIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewServer={handleCreateServer}
-        onFilter={handleOpenFilter}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedServerIds: [] }))}
-        activeFilters={appliedFilters}
-        showFilters={true}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="agents-custom-mcps-page">
+      <AgentsCustomMCPsTour />
+      <div data-tour="agents-custom-mcps-header">
+        <CustomMCPServersHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedServerIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewServer={handleCreateServer}
+          onFilter={handleOpenFilter}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedServerIds: [] }))}
+          activeFilters={appliedFilters}
+          showFilters={true}
+        />
+      </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="agents-custom-mcps-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -390,7 +394,7 @@ export default function CustomMCPServers() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="agents-custom-mcps-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading.servers')}</div>

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { useLanguage } from '@/hooks/useLanguage';
+import { AgentsCustomToolsTour } from '@/tours';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Button } from '@evoapi/design-system';
 import { Grid3X3, List, Wand } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
@@ -327,22 +328,25 @@ export default function CustomTools() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <CustomToolsHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedToolIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewTool={handleCreateTool}
-        onFilter={handleOpenFilter}
+    <div className="h-full flex flex-col p-4" data-tour="agents-custom-tools-page">
+      <AgentsCustomToolsTour />
+      <div data-tour="agents-custom-tools-header">
+        <CustomToolsHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedToolIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewTool={handleCreateTool}
+          onFilter={handleOpenFilter}
 
-        onClearSelection={() => setState(prev => ({ ...prev, selectedToolIds: [] }))}
-        activeFilters={appliedFilters}
-        showFilters={true}
-      />
+          onClearSelection={() => setState(prev => ({ ...prev, selectedToolIds: [] }))}
+          activeFilters={appliedFilters}
+          showFilters={true}
+        />
+      </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="agents-custom-tools-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -364,7 +368,7 @@ export default function CustomTools() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="agents-custom-tools-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading.tools')}</div>

--- a/src/pages/Customer/Channels/Channels.tsx
+++ b/src/pages/Customer/Channels/Channels.tsx
@@ -27,6 +27,7 @@ import {
 import EmptyState from '@/components/base/EmptyState';
 // table types imported where needed in ChannelsTable
 import { useNavigate } from 'react-router-dom';
+import { ChannelsTour } from '@/tours';
 
 export default function Channels() {
   const { can, isReady: permissionsReady, loading: permissionsLoading } = useUserPermissions();
@@ -169,16 +170,19 @@ export default function Channels() {
 
   return (
     <div className="h-full flex flex-col p-4">
-      <ChannelsHeader
-        totalCount={totalCount}
-        selectedCount={0}
-        searchValue={query}
-        onSearchChange={setQuery}
-        onNewChannel={handleNewChannel}
-        onClearSelection={() => {}}
-      />
+      <ChannelsTour />
+      <div data-tour="channels-header">
+        <ChannelsHeader
+          totalCount={totalCount}
+          selectedCount={0}
+          searchValue={query}
+          onSearchChange={setQuery}
+          onNewChannel={handleNewChannel}
+          onClearSelection={() => {}}
+        />
+      </div>
 
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="channels-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -199,7 +203,7 @@ export default function Channels() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="channels-list">
         {isLoadingInboxes ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {Array.from({ length: 6 }).map((_, idx) => (
@@ -238,15 +242,17 @@ export default function Channels() {
 
       {/* Pagination */}
       {totalCount > 0 && (
-        <ChannelsPagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          totalCount={totalCount}
-          perPage={perPage}
-          onPageChange={setCurrentPage}
-          onPerPageChange={setPerPage}
-          loading={isLoadingInboxes}
-        />
+        <div data-tour="channels-pagination">
+          <ChannelsPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalCount={totalCount}
+            perPage={perPage}
+            onPageChange={setCurrentPage}
+            onPerPageChange={setPerPage}
+            loading={isLoadingInboxes}
+          />
+        </div>
       )}
 
       {/* Delete Confirmation Modal */}

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -30,6 +30,7 @@ import {
 } from '@evoapi/design-system/alert-dialog';
 
 import ErrorBoundary from '../../../components/ErrorBoundary';
+import { ChatTour } from '@/tours';
 
 // Novos componentes refatorados
 import ChatSidebar from '@/components/chat/chat-sidebar/ChatSidebar';
@@ -678,6 +679,7 @@ const Chat = () => {
 
   return (
     <ErrorBoundary>
+      <ChatTour />
       <div className="h-full w-full flex flex-col md:flex-row overflow-hidden">
         {/* Chat List Sidebar */}
         <ChatSidebar
@@ -706,6 +708,7 @@ const Chat = () => {
 
         {/* Chat Area */}
         <div
+          data-tour="chat-main-area"
           className={`
           ${mobileView === 'chat' ? 'flex' : 'hidden'} md:flex
           flex-1 flex-col h-full min-h-0 max-h-full overflow-hidden

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -34,6 +34,7 @@ import ContactExportModal from '@/components/contacts/ContactExportModal';
 import ContactEventsModal from '@/components/contacts/ContactEventsModal';
 import ContactMergeModal from '@/components/contacts/ContactMergeModal';
 import { AxiosError } from 'axios';
+import { ContactsTour } from '@/tours';
 
 const INITIAL_STATE: ContactsState = {
   contacts: [],
@@ -757,6 +758,8 @@ export default function Contacts() {
 
   return (
     <div className="h-full flex flex-col p-4">
+      <ContactsTour />
+      <div data-tour="contacts-header">
       <ContactsHeader
         totalCount={state.meta.pagination.total}
         selectedCount={state.selectedContactIds.length}
@@ -772,9 +775,10 @@ export default function Contacts() {
         activeFilters={appliedFilters}
         showFilters={true}
       />
+      </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="contacts-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -796,7 +800,7 @@ export default function Contacts() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="contacts-list">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading.contacts')}</div>
@@ -867,15 +871,17 @@ export default function Contacts() {
 
       {/* Pagination */}
       {state.meta.pagination.total > 0 && (
-        <ContactsPagination
-          currentPage={state.meta.pagination.page}
-          totalPages={state.meta.pagination.total_pages}
-          totalCount={state.meta.pagination.total}
-          perPage={state.meta.pagination.page_size}
-          onPageChange={handlePageChange}
-          onPerPageChange={handlePerPageChange}
-          loading={state.loading.list}
-        />
+        <div data-tour="contacts-pagination">
+          <ContactsPagination
+            currentPage={state.meta.pagination.page}
+            totalPages={state.meta.pagination.total_pages}
+            totalCount={state.meta.pagination.total}
+            perPage={state.meta.pagination.page_size}
+            onPageChange={handlePageChange}
+            onPerPageChange={handlePerPageChange}
+            loading={state.loading.list}
+          />
+        </div>
       )}
 
       {/* Delete Contact Dialog */}

--- a/src/pages/Customer/Contacts/ScheduledActions.tsx
+++ b/src/pages/Customer/Contacts/ScheduledActions.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
+import { ScheduledActionsTour } from '@/tours';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { scheduledActionsService } from '@/services/scheduledActions/scheduledActionsService';
@@ -219,7 +220,9 @@ export default function ScheduledActions() {
   const filteredActions = getFilteredActions();
 
   return (
-    <div className="h-full flex flex-col p-6">
+    <div className="h-full flex flex-col p-6" data-tour="scheduled-actions-page">
+      <ScheduledActionsTour />
+      <div data-tour="scheduled-actions-header">
       <ScheduledActionsHeader
         totalCount={state.meta.total_count}
         selectedCount={state.selectedActionIds.length}
@@ -229,7 +232,9 @@ export default function ScheduledActions() {
         onBulkCancel={handleBulkCancel}
         onClearSelection={handleClearSelection}
       />
+      </div>
 
+      <div data-tour="scheduled-actions-content">
       {state.loading.list && state.actions.length === 0 ? (
         <div className="flex items-center justify-center py-12">
           <div className="text-center">
@@ -275,6 +280,8 @@ export default function ScheduledActions() {
           )}
         </>
       )}
+
+      </div>
 
       {modalOpen && (
         <ScheduleActionModal

--- a/src/pages/Customer/Dashboard/index.tsx
+++ b/src/pages/Customer/Dashboard/index.tsx
@@ -15,6 +15,7 @@ import DashboardMetricsSection from './components/DashboardMetricsSection';
 import DashboardTrendsSection from './components/DashboardTrendsSection';
 import DashboardPerformanceSection from './components/DashboardPerformanceSection';
 import type { DashboardFilterState, DashboardOption } from './components/types';
+import { DashboardTour } from '@/tours';
 
 const ALL_FILTER_VALUE = '__all__';
 
@@ -270,23 +271,33 @@ const CustomerDashboardPage = () => {
 
   return (
     <div className="h-full flex flex-col p-4 gap-6">
-      <BaseHeader
-        title={t('dashboard.title')}
-        subtitle={t('dashboard.subtitle')}
-        filters={appliedHeaderFilters}
-        onFilterClick={handleOpenFilter}
-        showFilters
-      />
+      <DashboardTour />
+      <div data-tour="dashboard-header">
+        <BaseHeader
+          title={t('dashboard.title')}
+          subtitle={t('dashboard.subtitle')}
+          filters={appliedHeaderFilters}
+          onFilterClick={handleOpenFilter}
+          showFilters
+          filterButtonDataTour="dashboard-filter-button"
+        />
+      </div>
 
-      <div className="-mt-3 flex justify-end">
+      <div className="-mt-3 flex justify-end" data-tour="dashboard-period-badge">
         <Badge variant="secondary">
           {currentPeriodLabel} ({data.period.days} dias)
         </Badge>
       </div>
 
-      <DashboardMetricsSection data={data} t={t} />
-      <DashboardTrendsSection data={data} t={t} channelShareData={channelShareData} />
-      <DashboardPerformanceSection data={data} t={t} />
+      <div data-tour="dashboard-metrics">
+        <DashboardMetricsSection data={data} t={t} />
+      </div>
+      <div data-tour="dashboard-trends">
+        <DashboardTrendsSection data={data} t={t} channelShareData={channelShareData} />
+      </div>
+      <div data-tour="dashboard-performance">
+        <DashboardPerformanceSection data={data} t={t} />
+      </div>
 
       <DashboardFiltersDialog
         open={filterModalOpen}

--- a/src/pages/Customer/Pipelines/Pipelines.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.tsx
@@ -33,6 +33,7 @@ import {
   EditPipelineModal,
   DuplicatePipelineModal,
 } from '@/components/pipelines/index';
+import { PipelinesTour } from '@/tours';
 
 const INITIAL_STATE: PipelinesState = {
   pipelines: [],
@@ -305,15 +306,18 @@ export default function Pipelines() {
 
   return (
     <div className="h-full flex flex-col p-4">
-      <PipelinesHeader
-        totalCount={state.meta.pagination.total}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewPipeline={handleCreatePipeline}
-      />
+      <PipelinesTour />
+      <div data-tour="pipelines-header">
+        <PipelinesHeader
+          totalCount={state.meta.pagination.total}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewPipeline={handleCreatePipeline}
+        />
+      </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="pipelines-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -335,7 +339,7 @@ export default function Pipelines() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="pipelines-list">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading.pipelines')}</div>

--- a/src/pages/Customer/Settings/AccessTokens/AccessTokens.tsx
+++ b/src/pages/Customer/Settings/AccessTokens/AccessTokens.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
+import { SettingsAccessTokensTour } from '@/tours';
 import {
   Dialog,
   DialogContent,
@@ -383,20 +384,23 @@ export default function AccessTokens() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <AccessTokensHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedTokenIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewToken={handleCreateToken}
-        onBulkDelete={handleBulkDelete}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedTokenIds: [] }))}
-        showBulkActions={state.selectedTokenIds.length > 0}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-access-tokens-page">
+      <SettingsAccessTokensTour />
+      <div data-tour="settings-access-tokens-header">
+        <AccessTokensHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedTokenIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewToken={handleCreateToken}
+          onBulkDelete={handleBulkDelete}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedTokenIds: [] }))}
+          showBulkActions={state.selectedTokenIds.length > 0}
+        />
+      </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto mt-6">
+      <div className="flex-1 overflow-auto mt-6" data-tour="settings-access-tokens-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('messages.loading')}</div>

--- a/src/pages/Customer/Settings/Account/AccountSettings.tsx
+++ b/src/pages/Customer/Settings/Account/AccountSettings.tsx
@@ -19,6 +19,7 @@ import { accountService } from '@/services/account/accountService';
 import type { Account, FormDataOptions } from '@/types/settings';
 import { Copy } from 'lucide-react';
 import { getPrimaryButtonClasses } from '@/utils/whitelabelStyles';
+import { SettingsTour } from '@/tours';
 
 // Componente para seção
 interface SectionLayoutProps {
@@ -293,11 +294,15 @@ export default function AccountSettings() {
 
   return (
     <div className="h-full flex flex-col p-4">
-      <BaseHeader title={t('title')} subtitle={t('subtitle')} />
+      <SettingsTour />
+      <div data-tour="settings-header">
+        <BaseHeader title={t('title')} subtitle={t('subtitle')} />
+      </div>
 
       <div className="flex-1 overflow-auto">
         <div className="max-w-5xl w-full mx-auto">
           {/* Configurações Gerais */}
+          <div data-tour="settings-general">
           <SectionLayout
             title={t('sections.general.title')}
             description={t('sections.general.description')}
@@ -381,8 +386,10 @@ export default function AccountSettings() {
               </div>
             </form>
           </SectionLayout>
+          </div>
 
           {/* Auto-Resolução */}
+          <div data-tour="settings-auto-resolve">
           <SectionLayout
             title={t('sections.autoResolve.title')}
             description={t('sections.autoResolve.description')}
@@ -484,6 +491,7 @@ export default function AccountSettings() {
               </div>
             )}
           </SectionLayout>
+          </div>
 
           {/* Transcrição de Áudio */}
           {isOnEvolutionCloud && (
@@ -503,6 +511,7 @@ export default function AccountSettings() {
           )}
 
           {/* ID da Conta */}
+          <div data-tour="settings-account-id">
           <SectionLayout
             title={t('sections.accountId.title')}
             description={t('sections.accountId.description')}
@@ -515,6 +524,7 @@ export default function AccountSettings() {
               </Button>
             </div>
           </SectionLayout>
+          </div>
 
           {/* Informações de Build */}
           <div className="text-center py-4 text-sm text-sidebar-foreground/60 border-t border-sidebar-border">

--- a/src/pages/Customer/Settings/CannedResponses/CannedResponses.tsx
+++ b/src/pages/Customer/Settings/CannedResponses/CannedResponses.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { SettingsCannedResponsesTour } from '@/tours';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -276,20 +277,23 @@ export default function CannedResponses() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <CannedResponsesHeader
-        totalCount={searchFilteredCannedResponses.length}
-        selectedCount={state.selectedCannedResponseIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewCannedResponse={handleCreateCannedResponse}
-        onBulkDelete={handleBulkDelete}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedCannedResponseIds: [] }))}
-        showBulkActions={state.selectedCannedResponseIds.length > 0}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-canned-responses-page">
+      <SettingsCannedResponsesTour />
+      <div data-tour="settings-canned-responses-header">
+        <CannedResponsesHeader
+          totalCount={searchFilteredCannedResponses.length}
+          selectedCount={state.selectedCannedResponseIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewCannedResponse={handleCreateCannedResponse}
+          onBulkDelete={handleBulkDelete}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedCannedResponseIds: [] }))}
+          showBulkActions={state.selectedCannedResponseIds.length > 0}
+        />
+      </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto mt-6">
+      <div className="flex-1 overflow-auto mt-6" data-tour="settings-canned-responses-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading')}</div>

--- a/src/pages/Customer/Settings/CustomAttributes/CustomAttributes.tsx
+++ b/src/pages/Customer/Settings/CustomAttributes/CustomAttributes.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { SettingsCustomAttributesTour } from '@/tours';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -299,20 +300,24 @@ export default function CustomAttributes() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <CustomAttributesHeader
-        totalCount={searchFilteredAttributes.length}
-        selectedCount={state.selectedAttributeIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewAttribute={handleCreateAttribute}
-        onBulkDelete={handleBulkDelete}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedAttributeIds: [] }))}
-        showBulkActions={state.selectedAttributeIds.length > 0}
-        activeTab={state.activeTab}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-custom-attributes-page">
+      <SettingsCustomAttributesTour />
+      <div data-tour="settings-custom-attributes-header">
+        <CustomAttributesHeader
+          totalCount={searchFilteredAttributes.length}
+          selectedCount={state.selectedAttributeIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewAttribute={handleCreateAttribute}
+          onBulkDelete={handleBulkDelete}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedAttributeIds: [] }))}
+          showBulkActions={state.selectedAttributeIds.length > 0}
+          activeTab={state.activeTab}
+        />
+      </div>
 
       {/* Tabs */}
+      <div data-tour="settings-custom-attributes-tabs">
       <Tabs value={state.activeTab} onValueChange={handleTabChange} className="mt-6">
         <TabsList className="mb-4">
           {ATTRIBUTE_TABS.map(tab => (
@@ -381,6 +386,7 @@ export default function CustomAttributes() {
           </TabsContent>
         ))}
       </Tabs>
+      </div>
 
       {/* Pagination fixa em baixo */}
       {searchFilteredAttributes.length > 0 && (

--- a/src/pages/Customer/Settings/Integrations/Integrations.tsx
+++ b/src/pages/Customer/Settings/Integrations/Integrations.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useNavigate } from 'react-router-dom';
+import { SettingsIntegrationsTour } from '@/tours';
 import {
   Card,
   Badge,
@@ -229,11 +230,14 @@ export default function Integrations() {
   }
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <BaseHeader title={t('title')} subtitle={t('subtitle')} />
+    <div className="h-full flex flex-col p-4" data-tour="settings-integrations-page">
+      <SettingsIntegrationsTour />
+      <div data-tour="settings-integrations-header">
+        <BaseHeader title={t('title')} subtitle={t('subtitle')} />
+      </div>
 
       {/* Search */}
-      <div className="flex flex-col sm:flex-row gap-4 mt-6">
+      <div className="flex flex-col sm:flex-row gap-4 mt-6" data-tour="settings-integrations-search">
         <div className="relative flex-1 max-w-md">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-slate-400 h-4 w-4" />
           <Input
@@ -246,6 +250,7 @@ export default function Integrations() {
       </div>
 
       {/* Category Tabs */}
+      <div data-tour="settings-integrations-categories">
       <Tabs
         value={selectedCategory}
         onValueChange={setSelectedCategory}
@@ -298,6 +303,7 @@ export default function Integrations() {
           )}
         </TabsContent>
       </Tabs>
+      </div>
     </div>
   );
 }

--- a/src/pages/Customer/Settings/Labels/Labels.tsx
+++ b/src/pages/Customer/Settings/Labels/Labels.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { SettingsLabelsTour } from '@/tours';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -304,20 +305,23 @@ export default function Labels() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <LabelsHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedLabelIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewLabel={handleCreateLabel}
-        onBulkDelete={handleBulkDelete}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedLabelIds: [] }))}
-        showBulkActions={state.selectedLabelIds.length > 0}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-labels-page">
+      <SettingsLabelsTour />
+      <div data-tour="settings-labels-header">
+        <LabelsHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedLabelIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewLabel={handleCreateLabel}
+          onBulkDelete={handleBulkDelete}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedLabelIds: [] }))}
+          showBulkActions={state.selectedLabelIds.length > 0}
+        />
+      </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto mt-6">
+      <div className="flex-1 overflow-auto mt-6" data-tour="settings-labels-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading')}</div>

--- a/src/pages/Customer/Settings/Macros/Macros.tsx
+++ b/src/pages/Customer/Settings/Macros/Macros.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { SettingsMacrosTour } from '@/tours';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -290,22 +291,25 @@ export default function Macros() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <MacrosHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedMacroIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewMacro={handleCreateMacro}
-        onBulkDelete={handleBulkDelete}
-        onFilter={() => setFilterModalOpen(true)}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedMacroIds: [] }))}
-        activeFilters={appliedFilters}
-        showFilters={false} // Disable filters for now
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-macros-page">
+      <SettingsMacrosTour />
+      <div data-tour="settings-macros-header">
+        <MacrosHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedMacroIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewMacro={handleCreateMacro}
+          onBulkDelete={handleBulkDelete}
+          onFilter={() => setFilterModalOpen(true)}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedMacroIds: [] }))}
+          activeFilters={appliedFilters}
+          showFilters={false} // Disable filters for now
+        />
+      </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto mt-6">
+      <div className="flex-1 overflow-auto mt-6" data-tour="settings-macros-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading')}</div>

--- a/src/pages/Customer/Settings/Teams/Teams.tsx
+++ b/src/pages/Customer/Settings/Teams/Teams.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { SettingsTeamsTour } from '@/tours';
 import { toast } from 'sonner';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Button } from '@evoapi/design-system';
 import { Grid3X3, List, Users } from 'lucide-react';
@@ -328,24 +329,27 @@ export default function Teams() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <TeamsHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedTeamIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewTeam={handleCreateTeam}
-        onImport={handleImportTeams}
-        onExport={handleExportTeams}
-        onFilter={handleFilterTeams}
-        onBulkDelete={handleBulkDelete}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedTeamIds: [] }))}
-        activeFilters={[]}
-        showFilters={false}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-teams-page">
+      <SettingsTeamsTour />
+      <div data-tour="settings-teams-header">
+        <TeamsHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedTeamIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewTeam={handleCreateTeam}
+          onImport={handleImportTeams}
+          onExport={handleExportTeams}
+          onFilter={handleFilterTeams}
+          onBulkDelete={handleBulkDelete}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedTeamIds: [] }))}
+          activeFilters={[]}
+          showFilters={false}
+        />
+      </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="settings-teams-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -367,7 +371,7 @@ export default function Teams() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="settings-teams-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading')}</div>

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { SettingsAgentsTour } from '@/tours';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -389,23 +390,26 @@ export default function Users() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
-      <UsersHeader
-        totalCount={state.meta.pagination.total}
-        selectedCount={state.selectedUserIds.length}
-        searchValue={state.searchQuery}
-        onSearchChange={handleSearchChange}
-        onNewUser={handleCreateUser}
-        onBulkInvite={handleBulkInvite}
-        onFilter={handleOpenFilter}
-        onBulkDelete={handleBulkDelete}
-        onClearSelection={() => setState(prev => ({ ...prev, selectedUserIds: [] }))}
-        activeFilters={appliedFilters}
-        showFilters={true}
-      />
+    <div className="h-full flex flex-col p-4" data-tour="settings-agents-page">
+      <SettingsAgentsTour />
+      <div data-tour="settings-agents-header">
+        <UsersHeader
+          totalCount={state.meta.pagination.total}
+          selectedCount={state.selectedUserIds.length}
+          searchValue={state.searchQuery}
+          onSearchChange={handleSearchChange}
+          onNewUser={handleCreateUser}
+          onBulkInvite={handleBulkInvite}
+          onFilter={handleOpenFilter}
+          onBulkDelete={handleBulkDelete}
+          onClearSelection={() => setState(prev => ({ ...prev, selectedUserIds: [] }))}
+          activeFilters={appliedFilters}
+          showFilters={true}
+        />
+      </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3">
+      <div className="flex items-center justify-end mb-3" data-tour="settings-agents-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
@@ -427,7 +431,7 @@ export default function Users() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto" data-tour="settings-agents-content">
         {state.loading.list ? (
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading')}</div>
@@ -485,7 +489,7 @@ export default function Users() {
 
       {/* Pagination */}
       {state.meta.pagination.total > 0 && (
-        <div className="mt-auto pt-4 border-t border-sidebar-border">
+        <div className="mt-auto pt-4 border-t border-sidebar-border" data-tour="settings-agents-pagination">
           <UsersPagination
             currentPage={state.meta.pagination.page}
             totalPages={state.meta.pagination.total_pages}

--- a/src/tours/AgentsTour.tsx
+++ b/src/tours/AgentsTour.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/agents/list';
+
+export function AgentsTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'agents',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="agents-header"]',
+          title: t('agents.step1.title'),
+          content: t('agents.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="agents-new-button"]',
+          title: t('agents.step2.title'),
+          content: t('agents.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="agents-api-keys"]',
+          title: t('agents.step3.title'),
+          content: t('agents.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="agents-view-toggle"]',
+          title: t('agents.step4.title'),
+          content: t('agents.step4.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="agents-list"]',
+          title: t('agents.step5.title'),
+          content: t('agents.step5.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Custom Tools Tour
+// ---------------------------------------------------------------------------
+const CUSTOM_TOOLS_ROUTE = '/agents/custom-tools';
+
+export function AgentsCustomToolsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'agents-custom-tools',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="agents-custom-tools-page"]',
+          title: 'Custom Tools',
+          content: 'Crie e gerencie ferramentas personalizadas que seus Agentes de IA podem utilizar durante o atendimento.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="agents-custom-tools-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Busque tools existentes, aplique filtros ou crie uma nova tool clicando em "Nova Tool".',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="agents-custom-tools-view-toggle"]',
+          title: 'Modo de Visualização',
+          content: 'Alterne entre visualização em cards e em tabela.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="agents-custom-tools-content"]',
+          title: 'Lista de Custom Tools',
+          content: 'Cada card exibe nome, descrição e status da tool. Use as ações para editar, testar ou excluir. Ferramentas testadas garantem que o Agente as use corretamente.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(CUSTOM_TOOLS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(CUSTOM_TOOLS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Custom MCP Servers Tour
+// ---------------------------------------------------------------------------
+const CUSTOM_MCPS_ROUTE = '/agents/custom-mcp-servers';
+
+export function AgentsCustomMCPsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'agents-custom-mcps',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="agents-custom-mcps-page"]',
+          title: 'Custom MCP Servers',
+          content: 'Configure servidores MCP personalizados para expandir as capacidades dos seus Agentes de IA com contextos e ferramentas externas.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="agents-custom-mcps-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Busque servidores MCP existentes, filtre por critérios ou adicione um novo servidor clicando em "Novo Servidor".',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="agents-custom-mcps-view-toggle"]',
+          title: 'Modo de Visualização',
+          content: 'Alterne entre visualização em cards e em tabela conforme sua preferência.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="agents-custom-mcps-content"]',
+          title: 'Lista de Servidores MCP',
+          content: 'Cada servidor exibe nome, URL de conexão e status. Use as ações para editar, testar a conexão ou excluir o servidor.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(CUSTOM_MCPS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(CUSTOM_MCPS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/CampaignsTour.tsx
+++ b/src/tours/CampaignsTour.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/campaigns';
+
+export function CampaignsTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'campaigns',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="campaigns-header"]',
+          title: t('campaigns.step1.title'),
+          content: t('campaigns.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="campaigns-new-button"]',
+          title: t('campaigns.step2.title'),
+          content: t('campaigns.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="campaigns-filter-button"]',
+          title: t('campaigns.step3.title'),
+          content: t('campaigns.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="campaigns-list"]',
+          title: t('campaigns.step4.title'),
+          content: t('campaigns.step4.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="campaigns-pagination"]',
+          title: t('campaigns.step5.title'),
+          content: t('campaigns.step5.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/ChannelsTour.tsx
+++ b/src/tours/ChannelsTour.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/channels';
+
+export function ChannelsTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'channels',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="channels-header"]',
+          title: t('channels.step1.title'),
+          content: t('channels.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="channels-new-button"]',
+          title: t('channels.step2.title'),
+          content: t('channels.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="channels-view-toggle"]',
+          title: t('channels.step3.title'),
+          content: t('channels.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="channels-list"]',
+          title: t('channels.step4.title'),
+          content: t('channels.step4.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="channels-pagination"]',
+          title: t('channels.step5.title'),
+          content: t('channels.step5.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/ChatTour.tsx
+++ b/src/tours/ChatTour.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/conversations';
+
+export function ChatTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'chat',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="chat-sidebar"]',
+          title: t('conversations.step1.title'),
+          content: t('conversations.step1.content'),
+          placement: 'right',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="chat-search"]',
+          title: t('conversations.step2.title'),
+          content: t('conversations.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="chat-filter-button"]',
+          title: t('conversations.step3.title'),
+          content: t('conversations.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="chat-conversations-list"]',
+          title: t('conversations.step4.title'),
+          content: t('conversations.step4.content'),
+          placement: 'right',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="chat-main-area"]',
+          title: t('conversations.step5.title'),
+          content: t('conversations.step5.content'),
+          placement: 'left',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/ContactsTour.tsx
+++ b/src/tours/ContactsTour.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/contacts';
+
+export function ContactsTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'contacts',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="contacts-header"]',
+          title: t('contacts.step1.title'),
+          content: t('contacts.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="contacts-new-button"]',
+          title: t('contacts.step2.title'),
+          content: t('contacts.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="contacts-filter-button"]',
+          title: t('contacts.step3.title'),
+          content: t('contacts.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="contacts-view-toggle"]',
+          title: t('contacts.step4.title'),
+          content: t('contacts.step4.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="contacts-list"]',
+          title: t('contacts.step5.title'),
+          content: t('contacts.step5.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="contacts-pagination"]',
+          title: t('contacts.step6.title'),
+          content: t('contacts.step6.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/DashboardTour.tsx
+++ b/src/tours/DashboardTour.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/dashboard';
+
+export function DashboardTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'dashboard',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="dashboard-header"]',
+          title: t('dashboard.step1.title'),
+          content: t('dashboard.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="dashboard-filter-button"]',
+          title: t('dashboard.step2.title'),
+          content: t('dashboard.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="dashboard-period-badge"]',
+          title: t('dashboard.step3.title'),
+          content: t('dashboard.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="dashboard-metrics"]',
+          title: t('dashboard.step4.title'),
+          content: t('dashboard.step4.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="dashboard-trends"]',
+          title: t('dashboard.step5.title'),
+          content: t('dashboard.step5.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="dashboard-performance"]',
+          title: t('dashboard.step6.title'),
+          content: t('dashboard.step6.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/JourneyTour.tsx
+++ b/src/tours/JourneyTour.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/journey';
+
+export function JourneyTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'journey',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="journey-header"]',
+          title: t('journey.step1.title'),
+          content: t('journey.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="journey-new-button"]',
+          title: t('journey.step2.title'),
+          content: t('journey.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="journey-list"]',
+          title: t('journey.step3.title'),
+          content: t('journey.step3.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/JoyrideTooltip.tsx
+++ b/src/tours/JoyrideTooltip.tsx
@@ -1,0 +1,161 @@
+import type { TooltipRenderProps } from 'react-joyride';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export function JoyrideTooltip({
+  continuous,
+  index,
+  isLastStep,
+  size,
+  step,
+  backProps,
+  closeProps,
+  primaryProps,
+  tooltipProps,
+}: TooltipRenderProps) {
+  const { t } = useTranslation('tours');
+  return (
+    <div
+      {...tooltipProps}
+      style={{
+        background: '#252836',
+        border: '1px solid #2e3344',
+        borderRadius: '10px',
+        padding: '16px',
+        maxWidth: '340px',
+        width: '340px',
+        boxSizing: 'border-box',
+        fontFamily: 'inherit',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '10px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          <div
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: '50%',
+              background: '#00C48C',
+              flexShrink: 0,
+            }}
+          />
+          {step.title && (
+            <span
+              style={{
+                color: '#ffffff',
+                fontWeight: 500,
+                fontSize: '14px',
+                lineHeight: 1.4,
+              }}
+            >
+              {step.title}
+            </span>
+          )}
+        </div>
+        <button
+          {...closeProps}
+          style={{
+            background: 'none',
+            border: 'none',
+            color: '#8b8fa8',
+            cursor: 'pointer',
+            padding: '0 0 0 8px',
+            fontSize: '18px',
+            lineHeight: 1,
+            flexShrink: 0,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Content */}
+      <div
+        style={{
+          color: '#8b8fa8',
+          fontSize: '13px',
+          lineHeight: 1.6,
+          marginBottom: '16px',
+        }}
+      >
+        {step.content}
+      </div>
+
+      {/* Footer */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        {/* Left: "X de Y" + progress dots */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <span style={{ color: '#8b8fa8', fontSize: '11px', whiteSpace: 'nowrap' }}>
+            {t('stepOf', { current: index + 1, total: size })}
+          </span>
+          <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+            {Array.from({ length: size }).map((_, i) => (
+              <div
+                key={i}
+                style={{
+                  width: 5,
+                  height: 5,
+                  borderRadius: '50%',
+                  background: i === index ? '#00C48C' : '#2e3344',
+                  flexShrink: 0,
+                }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Right: Back + Next/Finish buttons */}
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+          {index > 0 && (
+            <button
+              {...backProps}
+              style={{
+                background: 'transparent',
+                border: '1px solid #2e3344',
+                color: '#8b8fa8',
+                borderRadius: '6px',
+                padding: '6px 14px',
+                fontSize: '12px',
+                cursor: 'pointer',
+                lineHeight: 1.4,
+              }}
+            >
+              {t('back')}
+            </button>
+          )}
+          {continuous && (
+            <button
+              {...primaryProps}
+              style={{
+                background: '#00C48C',
+                border: 'none',
+                color: '#ffffff',
+                borderRadius: '6px',
+                padding: '6px 16px',
+                fontSize: '12px',
+                fontWeight: 500,
+                cursor: 'pointer',
+                lineHeight: 1.4,
+              }}
+            >
+              {isLastStep ? t('finish') : t('next')}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/tours/PipelinesTour.tsx
+++ b/src/tours/PipelinesTour.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/pipelines';
+
+export function PipelinesTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'pipelines',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="pipelines-header"]',
+          title: t('pipelines.step1.title'),
+          content: t('pipelines.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="pipelines-new-button"]',
+          title: t('pipelines.step2.title'),
+          content: t('pipelines.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="pipelines-view-toggle"]',
+          title: t('pipelines.step3.title'),
+          content: t('pipelines.step3.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="pipelines-list"]',
+          title: t('pipelines.step4.title'),
+          content: t('pipelines.step4.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/ScheduledActionsTour.tsx
+++ b/src/tours/ScheduledActionsTour.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/contacts/scheduled-actions';
+
+export function ScheduledActionsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'scheduled-actions',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="scheduled-actions-page"]',
+          title: 'Ações Agendadas',
+          content: 'Aqui você visualiza e gerencia todas as ações programadas para serem executadas automaticamente em contatos — como envio de mensagens em datas específicas.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="scheduled-actions-search"]',
+          title: 'Buscar Ações',
+          content: 'Pesquise ações agendadas pelo nome do contato, tipo de ação ou qualquer outro campo para encontrar rapidamente o que precisa.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="scheduled-actions-new-button"]',
+          title: 'Nova Ação Agendada',
+          content: 'Clique aqui para criar uma nova ação agendada. Você poderá escolher o contato, definir o tipo de ação e configurar a data e hora de execução.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="scheduled-actions-content"]',
+          title: 'Lista de Ações',
+          content: 'Todas as ações agendadas aparecem aqui com status (agendada, executada, cancelada) e contagem regressiva. Use as ações da linha para editar ou cancelar uma ação antes da execução.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/SettingsTour.tsx
+++ b/src/tours/SettingsTour.tsx
@@ -1,0 +1,480 @@
+import { useEffect, useMemo, useRef } from 'react';
+import type { Step } from 'react-joyride';
+import { useJoyride } from '@/hooks/useJoyride';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tourRegistry } from './tourRegistry';
+
+const ROUTE = '/settings/account';
+
+export function SettingsTour() {
+  const { t } = useTranslation('tours');
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-header"]',
+          title: t('settings.step1.title'),
+          content: t('settings.step1.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="settings-general"]',
+          title: t('settings.step2.title'),
+          content: t('settings.step2.content'),
+          placement: 'bottom',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="settings-auto-resolve"]',
+          title: t('settings.step3.title'),
+          content: t('settings.step3.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+        {
+          target: '[data-tour="settings-account-id"]',
+          title: t('settings.step4.title'),
+          content: t('settings.step4.content'),
+          placement: 'top',
+          skipBeacon: true,
+          skipScroll: false,
+          scrollOffset: 80,
+        },
+      ],
+      [t],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Atendentes Tour
+// ---------------------------------------------------------------------------
+const AGENTS_ROUTE = '/settings/users';
+
+export function SettingsAgentsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-agents',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-agents-page"]',
+          title: 'Atendentes',
+          content: 'Nesta seção você gerencia todos os atendentes da sua equipe.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-agents-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Use a busca para encontrar atendentes, crie novos ou faça convite em massa.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-agents-view-toggle"]',
+          title: 'Modo de Visualização',
+          content: 'Alterne entre a visualização em cards e em tabela conforme sua preferência.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-agents-content"]',
+          title: 'Lista de Atendentes',
+          content: 'Aqui são exibidos todos os atendentes. Clique em um para editar ou remover.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(AGENTS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(AGENTS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Times Tour
+// ---------------------------------------------------------------------------
+const TEAMS_ROUTE = '/settings/teams';
+
+export function SettingsTeamsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-teams',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-teams-page"]',
+          title: 'Times',
+          content: 'Organize seus atendentes em times para facilitar a distribuição de conversas.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-teams-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Crie novos times, importe/exporte dados e busque times existentes.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-teams-view-toggle"]',
+          title: 'Modo de Visualização',
+          content: 'Alterne entre a visualização em cards e em tabela.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-teams-content"]',
+          title: 'Lista de Times',
+          content: 'Veja todos os times cadastrados. Clique em "Gerenciar Membros" para adicionar ou remover atendentes de um time.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(TEAMS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(TEAMS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Etiquetas Tour
+// ---------------------------------------------------------------------------
+const LABELS_ROUTE = '/settings/labels';
+
+export function SettingsLabelsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-labels',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-labels-page"]',
+          title: 'Etiquetas',
+          content: 'Crie etiquetas coloridas para categorizar e organizar suas conversas.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-labels-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Pesquise etiquetas existentes ou crie uma nova clicando no botão "Nova Etiqueta".',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-labels-content"]',
+          title: 'Lista de Etiquetas',
+          content: 'Todas as etiquetas são exibidas aqui com seu nome, descrição e cor. Clique nos ícones de ação para editar ou excluir.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(LABELS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(LABELS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Atributos Personalizados Tour
+// ---------------------------------------------------------------------------
+const CUSTOM_ATTRIBUTES_ROUTE = '/settings/attributes';
+
+export function SettingsCustomAttributesTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-custom-attributes',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-custom-attributes-page"]',
+          title: 'Atributos Personalizados',
+          content: 'Crie campos extras para enriquecer informações de conversas, contatos e pipelines.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-custom-attributes-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Pesquise atributos ou adicione novos clicando em "Novo Atributo".',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-custom-attributes-tabs"]',
+          title: 'Categorias de Atributos',
+          content: 'Use as abas para filtrar entre atributos de Conversa, Contato ou Pipeline.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(CUSTOM_ATTRIBUTES_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(CUSTOM_ATTRIBUTES_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Respostas Rápidas Tour
+// ---------------------------------------------------------------------------
+const CANNED_RESPONSES_ROUTE = '/settings/canned-responses';
+
+export function SettingsCannedResponsesTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-canned-responses',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-canned-responses-page"]',
+          title: 'Respostas Rápidas',
+          content: 'Crie atalhos de texto para agilizar o atendimento com respostas pré-definidas.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-canned-responses-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Busque respostas por código ou conteúdo, ou crie uma nova resposta rápida.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-canned-responses-content"]',
+          title: 'Lista de Respostas Rápidas',
+          content: 'Aqui ficam todas as respostas cadastradas com seu código de atalho e conteúdo. Durante o atendimento, use "/" para acessá-las rapidamente.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(CANNED_RESPONSES_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(CANNED_RESPONSES_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Macros Tour
+// ---------------------------------------------------------------------------
+const MACROS_ROUTE = '/settings/macros';
+
+export function SettingsMacrosTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-macros',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-macros-page"]',
+          title: 'Macros',
+          content: 'Macros são sequências de ações automatizadas que podem ser aplicadas a conversas com um único clique.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-macros-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Crie novos macros ou busque entre os existentes pelo nome.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-macros-content"]',
+          title: 'Lista de Macros',
+          content: 'Todos os macros cadastrados aparecem aqui. Clique em um macro para editar suas ações, ou use o botão de execução para aplicá-lo.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(MACROS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(MACROS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Integrações Tour
+// ---------------------------------------------------------------------------
+const INTEGRATIONS_ROUTE = '/settings/integrations';
+
+export function SettingsIntegrationsTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-integrations',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-integrations-page"]',
+          title: 'Integrações',
+          content: 'Conecte o sistema a ferramentas externas como CRM, comunicação, produtividade e IA.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-integrations-header"]',
+          title: 'Título e Descrição',
+          content: 'Visão geral das integrações disponíveis na plataforma.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-integrations-search"]',
+          title: 'Busca de Integrações',
+          content: 'Encontre rapidamente uma integração específica pelo nome ou descrição.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-integrations-categories"]',
+          title: 'Categorias',
+          content: 'Filtre as integrações por categoria: CRM, Comunicação, Produtividade, IA ou Personalizadas. Cada card permite configurar ou ativar/desativar a integração.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(INTEGRATIONS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(INTEGRATIONS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}
+
+// ---------------------------------------------------------------------------
+// Tokens de Acesso Tour
+// ---------------------------------------------------------------------------
+const ACCESS_TOKENS_ROUTE = '/settings/access-tokens';
+
+export function SettingsAccessTokensTour() {
+  const { Tour, controls } = useJoyride({
+    tourKey: 'settings-access-tokens',
+    steps: useMemo<Step[]>(
+      () => [
+        {
+          target: '[data-tour="settings-access-tokens-page"]',
+          title: 'Tokens de Acesso',
+          content: 'Gere e gerencie tokens de API para integrar o sistema com aplicações externas de forma segura.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-access-tokens-header"]',
+          title: 'Barra de Ferramentas',
+          content: 'Crie novos tokens ou pesquise entre os existentes pelo nome, valor ou escopo.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+        {
+          target: '[data-tour="settings-access-tokens-content"]',
+          title: 'Lista de Tokens',
+          content: 'Todos os tokens aparecem aqui com nome, escopos e validade. Use as ações para visualizar o valor completo, regenerar ou excluir o token.',
+          placement: 'auto',
+          disableBeacon: true,
+          disableScrolling: true,
+        },
+      ],
+      [],
+    ),
+  });
+  const controlsRef = useRef(controls);
+  controlsRef.current = controls;
+
+  useEffect(() => {
+    tourRegistry.register(ACCESS_TOKENS_ROUTE, () => controlsRef.current.reset(true));
+    return () => tourRegistry.unregister(ACCESS_TOKENS_ROUTE);
+  }, []);
+
+  return <>{Tour}</>;
+}

--- a/src/tours/index.ts
+++ b/src/tours/index.ts
@@ -1,0 +1,18 @@
+export { DashboardTour } from './DashboardTour';
+export { ChatTour } from './ChatTour';
+export { ContactsTour } from './ContactsTour';
+export { AgentsTour, AgentsCustomToolsTour, AgentsCustomMCPsTour } from './AgentsTour';
+export { ScheduledActionsTour } from './ScheduledActionsTour';
+export { ChannelsTour } from './ChannelsTour';
+export { PipelinesTour } from './PipelinesTour';
+export {
+  SettingsTour,
+  SettingsAgentsTour,
+  SettingsTeamsTour,
+  SettingsLabelsTour,
+  SettingsCustomAttributesTour,
+  SettingsCannedResponsesTour,
+  SettingsMacrosTour,
+  SettingsIntegrationsTour,
+  SettingsAccessTokensTour,
+} from './SettingsTour';

--- a/src/tours/tourRegistry.ts
+++ b/src/tours/tourRegistry.ts
@@ -1,0 +1,53 @@
+type StartFn = () => void;
+type Snapshot = Readonly<Record<string, StartFn>>;
+type Listener = () => void;
+
+let snapshot: Snapshot = {};
+const listeners = new Set<Listener>();
+
+function notify() {
+  listeners.forEach(l => l());
+}
+
+export const tourRegistry = {
+  register(route: string, startFn: StartFn): void {
+    snapshot = { ...snapshot, [route]: startFn };
+    notify();
+  },
+
+  unregister(route: string): void {
+    const { [route]: _, ...rest } = snapshot as Record<string, StartFn>;
+    snapshot = rest;
+    notify();
+  },
+
+  start(route: string): boolean {
+    const fn = (snapshot as Record<string, StartFn>)[route];
+    if (fn) {
+      fn();
+      return true;
+    }
+    return false;
+  },
+
+  has(route: string): boolean {
+    return route in snapshot;
+  },
+
+  // Required for useSyncExternalStore
+  subscribe(listener: Listener): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+
+  getSnapshot(): Snapshot {
+    return snapshot;
+  },
+};
+
+/** Returns the tour route key that matches the given pathname, or undefined. */
+export function matchTourRoute(pathname: string, registry: Snapshot): string | undefined {
+  return Object.keys(registry).find(route => {
+    return pathname === route || pathname.startsWith(route + '/');
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,7 +40,7 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz"
   integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
 
-"@babel/core@^7.28.0":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0-0", "@babel/core@^7.28.0":
   version "7.28.0"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz"
   integrity sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==
@@ -219,12 +219,12 @@
     "@csstools/color-helpers" "^5.1.0"
     "@csstools/css-calc" "^2.1.4"
 
-"@csstools/css-parser-algorithms@^3.0.4":
+"@csstools/css-parser-algorithms@^3.0.4", "@csstools/css-parser-algorithms@^3.0.5":
   version "3.0.5"
   resolved "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz"
   integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
 
-"@csstools/css-tokenizer@^3.0.3":
+"@csstools/css-tokenizer@^3.0.3", "@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
@@ -234,271 +234,14 @@
   resolved "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz"
   integrity sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==
 
-"@emnapi/core@^1.4.3":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.0.tgz#4a54213b208fcf288cce25076c74e0f7613e6100"
-  integrity sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==
-  dependencies:
-    "@emnapi/wasi-threads" "1.2.0"
-    tslib "^2.4.0"
-
-"@emnapi/runtime@^1.4.3":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.9.0.tgz#91c54a6e77c36154c125e873409472e2b70efd5b"
-  integrity sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==
-  dependencies:
-    tslib "^2.4.0"
-
-"@emnapi/wasi-threads@1.2.0", "@emnapi/wasi-threads@^1.0.2":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz#a19d9772cc3d195370bf6e2a805eec40aa75e18e"
-  integrity sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==
-  dependencies:
-    tslib "^2.4.0"
-
-"@esbuild/aix-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
-  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
-
-"@esbuild/aix-ppc64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz#a1414903bb38027382f85f03dda6065056757727"
-  integrity sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==
-
-"@esbuild/android-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
-  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
-
-"@esbuild/android-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz#c859994089e9767224269884061f89dae6fb51c6"
-  integrity sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==
-
-"@esbuild/android-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
-  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
-
-"@esbuild/android-arm@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.8.tgz#96a8f2ca91c6cd29ea90b1af79d83761c8ba0059"
-  integrity sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==
-
-"@esbuild/android-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
-  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
-
-"@esbuild/android-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.8.tgz#a3a626c4fec4a024a9fa8c7679c39996e92916f0"
-  integrity sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==
-
-"@esbuild/darwin-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
-  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
-
-"@esbuild/darwin-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz#a5e1252ca2983d566af1c0ea39aded65736fc66d"
-  integrity sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==
-
-"@esbuild/darwin-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
-  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
-
-"@esbuild/darwin-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz#5271b0df2bb12ce8df886704bfdd1c7cc01385d2"
-  integrity sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==
-
-"@esbuild/freebsd-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
-  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
-
-"@esbuild/freebsd-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz#d0a0e7fdf19733b8bb1566b81df1aa0bb7e46ada"
-  integrity sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==
-
-"@esbuild/freebsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
-  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
-
-"@esbuild/freebsd-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz#2de8b2e0899d08f1cb1ef3128e159616e7e85343"
-  integrity sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==
-
-"@esbuild/linux-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
-  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
-
-"@esbuild/linux-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz#a4209efadc0c2975716458484a4e90c237c48ae9"
-  integrity sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==
-
-"@esbuild/linux-arm@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
-  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
-
-"@esbuild/linux-arm@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz#ccd9e291c24cd8d9142d819d463e2e7200d25b19"
-  integrity sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==
-
-"@esbuild/linux-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
-  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
-
-"@esbuild/linux-ia32@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz#006ad1536d0c2b28fb3a1cf0b53bcb85aaf92c4d"
-  integrity sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==
-
-"@esbuild/linux-loong64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
-  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
-
-"@esbuild/linux-loong64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz#127b3fbfb2c2e08b1397e985932f718f09a8f5c4"
-  integrity sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==
-
-"@esbuild/linux-mips64el@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
-  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
-
-"@esbuild/linux-mips64el@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz#837d1449517791e3fa7d82675a2d06d9f56cb340"
-  integrity sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==
-
-"@esbuild/linux-ppc64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
-  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
-
-"@esbuild/linux-ppc64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz#aa2e3bd93ab8df084212f1895ca4b03c42d9e0fe"
-  integrity sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==
-
-"@esbuild/linux-riscv64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
-  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
-
-"@esbuild/linux-riscv64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz#a340620e31093fef72767dd28ab04214b3442083"
-  integrity sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==
-
-"@esbuild/linux-s390x@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
-  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
-
-"@esbuild/linux-s390x@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz#ddfed266c8c13f5efb3105a0cd47f6dcd0e79e71"
-  integrity sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==
-
-"@esbuild/linux-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
-  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
-
-"@esbuild/linux-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz"
-  integrity sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==
-
-"@esbuild/netbsd-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz#902c80e1d678047926387230bc037e63e00697d0"
-  integrity sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==
-
-"@esbuild/netbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
-  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
-
-"@esbuild/netbsd-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz#2d9eb4692add2681ff05a14ce99de54fbed7079c"
-  integrity sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==
-
-"@esbuild/openbsd-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz#89c3b998c6de739db38ab7fb71a8a76b3fa84a45"
-  integrity sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==
-
-"@esbuild/openbsd-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
-  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
-
-"@esbuild/openbsd-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz#2f01615cf472b0e48c077045cfd96b5c149365cc"
-  integrity sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==
-
-"@esbuild/openharmony-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz#a201f720cd2c3ebf9a6033fcc3feb069a54b509a"
-  integrity sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==
-
-"@esbuild/sunos-x64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
-  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
-
-"@esbuild/sunos-x64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz#07046c977985a3334667f19e6ab3a01a80862afb"
-  integrity sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==
-
-"@esbuild/win32-arm64@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
-  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
-
-"@esbuild/win32-arm64@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz#4a5470caf0d16127c05d4833d4934213c69392d1"
-  integrity sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==
-
-"@esbuild/win32-ia32@0.21.5":
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
-  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
-
-"@esbuild/win32-ia32@0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz#3de3e8470b7b328d99dbc3e9ec1eace207e5bbc4"
-  integrity sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==
-
 "@esbuild/win32-x64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz"
   integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@esbuild/win32-x64@0.25.8":
   version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz#610d7ea539d2fcdbe39237b5cc175eb2c4451f9c"
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz"
   integrity sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.7.0":
@@ -549,7 +292,7 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@9.32.0", "@eslint/js@^9.22.0":
+"@eslint/js@^9.22.0", "@eslint/js@9.32.0":
   version "9.32.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-9.32.0.tgz"
   integrity sha512-BBpRFZK3eX6uMLKz8WxFOBIFFcGFJ/g8XuwjTHCqHROSIsopI+ddn/d5Cfh36+7+e5edVS8dbSHnBNhrLEX0zg==
@@ -617,32 +360,56 @@
     vaul "^1.1.2"
     zod "^3.25.67"
 
-"@floating-ui/core@^1.7.3":
-  version "1.7.3"
-  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz"
-  integrity sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==
-  dependencies:
-    "@floating-ui/utils" "^0.2.10"
+"@fastify/deepmerge@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.2.1.tgz"
+  integrity sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA==
 
-"@floating-ui/dom@^1.7.4":
-  version "1.7.4"
-  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz"
-  integrity sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==
+"@floating-ui/core@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz"
+  integrity sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
   dependencies:
-    "@floating-ui/core" "^1.7.3"
-    "@floating-ui/utils" "^0.2.10"
+    "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/react-dom@^2.0.0":
-  version "2.1.6"
-  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz"
-  integrity sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==
+"@floating-ui/dom@^1.7.6":
+  version "1.7.6"
+  resolved "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz"
+  integrity sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
   dependencies:
-    "@floating-ui/dom" "^1.7.4"
+    "@floating-ui/core" "^1.7.5"
+    "@floating-ui/utils" "^0.2.11"
 
-"@floating-ui/utils@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz"
-  integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
+"@floating-ui/react-dom@^2.0.0", "@floating-ui/react-dom@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz"
+  integrity sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==
+  dependencies:
+    "@floating-ui/dom" "^1.7.6"
+
+"@floating-ui/utils@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz"
+  integrity sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==
+
+"@gilbarbara/deep-equal@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.4.1.tgz"
+  integrity sha512-QF2BGeQjsa59T59XvFdR3is5jrl28Eg0J6giXAC5919bcqvR8XP4B+07tpbs6Y6/IQd4FBncaL2WVXIBgSxt4w==
+
+"@gilbarbara/hooks@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/@gilbarbara/hooks/-/hooks-0.11.0.tgz"
+  integrity sha512-CIVazdxqFRplUfm9wZL3/0X1TURJekhPMWGFdWzEmyJrGPiotX2yxA1KiB8N7VnhawIaMtb2Apnda4Y6DRwi2Q==
+  dependencies:
+    "@gilbarbara/deep-equal" "^0.4.1"
+
+"@gilbarbara/types@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.npmjs.org/@gilbarbara/types/-/types-0.2.2.tgz"
+  integrity sha512-QuQDBRRcm1Q8AbSac2W1YElurOhprj3Iko/o+P1fJxUWS4rOGKMVli98OXS7uo4z+cKAif6a+L9bcZFSyauQpQ==
+  dependencies:
+    type-fest "^4.1.0"
 
 "@hookform/resolvers@^5.0.1", "@hookform/resolvers@^5.1.1":
   version "5.2.1"
@@ -712,15 +479,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@napi-rs/wasm-runtime@^0.2.11":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz#3e78a8b96e6c33a6c517e1894efbd5385a7cb6f2"
-  integrity sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==
-  dependencies:
-    "@emnapi/core" "^1.4.3"
-    "@emnapi/runtime" "^1.4.3"
-    "@tybys/wasm-util" "^0.10.0"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -729,7 +487,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -818,7 +576,7 @@
     "@radix-ui/react-use-previous" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
 
-"@radix-ui/react-collapsible@1.1.12", "@radix-ui/react-collapsible@^1.1.11":
+"@radix-ui/react-collapsible@^1.1.11", "@radix-ui/react-collapsible@1.1.12":
   version "1.1.12"
   resolved "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz"
   integrity sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==
@@ -842,7 +600,7 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-slot" "1.2.3"
 
-"@radix-ui/react-compose-refs@1.1.2", "@radix-ui/react-compose-refs@^1.1.1":
+"@radix-ui/react-compose-refs@^1.1.1", "@radix-ui/react-compose-refs@1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
@@ -869,7 +627,7 @@
   resolved "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz"
   integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
 
-"@radix-ui/react-dialog@1.1.15", "@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.14", "@radix-ui/react-dialog@^1.1.6":
+"@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.14", "@radix-ui/react-dialog@^1.1.6", "@radix-ui/react-dialog@1.1.15":
   version "1.1.15"
   resolved "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz"
   integrity sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==
@@ -947,7 +705,7 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-use-controllable-state" "1.2.2"
 
-"@radix-ui/react-id@1.1.1", "@radix-ui/react-id@^1.1.0":
+"@radix-ui/react-id@^1.1.0", "@radix-ui/react-id@1.1.1":
   version "1.1.1"
   resolved "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz"
   integrity sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==
@@ -1074,7 +832,7 @@
     "@radix-ui/react-compose-refs" "1.1.2"
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
-"@radix-ui/react-primitive@2.1.3", "@radix-ui/react-primitive@^2.0.2":
+"@radix-ui/react-primitive@^2.0.2", "@radix-ui/react-primitive@2.1.3":
   version "2.1.3"
   resolved "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz"
   integrity sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==
@@ -1193,17 +951,17 @@
     "@radix-ui/react-use-previous" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
 
+"@radix-ui/react-slot@^1.2.3", "@radix-ui/react-slot@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz"
+  integrity sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.2"
+
 "@radix-ui/react-slot@1.2.3":
   version "1.2.3"
   resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz"
   integrity sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==
-  dependencies:
-    "@radix-ui/react-compose-refs" "1.1.2"
-
-"@radix-ui/react-slot@1.2.4", "@radix-ui/react-slot@^1.2.3":
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz"
-  integrity sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
 
@@ -1247,7 +1005,7 @@
     "@radix-ui/react-toggle" "1.1.10"
     "@radix-ui/react-use-controllable-state" "1.2.2"
 
-"@radix-ui/react-toggle@1.1.10", "@radix-ui/react-toggle@^1.1.9":
+"@radix-ui/react-toggle@^1.1.9", "@radix-ui/react-toggle@1.1.10":
   version "1.1.10"
   resolved "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz"
   integrity sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==
@@ -1366,104 +1124,9 @@
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz"
   integrity sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==
 
-"@rollup/rollup-android-arm-eabi@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz#292e25953d4988d3bd1af0f5ebbd5ee4d65c90b4"
-  integrity sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==
-
-"@rollup/rollup-android-arm64@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz#053b3def3451e6fc1a9078188f22799e868d7c59"
-  integrity sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==
-
-"@rollup/rollup-darwin-arm64@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz#98d90445282dec54fd05440305a5e8df79a91ece"
-  integrity sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==
-
-"@rollup/rollup-darwin-x64@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz#fe05f95a736423af5f9c3a59a70f41ece52a1f20"
-  integrity sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==
-
-"@rollup/rollup-freebsd-arm64@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz#41e1fbdc1f8c3dc9afb6bc1d6e3fb3104bd81eee"
-  integrity sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==
-
-"@rollup/rollup-freebsd-x64@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz#69131e69cb149d547abb65ef3b38fc746c940e24"
-  integrity sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==
-
-"@rollup/rollup-linux-arm-gnueabihf@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz#977ded91c7cf6fc0d9443bb9c0a064e45a805267"
-  integrity sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==
-
-"@rollup/rollup-linux-arm-musleabihf@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz#dc034fc3c0f0eb5c75b6bc3eca3b0b97fd35f49a"
-  integrity sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==
-
-"@rollup/rollup-linux-arm64-gnu@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz#5e92613768d3de3ffcabc965627dd0a59b3e7dfc"
-  integrity sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==
-
-"@rollup/rollup-linux-arm64-musl@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz#2a44f88e83d28b646591df6e50aa0a5a931833d8"
-  integrity sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==
-
-"@rollup/rollup-linux-loongarch64-gnu@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz#bd5897e92db7fbf7dc456f61d90fff96c4651f2e"
-  integrity sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==
-
-"@rollup/rollup-linux-ppc64-gnu@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz#a7065025411c14ad9ec34cc1cd1414900ec2a303"
-  integrity sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==
-
-"@rollup/rollup-linux-riscv64-gnu@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz#17f9c0c675e13ef4567cfaa3730752417257ccc3"
-  integrity sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==
-
-"@rollup/rollup-linux-riscv64-musl@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz#bc6ed3db2cedc1ba9c0a2183620fe2f792c3bf3f"
-  integrity sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==
-
-"@rollup/rollup-linux-s390x-gnu@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz#440c4f6753274e2928e06d2a25613e5a1cf97b41"
-  integrity sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==
-
-"@rollup/rollup-linux-x64-gnu@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz"
-  integrity sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==
-
-"@rollup/rollup-linux-x64-musl@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz"
-  integrity sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==
-
-"@rollup/rollup-win32-arm64-msvc@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz#b4ad4a79219892aac112ed1c9d1356cad0566ef5"
-  integrity sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==
-
-"@rollup/rollup-win32-ia32-msvc@4.46.2":
-  version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz#b1b22eb2a9568048961e4a6f540438b4a762aa62"
-  integrity sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==
-
 "@rollup/rollup-win32-x64-msvc@4.46.2":
   version "4.46.2"
-  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz#87079f137b5fdb75da11508419aa998cc8cc3d8b"
+  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz"
   integrity sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==
 
 "@standard-schema/spec@^1.0.0":
@@ -1489,71 +1152,9 @@
     source-map-js "^1.2.1"
     tailwindcss "4.1.11"
 
-"@tailwindcss/oxide-android-arm64@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.11.tgz#1f387d8302f011b61c226deb0c3a1d2bd79c6915"
-  integrity sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==
-
-"@tailwindcss/oxide-darwin-arm64@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.11.tgz#acd35ffb7e4eae83d0a3fe2f8ea36cfcc9b21f7e"
-  integrity sha512-ESgStEOEsyg8J5YcMb1xl8WFOXfeBmrhAwGsFxxB2CxY9evy63+AtpbDLAyRkJnxLy2WsD1qF13E97uQyP1lfQ==
-
-"@tailwindcss/oxide-darwin-x64@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.11.tgz#a0022312993a3893d6ff0312d6e3c83c4636fef4"
-  integrity sha512-EgnK8kRchgmgzG6jE10UQNaH9Mwi2n+yw1jWmof9Vyg2lpKNX2ioe7CJdf9M5f8V9uaQxInenZkOxnTVL3fhAw==
-
-"@tailwindcss/oxide-freebsd-x64@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.11.tgz#dd8e55eb0b88fe7995b8148c0e0ae5fa27092d22"
-  integrity sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==
-
-"@tailwindcss/oxide-linux-arm-gnueabihf@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.11.tgz#02ee99090988847d3f13d277679012cbffcdde37"
-  integrity sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==
-
-"@tailwindcss/oxide-linux-arm64-gnu@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.11.tgz#4837559c102bebe65089879f6a0278ed473b4813"
-  integrity sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==
-
-"@tailwindcss/oxide-linux-arm64-musl@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.11.tgz#bec465112a13a1383558ff36afdf28b8a8cb9021"
-  integrity sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==
-
-"@tailwindcss/oxide-linux-x64-gnu@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz"
-  integrity sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==
-
-"@tailwindcss/oxide-linux-x64-musl@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.11.tgz"
-  integrity sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==
-
-"@tailwindcss/oxide-wasm32-wasi@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.11.tgz#a1762f4939c6ebaa824696fda2fd7db1b85fbed2"
-  integrity sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==
-  dependencies:
-    "@emnapi/core" "^1.4.3"
-    "@emnapi/runtime" "^1.4.3"
-    "@emnapi/wasi-threads" "^1.0.2"
-    "@napi-rs/wasm-runtime" "^0.2.11"
-    "@tybys/wasm-util" "^0.9.0"
-    tslib "^2.8.0"
-
-"@tailwindcss/oxide-win32-arm64-msvc@4.1.11":
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz#70ba392dca0fa3707ebe27d2bd6ac3e69d35e3b7"
-  integrity sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==
-
 "@tailwindcss/oxide-win32-x64-msvc@4.1.11":
   version "4.1.11"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz#cdcb9eea9225a346c0695f67f621990b0534763f"
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz"
   integrity sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==
 
 "@tailwindcss/oxide@4.1.11":
@@ -1586,7 +1187,7 @@
     "@tailwindcss/oxide" "4.1.11"
     tailwindcss "4.1.11"
 
-"@testing-library/dom@^10.4.1":
+"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -1618,20 +1219,6 @@
   integrity sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==
   dependencies:
     "@babel/runtime" "^7.12.5"
-
-"@tybys/wasm-util@^0.10.0":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
-  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
-  dependencies:
-    tslib "^2.4.0"
-
-"@tybys/wasm-util@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.9.0.tgz#3e75eb00604c8d6db470bf18c37b7d984a0e3355"
-  integrity sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==
-  dependencies:
-    tslib "^2.4.0"
 
 "@types/aria-query@^5.0.1":
   version "5.0.4"
@@ -1749,7 +1336,7 @@
     "@types/d3-interpolate" "*"
     "@types/d3-selection" "*"
 
-"@types/estree@1.0.8", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
+"@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@1.0.8":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -1759,19 +1346,19 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@^22.16.0":
+"@types/node@^18.0.0 || ^20.0.0 || >=22.0.0", "@types/node@^18.0.0 || >=20.0.0", "@types/node@^22.16.0":
   version "22.17.0"
   resolved "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz"
   integrity sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==
   dependencies:
     undici-types "~6.21.0"
 
-"@types/react-dom@^19.0.4":
+"@types/react-dom@*", "@types/react-dom@^18.0.0 || ^19.0.0", "@types/react-dom@^19.0.4":
   version "19.1.7"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz"
   integrity sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==
 
-"@types/react@^19.0.10":
+"@types/react@*", "@types/react@^18.0.0 || ^19.0.0", "@types/react@^18.2.25 || ^19", "@types/react@^19.0.0", "@types/react@^19.0.10", "@types/react@>=0.0.0 <=99", "@types/react@>=16.8", "@types/react@>=18.0.0":
   version "19.1.9"
   resolved "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz"
   integrity sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==
@@ -1798,7 +1385,7 @@
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@8.39.0":
+"@typescript-eslint/parser@^8.39.0", "@typescript-eslint/parser@8.39.0":
   version "8.39.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.39.0.tgz"
   integrity sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==
@@ -1826,7 +1413,7 @@
     "@typescript-eslint/types" "8.39.0"
     "@typescript-eslint/visitor-keys" "8.39.0"
 
-"@typescript-eslint/tsconfig-utils@8.39.0", "@typescript-eslint/tsconfig-utils@^8.39.0":
+"@typescript-eslint/tsconfig-utils@^8.39.0", "@typescript-eslint/tsconfig-utils@8.39.0":
   version "8.39.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz"
   integrity sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==
@@ -1842,7 +1429,7 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@8.39.0", "@typescript-eslint/types@^8.39.0":
+"@typescript-eslint/types@^8.39.0", "@typescript-eslint/types@8.39.0":
   version "8.39.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.39.0.tgz"
   integrity sha512-ArDdaOllnCj3yn/lzKn9s0pBQYmmyme/v1HbGIGB0GB/knFI3fWMHloC+oYTJW46tVbYnGKTMDK4ah1sC2v0Kg==
@@ -1912,7 +1499,7 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.12"
 
-"@vitest/pretty-format@2.1.9", "@vitest/pretty-format@^2.1.9":
+"@vitest/pretty-format@^2.1.9", "@vitest/pretty-format@2.1.9":
   version "2.1.9"
   resolved "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz"
   integrity sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==
@@ -1981,7 +1568,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.15.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -2030,7 +1617,7 @@ aria-hidden@^1.2.4:
   dependencies:
     tslib "^2.0.0"
 
-aria-query@5.3.0, aria-query@^5.0.0:
+aria-query@^5.0.0, aria-query@5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz"
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
@@ -2088,7 +1675,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, "browserslist@>= 4.21.0":
   version "4.25.1"
   resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz"
   integrity sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==
@@ -2253,7 +1840,7 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-"d3-array@2 - 3", "d3-array@2.10.0 - 3", d3-array@^3.1.6:
+d3-array@^3.1.6, "d3-array@2 - 3", "d3-array@2.10.0 - 3":
   version "3.2.4"
   resolved "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz"
   integrity sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
@@ -2270,7 +1857,7 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz"
   integrity sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
 
-"d3-drag@2 - 3", d3-drag@^3.0.0:
+d3-drag@^3.0.0, "d3-drag@2 - 3":
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz"
   integrity sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
@@ -2278,7 +1865,7 @@ csstype@^3.0.2:
     d3-dispatch "1 - 3"
     d3-selection "3"
 
-"d3-ease@1 - 3", d3-ease@^3.0.1:
+d3-ease@^3.0.1, "d3-ease@1 - 3":
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz"
   integrity sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
@@ -2288,7 +1875,7 @@ csstype@^3.0.2:
   resolved "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
 
-"d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3", d3-interpolate@^3.0.1:
+d3-interpolate@^3.0.1, "d3-interpolate@1 - 3", "d3-interpolate@1.2.0 - 3":
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz"
   integrity sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
@@ -2311,7 +1898,7 @@ d3-scale@^4.0.2:
     d3-time "2.1.1 - 3"
     d3-time-format "2 - 4"
 
-"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+d3-selection@^3.0.0, "d3-selection@2 - 3", d3-selection@3:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
@@ -2330,14 +1917,14 @@ d3-shape@^3.1.0:
   dependencies:
     d3-time "1 - 3"
 
-"d3-time@1 - 3", "d3-time@2.1.1 - 3", d3-time@^3.0.0:
+d3-time@^3.0.0, "d3-time@1 - 3", "d3-time@2.1.1 - 3":
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz"
   integrity sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
   dependencies:
     d3-array "2 - 3"
 
-"d3-timer@1 - 3", d3-timer@^3.0.1:
+d3-timer@^3.0.1, "d3-timer@1 - 3":
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
@@ -2382,7 +1969,7 @@ date-fns@^4.1.0:
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7:
+debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7, debug@4:
   version "4.4.1"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -2627,7 +2214,7 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
-eslint@^9.22.0:
+"eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^8.57.0 || ^9.0.0", eslint@^9.22.0, eslint@>=8.40:
   version "9.32.0"
   resolved "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz"
   integrity sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==
@@ -2824,11 +2411,6 @@ form-data@^4.0.4:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -2961,7 +2543,7 @@ https-proxy-agent@^7.0.6:
     agent-base "^7.1.2"
     debug "4"
 
-i18next@^25.3.2:
+i18next@^25.3.2, "i18next@>= 23.2.3":
   version "25.3.2"
   resolved "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz"
   integrity sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==
@@ -2992,7 +2574,7 @@ imask@^7.6.1:
   dependencies:
     "@babel/runtime-corejs3" "^7.24.4"
 
-immer@^10.1.1:
+immer@^10.1.1, immer@>=9.0.6:
   version "10.1.1"
   resolved "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz"
   integrity sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==
@@ -3049,6 +2631,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   dependencies:
     is-extglob "^2.1.1"
 
+is-lite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/is-lite/-/is-lite-2.0.0.tgz"
+  integrity sha512-70f2BMIQlbSUXVKaZUd9a9fJH3IH1PDckV0m4BIIO4LjnNYvOh4Ng7vXIXEwpA0KDZknRq+7fHwGTu0jIdx28g==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
@@ -3064,7 +2651,7 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-jiti@^2.4.2:
+jiti@*, jiti@^2.4.2, jiti@>=1.21.0:
   version "2.5.1"
   resolved "https://registry.npmjs.org/jiti/-/jiti-2.5.1.tgz"
   integrity sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==
@@ -3081,7 +2668,7 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^26.1.0:
+jsdom@*, jsdom@^26.1.0:
   version "26.1.0"
   resolved "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz"
   integrity sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==
@@ -3152,57 +2739,12 @@ libphonenumber-js@^1.12.27:
   resolved "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.31.tgz"
   integrity sha512-Z3IhgVgrqO1S5xPYM3K5XwbkDasU67/Vys4heW+lfSBALcUZjeIIzI8zCLifY+OCzSq+fpDdywMDa7z+4srJPQ==
 
-lightningcss-darwin-arm64@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz#3d47ce5e221b9567c703950edf2529ca4a3700ae"
-  integrity sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==
-
-lightningcss-darwin-x64@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz#e81105d3fd6330860c15fe860f64d39cff5fbd22"
-  integrity sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==
-
-lightningcss-freebsd-x64@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz#a0e732031083ff9d625c5db021d09eb085af8be4"
-  integrity sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==
-
-lightningcss-linux-arm-gnueabihf@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz#1f5ecca6095528ddb649f9304ba2560c72474908"
-  integrity sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==
-
-lightningcss-linux-arm64-gnu@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz#eee7799726103bffff1e88993df726f6911ec009"
-  integrity sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==
-
-lightningcss-linux-arm64-musl@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz#f2e4b53f42892feeef8f620cbb889f7c064a7dfe"
-  integrity sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==
-
-lightningcss-linux-x64-gnu@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz"
-  integrity sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==
-
-lightningcss-linux-x64-musl@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz"
-  integrity sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==
-
-lightningcss-win32-arm64-msvc@1.30.1:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz#7d8110a19d7c2d22bfdf2f2bb8be68e7d1b69039"
-  integrity sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==
-
 lightningcss-win32-x64-msvc@1.30.1:
   version "1.30.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz#fd7dd008ea98494b85d24b4bea016793f2e0e352"
+  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz"
   integrity sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==
 
-lightningcss@1.30.1:
+lightningcss@^1.21.0, lightningcss@1.30.1:
   version "1.30.1"
   resolved "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz"
   integrity sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==
@@ -3449,7 +2991,7 @@ pathval@^2.0.0:
   resolved "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@1.1.1, picocolors@^1.1.1:
+picocolors@^1.1.1, picocolors@1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -3459,7 +3001,7 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-picomatch@^4.0.2, picomatch@^4.0.3:
+"picomatch@^3 || ^4", picomatch@^4.0.2, picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -3595,7 +3137,7 @@ react-day-picker@^9.7.0:
     date-fns "^4.1.0"
     date-fns-jalali "^4.1.0-0"
 
-react-dom@^19.0.0:
+"react-dom@^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom@^18 || ^19 || ^19.0.0-rc", "react-dom@^18.0.0 || ^19.0.0", "react-dom@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react-dom@^19.0.0, react-dom@>=16.4.0, react-dom@>=16.8, react-dom@>=16.8.0, react-dom@>=17, react-dom@>=18, react-dom@>=18.0.0, react-dom@>=18.1.0, "react-dom@16.8 - 19":
   version "19.1.1"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz"
   integrity sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==
@@ -3626,7 +3168,7 @@ react-email-editor@^1.7.11:
   dependencies:
     unlayer-types latest
 
-react-hook-form@^7.56.3, react-hook-form@^7.59.0:
+react-hook-form@^7.55.0, react-hook-form@^7.56.3, react-hook-form@^7.59.0:
   version "7.62.0"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz"
   integrity sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==
@@ -3647,15 +3189,41 @@ react-imask@^7.6.1:
     imask "^7.6.1"
     prop-types "^15.8.1"
 
+react-innertext@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz"
+  integrity sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+"react-is@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0":
+  version "19.2.0"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-19.2.0.tgz"
+  integrity sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-joyride@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/react-joyride/-/react-joyride-3.0.2.tgz"
+  integrity sha512-Tm+zXo/O8rFOUkN1yH+t38HqLvOCB8p5JTqgQD3IlLyZGCXzJEnCXtyB/BQIUC7X07kEaw0BqtKjWFzF4fyDVw==
+  dependencies:
+    "@fastify/deepmerge" "^3.2.1"
+    "@floating-ui/react-dom" "^2.1.8"
+    "@gilbarbara/deep-equal" "^0.4.1"
+    "@gilbarbara/hooks" "^0.11.0"
+    "@gilbarbara/types" "^0.2.2"
+    is-lite "^2.0.0"
+    react-innertext "^1.1.5"
+    scroll "^3.0.1"
+    scrollparent "^2.1.0"
+    use-sync-external-store "^1.6.0"
 
 react-phone-number-input@^3.4.14:
   version "3.4.14"
@@ -3668,7 +3236,7 @@ react-phone-number-input@^3.4.14:
     libphonenumber-js "^1.12.27"
     prop-types "^15.8.1"
 
-"react-redux@8.x.x || 9.x.x":
+"react-redux@^7.2.1 || ^8.1.3 || ^9.0.0", "react-redux@8.x.x || 9.x.x":
   version "9.2.0"
   resolved "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz"
   integrity sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==
@@ -3728,7 +3296,7 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react@^19.0.0:
+"react@^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react@^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17 || ^18 || ^19", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react@^16.9.0 || ^17.0.0 || ^18 || ^19", "react@^18 || ^19 || ^19.0.0-rc", "react@^18.0 || ^19", "react@^18.0.0 || ^19.0.0", "react@^18.0.0 || ^19.0.0 || ^19.0.0-rc", react@^19.0.0, react@^19.1.1, "react@>= 16.8 || 18.0.0", "react@>= 16.8.0", "react@>=0.0.0 <=99", react@>=0.14.0, react@>=15, react@>=16, react@>=16.4.0, react@>=16.8, react@>=16.8.0, react@>=17, react@>=18, react@>=18.0.0, react@>=18.1.0, "react@16.8 - 19":
   version "19.1.1"
   resolved "https://registry.npmjs.org/react/-/react-19.1.1.tgz"
   integrity sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==
@@ -3763,12 +3331,12 @@ redux-thunk@^3.1.0:
   resolved "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz"
   integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
 
-redux@^5.0.1:
+redux@^5.0.0, redux@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz"
   integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
 
-reselect@5.1.1, reselect@^5.1.0:
+reselect@^5.1.0, reselect@5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz"
   integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
@@ -3845,6 +3413,16 @@ scheduler@^0.26.0:
   version "0.26.0"
   resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz"
   integrity sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==
+
+scroll@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/scroll/-/scroll-3.0.1.tgz"
+  integrity sha512-pz7y517OVls1maEzlirKO5nPYle9AXsFzTMNJrRGmT951mzpIBy7sNHOg5o/0MQd/NqliCiWnAi0kZneMPFLcg==
+
+scrollparent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/scrollparent/-/scrollparent-2.1.0.tgz"
+  integrity sha512-bnnvJL28/Rtz/kz2+4wpBjHzWoEzXhVg/TE8BeVGJHUqE8THNIRnDxDWMktwM+qahvlRdvlLdsQfYe+cuqfZeA==
 
 semver@^6.3.1:
   version "6.3.1"
@@ -3927,7 +3505,7 @@ tailwind-merge@^3.2.0, tailwind-merge@^3.3.1:
   resolved "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz"
   integrity sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==
 
-tailwindcss@4.1.11, tailwindcss@^4.1.11:
+tailwindcss@^4.1.10, tailwindcss@^4.1.11, tailwindcss@4.1.11:
   version "4.1.11"
   resolved "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz"
   integrity sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==
@@ -4025,7 +3603,7 @@ ts-api-utils@^2.1.0:
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz"
   integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.7.0, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.7.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -4042,6 +3620,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-fest@^4.1.0:
+  version "4.41.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 typescript-eslint@^8.26.1:
   version "8.39.0"
   resolved "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.39.0.tgz"
@@ -4052,7 +3635,7 @@ typescript-eslint@^8.26.1:
     "@typescript-eslint/typescript-estree" "8.39.0"
     "@typescript-eslint/utils" "8.39.0"
 
-typescript@~5.7.2:
+typescript@^5, typescript@>=4.8.4, "typescript@>=4.8.4 <6.0.0", typescript@~5.7.2:
   version "5.7.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz"
   integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
@@ -4097,10 +3680,10 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz"
-  integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
+use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-external-store@^1.5.0, use-sync-external-store@^1.6.0, use-sync-external-store@>=1.2.0:
+  version "1.6.0"
+  resolved "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 uuid@^11.1.0:
   version "11.1.0"
@@ -4145,18 +3728,7 @@ vite-node@2.1.9:
     pathe "^1.1.2"
     vite "^5.0.0"
 
-vite@^5.0.0:
-  version "5.4.21"
-  resolved "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz"
-  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
-  dependencies:
-    esbuild "^0.21.3"
-    postcss "^8.4.43"
-    rollup "^4.20.0"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@^6.3.1:
+"vite@^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0", "vite@^5.2.0 || ^6 || ^7", vite@^6.3.1:
   version "6.3.5"
   resolved "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz"
   integrity sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==
@@ -4167,6 +3739,17 @@ vite@^6.3.1:
     postcss "^8.5.3"
     rollup "^4.34.9"
     tinyglobby "^0.2.13"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vite@^5.0.0:
+  version "5.4.21"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
 


### PR DESCRIPTION
- Implement TourFab button in the app header that auto-detects the current route and shows a tour trigger when a tour is registered
- Add WelcomeTourModal for onboarding new users on first access
- Create tourRegistry (pub/sub store) and matchTourRoute for route-based tour discovery
- Add useJoyride hook and JoyrideTooltip custom component
- Add i18n tour translations for pt-BR, pt, en, es, fr and it

Tours created (route → tourKey):
  /dashboard              → DashboardTour
  /chat                   → ChatTour
  /contacts               → ContactsTour
  /contacts/scheduled-actions → ScheduledActionsTour
  /pipelines              → PipelinesTour
  /agents/list            → AgentsTour
  /agents/custom-tools    → AgentsCustomToolsTour
  /agents/custom-mcp-servers → AgentsCustomMCPsTour
  /settings/account       → SettingsTour
  /settings/users         → SettingsAgentsTour
  /settings/teams         → SettingsTeamsTour
  /settings/labels        → SettingsLabelsTour
  /settings/attributes    → SettingsCustomAttributesTour
  /settings/canned-responses → SettingsCannedResponsesTour
  /settings/macros        → SettingsMacrosTour
  /settings/integrations  → SettingsIntegrationsTour
  /settings/access-tokens → SettingsAccessTokensTour
  /channels               → ChannelsTour
  /campaigns              → CampaignsTour
  /journeys               → JourneyTour

- Add data-tour attributes to all targeted page components
- Add searchDataTour prop to BaseHeader for granular search targeting
- Mount each tour component inside its own page following the existing AccountSettings pattern