### PR TITLE
fix(agents,pipelines): wizard test chat, header overlap, copy-id menus

### DIFF
--- a/src/components/agents/AgentActionsDropdown.tsx
+++ b/src/components/agents/AgentActionsDropdown.tsx
@@ -6,7 +6,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@evoapi/design-system';
-import { Edit, Trash2 } from 'lucide-react';
+import { Copy, Edit, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Agent } from '@/types/agents';
 
 interface AgentActionsDropdownProps {
@@ -35,6 +36,15 @@ export default function AgentActionsDropdown({
         <DropdownMenuItem onClick={() => onEdit(agent)}>
           <Edit className="h-4 w-4 mr-2" />
           {t('dropdown.edit')}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={async () => {
+            await navigator.clipboard.writeText(agent.id);
+            toast.success(t('dropdown.idCopied'));
+          }}
+        >
+          <Copy className="h-4 w-4 mr-2" />
+          {t('dropdown.copyId')}
         </DropdownMenuItem>
         {/* {onExportAsJSON && (
           <DropdownMenuItem onClick={() => onExportAsJSON(agent)}>

--- a/src/components/agents/chat/AgentChatArea.tsx
+++ b/src/components/agents/chat/AgentChatArea.tsx
@@ -58,8 +58,8 @@ export function AgentChatArea({ agent }: AgentChatAreaProps) {
   return (
     <div className="flex-1 flex flex-col overflow-hidden h-full">
       {/* Header - Fixed at top */}
-      <div className="flex-shrink-0 p-4 border-b bg-card">
-        <div className="flex justify-between items-center">
+      <div className="flex-shrink-0 p-4 pr-12 border-b bg-card">
+        <div className="flex justify-between items-center gap-3">
           <h2 className="text-xl font-bold flex items-center gap-2">
             <div className="p-1 rounded-full bg-primary/20">
               <MessageSquare className="h-5 w-5 text-primary" />

--- a/src/components/pipelines/PipelineCard.tsx
+++ b/src/components/pipelines/PipelineCard.tsx
@@ -1,7 +1,8 @@
 import { useLanguage } from '@/hooks/useLanguage';
 import { Card, CardContent } from '@evoapi/design-system';
 import { Button } from '@evoapi/design-system';
-import { GitBranch, Eye, Edit, Trash2, Copy, Power, MoreVertical, Star } from 'lucide-react';
+import { GitBranch, Eye, Edit, Trash2, Copy, CopyPlus, Power, MoreVertical, Star } from 'lucide-react';
+import { toast } from 'sonner';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -142,8 +143,18 @@ export default function PipelineCard({
                   onDuplicate(pipeline);
                 }}
               >
-                <Copy className="h-4 w-4 mr-2" />
+                <CopyPlus className="h-4 w-4 mr-2" />
                 {t('pipelineCard.duplicate')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={async e => {
+                  e.stopPropagation();
+                  await navigator.clipboard.writeText(String(pipeline.id));
+                  toast.success(t('pipelineCard.idCopied'));
+                }}
+              >
+                <Copy className="h-4 w-4 mr-2" />
+                {t('pipelineCard.copyId')}
               </DropdownMenuItem>
               <DropdownMenuItem
                 onClick={e => {

--- a/src/components/pipelines/PipelinesTable.tsx
+++ b/src/components/pipelines/PipelinesTable.tsx
@@ -13,11 +13,13 @@ import {
   Edit,
   Trash2,
   Copy,
+  CopyPlus,
   Power,
   MoreVertical,
   ChevronUp,
   ChevronDown,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -185,8 +187,17 @@ export default function PipelinesTable({
                       {t('pipelinesTable.actions.edit')}
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => onDuplicate(pipeline)}>
-                      <Copy className="h-4 w-4 mr-2" />
+                      <CopyPlus className="h-4 w-4 mr-2" />
                       {t('pipelinesTable.actions.duplicate')}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={async () => {
+                        await navigator.clipboard.writeText(String(pipeline.id));
+                        toast.success(t('pipelinesTable.actions.idCopied'));
+                      }}
+                    >
+                      <Copy className="h-4 w-4 mr-2" />
+                      {t('pipelinesTable.actions.copyId')}
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => onToggleStatus(pipeline)}>
                       <Power className="h-4 w-4 mr-2" />

--- a/src/i18n/locales/en/agents.json
+++ b/src/i18n/locales/en/agents.json
@@ -126,6 +126,8 @@
   "dropdown": {
     "testA2A": "Test A2A",
     "edit": "Edit",
+    "copyId": "Copy ID",
+    "idCopied": "ID copied to clipboard",
     "moveToFolder": "Move to folder",
     "exportJSON": "Export JSON",
     "share": "Share",

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -424,6 +424,8 @@
     "default": "Default",
     "edit": "Edit",
     "duplicate": "Duplicate",
+    "copyId": "Copy ID",
+    "idCopied": "ID copied to clipboard",
     "activate": "Activate",
     "deactivate": "Deactivate",
     "delete": "Delete",
@@ -471,6 +473,8 @@
       "view": "View",
       "edit": "Edit",
       "duplicate": "Duplicate",
+      "copyId": "Copy ID",
+      "idCopied": "ID copied to clipboard",
       "activate": "Activate",
       "deactivate": "Deactivate",
       "delete": "Delete"
@@ -538,6 +542,8 @@
     "save": "Save Order"
   },
   "kanban": {
+    "copyId": "Copy ID",
+    "idCopied": "ID copied to clipboard",
     "header": {
       "conversations": "Items",
       "stages": "Stages",

--- a/src/i18n/locales/es/agents.json
+++ b/src/i18n/locales/es/agents.json
@@ -126,6 +126,8 @@
   "dropdown": {
     "testA2A": "Probar A2A",
     "edit": "Editar",
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado al portapapeles",
     "moveToFolder": "Mover a carpeta",
     "exportJSON": "Exportar JSON",
     "share": "Compartir",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -385,6 +385,8 @@
     "default": "Predeterminado",
     "edit": "Editar",
     "duplicate": "Duplicar",
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado al portapapeles",
     "activate": "Activar",
     "deactivate": "Desactivar",
     "delete": "Eliminar",
@@ -432,6 +434,8 @@
       "view": "Visualizar",
       "edit": "Editar",
       "duplicate": "Duplicar",
+      "copyId": "Copiar ID",
+      "idCopied": "ID copiado al portapapeles",
       "activate": "Activar",
       "deactivate": "Desactivar",
       "delete": "Eliminar"
@@ -499,6 +503,8 @@
     "save": "Guardar Orden"
   },
   "kanban": {
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado al portapapeles",
     "header": {
       "conversations": "Conversaciones",
       "stages": "Etapas",

--- a/src/i18n/locales/fr/agents.json
+++ b/src/i18n/locales/fr/agents.json
@@ -126,6 +126,8 @@
   "dropdown": {
     "testA2A": "Tester A2A",
     "edit": "Modifier",
+    "copyId": "Copier l'ID",
+    "idCopied": "ID copié dans le presse-papiers",
     "moveToFolder": "Déplacer vers un dossier",
     "exportJSON": "Exporter JSON",
     "share": "Partager",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -386,6 +386,8 @@
     "default": "Par défaut",
     "edit": "Modifier",
     "duplicate": "Dupliquer",
+    "copyId": "Copier l'ID",
+    "idCopied": "ID copié dans le presse-papiers",
     "activate": "Activer",
     "deactivate": "Désactiver",
     "delete": "Supprimer",
@@ -434,6 +436,8 @@
       "view": "Visualiser",
       "edit": "Modifier",
       "duplicate": "Dupliquer",
+      "copyId": "Copier l'ID",
+      "idCopied": "ID copié dans le presse-papiers",
       "activate": "Activer",
       "deactivate": "Désactiver",
       "delete": "Supprimer"
@@ -501,6 +505,8 @@
     "save": "Enregistrer l'Ordre"
   },
   "kanban": {
+    "copyId": "Copier l'ID",
+    "idCopied": "ID copié dans le presse-papiers",
     "header": {
       "conversations": "Conversations",
       "stages": "Étapes",

--- a/src/i18n/locales/it/agents.json
+++ b/src/i18n/locales/it/agents.json
@@ -126,6 +126,8 @@
   "dropdown": {
     "testA2A": "Testa A2A",
     "edit": "Modifica",
+    "copyId": "Copia ID",
+    "idCopied": "ID copiato negli appunti",
     "moveToFolder": "Sposta in cartella",
     "exportJSON": "Esporta JSON",
     "share": "Condividi",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -384,6 +384,8 @@
     "inactive": "Inattiva",
     "edit": "Modifica",
     "duplicate": "Duplica",
+    "copyId": "Copia ID",
+    "idCopied": "ID copiato negli appunti",
     "activate": "Attiva",
     "deactivate": "Disattiva",
     "delete": "Elimina",
@@ -430,6 +432,8 @@
       "view": "Visualizza",
       "edit": "Modifica",
       "duplicate": "Duplica",
+      "copyId": "Copia ID",
+      "idCopied": "ID copiato negli appunti",
       "activate": "Attiva",
       "deactivate": "Disattiva",
       "delete": "Elimina"
@@ -497,6 +501,8 @@
     "save": "Salva Ordine"
   },
   "kanban": {
+    "copyId": "Copia ID",
+    "idCopied": "ID copiato negli appunti",
     "header": {
       "conversations": "Conversazioni",
       "stages": "Fasi",

--- a/src/i18n/locales/pt-BR/agents.json
+++ b/src/i18n/locales/pt-BR/agents.json
@@ -126,6 +126,8 @@
   "dropdown": {
     "testA2A": "Testar A2A",
     "edit": "Editar",
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado para a área de transferência",
     "moveToFolder": "Mover para pasta",
     "exportJSON": "Exportar JSON",
     "share": "Compartilhar",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -424,6 +424,8 @@
     "default": "Padrão",
     "edit": "Editar",
     "duplicate": "Duplicar",
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado para a área de transferência",
     "activate": "Ativar",
     "deactivate": "Desativar",
     "delete": "Deletar",
@@ -471,6 +473,8 @@
       "view": "Visualizar",
       "edit": "Editar",
       "duplicate": "Duplicar",
+      "copyId": "Copiar ID",
+      "idCopied": "ID copiado para a área de transferência",
       "activate": "Ativar",
       "deactivate": "Desativar",
       "delete": "Deletar"
@@ -538,6 +542,8 @@
     "save": "Salvar Ordem"
   },
   "kanban": {
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado para a área de transferência",
     "header": {
       "conversations": "Itens",
       "stages": "Etapas",

--- a/src/i18n/locales/pt/agents.json
+++ b/src/i18n/locales/pt/agents.json
@@ -126,6 +126,8 @@
   "dropdown": {
     "testA2A": "Testar A2A",
     "edit": "Editar",
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado para a área de transferência",
     "moveToFolder": "Mover para pasta",
     "exportJSON": "Exportar JSON",
     "share": "Compartilhar",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -412,6 +412,8 @@
     "default": "Padrão",
     "edit": "Editar",
     "duplicate": "Duplicar",
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado para a área de transferência",
     "activate": "Ativar",
     "deactivate": "Desativar",
     "delete": "Deletar",
@@ -459,6 +461,8 @@
       "view": "Visualizar",
       "edit": "Editar",
       "duplicate": "Duplicar",
+      "copyId": "Copiar ID",
+      "idCopied": "ID copiado para a área de transferência",
       "activate": "Ativar",
       "deactivate": "Desativar",
       "delete": "Deletar"
@@ -526,6 +530,8 @@
     "save": "Salvar Ordem"
   },
   "kanban": {
+    "copyId": "Copiar ID",
+    "idCopied": "ID copiado para a área de transferência",
     "header": {
       "conversations": "Itens",
       "stages": "Etapas",

--- a/src/pages/Customer/Agents/Agent/AgentEditPage.tsx
+++ b/src/pages/Customer/Agents/Agent/AgentEditPage.tsx
@@ -221,6 +221,15 @@ const AgentEditPage = () => {
     }
   }, [searchParams, setSearchParams]);
 
+  // Open test chat drawer when ?test=1 is present (wizard "test agent" card)
+  useEffect(() => {
+    if (searchParams.get('test') === '1') {
+      setIsTestChatOpen(true);
+      searchParams.delete('test');
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
   // Redirect blocked menus for external agents
   useEffect(() => {
     if (agent?.type === 'external') {

--- a/src/pages/Customer/Agents/Agent/wizard/WizardStep4_Success.tsx
+++ b/src/pages/Customer/Agents/Agent/wizard/WizardStep4_Success.tsx
@@ -14,13 +14,18 @@ const WizardStep4_Success = ({ agentId, agentName, onFinish }: WizardStep4Props)
   const { t } = useLanguage('aiAgents');
 
   const handleViewAgent = () => {
-    navigate(`/agents/${agentId}/edit`);
     onFinish();
+    navigate(`/agents/${agentId}/edit`);
+  };
+
+  const handleTestAgent = () => {
+    onFinish();
+    navigate(`/agents/${agentId}/edit?test=1`);
   };
 
   const handleGoToList = () => {
-    navigate('/agents/list');
     onFinish();
+    navigate('/agents/list');
   };
 
   return (
@@ -49,7 +54,7 @@ const WizardStep4_Success = ({ agentId, agentName, onFinish }: WizardStep4Props)
 
           <Card
             className="cursor-pointer transition-all hover:shadow-lg hover:border-primary group"
-            onClick={() => navigate('/conversations')}
+            onClick={handleTestAgent}
           >
             <CardContent className="p-3.5">
               <div className="flex items-center gap-3">

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -18,6 +18,7 @@ import {
   GripVertical,
   Edit,
   Trash2,
+  Copy,
   ArrowUpDown,
   Phone,
   Mail,
@@ -516,6 +517,16 @@ export default function PipelineKanban() {
                       <Edit className="h-4 w-4 mr-2" />
                       {t('kanban.header.editPipeline')}
                     </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={async () => {
+                        if (!pipeline?.id) return;
+                        await navigator.clipboard.writeText(String(pipeline.id));
+                        toast.success(t('kanban.idCopied'));
+                      }}
+                    >
+                      <Copy className="h-4 w-4 mr-2" />
+                      {t('kanban.copyId')}
+                    </DropdownMenuItem>
                     <DropdownMenuItem onClick={handleReorderStages}>
                       <ArrowUpDown className="h-4 w-4 mr-2" />
                       {t('kanban.header.reorderStages')}
@@ -581,6 +592,15 @@ export default function PipelineKanban() {
                               <Edit className="h-4 w-4 mr-2" />
                               {t('kanban.stage.editStage')}
                             </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={async () => {
+                                await navigator.clipboard.writeText(String(stage.id));
+                                toast.success(t('kanban.idCopied'));
+                              }}
+                            >
+                              <Copy className="h-4 w-4 mr-2" />
+                              {t('kanban.copyId')}
+                            </DropdownMenuItem>
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
                               className="text-destructive"
@@ -634,6 +654,15 @@ export default function PipelineKanban() {
                                   <DropdownMenuItem onClick={() => handleEditItem(item)}>
                                     <Edit className="h-4 w-4 mr-2" />
                                     {t('kanban.item.editItem')}
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    onClick={async () => {
+                                      await navigator.clipboard.writeText(String(item.id));
+                                      toast.success(t('kanban.idCopied'));
+                                    }}
+                                  >
+                                    <Copy className="h-4 w-4 mr-2" />
+                                    {t('kanban.copyId')}
                                   </DropdownMenuItem>
                                   <DropdownMenuItem
                                     onClick={() => {


### PR DESCRIPTION
## Resumo

Três melhorias de UX no frontend community (todas verificadas localmente).

### 1. Wizard de criação de agente — botão "Testar agente no chat"
O card de teste no passo final do wizard navegava para `/conversations` (inbox global), onde não há como testar o agente recém-criado. Agora ele vai para a página de edição com `?test=1`, que abre automaticamente o drawer `AgentTestChat` (mesma tela acessível pelo botão Testar do header).

**Arquivos**: `WizardStep4_Success.tsx`, `AgentEditPage.tsx`.

### 2. Nome do agente atrás do botão X no drawer de teste
O `Badge` com o nome do agente no cabeçalho do `AgentChatArea` ficava sob o botão de fechar do Dialog do Radix. Adicionado padding à direita e `gap-3` no cabeçalho.

**Arquivos**: `AgentChatArea.tsx`.

### 3. Ação "Copiar ID" em menus de agentes e pipelines
Adicionado item "Copiar ID" (com toast de confirmação) nos dropdowns de:
- Lista de agentes (`AgentActionsDropdown`)
- Lista de pipelines em tabela (`PipelinesTable`)
- Card de pipeline (`PipelineCard`)
- Kanban: menus do pipeline, da etapa e do item (`PipelineKanban`)

Para manter os ícones visualmente distintos na lista de pipelines (onde "Duplicar" já usava `Copy`), "Duplicar" passou a usar `CopyPlus`. Chaves de tradução adicionadas para todos os seis locales (en, es, fr, it, pt, pt-BR).

## Test plan

- [ ] Criar um agente pelo wizard e clicar no card "Testar agente no chat" → drawer de teste abre na tela de edição
- [ ] No drawer de teste, confirmar que o nome do agente aparece inteiro à esquerda do X
- [ ] Em cada menu listado (agentes, lista de pipelines, card, kanban × 3), clicar em "Copiar ID" → clipboard recebe o UUID e o toast aparece
- [ ] Na lista de pipelines, confirmar que "Duplicar" e "Copiar ID" têm ícones distintos

## Summary by Sourcery

Improve agent test experience and add ID copy actions across agent and pipeline UIs.

New Features:
- Add a wizard flow that opens the agent edit page with the test chat drawer when choosing to test a newly created agent.
- Provide a copy ID action with confirmation toast in agent dropdowns and multiple pipeline menus, including table, cards, and kanban views.

Enhancements:
- Adjust the agent test chat header layout so the agent name is fully visible beside the close button.
- Use distinct icons for duplicating pipelines versus copying their IDs to clarify actions in the UI.