### PR TITLE
feat(agents): load AI models from provider via api-key id

### DIFF
--- a/src/components/ai_agents/ModelSelector.tsx
+++ b/src/components/ai_agents/ModelSelector.tsx
@@ -14,8 +14,9 @@ import {
   CommandItem,
   Input,
 } from '@evoapi/design-system';
-import { Check, ChevronsUpDown } from 'lucide-react';
-import { ApiKey } from '@/types/agents';
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';
+import { ApiKey, ApiKeyModelInfo } from '@/types/agents';
+import { agentsService } from '@/services/agents/agentService';
 
 const CUSTOM_MODEL_OPTION = '__custom_model__';
 const CUSTOM_OPENAI_PROVIDER = 'custom_openai_compatible';
@@ -142,15 +143,7 @@ const ModelSelector = ({
   const { t } = useLanguage('aiAgents');
   const [open, setOpen] = useState(false);
 
-  const selectedModel = useMemo(() => {
-    return availableModels.find(model => model.value === value);
-  }, [value]);
-
-  const [isCustomMode, setIsCustomMode] = useState(Boolean(value) && !selectedModel);
-
-  useEffect(() => {
-    setIsCustomMode(Boolean(value) && !selectedModel);
-  }, [value, selectedModel]);
+  const [isCustomMode, setIsCustomMode] = useState(false);
 
   const selectedApiKey = useMemo(() => {
     return apiKeys.find(key => key.id === apiKeyId);
@@ -158,15 +151,61 @@ const ModelSelector = ({
 
   const customProviderSelected = selectedApiKey?.provider === CUSTOM_OPENAI_PROVIDER;
 
+  // Dynamic model list fetched from the provider via the backend. Populated
+  // when the user picks an API key for a provider the backend supports. Falls
+  // back to the hardcoded `availableModels` below if this is null or empty.
+  const [dynamicModels, setDynamicModels] = useState<ApiKeyModelInfo[] | null>(null);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+
+  useEffect(() => {
+    if (!apiKeyId || customProviderSelected) {
+      setDynamicModels(null);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingModels(true);
+    agentsService
+      .listApiKeyModels(apiKeyId)
+      .then(res => {
+        if (cancelled) return;
+        setDynamicModels(res.supported && res.models.length > 0 ? res.models : null);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDynamicModels(null);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoadingModels(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiKeyId, customProviderSelected]);
+
   const filteredModels = useMemo(() => {
     if (customProviderSelected) {
       return [];
+    }
+    if (dynamicModels && dynamicModels.length > 0) {
+      return dynamicModels;
     }
     if (!selectedApiKey) {
       return availableModels;
     }
     return availableModels.filter(model => model.provider === selectedApiKey.provider);
-  }, [selectedApiKey, customProviderSelected]);
+  }, [selectedApiKey, customProviderSelected, dynamicModels]);
+
+  const selectedModel = useMemo(() => {
+    return filteredModels.find(model => model.value === value)
+      || availableModels.find(model => model.value === value);
+  }, [value, filteredModels]);
+
+  useEffect(() => {
+    setIsCustomMode(Boolean(value) && !selectedModel);
+  }, [value, selectedModel]);
 
   useEffect(() => {
     if (customProviderSelected) {
@@ -227,13 +266,18 @@ const ModelSelector = ({
                   variant="outline"
                   role="combobox"
                   aria-expanded={open}
+                  disabled={isLoadingModels}
                   className={`${className} justify-between ${error || customModelError ? 'border-red-500' : ''}`}
                   id={id}
                 >
-                  {value
-                    ? selectedModel?.label || value
-                    : t('llmConfig.searchOrSelectModel')}
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                  {isLoadingModels
+                    ? t('llmConfig.loadingModels', { defaultValue: 'Loading models...' })
+                    : value
+                      ? selectedModel?.label || value
+                      : t('llmConfig.searchOrSelectModel')}
+                  {isLoadingModels
+                    ? <Loader2 className="ml-2 h-4 w-4 shrink-0 animate-spin opacity-70" />
+                    : <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />}
                 </Button>
               </PopoverTrigger>
               <PopoverContent className={`${className} p-0`} align="start">

--- a/src/services/agents/agentService.ts
+++ b/src/services/agents/agentService.ts
@@ -11,6 +11,7 @@ import {
   AgentDeleteResponse,
   FolderDeleteResponse,
   ApiKeyDeleteResponse,
+  ApiKeyModelsResponse,
   AgentListResponse,
 } from '@/types/agents';
 import { processAgentData } from '@/utils/agentUtils';
@@ -127,6 +128,11 @@ class AgentsService {
   async deleteApiKey(keyId: string): Promise<ApiKeyDeleteResponse> {
     const response = await evoaiApi.delete(`/agents/apikeys/${keyId}`);
     return extractData<ApiKeyDeleteResponse>(response);
+  }
+
+  async listApiKeyModels(keyId: string): Promise<ApiKeyModelsResponse> {
+    const response = await evoaiApi.get(`/agents/apikeys/${keyId}/models`);
+    return extractData<ApiKeyModelsResponse>(response);
   }
 
   // Helper methods for backward compatibility

--- a/src/types/agents/agent.ts
+++ b/src/types/agents/agent.ts
@@ -226,3 +226,15 @@ export interface FolderDeleteResponse extends StandardResponse<{ message: string
 export interface AgentListResponse extends PaginatedResponse<Agent> {}
 
 export interface ApiKeyDeleteResponse extends StandardResponse<{ message: string }> {}
+
+export interface ApiKeyModelInfo {
+  value: string;
+  label: string;
+  provider: string;
+}
+
+export interface ApiKeyModelsResponse {
+  provider: string;
+  supported: boolean;
+  models: ApiKeyModelInfo[];
+}


### PR DESCRIPTION
## Summary

- \`ModelSelector\` now calls \`GET /api/v1/agents/apikeys/:id/models\` on the core service whenever the user picks an API key, and uses the returned list instead of the hardcoded \`availableModels\` catalog
- Falls back to the existing hardcoded list when the provider isn't supported dynamically (Perplexity, Bedrock, Vertex AI) or when the call fails — nothing regresses for existing stacks
- Adds a loading state on the trigger button while models are being fetched and a new \`ApiKeyModelsResponse\` type

## Why

Paired with the matching change on \`evo-ai-core-service-community\` — without this, the new endpoint exists but the UI keeps using the stale hardcoded list. Together they end the churn where the model catalog had to be edited every time a provider shipped a new family (the immediate trigger was GPT-5 not appearing).

## Test plan

- [x] Pick an OpenAI key → dropdown shows GPT-5 family fetched live
- [x] Pick a Bedrock/Vertex key → falls back to hardcoded list, no broken state
- [x] Backend down / 500 → falls back to hardcoded list
- [x] Selecting a model saves the wizard correctly

## Summary by Sourcery

Load AI model options dynamically per API key via backend and improve the model selector UX.

New Features:
- Fetch available models for a selected API key from the backend instead of relying solely on a hardcoded catalog.
- Add API types and a service method for retrieving models associated with an API key from the core service.

Enhancements:
- Fallback to the existing hardcoded model list when dynamic loading is not supported or fails, preserving current behavior.
- Show a loading state and spinner on the model selector trigger while models are being fetched.