### PR TITLE
feat(dashboard): add inline tooltips with tour copy to all dashboard …

### DIFF
--- a/src/components/TourFab.tsx
+++ b/src/components/TourFab.tsx
@@ -4,6 +4,7 @@ import { CircleHelp } from 'lucide-react';
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@evoapi/design-system';
 import { tourRegistry, matchTourRoute } from '@/tours/tourRegistry';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useAuthStore } from '@/store/authStore';
 
 export function TourFab() {
   const { t } = useTranslation('tours');
@@ -12,9 +13,13 @@ export function TourFab() {
     tourRegistry.getSnapshot,
   );
   const { pathname } = useLocation();
+  const tours = useAuthStore(state => state.tours);
   const matchedRoute = matchTourRoute(pathname, snapshot);
 
   if (!matchedRoute) return null;
+
+  const tourKey = matchedRoute.slice(1);
+  const tourSeen = tours[tourKey] === 'completed' || tours[tourKey] === 'skipped';
 
   return (
     <Tooltip>
@@ -30,9 +35,11 @@ export function TourFab() {
           <CircleHelp className="h-5 w-5" />
         </Button>
       </TooltipTrigger>
-      <TooltipContent>
-        <p>{t('viewPageTour')}</p>
-      </TooltipContent>
+      {tourSeen && (
+        <TooltipContent>
+          <p>{t('viewPageTour')}</p>
+        </TooltipContent>
+      )}
     </Tooltip>
   );
 }

--- a/src/components/base/TooltipInfo.tsx
+++ b/src/components/base/TooltipInfo.tsx
@@ -1,0 +1,25 @@
+import { HelpCircle } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@evoapi/design-system';
+
+interface TooltipInfoProps {
+  title: string;
+  content: string;
+}
+
+export function TooltipInfo({ title, content }: TooltipInfoProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex cursor-help text-primary/60 hover:text-primary transition-colors shrink-0">
+            <HelpCircle className="h-4 w-4" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[280px] p-3" side="top">
+          <p className="font-semibold text-sm mb-1">{title}</p>
+          <p className="text-xs leading-relaxed">{content}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -6,6 +6,7 @@ export { default as BaseFilter } from './BaseFilter';
 export { default as BaseFilterRow } from './BaseFilterRow';
 export { default as EmptyState } from './EmptyState';
 export { default as PrimaryActionButton } from './PrimaryActionButton';
+export { TooltipInfo } from './TooltipInfo';
 export { default as BaseStatusBadge } from './BaseStatusBadge';
 export { default as BaseStatsCard } from './BaseStatsCard';
 export { default as BaseStatsGrid } from './BaseStatsGrid';

--- a/src/components/charts/AreaChartCard.tsx
+++ b/src/components/charts/AreaChartCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@evoapi/design-system';
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { LucideIcon } from 'lucide-react';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface AreaChartCardProps {
   title: string;
@@ -11,6 +12,10 @@ interface AreaChartCardProps {
   gradientFrom?: string;
   gradientTo?: string;
   valueFormatter?: (value: number) => string;
+  tooltip?: {
+    title: string;
+    content: string;
+  };
 }
 
 const toChartId = (value: string) =>
@@ -30,6 +35,7 @@ const AreaChartCard = ({
   gradientFrom = '#3b82f6',
   gradientTo = '#8b5cf6',
   valueFormatter = (value) => value.toLocaleString(),
+  tooltip,
 }: AreaChartCardProps) => {
   const chartId = toChartId(title);
   const areaGradientId = `gradient-${chartId}`;
@@ -58,6 +64,7 @@ const AreaChartCard = ({
             </div>
           )}
           {title}
+          {tooltip && <TooltipInfo title={tooltip.title} content={tooltip.content} />}
         </CardTitle>
         {description && (
           <CardDescription className="mt-1">{description}</CardDescription>

--- a/src/components/charts/BarChartCard.tsx
+++ b/src/components/charts/BarChartCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@evoapi/design-system';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { LucideIcon } from 'lucide-react';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface BarChartCardProps {
   title: string;
@@ -12,6 +13,10 @@ interface BarChartCardProps {
   gradientTo?: string;
   valueFormatter?: (value: number) => string;
   highlightMax?: boolean;
+  tooltip?: {
+    title: string;
+    content: string;
+  };
 }
 
 const toChartId = (value: string) =>
@@ -32,6 +37,7 @@ const BarChartCard = ({
   gradientTo = '#8b5cf6',
   valueFormatter = (value) => value.toLocaleString(),
   highlightMax = true,
+  tooltip,
 }: BarChartCardProps) => {
   const maxValue = data.length > 0 ? Math.max(...data.map(d => d.value)) : 0;
   const chartId = toChartId(title);
@@ -62,6 +68,7 @@ const BarChartCard = ({
             </div>
           )}
           {title}
+          {tooltip && <TooltipInfo title={tooltip.title} content={tooltip.content} />}
         </CardTitle>
         {description && (
           <CardDescription className="mt-1">{description}</CardDescription>

--- a/src/components/charts/DonutChartCard.tsx
+++ b/src/components/charts/DonutChartCard.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle, CardDescription, Badge } from '@evoapi/design-system';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip } from 'recharts';
 import { LucideIcon } from 'lucide-react';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface DonutChartData {
   name: string;
@@ -19,6 +20,10 @@ interface DonutChartCardProps {
   showLegend?: boolean;
   centerLabel?: string;
   centerValue?: string;
+  tooltip?: {
+    title: string;
+    content: string;
+  };
 }
 
 const DonutChartCard = ({
@@ -31,6 +36,7 @@ const DonutChartCard = ({
   showLegend = true,
   centerLabel,
   centerValue,
+  tooltip,
 }: DonutChartCardProps) => {
   const CustomTooltip = ({ active, payload }: any) => {
     if (active && payload && payload.length) {
@@ -80,6 +86,7 @@ const DonutChartCard = ({
             </div>
           )}
           {title}
+          {tooltip && <TooltipInfo title={tooltip.title} content={tooltip.content} />}
         </CardTitle>
         {description && (
           <CardDescription className="mt-1">{description}</CardDescription>

--- a/src/components/charts/OperationHeatmapCard.tsx
+++ b/src/components/charts/OperationHeatmapCard.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, Badge, Button } from '@evoapi/design-system';
 import { useState } from 'react';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface OperationHeatmapData {
   timezone: string;
@@ -29,6 +30,10 @@ interface OperationHeatmapCardProps {
     collapse?: string;
     showing?: string;
   };
+  tooltip?: {
+    title: string;
+    content: string;
+  };
 }
 
 const toHourLabel = (hour: number) => `${String(hour).padStart(2, '0')}h`;
@@ -53,6 +58,7 @@ const OperationHeatmapCard = ({
   data,
   peakDayInPeriod,
   labels,
+  tooltip,
 }: OperationHeatmapCardProps) => {
   const [expanded, setExpanded] = useState(false);
   const byKey = new Map<string, number>();
@@ -68,7 +74,10 @@ const OperationHeatmapCard = ({
   return (
     <Card>
       <CardHeader className="pb-2" data-tour="dashboard-heatmap">
-        <CardTitle className="text-lg">{title}</CardTitle>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          {title}
+          {tooltip && <TooltipInfo title={tooltip.title} content={tooltip.content} />}
+        </CardTitle>
         {description && <CardDescription>{description}</CardDescription>}
       </CardHeader>
       <CardContent className="space-y-4">

--- a/src/pages/Customer/Dashboard/components/DashboardMetricCard.tsx
+++ b/src/pages/Customer/Dashboard/components/DashboardMetricCard.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import { Badge, Card, CardContent, CardHeader, CardTitle } from '@evoapi/design-system';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 type CardTone = 'good' | 'warning' | 'critical' | 'neutral';
 
@@ -15,6 +16,10 @@ interface DashboardMetricCardProps {
   status?: {
     label: string;
     tone: CardTone;
+  };
+  tooltip?: {
+    title: string;
+    content: string;
   };
 }
 
@@ -33,6 +38,7 @@ const DashboardMetricCard = ({
   accentClassName,
   importance = 'secondary',
   status,
+  tooltip,
 }: DashboardMetricCardProps) => {
   const valueClassName = importance === 'primary' ? 'text-3xl font-semibold' : 'text-2xl font-semibold';
 
@@ -40,7 +46,10 @@ const DashboardMetricCard = ({
     <Card className={importance === 'primary' ? 'border-primary/30 bg-primary/[0.03] h-full' : 'h-full'}>
       <CardHeader className="flex flex-row items-start justify-between pb-2 gap-3">
         <div className="min-w-0">
-          <CardTitle className="text-sm font-medium text-muted-foreground truncate">{title}</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1">
+            <span className="truncate">{title}</span>
+            {tooltip && <TooltipInfo title={tooltip.title} content={tooltip.content} />}
+          </CardTitle>
           {status && (
             <Badge variant="outline" className={`mt-2 ${toneClasses[status.tone]}`}>
               {status.label}

--- a/src/pages/Customer/Dashboard/components/DashboardMetricsSection.tsx
+++ b/src/pages/Customer/Dashboard/components/DashboardMetricsSection.tsx
@@ -3,6 +3,8 @@ import { Badge, Card, CardContent, CardHeader, CardTitle } from '@evoapi/design-
 import type { CustomerDashboardResponse } from '@/types/analytics/dashboard';
 import DashboardMetricCard from './DashboardMetricCard';
 import { formatSeconds } from './dashboardUtils';
+import { useTranslation } from '@/hooks/useTranslation';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface DashboardMetricsSectionProps {
   data: CustomerDashboardResponse;
@@ -10,6 +12,7 @@ interface DashboardMetricsSectionProps {
 }
 
 const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
+  const { t: tTours } = useTranslation('tours');
   const tx = (key: string, fallback: string) => {
     const value = t(key);
     return value === key ? fallback : value;
@@ -64,6 +67,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
               label: tx('dashboard.status.volume', 'Volume no período'),
               tone: 'neutral',
             }}
+            tooltip={{ title: tTours('dashboard.step2.title'), content: tTours('dashboard.step2.content') }}
           />
         </div>
 
@@ -76,6 +80,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
             accentClassName="bg-emerald-500/20 text-emerald-400"
             importance="primary"
             status={responseStatus}
+            tooltip={{ title: tTours('dashboard.step3.title'), content: tTours('dashboard.step3.content') }}
           />
         </div>
 
@@ -88,6 +93,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
             accentClassName="bg-violet-500/20 text-violet-400"
             importance="primary"
             status={csatStatus}
+            tooltip={{ title: tTours('dashboard.step4.title'), content: tTours('dashboard.step4.content') }}
           />
         </div>
 
@@ -100,6 +106,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
             accentClassName="bg-amber-500/20 text-amber-400"
             importance="primary"
             status={followUpStatus}
+            tooltip={{ title: tTours('dashboard.step5.title'), content: tTours('dashboard.step5.content') }}
           />
         </div>
       </div>
@@ -110,6 +117,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
             <CardTitle className="text-base flex items-center gap-2">
               <Bot className="h-4 w-4 text-primary" />
               {tx('dashboard.aiVsHuman.title', 'IA vs Humano')}
+              <TooltipInfo title={tTours('dashboard.step6.title')} content={tTours('dashboard.step6.content')} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -177,6 +185,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
               <CardTitle className="text-sm font-medium flex items-center gap-2">
                 <MessageSquare className="h-4 w-4 text-amber-400" />
                 {tx('dashboard.stats.activeConversations', 'Conversas ativas agora')}
+                <TooltipInfo title={tTours('dashboard.step7.title')} content={tTours('dashboard.step7.content')} />
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -199,6 +208,7 @@ const DashboardMetricsSection = ({ data, t }: DashboardMetricsSectionProps) => {
               <CardTitle className="text-sm font-medium flex items-center gap-2">
                 <UserX className="h-4 w-4 text-rose-400" />
                 {tx('dashboard.stats.unassignedConversations', 'Conversas sem responsável')}
+                <TooltipInfo title={tTours('dashboard.step8.title')} content={tTours('dashboard.step8.content')} />
               </CardTitle>
             </CardHeader>
             <CardContent>

--- a/src/pages/Customer/Dashboard/components/DashboardPerformanceSection.tsx
+++ b/src/pages/Customer/Dashboard/components/DashboardPerformanceSection.tsx
@@ -3,6 +3,8 @@ import { Bot, Layers, TrendingUp, Users } from 'lucide-react';
 import { OperationHeatmapCard } from '@/components/charts';
 import type { CustomerDashboardResponse } from '@/types/analytics/dashboard';
 import { formatCurrency, formatSeconds } from './dashboardUtils';
+import { useTranslation } from '@/hooks/useTranslation';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface DashboardPerformanceSectionProps {
   data: CustomerDashboardResponse;
@@ -10,6 +12,7 @@ interface DashboardPerformanceSectionProps {
 }
 
 const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionProps) => {
+  const { t: tTours } = useTranslation('tours');
   const tx = (key: string, fallback: string) => {
     const value = t(key);
     return value === key ? fallback : value;
@@ -35,6 +38,7 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
         description={t('dashboard.charts.heatmapDescription') || 'Volume de conversas por dia da semana e hora'}
         data={data.trends.operation_heatmap}
         peakDayInPeriod={data.trends.peak_day_in_period}
+        tooltip={{ title: tTours('dashboard.step13.title'), content: tTours('dashboard.step13.content') }}
         labels={{
           peakSlot: t('dashboard.charts.heatmapPeakSlot') || 'Pico',
           peakWeekday: t('dashboard.charts.heatmapPeakWeekday') || 'Dia mais forte',
@@ -51,8 +55,9 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
         <Card data-tour="dashboard-csat-distribution">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               {t('dashboard.csat.breakdown') || 'Distribuição de notas'}
+              <TooltipInfo title={tTours('dashboard.step14.title')} content={tTours('dashboard.step14.content')} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
@@ -84,6 +89,7 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
                     <TrendingUp className="h-4 w-4 text-muted-foreground" />
                   </div>
                   {t('dashboard.pipeline.title')}
+                  <TooltipInfo title={tTours('dashboard.step15.title')} content={tTours('dashboard.step15.content')} />
                 </CardTitle>
                 <CardDescription className="mt-1">{t('dashboard.pipeline.subtitle')}</CardDescription>
               </div>
@@ -131,8 +137,9 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
         <Card data-tour="dashboard-funnel-summary">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               {tx('dashboard.pipeline.insights', 'Resumo do funil')}
+              <TooltipInfo title={tTours('dashboard.step16.title')} content={tTours('dashboard.step16.content')} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -158,6 +165,7 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
                 <Layers className="h-4 w-4 text-muted-foreground" />
               </div>
               {t('dashboard.channels.title')}
+              <TooltipInfo title={tTours('dashboard.step17.title')} content={tTours('dashboard.step17.content')} />
             </CardTitle>
             <CardDescription className="mt-1">{t('dashboard.channels.subtitle')}</CardDescription>
           </CardHeader>
@@ -190,8 +198,9 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
         <Card data-tour="dashboard-channels-value">
           <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
+            <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
               {tx('dashboard.channels.valueLeaders', 'Canais com maior valor')}
+              <TooltipInfo title={tTours('dashboard.step18.title')} content={tTours('dashboard.step18.content')} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
@@ -219,6 +228,7 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
                   <Users className="h-4 w-4 text-muted-foreground" />
                 </div>
                 {tx('dashboard.agents.humanTitle', 'Desempenho dos Atendentes')}
+                <TooltipInfo title={tTours('dashboard.step19.title')} content={tTours('dashboard.step19.content')} />
               </CardTitle>
               <CardDescription className="mt-1">
                 {tx('dashboard.agents.humanSubtitle', 'Performance do time humano no período filtrado')}
@@ -257,6 +267,7 @@ const DashboardPerformanceSection = ({ data, t }: DashboardPerformanceSectionPro
                   <Bot className="h-4 w-4 text-muted-foreground" />
                 </div>
                 {tx('dashboard.agents.aiTitle', 'Desempenho dos Agentes de IA')}
+                <TooltipInfo title={tTours('dashboard.step20.title')} content={tTours('dashboard.step20.content')} />
               </CardTitle>
               <CardDescription className="mt-1">
                 {tx('dashboard.agents.aiSubtitle', 'Volume e participação dos agentes IA nas respostas')}

--- a/src/pages/Customer/Dashboard/components/DashboardTrendsSection.tsx
+++ b/src/pages/Customer/Dashboard/components/DashboardTrendsSection.tsx
@@ -3,6 +3,8 @@ import { Badge, Card, CardContent, CardHeader, CardTitle } from '@evoapi/design-
 import { AreaChartCard, BarChartCard, DonutChartCard } from '@/components/charts';
 import type { CustomerDashboardResponse } from '@/types/analytics/dashboard';
 import { formatCurrency } from './dashboardUtils';
+import { useTranslation } from '@/hooks/useTranslation';
+import { TooltipInfo } from '@/components/base/TooltipInfo';
 
 interface DashboardTrendsSectionProps {
   data: CustomerDashboardResponse;
@@ -11,6 +13,7 @@ interface DashboardTrendsSectionProps {
 }
 
 const DashboardTrendsSection = ({ data, t, channelShareData }: DashboardTrendsSectionProps) => {
+  const { t: tTours } = useTranslation('tours');
   const tx = (key: string, fallback: string) => {
     const value = t(key);
     return value === key ? fallback : value;
@@ -45,6 +48,7 @@ const DashboardTrendsSection = ({ data, t, channelShareData }: DashboardTrendsSe
             gradientFrom="#22c55e"
             gradientTo="#10b981"
             valueFormatter={value => value.toFixed(0)}
+            tooltip={{ title: tTours('dashboard.step9.title'), content: tTours('dashboard.step9.content') }}
           />
         </div>
 
@@ -59,6 +63,7 @@ const DashboardTrendsSection = ({ data, t, channelShareData }: DashboardTrendsSe
             gradientTo="#8b5cf6"
             valueFormatter={value => `${Math.round(value)}s`}
             highlightMax
+            tooltip={{ title: tTours('dashboard.step10.title'), content: tTours('dashboard.step10.content') }}
           />
         </div>
       </div>
@@ -74,12 +79,16 @@ const DashboardTrendsSection = ({ data, t, channelShareData }: DashboardTrendsSe
             gradientTo="#8b5cf6"
             centerLabel={tx('dashboard.charts.channelsLabel', 'Canais')}
             centerValue={tx('dashboard.charts.shareLabel', 'Participação')}
+            tooltip={{ title: tTours('dashboard.step11.title'), content: tTours('dashboard.step11.content') }}
           />
         </div>
 
         <Card data-tour="dashboard-channel-insights">
           <CardHeader className="pb-2">
-            <CardTitle className="text-base">{tx('dashboard.channels.insights', 'Insights de canais')}</CardTitle>
+            <CardTitle className="text-base flex items-center gap-2">
+              {tx('dashboard.channels.insights', 'Insights de canais')}
+              <TooltipInfo title={tTours('dashboard.step12.title')} content={tTours('dashboard.step12.content')} />
+            </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
             <div className="rounded-md border p-3 bg-muted/10 flex items-center justify-between gap-3">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,7 +1187,7 @@
     "@tailwindcss/oxide" "4.1.11"
     tailwindcss "4.1.11"
 
-"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1":
+"@testing-library/dom@^10.0.0", "@testing-library/dom@^10.4.1", "@testing-library/dom@>=7.21.4":
   version "10.4.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz"
   integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
@@ -1219,6 +1219,11 @@
   integrity sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==
   dependencies:
     "@babel/runtime" "^7.12.5"
+
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
 
 "@types/aria-query@^5.0.1":
   version "5.0.4"


### PR DESCRIPTION
…cards

- Create TooltipInfo component (HelpCircle icon + hover popover)
- Add optional tooltip prop to DashboardMetricCard, AreaChartCard, BarChartCard, DonutChartCard and OperationHeatmapCard
- Wire tour i18n copy (steps 2–20) as hover tooltips across DashboardMetricsSection, DashboardTrendsSection and DashboardPerformanceSection — reuses existing translations in all 6 languages with no new keys required
- Fix TourFab: Ver tour desta página label now only appears after the page tour has been completed or skipped