### PR TITLE
feat(channels): tooltip on disabled channel cards + onboarding crmExperience field

### DIFF
--- a/src/components/channels/ProviderGrid.tsx
+++ b/src/components/channels/ProviderGrid.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Card, CardContent } from '@evoapi/design-system';
+import {
+  Card,
+  CardContent,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@evoapi/design-system';
 import { ArrowLeft } from 'lucide-react';
 import { ChannelIcon } from '@/components/channels';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -24,6 +31,7 @@ interface ProviderGridProps {
     | 'api';
   providers: Provider[];
   isDisabled?: (providerId: string) => boolean;
+  disabledTooltip?: (providerId: string) => string | undefined;
   onSelect: (provider: Provider) => void;
 }
 
@@ -31,6 +39,7 @@ const ProviderGrid: React.FC<ProviderGridProps> = ({
   channelType,
   providers,
   isDisabled,
+  disabledTooltip,
   onSelect,
 }) => {
   const { t } = useLanguage('channels');
@@ -39,7 +48,9 @@ const ProviderGrid: React.FC<ProviderGridProps> = ({
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       {providers.map(provider => {
         const disabled = isDisabled ? isDisabled(provider.id) : false;
-        return (
+        const tooltipText = disabled && disabledTooltip ? disabledTooltip(provider.id) : undefined;
+
+        const card = (
           <Card
             key={provider.id}
             className={`h-full transition-all duration-200 border-sidebar-border rounded-lg relative ${
@@ -77,6 +88,23 @@ const ProviderGrid: React.FC<ProviderGridProps> = ({
             </CardContent>
           </Card>
         );
+
+        if (tooltipText) {
+          return (
+            <TooltipProvider key={provider.id}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="h-full">{card}</div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{tooltipText}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          );
+        }
+
+        return <React.Fragment key={provider.id}>{card}</React.Fragment>;
       })}
     </div>
   );

--- a/src/components/channels/ProviderSelection.tsx
+++ b/src/components/channels/ProviderSelection.tsx
@@ -8,6 +8,7 @@ interface ProviderSelectionProps {
   channelType: 'web_widget' | 'whatsapp' | 'facebook' | 'instagram' | 'telegram' | 'sms' | 'email' | 'api';
   providers: Provider[];
   isDisabled?: (providerId: string) => boolean;
+  disabledTooltip?: (providerId: string) => string | undefined;
   onProviderSelect: (provider: Provider) => void;
   onBack: () => void;
   onChannelListClick?: () => void;
@@ -19,6 +20,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
   channelType,
   providers,
   isDisabled,
+  disabledTooltip,
   onProviderSelect,
   onBack,
   onChannelListClick,
@@ -59,6 +61,7 @@ const ProviderSelection: React.FC<ProviderSelectionProps> = ({
             channelType={channelType}
             providers={providers}
             isDisabled={isDisabled}
+            disabledTooltip={disabledTooltip}
             onSelect={onProviderSelect}
           />
         </div>

--- a/src/components/channels/channel-grid/ChannelCard.tsx
+++ b/src/components/channels/channel-grid/ChannelCard.tsx
@@ -1,16 +1,30 @@
-import { Card, CardContent } from '@evoapi/design-system';
+import {
+  Card,
+  CardContent,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@evoapi/design-system';
 import { ChannelIcon } from '@/components/channels';
 import { ChannelType } from '@/hooks/channels/useChannelForm';
 
 interface ChannelCardProps {
   channel: ChannelType;
   disabled?: boolean;
+  disabledTooltip?: string;
   onClick: () => void;
   'data-tour'?: string;
 }
 
-export const ChannelCard = ({ channel, disabled = false, onClick, 'data-tour': dataTour }: ChannelCardProps) => {
-  return (
+export const ChannelCard = ({
+  channel,
+  disabled = false,
+  disabledTooltip,
+  onClick,
+  'data-tour': dataTour,
+}: ChannelCardProps) => {
+  const card = (
     <Card
       className={`h-full transition-all duration-200 border-sidebar-border rounded-lg ${
         disabled
@@ -31,4 +45,21 @@ export const ChannelCard = ({ channel, disabled = false, onClick, 'data-tour': d
       </CardContent>
     </Card>
   );
+
+  if (disabled && disabledTooltip) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="h-full">{card}</div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{disabledTooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return card;
 };

--- a/src/components/channels/channel-grid/index.tsx
+++ b/src/components/channels/channel-grid/index.tsx
@@ -64,6 +64,7 @@ export const ChannelGrid = ({ channels, onChannelSelect, canFB }: ChannelGridPro
               key={channel.id}
               channel={channel}
               disabled={disabled}
+              disabledTooltip={disabled ? t('newChannel.channelGrid.notConfiguredTooltip') : undefined}
               onClick={() => onChannelSelect(channel)}
               data-tour={index === 0 ? 'channel-grid-first-card' : undefined}
             />

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -122,7 +122,8 @@
     "channelGrid": {
       "title": "Select a channel type",
       "subtitle": "Choose the channel that best meets your communication needs",
-      "searchPlaceholder": "Search channels..."
+      "searchPlaceholder": "Search channels...",
+      "notConfiguredTooltip": "This channel is not configured. Set it up under Admin Settings > Channels before using it."
     },
     "channelTypes": {
       "website": {

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -120,7 +120,8 @@
     "channelGrid": {
       "title": "Seleccione un tipo de canal",
       "subtitle": "Elija el canal que mejor atienda sus necesidades de comunicación",
-      "searchPlaceholder": "Buscar canales..."
+      "searchPlaceholder": "Buscar canales...",
+      "notConfiguredTooltip": "Este canal no está configurado. Configúrelo en Configuración de Admin > Canales antes de usarlo."
     },
     "channelTypes": {
       "website": {

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -120,7 +120,8 @@
     "channelGrid": {
       "title": "Sélectionnez un type de canal",
       "subtitle": "Choisissez le canal qui répond le mieux à vos besoins de communication",
-      "searchPlaceholder": "Rechercher des canaux..."
+      "searchPlaceholder": "Rechercher des canaux...",
+      "notConfiguredTooltip": "Ce canal n'est pas configuré. Configurez-le dans Paramètres Admin > Canaux avant de l'utiliser."
     },
     "channelTypes": {
       "website": {

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -120,7 +120,8 @@
     "channelGrid": {
       "title": "Seleziona un tipo di canale",
       "subtitle": "Scegli il canale che meglio soddisfa le tue esigenze di comunicazione",
-      "searchPlaceholder": "Cerca canali..."
+      "searchPlaceholder": "Cerca canali...",
+      "notConfiguredTooltip": "Questo canale non è configurato. Configuralo in Impostazioni Admin > Canali prima di utilizzarlo."
     },
     "channelTypes": {
       "website": {

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -122,7 +122,8 @@
     "channelGrid": {
       "title": "Selecione um tipo de canal",
       "subtitle": "Escolha o canal que melhor atende às suas necessidades de comunicação",
-      "searchPlaceholder": "Buscar canais..."
+      "searchPlaceholder": "Buscar canais...",
+      "notConfiguredTooltip": "Este canal não está configurado. Configure em Configurações do Admin > Canais antes de usá-lo."
     },
     "channelTypes": {
       "website": {

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -122,7 +122,8 @@
     "channelGrid": {
       "title": "Selecione um tipo de canal",
       "subtitle": "Escolha o canal que melhor atende às suas necessidades de comunicação",
-      "searchPlaceholder": "Buscar canais..."
+      "searchPlaceholder": "Buscar canais...",
+      "notConfiguredTooltip": "Este canal não está configurado. Configure em Configurações do Admin > Canais antes de usá-lo."
     },
     "channelTypes": {
       "website": {

--- a/src/pages/Customer/Channels/NewChannel/index.tsx
+++ b/src/pages/Customer/Channels/NewChannel/index.tsx
@@ -360,6 +360,12 @@ export default function NewChannel() {
                 }
                 return false;
               }}
+              disabledTooltip={providerId => {
+                if (providerId === 'whatsapp_cloud' && !canWpCloud) {
+                  return t('newChannel.channelGrid.notConfiguredTooltip');
+                }
+                return undefined;
+              }}
               onProviderSelect={handleProviderSelectWithValidation}
               onBack={handleGoBack}
               onChannelListClick={() => navigate('/channels')}

--- a/src/pages/Setup/OnboardingPage.tsx
+++ b/src/pages/Setup/OnboardingPage.tsx
@@ -15,6 +15,7 @@ export interface OnboardingFormData {
   mainChannelOther: string;
   usesAI: string;
   biggestPain: string;
+  crmExperience: string;
   mainGoal: string;
 }
 
@@ -122,6 +123,7 @@ export default function OnboardingPage() {
     mainChannelOther: '',
     usesAI: '',
     biggestPain: '',
+    crmExperience: '',
     mainGoal: '',
   });
   const [loading, setLoading] = useState(false);
@@ -154,10 +156,11 @@ export default function OnboardingPage() {
     isChannelValid ? 'ok' : '',
     form.usesAI,
     form.biggestPain,
+    form.crmExperience,
     form.mainGoal,
   ].filter(Boolean).length;
 
-  const progressPct = Math.round((filledCount / 6) * 100);
+  const progressPct = Math.round((filledCount / 7) * 100);
 
   const handleSubmit = async () => {
     if (loading) return;
@@ -191,6 +194,7 @@ export default function OnboardingPage() {
   const channelOptions    = t('survey.channel.options', { returnObjects: true }) as unknown as string[];
   const aiOptions         = t('survey.ai.options', { returnObjects: true }) as unknown as string[];
   const painOptions       = t('survey.pain.options', { returnObjects: true }) as unknown as string[];
+  const crmOptions        = t('survey.crm.options', { returnObjects: true }) as unknown as string[];
   const goalOptions       = t('survey.goal.options', { returnObjects: true }) as unknown as string[];
 
   return (
@@ -432,6 +436,14 @@ export default function OnboardingPage() {
                 value={form.biggestPain}
                 options={Array.isArray(painOptions) ? painOptions : []}
                 onChange={set('biggestPain')}
+              />
+
+              <SelectField
+                label={t('survey.crm.label')}
+                id="crmExperience"
+                value={form.crmExperience}
+                options={Array.isArray(crmOptions) ? crmOptions : []}
+                onChange={set('crmExperience')}
               />
 
               <SelectField

--- a/src/services/survey/surveyService.ts
+++ b/src/services/survey/surveyService.ts
@@ -9,6 +9,7 @@ function toSnakeCase(data: OnboardingFormData) {
     main_channel_other: data.mainChannelOther,
     uses_ai:            data.usesAI,
     biggest_pain:       data.biggestPain,
+    crm_experience:     data.crmExperience,
     main_goal:          data.mainGoal,
   };
 }


### PR DESCRIPTION
## Summary

Two fixes bundled into the same PR because they share locale files and were caught in the same session.

### Tooltip on disabled channel and provider cards

In the new-channel flow, Facebook and Instagram cards in the channel grid are disabled when `canFB` is false (FB app id / version not configured), and the WhatsApp Cloud provider card is disabled when `canWpCloud` is false. Before, the cards were only visually dimmed with no hint about why the user could not click them.

- `ChannelCard` now accepts an optional `disabledTooltip?: string`. When `disabled && disabledTooltip`, the card is wrapped in a Radix `Tooltip` (with a `<div>` wrapper, since disabled Radix triggers need a wrapper to receive pointer events).
- `ProviderGrid` accepts an analogous `disabledTooltip?: (providerId) => string | undefined` resolver, and `ProviderSelection` passes it through.
- `ChannelGrid` and the `NewChannel` page wire the resolver so Facebook, Instagram, and `whatsapp_cloud` cards all show the same i18n string when disabled.
- New i18n key `channelGrid.notConfiguredTooltip` added to all six locales (`pt-BR`, `pt`, `en`, `es`, `fr`, `it`). The text points the user at "Configurações do Admin > Canais", matching the real menu labels in `adminSettings.json` (not invented paths).

### Onboarding `crmExperience` field

`npm run build` was failing with:

```
src/services/setup/setupService.ts(56,34): error TS2339: Property 'crmExperience' does not exist on type 'OnboardingFormData'.
```

`setupService` was already sending `form.crmExperience` in the pre-login survey payload, but the field was missing from the `OnboardingFormData` type, the form state, and the UI. Post-login submissions via `surveyService` were silently dropping the same data even when filled in.

- Added `crmExperience: string` to the type and initial state.
- Rendered a new `SelectField` between the "biggest pain" and "main goal" questions using the existing `survey.crm.label` / `survey.crm.options` i18n keys (already translated in all six locales).
- Bumped the progress bar total from 6 to 7.
- Taught `surveyService.toSnakeCase` to include `crm_experience` so both pre-login and post-login paths stay consistent.

Issue: [EVO-937](https://linear.app/evoai/issue/EVO-937)

## Test plan

- [ ] `npm run build` passes
- [ ] Visit `/channels/new` without configuring Facebook in admin and hover the Facebook/Instagram cards — tooltip should appear
- [ ] Pick WhatsApp on the channel grid, then hover the Cloud / Nuvem provider card while WhatsApp is unconfigured — tooltip should appear
- [ ] Complete the onboarding survey and verify the new "have you used a CRM before" question is rendered, and that `crm_experience` reaches the backend payload (both via `setupService` pre-login and `surveyService` post-login)
- [ ] Visual: progress bar denominator should now read `0 of 7` instead of `0 of 6`