### PR TITLE
feat(admin): require mandatory fields in channel integrations form

### DIFF
--- a/src/components/channels/FacebookChannelForm.tsx
+++ b/src/components/channels/FacebookChannelForm.tsx
@@ -134,7 +134,6 @@ export default function FacebookChannelForm({ onSuccess, onCancel }: FacebookCha
       script.src = 'https://connect.facebook.net/en_US/sdk.js';
       script.async = true;
       script.defer = true;
-      script.crossOrigin = 'anonymous';
       script.onerror = () => {
         console.error('[Facebook Messenger SDK] Failed to load Facebook SDK script');
         reject(new Error('ScriptLoaderError'));

--- a/src/components/channels/channel-grid/index.tsx
+++ b/src/components/channels/channel-grid/index.tsx
@@ -9,9 +9,10 @@ interface ChannelGridProps {
   channels: ChannelType[];
   onChannelSelect: (channel: ChannelType) => void;
   canFB: boolean;
+  canIG: boolean;
 }
 
-export const ChannelGrid = ({ channels, onChannelSelect, canFB }: ChannelGridProps) => {
+export const ChannelGrid = ({ channels, onChannelSelect, canFB, canIG }: ChannelGridProps) => {
   const [searchQuery, setSearchQuery] = useState('');
   const { t } = useLanguage('channels');
 
@@ -56,8 +57,15 @@ export const ChannelGrid = ({ channels, onChannelSelect, canFB }: ChannelGridPro
       {/* Channel Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6 pb-8" data-tour="channel-grid-list">
         {filteredChannels.map((channel, index) => {
+          // Gate tiles by the backend-sourced `hasXxxConfig` booleans (single
+          // source of truth with the admin save endpoint). Twitter has no
+          // channel type yet — extend here if/when it lands.
           const disabled =
-            channel.type === 'facebook' || channel.type === 'instagram' ? !canFB : false;
+            channel.type === 'facebook'
+              ? !canFB
+              : channel.type === 'instagram'
+              ? !canIG
+              : false;
 
           return (
             <ChannelCard

--- a/src/components/channels/forms/whatsapp/CloudWhatsappForm.tsx
+++ b/src/components/channels/forms/whatsapp/CloudWhatsappForm.tsx
@@ -54,10 +54,13 @@ export const CloudWhatsappForm = ({ form, onFormChange, canFB }: CloudWhatsappFo
 
   // Load Facebook SDK on component mount
   useEffect(() => {
-    if (canFB) {
+    // The SDK initializes with wpAppId — if the GlobalConfig response hasn't
+    // arrived yet (context races with initial render), bail. When config
+    // hydrates, wpAppId/wpApiVersion become truthy and the effect re-runs.
+    if (canFB && config.wpAppId) {
       loadFacebookSDK();
     }
-  }, [canFB]);
+  }, [canFB, config.wpAppId, config.wpApiVersion]);
 
   // Listen for Facebook postMessage events
   useEffect(() => {
@@ -160,11 +163,12 @@ export const CloudWhatsappForm = ({ form, onFormChange, canFB }: CloudWhatsappFo
       setFbSDKReady(true);
     };
 
-    // Create script element
+    // Create script element — no crossOrigin; Facebook's CDN doesn't emit the
+    // CORS headers required by crossOrigin='anonymous' and the browser would
+    // block the script load entirely.
     const script = document.createElement('script');
     script.async = true;
     script.defer = true;
-    script.crossOrigin = 'anonymous';
     script.src = 'https://connect.facebook.net/en_US/sdk.js';
     document.head.appendChild(script);
   };

--- a/src/components/channels/settings/AuthorizationBanners.tsx
+++ b/src/components/channels/settings/AuthorizationBanners.tsx
@@ -287,7 +287,6 @@ const AuthorizationSuccessBanner: React.FC<{
       script.src = 'https://connect.facebook.net/en_US/sdk.js';
       script.async = true;
       script.defer = true;
-      script.crossOrigin = 'anonymous';
       script.onerror = () => reject(new Error('ScriptLoaderError'));
       document.head.appendChild(script);
     });

--- a/src/components/integrations/forms/WhatsAppForm.tsx
+++ b/src/components/integrations/forms/WhatsAppForm.tsx
@@ -18,6 +18,7 @@ export function WhatsAppForm({ config, onConfigChange }: IntegrationFormProps) {
         value={getValue('wpAppId')}
         onChange={(value) => onConfigChange('wpAppId', value)}
         placeholder={t('integrations.whatsapp.placeholders.appId')}
+        required
       />
       <FormField
         id="WP_APP_SECRET"
@@ -33,6 +34,7 @@ export function WhatsAppForm({ config, onConfigChange }: IntegrationFormProps) {
         value={getValue('wpWhatsappConfigId')}
         onChange={(value) => onConfigChange('wpWhatsappConfigId', value)}
         placeholder={t('integrations.whatsapp.placeholders.configId')}
+        required
       />
       <FormField
         id="WP_VERIFY_TOKEN"

--- a/src/contexts/GlobalConfigContext.tsx
+++ b/src/contexts/GlobalConfigContext.tsx
@@ -14,8 +14,12 @@ export interface GlobalConfig {
   azureAppId?: string;
   // 🔒 SECURITY: Don't expose sensitive API URLs to frontend
   // Only boolean indicators to check if config exists
+  hasFacebookConfig?: boolean;
+  hasWhatsappConfig?: boolean;
+  hasInstagramConfig?: boolean;
   hasEvolutionConfig?: boolean;
   hasEvolutionGoConfig?: boolean;
+  hasTwitterConfig?: boolean;
   openaiConfigured?: boolean;
   enableAccountSignup?: boolean;
   recaptchaSiteKey?: string;
@@ -85,10 +89,14 @@ export const fetchSetupStatus = async (): Promise<boolean> => {
 
 // Listeners para notificar componentes React quando o cache é limpo
 const setupCacheListeners: Set<() => void> = new Set();
+const globalConfigListeners: Set<() => void> = new Set();
 
 export const clearGlobalConfigCache = () => {
   globalConfigCache = null;
   globalConfigPromise = null;
+  // Notificar listeners para re-fetch (ex.: após admin salvar uma config, os
+  // booleans `hasXxxConfig` mudam e o fluxo de criação de canal precisa refletir)
+  globalConfigListeners.forEach(listener => listener());
 };
 
 export const clearSetupCache = () => {
@@ -130,9 +138,16 @@ export const GlobalConfigProvider: React.FC<{ children: React.ReactNode }> = ({ 
     };
     setupCacheListeners.add(onCacheCleared);
 
+    // Re-fetch when global config cache is cleared (admin save invalidates it)
+    const onGlobalConfigCleared = () => {
+      if (mounted) loadConfig();
+    };
+    globalConfigListeners.add(onGlobalConfigCleared);
+
     return () => {
       mounted = false;
       setupCacheListeners.delete(onCacheCleared);
+      globalConfigListeners.delete(onGlobalConfigCleared);
     };
   }, []);
 

--- a/src/hooks/channels/useChannelForm.ts
+++ b/src/hooks/channels/useChannelForm.ts
@@ -235,10 +235,6 @@ export const useChannelForm = () => {
     return false; // indica que deve sair da página
   };
 
-  // Helper function to check if a value is a valid non-empty string
-  const isValidString = (value: unknown): value is string =>
-    typeof value === 'string' && value.trim().length > 0;
-
   return {
     // State
     selectedChannel,
@@ -257,11 +253,16 @@ export const useChannelForm = () => {
     resetForm,
     goBack,
 
-    // Config helpers
+    // Config helpers — derived from backend `hasXxxConfig` booleans, which share
+    // the `IntegrationRequirements` source of truth with the admin save endpoint.
     hasEvolutionConfig: config.hasEvolutionConfig === true,
     hasEvolutionGoConfig: config.hasEvolutionGoConfig === true,
-    canFB: isValidString(config.fbAppId) && isValidString(config.fbApiVersion),
-    canWpCloud: isValidString(config.wpAppId) && isValidString(config.wpWhatsappConfigId),
+    canFB: config.hasFacebookConfig === true,
+    canWpCloud: config.hasWhatsappConfig === true,
+    canIG: config.hasInstagramConfig === true,
+    canTwitter: config.hasTwitterConfig === true,
+    canEmailGoogle: typeof config.googleOAuthClientId === 'string' && config.googleOAuthClientId.length > 0,
+    canEmailMicrosoft: typeof config.azureAppId === 'string' && config.azureAppId.length > 0,
     config,
   };
 };

--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -163,6 +163,7 @@
     "clearSecret": "Clear saved value",
     "save": "Save Configuration",
     "saving": "Saving...",
+    "dismissError": "Dismiss error",
     "facebook": {
       "tabTitle": "Facebook",
       "fields": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -142,5 +142,8 @@
       "light": "Light mode",
       "dark": "Dark mode"
     }
+  },
+  "validation": {
+    "required": "This field is required"
   }
 }

--- a/src/i18n/locales/en/whatsapp.json
+++ b/src/i18n/locales/en/whatsapp.json
@@ -413,7 +413,8 @@
       "title": "Facebook Integration",
       "connectButton": "Connect with Facebook",
       "description": "Connect your Facebook account to automatically fill in the WhatsApp Business information",
-      "connecting": "Connecting..."
+      "connecting": "Connecting...",
+      "loadingSDK": "Loading Facebook SDK..."
     },
     "autoFilled": {
       "title": "Fields Filled Automatically",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -163,6 +163,7 @@
     "clearSecret": "Borrar valor guardado",
     "save": "Guardar Configuracion",
     "saving": "Guardando...",
+    "dismissError": "Cerrar error",
     "facebook": {
       "tabTitle": "Facebook",
       "fields": {
@@ -333,29 +334,53 @@
     "saving": "Guardando...",
     "linear": {
       "cardTitle": "Linear",
-      "fields": { "clientId": "ID de Cliente", "clientSecret": "Secreto de Cliente" },
-      "placeholders": { "clientId": "Su Linear Client ID", "clientSecret": "Ingrese el nuevo secreto de cliente" },
+      "fields": {
+        "clientId": "ID de Cliente",
+        "clientSecret": "Secreto de Cliente"
+      },
+      "placeholders": {
+        "clientId": "Su Linear Client ID",
+        "clientSecret": "Ingrese el nuevo secreto de cliente"
+      },
       "saveSuccess": "Configuracion de Linear guardada exitosamente",
       "saveError": "Error al guardar la configuracion de Linear"
     },
     "hubspot": {
       "cardTitle": "HubSpot",
-      "fields": { "clientId": "ID de Cliente", "clientSecret": "Secreto de Cliente" },
-      "placeholders": { "clientId": "Su HubSpot Client ID", "clientSecret": "Ingrese el nuevo secreto de cliente" },
+      "fields": {
+        "clientId": "ID de Cliente",
+        "clientSecret": "Secreto de Cliente"
+      },
+      "placeholders": {
+        "clientId": "Su HubSpot Client ID",
+        "clientSecret": "Ingrese el nuevo secreto de cliente"
+      },
       "saveSuccess": "Configuracion de HubSpot guardada exitosamente",
       "saveError": "Error al guardar la configuracion de HubSpot"
     },
     "shopify": {
       "cardTitle": "Shopify",
-      "fields": { "clientId": "ID de Cliente", "clientSecret": "Secreto de Cliente" },
-      "placeholders": { "clientId": "Su Shopify Client ID", "clientSecret": "Ingrese el nuevo secreto de cliente" },
+      "fields": {
+        "clientId": "ID de Cliente",
+        "clientSecret": "Secreto de Cliente"
+      },
+      "placeholders": {
+        "clientId": "Su Shopify Client ID",
+        "clientSecret": "Ingrese el nuevo secreto de cliente"
+      },
       "saveSuccess": "Configuracion de Shopify guardada exitosamente",
       "saveError": "Error al guardar la configuracion de Shopify"
     },
     "slack": {
       "cardTitle": "Slack",
-      "fields": { "clientId": "ID de Cliente", "clientSecret": "Secreto de Cliente" },
-      "placeholders": { "clientId": "Su Slack Client ID", "clientSecret": "Ingrese el nuevo secreto de cliente" },
+      "fields": {
+        "clientId": "ID de Cliente",
+        "clientSecret": "Secreto de Cliente"
+      },
+      "placeholders": {
+        "clientId": "Su Slack Client ID",
+        "clientSecret": "Ingrese el nuevo secreto de cliente"
+      },
       "saveSuccess": "Configuracion de Slack guardada exitosamente",
       "saveError": "Error al guardar la configuracion de Slack"
     },

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -132,5 +132,8 @@
   "close": "Cerrar",
   "table": {
     "inUse": "En uso"
+  },
+  "validation": {
+    "required": "Este campo es obligatorio"
   }
 }

--- a/src/i18n/locales/es/whatsapp.json
+++ b/src/i18n/locales/es/whatsapp.json
@@ -414,7 +414,8 @@
       "title": "Integración con Facebook",
       "connectButton": "Conectar con Facebook",
       "description": "Conecte con su cuenta de Facebook para completar automáticamente la información de WhatsApp Business",
-      "connecting": "Conectando..."
+      "connecting": "Conectando...",
+      "loadingSDK": "Cargando SDK de Facebook..."
     },
     "autoFilled": {
       "title": "Información Completada Automáticamente",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -163,6 +163,7 @@
     "clearSecret": "Effacer la valeur enregistree",
     "save": "Enregistrer la Configuration",
     "saving": "Enregistrement...",
+    "dismissError": "Fermer l'erreur",
     "facebook": {
       "tabTitle": "Facebook",
       "fields": {
@@ -333,29 +334,53 @@
     "saving": "Enregistrement...",
     "linear": {
       "cardTitle": "Linear",
-      "fields": { "clientId": "ID Client", "clientSecret": "Secret Client" },
-      "placeholders": { "clientId": "Votre Linear Client ID", "clientSecret": "Entrez le nouveau secret client" },
+      "fields": {
+        "clientId": "ID Client",
+        "clientSecret": "Secret Client"
+      },
+      "placeholders": {
+        "clientId": "Votre Linear Client ID",
+        "clientSecret": "Entrez le nouveau secret client"
+      },
       "saveSuccess": "Configuration Linear enregistree avec succes",
       "saveError": "Echec de l'enregistrement de la configuration Linear"
     },
     "hubspot": {
       "cardTitle": "HubSpot",
-      "fields": { "clientId": "ID Client", "clientSecret": "Secret Client" },
-      "placeholders": { "clientId": "Votre HubSpot Client ID", "clientSecret": "Entrez le nouveau secret client" },
+      "fields": {
+        "clientId": "ID Client",
+        "clientSecret": "Secret Client"
+      },
+      "placeholders": {
+        "clientId": "Votre HubSpot Client ID",
+        "clientSecret": "Entrez le nouveau secret client"
+      },
       "saveSuccess": "Configuration HubSpot enregistree avec succes",
       "saveError": "Echec de l'enregistrement de la configuration HubSpot"
     },
     "shopify": {
       "cardTitle": "Shopify",
-      "fields": { "clientId": "ID Client", "clientSecret": "Secret Client" },
-      "placeholders": { "clientId": "Votre Shopify Client ID", "clientSecret": "Entrez le nouveau secret client" },
+      "fields": {
+        "clientId": "ID Client",
+        "clientSecret": "Secret Client"
+      },
+      "placeholders": {
+        "clientId": "Votre Shopify Client ID",
+        "clientSecret": "Entrez le nouveau secret client"
+      },
       "saveSuccess": "Configuration Shopify enregistree avec succes",
       "saveError": "Echec de l'enregistrement de la configuration Shopify"
     },
     "slack": {
       "cardTitle": "Slack",
-      "fields": { "clientId": "ID Client", "clientSecret": "Secret Client" },
-      "placeholders": { "clientId": "Votre Slack Client ID", "clientSecret": "Entrez le nouveau secret client" },
+      "fields": {
+        "clientId": "ID Client",
+        "clientSecret": "Secret Client"
+      },
+      "placeholders": {
+        "clientId": "Votre Slack Client ID",
+        "clientSecret": "Entrez le nouveau secret client"
+      },
       "saveSuccess": "Configuration Slack enregistree avec succes",
       "saveError": "Echec de l'enregistrement de la configuration Slack"
     },

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -132,5 +132,8 @@
   "close": "Fermer",
   "table": {
     "inUse": "En cours d'utilisation"
+  },
+  "validation": {
+    "required": "Ce champ est obligatoire"
   }
 }

--- a/src/i18n/locales/fr/whatsapp.json
+++ b/src/i18n/locales/fr/whatsapp.json
@@ -414,7 +414,8 @@
       "title": "Intégration avec Facebook",
       "connectButton": "Connecter avec Facebook",
       "description": "Connectez-vous avec votre compte Facebook pour remplir automatiquement les informations de WhatsApp Business",
-      "connecting": "Connexion en cours..."
+      "connecting": "Connexion en cours...",
+      "loadingSDK": "Chargement du SDK Facebook..."
     },
     "autoFilled": {
       "title": "Informations Remplies Automatiquement",

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -163,6 +163,7 @@
     "clearSecret": "Cancella valore salvato",
     "save": "Salva Configurazione",
     "saving": "Salvataggio...",
+    "dismissError": "Chiudi errore",
     "facebook": {
       "tabTitle": "Facebook",
       "fields": {
@@ -333,29 +334,53 @@
     "saving": "Salvataggio...",
     "linear": {
       "cardTitle": "Linear",
-      "fields": { "clientId": "ID Cliente", "clientSecret": "Segreto Cliente" },
-      "placeholders": { "clientId": "Il tuo Linear Client ID", "clientSecret": "Inserisci il nuovo segreto cliente" },
+      "fields": {
+        "clientId": "ID Cliente",
+        "clientSecret": "Segreto Cliente"
+      },
+      "placeholders": {
+        "clientId": "Il tuo Linear Client ID",
+        "clientSecret": "Inserisci il nuovo segreto cliente"
+      },
       "saveSuccess": "Configurazione Linear salvata con successo",
       "saveError": "Errore nel salvataggio della configurazione Linear"
     },
     "hubspot": {
       "cardTitle": "HubSpot",
-      "fields": { "clientId": "ID Cliente", "clientSecret": "Segreto Cliente" },
-      "placeholders": { "clientId": "Il tuo HubSpot Client ID", "clientSecret": "Inserisci il nuovo segreto cliente" },
+      "fields": {
+        "clientId": "ID Cliente",
+        "clientSecret": "Segreto Cliente"
+      },
+      "placeholders": {
+        "clientId": "Il tuo HubSpot Client ID",
+        "clientSecret": "Inserisci il nuovo segreto cliente"
+      },
       "saveSuccess": "Configurazione HubSpot salvata con successo",
       "saveError": "Errore nel salvataggio della configurazione HubSpot"
     },
     "shopify": {
       "cardTitle": "Shopify",
-      "fields": { "clientId": "ID Cliente", "clientSecret": "Segreto Cliente" },
-      "placeholders": { "clientId": "Il tuo Shopify Client ID", "clientSecret": "Inserisci il nuovo segreto cliente" },
+      "fields": {
+        "clientId": "ID Cliente",
+        "clientSecret": "Segreto Cliente"
+      },
+      "placeholders": {
+        "clientId": "Il tuo Shopify Client ID",
+        "clientSecret": "Inserisci il nuovo segreto cliente"
+      },
       "saveSuccess": "Configurazione Shopify salvata con successo",
       "saveError": "Errore nel salvataggio della configurazione Shopify"
     },
     "slack": {
       "cardTitle": "Slack",
-      "fields": { "clientId": "ID Cliente", "clientSecret": "Segreto Cliente" },
-      "placeholders": { "clientId": "Il tuo Slack Client ID", "clientSecret": "Inserisci il nuovo segreto cliente" },
+      "fields": {
+        "clientId": "ID Cliente",
+        "clientSecret": "Segreto Cliente"
+      },
+      "placeholders": {
+        "clientId": "Il tuo Slack Client ID",
+        "clientSecret": "Inserisci il nuovo segreto cliente"
+      },
       "saveSuccess": "Configurazione Slack salvata con successo",
       "saveError": "Errore nel salvataggio della configurazione Slack"
     },

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -132,5 +132,8 @@
   "close": "Chiudi",
   "table": {
     "inUse": "In uso"
+  },
+  "validation": {
+    "required": "Questo campo è obbligatorio"
   }
 }

--- a/src/i18n/locales/it/whatsapp.json
+++ b/src/i18n/locales/it/whatsapp.json
@@ -414,7 +414,8 @@
       "title": "Integrazione con Facebook",
       "connectButton": "Connetti con Facebook",
       "description": "Connetti il tuo account Facebook per compilare automaticamente le informazioni di WhatsApp Business",
-      "connecting": "Connessione in corso..."
+      "connecting": "Connessione in corso...",
+      "loadingSDK": "Caricamento SDK Facebook..."
     },
     "autoFilled": {
       "title": "Informazioni Compilate Automaticamente",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -163,6 +163,7 @@
     "clearSecret": "Limpar valor salvo",
     "save": "Salvar Configuracao",
     "saving": "Salvando...",
+    "dismissError": "Fechar erro",
     "facebook": {
       "tabTitle": "Facebook",
       "fields": {

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -142,5 +142,8 @@
       "light": "Modo claro",
       "dark": "Modo escuro"
     }
+  },
+  "validation": {
+    "required": "Este campo é obrigatório"
   }
 }

--- a/src/i18n/locales/pt-BR/whatsapp.json
+++ b/src/i18n/locales/pt-BR/whatsapp.json
@@ -414,7 +414,8 @@
       "title": "Integração com Facebook",
       "connectButton": "Conectar com Facebook",
       "description": "Conecte com sua conta do Facebook para preencher automaticamente as informações do WhatsApp Business",
-      "connecting": "Conectando..."
+      "connecting": "Conectando...",
+      "loadingSDK": "Carregando SDK do Facebook..."
     },
     "autoFilled": {
       "title": "Informações Preenchidas Automaticamente",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -163,6 +163,7 @@
     "clearSecret": "Limpar valor guardado",
     "save": "Guardar Configuracao",
     "saving": "A guardar...",
+    "dismissError": "Fechar erro",
     "facebook": {
       "tabTitle": "Facebook",
       "fields": {
@@ -333,29 +334,53 @@
     "saving": "A guardar...",
     "linear": {
       "cardTitle": "Linear",
-      "fields": { "clientId": "ID do Cliente", "clientSecret": "Segredo do Cliente" },
-      "placeholders": { "clientId": "Seu Linear Client ID", "clientSecret": "Introduza o novo segredo do cliente" },
+      "fields": {
+        "clientId": "ID do Cliente",
+        "clientSecret": "Segredo do Cliente"
+      },
+      "placeholders": {
+        "clientId": "Seu Linear Client ID",
+        "clientSecret": "Introduza o novo segredo do cliente"
+      },
       "saveSuccess": "Configuracao do Linear guardada com sucesso",
       "saveError": "Falha ao guardar configuracao do Linear"
     },
     "hubspot": {
       "cardTitle": "HubSpot",
-      "fields": { "clientId": "ID do Cliente", "clientSecret": "Segredo do Cliente" },
-      "placeholders": { "clientId": "Seu HubSpot Client ID", "clientSecret": "Introduza o novo segredo do cliente" },
+      "fields": {
+        "clientId": "ID do Cliente",
+        "clientSecret": "Segredo do Cliente"
+      },
+      "placeholders": {
+        "clientId": "Seu HubSpot Client ID",
+        "clientSecret": "Introduza o novo segredo do cliente"
+      },
       "saveSuccess": "Configuracao do HubSpot guardada com sucesso",
       "saveError": "Falha ao guardar configuracao do HubSpot"
     },
     "shopify": {
       "cardTitle": "Shopify",
-      "fields": { "clientId": "ID do Cliente", "clientSecret": "Segredo do Cliente" },
-      "placeholders": { "clientId": "Seu Shopify Client ID", "clientSecret": "Introduza o novo segredo do cliente" },
+      "fields": {
+        "clientId": "ID do Cliente",
+        "clientSecret": "Segredo do Cliente"
+      },
+      "placeholders": {
+        "clientId": "Seu Shopify Client ID",
+        "clientSecret": "Introduza o novo segredo do cliente"
+      },
       "saveSuccess": "Configuracao do Shopify guardada com sucesso",
       "saveError": "Falha ao guardar configuracao do Shopify"
     },
     "slack": {
       "cardTitle": "Slack",
-      "fields": { "clientId": "ID do Cliente", "clientSecret": "Segredo do Cliente" },
-      "placeholders": { "clientId": "Seu Slack Client ID", "clientSecret": "Introduza o novo segredo do cliente" },
+      "fields": {
+        "clientId": "ID do Cliente",
+        "clientSecret": "Segredo do Cliente"
+      },
+      "placeholders": {
+        "clientId": "Seu Slack Client ID",
+        "clientSecret": "Introduza o novo segredo do cliente"
+      },
       "saveSuccess": "Configuracao do Slack guardada com sucesso",
       "saveError": "Falha ao guardar configuracao do Slack"
     },

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -132,5 +132,8 @@
   "close": "Fechar",
   "table": {
     "inUse": "Em uso"
+  },
+  "validation": {
+    "required": "Este campo é obrigatório"
   }
 }

--- a/src/i18n/locales/pt/whatsapp.json
+++ b/src/i18n/locales/pt/whatsapp.json
@@ -424,7 +424,8 @@
       "title": "Integração com Facebook",
       "connectButton": "Conectar com Facebook",
       "description": "Conecte com sua conta do Facebook para preencher automaticamente as informações do WhatsApp Business",
-      "connecting": "Conectando..."
+      "connecting": "Conectando...",
+      "loadingSDK": "Carregando SDK do Facebook..."
     },
     "autoFilled": {
       "title": "Informações Preenchidas Automaticamente",

--- a/src/pages/Admin/Settings/ChannelConfig.spec.tsx
+++ b/src/pages/Admin/Settings/ChannelConfig.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { toast } from 'sonner';
 import ChannelConfig from './ChannelConfig';
@@ -342,10 +342,9 @@ describe('ChannelConfig', () => {
     });
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('channels.facebook.saveError', {
-        description: 'Test error',
-      });
+      expect(screen.getByRole('alert')).toHaveTextContent('Test error');
     });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('shows error toast when load fails', async () => {
@@ -572,7 +571,7 @@ describe('ChannelConfig', () => {
     await user.click(screen.getByText('channels.save'));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('channels.evolution.saveError', { description: 'Test error' });
+      expect(screen.getByRole('alert')).toHaveTextContent('Test error');
     });
   });
 
@@ -589,7 +588,7 @@ describe('ChannelConfig', () => {
     await user.click(screen.getByText('channels.save'));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('channels.evolutionGo.saveError', { description: 'Test error' });
+      expect(screen.getByRole('alert')).toHaveTextContent('Test error');
     });
   });
 
@@ -606,7 +605,7 @@ describe('ChannelConfig', () => {
     await user.click(screen.getByText('channels.save'));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('channels.twitter.saveError', { description: 'Test error' });
+      expect(screen.getByRole('alert')).toHaveTextContent('Test error');
     });
   });
 
@@ -674,5 +673,83 @@ describe('ChannelConfig', () => {
 
     const remaining = screen.queryAllByText('channels.secretConfigured');
     expect(remaining.length).toBe(0);
+  });
+
+  describe('required enforcement', () => {
+    // Each integration renders its own Save button inside its tab. The forms
+    // share the same required-string + SECRET_SENTINEL pattern, so we exercise
+    // the invariants on the default tab (Facebook) and on one representative
+    // secondary tab (WhatsApp) that has the largest required-key set.
+    it('disables Facebook Save button when required fields are empty on mount', async () => {
+      await renderAndWait();
+
+      const saveButton = screen.getAllByText('channels.save')[0].closest('button');
+      expect(saveButton).toBeDisabled();
+    });
+
+    it('enables Facebook Save button when all required fields + masked secret are populated', async () => {
+      await renderAndWait({ fbData: CONFIGURED_FACEBOOK });
+
+      const saveButton = screen.getAllByText('channels.save')[0].closest('button');
+      expect(saveButton).not.toBeDisabled();
+    });
+
+    it('shows inline required errors on Facebook only after first submit attempt', async () => {
+      await renderAndWait();
+
+      // Before any submit: no inline required errors
+      expect(screen.queryAllByText('common:validation.required').length).toBe(0);
+
+      // Save button is disabled in empty state; simulate Enter-key submit by firing
+      // the form submit event directly (the browser path when inputs are focused).
+      const form = screen.getAllByText('channels.save')[0].closest('form') as HTMLFormElement;
+      await act(async () => {
+        fireEvent.submit(form);
+      });
+
+      // Facebook has exactly 3 required fields: FB_APP_ID, FB_VERIFY_TOKEN, FB_APP_SECRET.
+      // Scope to the form so other tabs' fields never inflate the count.
+      await waitFor(() => {
+        expect(within(form).getAllByText('common:validation.required')).toHaveLength(3);
+      });
+      expect(within(form).getByLabelText('channels.facebook.fields.appId')).toHaveAttribute('aria-invalid', 'true');
+      expect(mockSaveConfig).not.toHaveBeenCalled();
+    });
+
+    it('saves Facebook when all required fields are filled', async () => {
+      await renderAndWait({ fbData: CONFIGURED_FACEBOOK });
+      mockSaveConfig.mockResolvedValue(CONFIGURED_FACEBOOK);
+
+      const saveButton = screen.getAllByText('channels.save')[0].closest('button') as HTMLButtonElement;
+      await act(async () => {
+        fireEvent.click(saveButton);
+      });
+
+      await waitFor(() => {
+        expect(mockSaveConfig).toHaveBeenCalledWith('facebook', expect.objectContaining({
+          FB_APP_ID: 'test-fb-app-id',
+          FB_VERIFY_TOKEN: 'test-verify-token',
+          // Masked secret loaded from backend → sentinel → buildPayload maps back to null.
+          FB_APP_SECRET: null,
+        }));
+      });
+    });
+
+    it('blocks WhatsApp save when a required key is cleared', async () => {
+      await renderAndWait({ wpData: CONFIGURED_WHATSAPP });
+      const user = userEvent.setup();
+
+      await user.click(screen.getByText('channels.whatsapp.tabTitle'));
+
+      const configIdInput = await screen.findByLabelText('channels.whatsapp.fields.configId');
+      await act(async () => {
+        fireEvent.change(configIdInput, { target: { value: '' } });
+      });
+
+      // The WhatsApp Save lives under the whatsapp tab; it's the Save button for
+      // that form. Same label for every card, so grab the visible one.
+      const whatsappSave = screen.getAllByText('channels.save')[0].closest('button');
+      expect(whatsappSave).toBeDisabled();
+    });
   });
 });

--- a/src/pages/Admin/Settings/ChannelConfig.tsx
+++ b/src/pages/Admin/Settings/ChannelConfig.tsx
@@ -19,63 +19,76 @@ import { Loader2, Lock, LockOpen, X } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { adminConfigService } from '@/services/admin/adminConfigService';
 import { extractError } from '@/utils/apiHelpers';
+import { clearGlobalConfigCache } from '@/contexts/GlobalConfigContext';
 import type { AdminConfigData } from '@/types/admin/adminConfig';
+
+// Sentinel used when the backend reports a secret as "configured" (masked).
+// The form stores this placeholder so zod's .min(1) required validation passes
+// without exposing the real value; buildPayload maps it back to `null` so the
+// backend preserves the existing DB value.
+const SECRET_SENTINEL = '__CONFIGURED__';
 
 // --- Schema factories ---
 
-function createFacebookSchema() {
+type T = (key: string) => string;
+
+const required = (t: T) =>
+  z.string({ required_error: t('common:validation.required') })
+    .min(1, { message: t('common:validation.required') });
+
+function createFacebookSchema(t: T) {
   return z.object({
-    FB_APP_ID: z.string().optional(),
-    FB_VERIFY_TOKEN: z.string().optional(),
-    FB_APP_SECRET: z.string().optional().nullable(),
+    FB_APP_ID: required(t),
+    FB_VERIFY_TOKEN: required(t),
+    FB_APP_SECRET: required(t),
     FACEBOOK_API_VERSION: z.string().optional(),
     ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT: z.union([z.boolean(), z.string()]).optional(),
     FB_FEED_COMMENTS_ENABLED: z.union([z.boolean(), z.string()]).optional(),
   });
 }
 
-function createWhatsappSchema() {
+function createWhatsappSchema(t: T) {
   return z.object({
-    WP_APP_ID: z.string().optional(),
-    WP_VERIFY_TOKEN: z.string().optional(),
-    WP_APP_SECRET: z.string().optional().nullable(),
-    WP_WHATSAPP_CONFIG_ID: z.string().optional(),
+    WP_APP_ID: required(t),
+    WP_VERIFY_TOKEN: required(t),
+    WP_APP_SECRET: required(t),
+    WP_WHATSAPP_CONFIG_ID: required(t),
     WP_API_VERSION: z.string().optional(),
   });
 }
 
-function createInstagramSchema() {
+function createInstagramSchema(t: T) {
   return z.object({
-    INSTAGRAM_APP_ID: z.string().optional(),
-    INSTAGRAM_APP_SECRET: z.string().optional().nullable(),
-    INSTAGRAM_VERIFY_TOKEN: z.string().optional(),
+    INSTAGRAM_APP_ID: required(t),
+    INSTAGRAM_APP_SECRET: required(t),
+    INSTAGRAM_VERIFY_TOKEN: required(t),
     INSTAGRAM_API_VERSION: z.string().optional(),
     ENABLE_INSTAGRAM_CHANNEL_HUMAN_AGENT: z.union([z.boolean(), z.string()]).optional(),
   });
 }
 
-function createEvolutionSchema() {
+function createEvolutionSchema(t: T) {
   return z.object({
-    EVOLUTION_API_URL: z.string().optional(),
-    EVOLUTION_ADMIN_SECRET: z.string().optional().nullable(),
+    EVOLUTION_API_URL: required(t),
+    EVOLUTION_ADMIN_SECRET: required(t),
   });
 }
 
-function createEvolutionGoSchema() {
+function createEvolutionGoSchema(t: T) {
   return z.object({
-    EVOLUTION_GO_API_URL: z.string().optional(),
-    EVOLUTION_GO_ADMIN_SECRET: z.string().optional().nullable(),
+    EVOLUTION_GO_API_URL: required(t),
+    EVOLUTION_GO_ADMIN_SECRET: required(t),
     EVOLUTION_GO_INSTANCE_ID: z.string().optional(),
     EVOLUTION_GO_INSTANCE_SECRET: z.string().optional().nullable(),
   });
 }
 
-function createTwitterSchema() {
+function createTwitterSchema(t: T) {
   return z.object({
-    TWITTER_APP_ID: z.string().optional(),
-    TWITTER_CONSUMER_KEY: z.string().optional(),
-    TWITTER_CONSUMER_SECRET: z.string().optional().nullable(),
-    TWITTER_ENVIRONMENT: z.string().optional(),
+    TWITTER_APP_ID: required(t),
+    TWITTER_CONSUMER_KEY: required(t),
+    TWITTER_CONSUMER_SECRET: required(t),
+    TWITTER_ENVIRONMENT: required(t),
   });
 }
 
@@ -89,7 +102,7 @@ type TwitterFormData = z.infer<ReturnType<typeof createTwitterSchema>>;
 const FACEBOOK_DEFAULTS: FacebookFormData = {
   FB_APP_ID: '',
   FB_VERIFY_TOKEN: '',
-  FB_APP_SECRET: null,
+  FB_APP_SECRET: '',
   FACEBOOK_API_VERSION: '',
   ENABLE_MESSENGER_CHANNEL_HUMAN_AGENT: false,
   FB_FEED_COMMENTS_ENABLED: false,
@@ -98,14 +111,14 @@ const FACEBOOK_DEFAULTS: FacebookFormData = {
 const WHATSAPP_DEFAULTS: WhatsAppFormData = {
   WP_APP_ID: '',
   WP_VERIFY_TOKEN: '',
-  WP_APP_SECRET: null,
+  WP_APP_SECRET: '',
   WP_WHATSAPP_CONFIG_ID: '',
   WP_API_VERSION: '',
 };
 
 const INSTAGRAM_DEFAULTS: InstagramFormData = {
   INSTAGRAM_APP_ID: '',
-  INSTAGRAM_APP_SECRET: null,
+  INSTAGRAM_APP_SECRET: '',
   INSTAGRAM_VERIFY_TOKEN: '',
   INSTAGRAM_API_VERSION: '',
   ENABLE_INSTAGRAM_CHANNEL_HUMAN_AGENT: false,
@@ -113,12 +126,12 @@ const INSTAGRAM_DEFAULTS: InstagramFormData = {
 
 const EVOLUTION_DEFAULTS: EvolutionFormData = {
   EVOLUTION_API_URL: '',
-  EVOLUTION_ADMIN_SECRET: null,
+  EVOLUTION_ADMIN_SECRET: '',
 };
 
 const EVOLUTION_GO_DEFAULTS: EvolutionGoFormData = {
   EVOLUTION_GO_API_URL: '',
-  EVOLUTION_GO_ADMIN_SECRET: null,
+  EVOLUTION_GO_ADMIN_SECRET: '',
   EVOLUTION_GO_INSTANCE_ID: '',
   EVOLUTION_GO_INSTANCE_SECRET: null,
 };
@@ -126,7 +139,7 @@ const EVOLUTION_GO_DEFAULTS: EvolutionGoFormData = {
 const TWITTER_DEFAULTS: TwitterFormData = {
   TWITTER_APP_ID: '',
   TWITTER_CONSUMER_KEY: '',
-  TWITTER_CONSUMER_SECRET: null,
+  TWITTER_CONSUMER_SECRET: '',
   TWITTER_ENVIRONMENT: '',
 };
 
@@ -151,23 +164,30 @@ function toBool(value: unknown): boolean {
   return false;
 }
 
-function buildFormValues<T extends Record<string, unknown>>(
+function buildFormValues<TData extends Record<string, unknown>>(
   data: Record<string, unknown>,
-  defaults: T,
+  defaults: TData,
   secretFields: string[],
   booleanFields: string[],
-): T {
+): TData {
   const formValues: Record<string, unknown> = { ...defaults };
   for (const [key, value] of Object.entries(data)) {
     if (secretFields.includes(key)) {
-      formValues[key] = isSecretMasked(value) ? '' : (value ?? '');
+      // Masked value from backend → fill sentinel so required-string schemas
+      // don't block the admin from saving unrelated fields.
+      formValues[key] = isSecretMasked(value) ? SECRET_SENTINEL : (value ?? '');
     } else if (booleanFields.includes(key)) {
       formValues[key] = toBool(value);
+    } else if (isSecretMasked(value)) {
+      // Defense in depth: a non-secret field should never arrive masked. If it
+      // does (backend misclassification), drop to the default so validation can
+      // surface the missing value instead of echoing the mask back on save.
+      formValues[key] = formValues[key] ?? '';
     } else {
       formValues[key] = value ?? formValues[key] ?? '';
     }
   }
-  return formValues as T;
+  return formValues as TData;
 }
 
 function updateSecretStatus(data: Record<string, unknown>, secretFields: string[]) {
@@ -186,6 +206,10 @@ function buildPayload(
   const payload: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(formData)) {
     if (secretFields.includes(key)) {
+      // Untouched secret field (whether backing sentinel or empty) → null so the
+      // backend preserves its existing value. If the admin *did* type the literal
+      // sentinel string themselves, secretModified[key] is true and we forward
+      // it verbatim — their call.
       if (!secretModified[key] || value === '') {
         payload[key] = null;
       } else {
@@ -200,19 +224,21 @@ function buildPayload(
 
 // --- SecretField subcomponent ---
 
-interface SecretFieldProps<T extends Record<string, unknown>> {
-  fieldName: string & keyof T;
+interface SecretFieldProps<TData extends Record<string, unknown>> {
+  fieldName: string & keyof TData;
   label: string;
   placeholder: string;
-  register: UseFormRegister<T>;
+  register: UseFormRegister<TData>;
   secretModified: Record<string, boolean>;
   onSecretModifiedChange: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
   secretConfigured: Record<string, boolean>;
   onClear: () => void;
   t: (key: string) => string;
+  required?: boolean;
+  error?: string;
 }
 
-function SecretField<T extends Record<string, unknown>>({
+function SecretField<TData extends Record<string, unknown>>({
   fieldName,
   label,
   placeholder,
@@ -222,11 +248,16 @@ function SecretField<T extends Record<string, unknown>>({
   secretConfigured,
   onClear,
   t,
-}: SecretFieldProps<T>) {
+  required,
+  error,
+}: SecretFieldProps<TData>) {
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label htmlFor={fieldName}>{label}</Label>
+        <div className="flex items-center">
+          <Label htmlFor={fieldName}>{label}</Label>
+          {required && <span className="text-destructive ml-1" aria-hidden="true">*</span>}
+        </div>
         {!secretModified[fieldName] && (
           secretConfigured[fieldName] ? (
             <span className="inline-flex items-center gap-1 text-xs text-green-600">
@@ -247,7 +278,9 @@ function SecretField<T extends Record<string, unknown>>({
           type="password"
           autoComplete="off"
           placeholder={placeholder}
-          {...register(fieldName as Path<T>, {
+          aria-required={required || undefined}
+          aria-invalid={error ? true : undefined}
+          {...register(fieldName as Path<TData>, {
             onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
               onSecretModifiedChange((prev) => ({ ...prev, [fieldName]: e.target.value.length > 0 })),
           })}
@@ -264,6 +297,7 @@ function SecretField<T extends Record<string, unknown>>({
           </button>
         )}
       </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   );
 }
@@ -279,17 +313,23 @@ interface TextFieldProps {
   error?: { message?: string };
   type?: string;
   readOnly?: boolean;
+  required?: boolean;
 }
 
-function TextField({ id, label, placeholder, register, error, type, readOnly }: TextFieldProps) {
+function TextField({ id, label, placeholder, register, error, type, readOnly, required }: TextFieldProps) {
   return (
     <div className="space-y-2">
-      <Label htmlFor={id}>{label}</Label>
+      <div className="flex items-center">
+        <Label htmlFor={id}>{label}</Label>
+        {required && <span className="text-destructive ml-1" aria-hidden="true">*</span>}
+      </div>
       <Input
         id={id}
         placeholder={placeholder}
         type={type}
         readOnly={readOnly}
+        aria-required={required || undefined}
+        aria-invalid={error ? true : undefined}
         className={readOnly ? 'bg-muted cursor-not-allowed' : undefined}
         {...register}
       />
@@ -303,18 +343,37 @@ function TextField({ id, label, placeholder, register, error, type, readOnly }: 
 interface ChannelFormCardProps {
   onSubmit: () => void;
   saving: boolean;
+  canSubmit: boolean;
+  saveError: string | null;
+  onDismissError: () => void;
   t: (key: string) => string;
   children: React.ReactNode;
 }
 
-function ChannelFormCard({ onSubmit, saving, t, children }: ChannelFormCardProps) {
+function ChannelFormCard({ onSubmit, saving, canSubmit, saveError, onDismissError, t, children }: ChannelFormCardProps) {
   return (
     <Card>
       <CardContent className="pt-6">
         <form onSubmit={onSubmit} className="space-y-5">
+          {saveError && (
+            <div
+              role="alert"
+              className="flex items-start justify-between gap-3 rounded-md border-2 border-destructive bg-destructive/20 p-4 text-sm font-medium text-destructive shadow-sm"
+            >
+              <span className="whitespace-pre-wrap break-words select-text">{saveError}</span>
+              <button
+                type="button"
+                onClick={onDismissError}
+                aria-label={t('channels.dismissError')}
+                className="shrink-0 rounded p-0.5 text-destructive hover:bg-destructive/20"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          )}
           {children}
           <div className="pt-2">
-            <Button type="submit" disabled={saving}>
+            <Button type="submit" disabled={saving || !canSubmit}>
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {saving ? t('channels.saving') : t('channels.save')}
             </Button>
@@ -378,41 +437,54 @@ export default function ChannelConfig() {
   const [twSecretModified, setTwSecretModified] = useState<Record<string, boolean>>({});
   const [twSecretConfigured, setTwSecretConfigured] = useState<Record<string, boolean>>({});
 
-  const facebookSchema = useMemo(() => createFacebookSchema(), []);
-  const whatsappSchema = useMemo(() => createWhatsappSchema(), []);
-  const instagramSchema = useMemo(() => createInstagramSchema(), []);
-  const evolutionSchema = useMemo(() => createEvolutionSchema(), []);
-  const evolutionGoSchema = useMemo(() => createEvolutionGoSchema(), []);
-  const twitterSchema = useMemo(() => createTwitterSchema(), []);
+  const [fbSaveError, setFbSaveError] = useState<string | null>(null);
+  const [wpSaveError, setWpSaveError] = useState<string | null>(null);
+  const [igSaveError, setIgSaveError] = useState<string | null>(null);
+  const [evoSaveError, setEvoSaveError] = useState<string | null>(null);
+  const [evoGoSaveError, setEvoGoSaveError] = useState<string | null>(null);
+  const [twSaveError, setTwSaveError] = useState<string | null>(null);
+
+  const facebookSchema = useMemo(() => createFacebookSchema(t), [t]);
+  const whatsappSchema = useMemo(() => createWhatsappSchema(t), [t]);
+  const instagramSchema = useMemo(() => createInstagramSchema(t), [t]);
+  const evolutionSchema = useMemo(() => createEvolutionSchema(t), [t]);
+  const evolutionGoSchema = useMemo(() => createEvolutionGoSchema(t), [t]);
+  const twitterSchema = useMemo(() => createTwitterSchema(t), [t]);
 
   const facebookForm = useForm<FacebookFormData>({
     resolver: zodResolver(facebookSchema),
     defaultValues: FACEBOOK_DEFAULTS,
+    mode: 'onChange',
   });
 
   const whatsappForm = useForm<WhatsAppFormData>({
     resolver: zodResolver(whatsappSchema),
     defaultValues: WHATSAPP_DEFAULTS,
+    mode: 'onChange',
   });
 
   const instagramForm = useForm<InstagramFormData>({
     resolver: zodResolver(instagramSchema),
     defaultValues: INSTAGRAM_DEFAULTS,
+    mode: 'onChange',
   });
 
   const evolutionForm = useForm<EvolutionFormData>({
     resolver: zodResolver(evolutionSchema),
     defaultValues: EVOLUTION_DEFAULTS,
+    mode: 'onChange',
   });
 
   const evolutionGoForm = useForm<EvolutionGoFormData>({
     resolver: zodResolver(evolutionGoSchema),
     defaultValues: EVOLUTION_GO_DEFAULTS,
+    mode: 'onChange',
   });
 
   const twitterForm = useForm<TwitterFormData>({
     resolver: zodResolver(twitterSchema),
     defaultValues: TWITTER_DEFAULTS,
+    mode: 'onChange',
   });
 
   const loadConfig = useCallback(async () => {
@@ -463,16 +535,18 @@ export default function ChannelConfig() {
 
   const onSubmitFacebook = async (formData: FacebookFormData) => {
     setSavingFacebook(true);
+    setFbSaveError(null);
     try {
       const payload = buildPayload(formData as Record<string, unknown>, FACEBOOK_SECRET_FIELDS, fbSecretModified);
       const data = await adminConfigService.saveConfig('facebook', payload as AdminConfigData);
       setFbSecretConfigured(updateSecretStatus(data, FACEBOOK_SECRET_FIELDS));
       setFbSecretModified({});
       facebookForm.reset(buildFormValues(data, FACEBOOK_DEFAULTS, FACEBOOK_SECRET_FIELDS, FACEBOOK_BOOLEAN_FIELDS));
+      clearGlobalConfigCache();
       toast.success(t('channels.facebook.saveSuccess'));
     } catch (error) {
       const errorInfo = extractError(error);
-      toast.error(t('channels.facebook.saveError'), { description: errorInfo.message });
+      setFbSaveError(errorInfo.message || t('channels.facebook.saveError'));
     } finally {
       setSavingFacebook(false);
     }
@@ -480,16 +554,18 @@ export default function ChannelConfig() {
 
   const onSubmitWhatsapp = async (formData: WhatsAppFormData) => {
     setSavingWhatsapp(true);
+    setWpSaveError(null);
     try {
       const payload = buildPayload(formData as Record<string, unknown>, WHATSAPP_SECRET_FIELDS, wpSecretModified);
       const data = await adminConfigService.saveConfig('whatsapp', payload as AdminConfigData);
       setWpSecretConfigured(updateSecretStatus(data, WHATSAPP_SECRET_FIELDS));
       setWpSecretModified({});
       whatsappForm.reset(buildFormValues(data, WHATSAPP_DEFAULTS, WHATSAPP_SECRET_FIELDS, []));
+      clearGlobalConfigCache();
       toast.success(t('channels.whatsapp.saveSuccess'));
     } catch (error) {
       const errorInfo = extractError(error);
-      toast.error(t('channels.whatsapp.saveError'), { description: errorInfo.message });
+      setWpSaveError(errorInfo.message || t('channels.whatsapp.saveError'));
     } finally {
       setSavingWhatsapp(false);
     }
@@ -497,16 +573,18 @@ export default function ChannelConfig() {
 
   const onSubmitInstagram = async (formData: InstagramFormData) => {
     setSavingInstagram(true);
+    setIgSaveError(null);
     try {
       const payload = buildPayload(formData as Record<string, unknown>, INSTAGRAM_SECRET_FIELDS, igSecretModified);
       const data = await adminConfigService.saveConfig('instagram', payload as AdminConfigData);
       setIgSecretConfigured(updateSecretStatus(data, INSTAGRAM_SECRET_FIELDS));
       setIgSecretModified({});
       instagramForm.reset(buildFormValues(data, INSTAGRAM_DEFAULTS, INSTAGRAM_SECRET_FIELDS, INSTAGRAM_BOOLEAN_FIELDS));
+      clearGlobalConfigCache();
       toast.success(t('channels.instagram.saveSuccess'));
     } catch (error) {
       const errorInfo = extractError(error);
-      toast.error(t('channels.instagram.saveError'), { description: errorInfo.message });
+      setIgSaveError(errorInfo.message || t('channels.instagram.saveError'));
     } finally {
       setSavingInstagram(false);
     }
@@ -514,16 +592,18 @@ export default function ChannelConfig() {
 
   const onSubmitEvolution = async (formData: EvolutionFormData) => {
     setSavingEvolution(true);
+    setEvoSaveError(null);
     try {
       const payload = buildPayload(formData as Record<string, unknown>, EVOLUTION_SECRET_FIELDS, evoSecretModified);
       const data = await adminConfigService.saveConfig('evolution', payload as AdminConfigData);
       setEvoSecretConfigured(updateSecretStatus(data, EVOLUTION_SECRET_FIELDS));
       setEvoSecretModified({});
       evolutionForm.reset(buildFormValues(data, EVOLUTION_DEFAULTS, EVOLUTION_SECRET_FIELDS, []));
+      clearGlobalConfigCache();
       toast.success(t('channels.evolution.saveSuccess'));
     } catch (error) {
       const errorInfo = extractError(error);
-      toast.error(t('channels.evolution.saveError'), { description: errorInfo.message });
+      setEvoSaveError(errorInfo.message || t('channels.evolution.saveError'));
     } finally {
       setSavingEvolution(false);
     }
@@ -531,16 +611,18 @@ export default function ChannelConfig() {
 
   const onSubmitEvolutionGo = async (formData: EvolutionGoFormData) => {
     setSavingEvolutionGo(true);
+    setEvoGoSaveError(null);
     try {
       const payload = buildPayload(formData as Record<string, unknown>, EVOLUTION_GO_SECRET_FIELDS, evoGoSecretModified);
       const data = await adminConfigService.saveConfig('evolution_go', payload as AdminConfigData);
       setEvoGoSecretConfigured(updateSecretStatus(data, EVOLUTION_GO_SECRET_FIELDS));
       setEvoGoSecretModified({});
       evolutionGoForm.reset(buildFormValues(data, EVOLUTION_GO_DEFAULTS, EVOLUTION_GO_SECRET_FIELDS, []));
+      clearGlobalConfigCache();
       toast.success(t('channels.evolutionGo.saveSuccess'));
     } catch (error) {
       const errorInfo = extractError(error);
-      toast.error(t('channels.evolutionGo.saveError'), { description: errorInfo.message });
+      setEvoGoSaveError(errorInfo.message || t('channels.evolutionGo.saveError'));
     } finally {
       setSavingEvolutionGo(false);
     }
@@ -548,48 +630,50 @@ export default function ChannelConfig() {
 
   const onSubmitTwitter = async (formData: TwitterFormData) => {
     setSavingTwitter(true);
+    setTwSaveError(null);
     try {
       const payload = buildPayload(formData as Record<string, unknown>, TWITTER_SECRET_FIELDS, twSecretModified);
       const data = await adminConfigService.saveConfig('twitter', payload as AdminConfigData);
       setTwSecretConfigured(updateSecretStatus(data, TWITTER_SECRET_FIELDS));
       setTwSecretModified({});
       twitterForm.reset(buildFormValues(data, TWITTER_DEFAULTS, TWITTER_SECRET_FIELDS, []));
+      clearGlobalConfigCache();
       toast.success(t('channels.twitter.saveSuccess'));
     } catch (error) {
       const errorInfo = extractError(error);
-      toast.error(t('channels.twitter.saveError'), { description: errorInfo.message });
+      setTwSaveError(errorInfo.message || t('channels.twitter.saveError'));
     } finally {
       setSavingTwitter(false);
     }
   };
 
   const handleClearFbSecret = (fieldName: keyof FacebookFormData) => {
-    facebookForm.setValue(fieldName, '');
+    facebookForm.setValue(fieldName, '', { shouldValidate: true });
     setFbSecretModified((prev) => ({ ...prev, [fieldName]: true }));
   };
 
   const handleClearWpSecret = (fieldName: keyof WhatsAppFormData) => {
-    whatsappForm.setValue(fieldName, '');
+    whatsappForm.setValue(fieldName, '', { shouldValidate: true });
     setWpSecretModified((prev) => ({ ...prev, [fieldName]: true }));
   };
 
   const handleClearIgSecret = (fieldName: keyof InstagramFormData) => {
-    instagramForm.setValue(fieldName, '');
+    instagramForm.setValue(fieldName, '', { shouldValidate: true });
     setIgSecretModified((prev) => ({ ...prev, [fieldName]: true }));
   };
 
   const handleClearEvoSecret = (fieldName: keyof EvolutionFormData) => {
-    evolutionForm.setValue(fieldName, '');
+    evolutionForm.setValue(fieldName, '', { shouldValidate: true });
     setEvoSecretModified((prev) => ({ ...prev, [fieldName]: true }));
   };
 
   const handleClearEvoGoSecret = (fieldName: keyof EvolutionGoFormData) => {
-    evolutionGoForm.setValue(fieldName, '');
+    evolutionGoForm.setValue(fieldName, '', { shouldValidate: true });
     setEvoGoSecretModified((prev) => ({ ...prev, [fieldName]: true }));
   };
 
   const handleClearTwSecret = (fieldName: keyof TwitterFormData) => {
-    twitterForm.setValue(fieldName, '');
+    twitterForm.setValue(fieldName, '', { shouldValidate: true });
     setTwSecretModified((prev) => ({ ...prev, [fieldName]: true }));
   };
 
@@ -600,6 +684,21 @@ export default function ChannelConfig() {
       </div>
     );
   }
+
+  // submitCount>0 gates inline error rendering; default reValidateMode ('onChange')
+  // then clears/re-shows errors as the user types.
+  const fbErrors = facebookForm.formState.errors;
+  const fbShowErrors = facebookForm.formState.submitCount > 0;
+  const wpErrors = whatsappForm.formState.errors;
+  const wpShowErrors = whatsappForm.formState.submitCount > 0;
+  const igErrors = instagramForm.formState.errors;
+  const igShowErrors = instagramForm.formState.submitCount > 0;
+  const evoErrors = evolutionForm.formState.errors;
+  const evoShowErrors = evolutionForm.formState.submitCount > 0;
+  const evoGoErrors = evolutionGoForm.formState.errors;
+  const evoGoShowErrors = evolutionGoForm.formState.submitCount > 0;
+  const twErrors = twitterForm.formState.errors;
+  const twShowErrors = twitterForm.formState.submitCount > 0;
 
   return (
     <div className="max-w-2xl">
@@ -620,13 +719,21 @@ export default function ChannelConfig() {
 
         {/* Facebook Tab */}
         <TabsContent value="facebook" className="mt-4">
-          <ChannelFormCard onSubmit={facebookForm.handleSubmit(onSubmitFacebook)} saving={savingFacebook} t={t}>
+          <ChannelFormCard
+            onSubmit={facebookForm.handleSubmit(onSubmitFacebook)}
+            saving={savingFacebook}
+            canSubmit={facebookForm.formState.isValid}
+            saveError={fbSaveError}
+            onDismissError={() => setFbSaveError(null)}
+            t={t}
+          >
             <TextField
               id="FB_APP_ID"
               label={t('channels.facebook.fields.appId')}
               placeholder={t('channels.facebook.placeholders.appId')}
               register={facebookForm.register('FB_APP_ID')}
-              error={facebookForm.formState.errors.FB_APP_ID}
+              error={fbShowErrors ? fbErrors.FB_APP_ID : undefined}
+              required
             />
             <TextField
               id="FB_VERIFY_TOKEN"
@@ -634,7 +741,8 @@ export default function ChannelConfig() {
               placeholder={t('channels.facebook.placeholders.verifyToken')}
               type="password"
               register={facebookForm.register('FB_VERIFY_TOKEN')}
-              error={facebookForm.formState.errors.FB_VERIFY_TOKEN}
+              error={fbShowErrors ? fbErrors.FB_VERIFY_TOKEN : undefined}
+              required
             />
             <SecretField<FacebookFormData>
               fieldName="FB_APP_SECRET"
@@ -646,13 +754,15 @@ export default function ChannelConfig() {
               secretConfigured={fbSecretConfigured}
               onClear={() => handleClearFbSecret('FB_APP_SECRET')}
               t={t}
+              required
+              error={fbShowErrors ? fbErrors.FB_APP_SECRET?.message : undefined}
             />
             <TextField
               id="FACEBOOK_API_VERSION"
               label={t('channels.facebook.fields.apiVersion')}
               placeholder={t('channels.facebook.placeholders.apiVersion')}
               register={facebookForm.register('FACEBOOK_API_VERSION')}
-              error={facebookForm.formState.errors.FACEBOOK_API_VERSION}
+              error={fbShowErrors ? fbErrors.FACEBOOK_API_VERSION : undefined}
             />
             <div className="space-y-3 rounded-md border p-4">
               <ToggleField
@@ -671,13 +781,21 @@ export default function ChannelConfig() {
 
         {/* WhatsApp Tab */}
         <TabsContent value="whatsapp" className="mt-4">
-          <ChannelFormCard onSubmit={whatsappForm.handleSubmit(onSubmitWhatsapp)} saving={savingWhatsapp} t={t}>
+          <ChannelFormCard
+            onSubmit={whatsappForm.handleSubmit(onSubmitWhatsapp)}
+            saving={savingWhatsapp}
+            canSubmit={whatsappForm.formState.isValid}
+            saveError={wpSaveError}
+            onDismissError={() => setWpSaveError(null)}
+            t={t}
+          >
             <TextField
               id="WP_APP_ID"
               label={t('channels.whatsapp.fields.appId')}
               placeholder={t('channels.whatsapp.placeholders.appId')}
               register={whatsappForm.register('WP_APP_ID')}
-              error={whatsappForm.formState.errors.WP_APP_ID}
+              error={wpShowErrors ? wpErrors.WP_APP_ID : undefined}
+              required
             />
             <TextField
               id="WP_VERIFY_TOKEN"
@@ -685,7 +803,8 @@ export default function ChannelConfig() {
               placeholder={t('channels.whatsapp.placeholders.verifyToken')}
               type="password"
               register={whatsappForm.register('WP_VERIFY_TOKEN')}
-              error={whatsappForm.formState.errors.WP_VERIFY_TOKEN}
+              error={wpShowErrors ? wpErrors.WP_VERIFY_TOKEN : undefined}
+              required
             />
             <SecretField<WhatsAppFormData>
               fieldName="WP_APP_SECRET"
@@ -697,33 +816,44 @@ export default function ChannelConfig() {
               secretConfigured={wpSecretConfigured}
               onClear={() => handleClearWpSecret('WP_APP_SECRET')}
               t={t}
+              required
+              error={wpShowErrors ? wpErrors.WP_APP_SECRET?.message : undefined}
             />
             <TextField
               id="WP_WHATSAPP_CONFIG_ID"
               label={t('channels.whatsapp.fields.configId')}
               placeholder={t('channels.whatsapp.placeholders.configId')}
               register={whatsappForm.register('WP_WHATSAPP_CONFIG_ID')}
-              error={whatsappForm.formState.errors.WP_WHATSAPP_CONFIG_ID}
+              error={wpShowErrors ? wpErrors.WP_WHATSAPP_CONFIG_ID : undefined}
+              required
             />
             <TextField
               id="WP_API_VERSION"
               label={t('channels.whatsapp.fields.apiVersion')}
               placeholder={t('channels.whatsapp.placeholders.apiVersion')}
               register={whatsappForm.register('WP_API_VERSION')}
-              error={whatsappForm.formState.errors.WP_API_VERSION}
+              error={wpShowErrors ? wpErrors.WP_API_VERSION : undefined}
             />
           </ChannelFormCard>
         </TabsContent>
 
         {/* Instagram Tab */}
         <TabsContent value="instagram" className="mt-4">
-          <ChannelFormCard onSubmit={instagramForm.handleSubmit(onSubmitInstagram)} saving={savingInstagram} t={t}>
+          <ChannelFormCard
+            onSubmit={instagramForm.handleSubmit(onSubmitInstagram)}
+            saving={savingInstagram}
+            canSubmit={instagramForm.formState.isValid}
+            saveError={igSaveError}
+            onDismissError={() => setIgSaveError(null)}
+            t={t}
+          >
             <TextField
               id="INSTAGRAM_APP_ID"
               label={t('channels.instagram.fields.appId')}
               placeholder={t('channels.instagram.placeholders.appId')}
               register={instagramForm.register('INSTAGRAM_APP_ID')}
-              error={instagramForm.formState.errors.INSTAGRAM_APP_ID}
+              error={igShowErrors ? igErrors.INSTAGRAM_APP_ID : undefined}
+              required
             />
             <SecretField<InstagramFormData>
               fieldName="INSTAGRAM_APP_SECRET"
@@ -735,6 +865,8 @@ export default function ChannelConfig() {
               secretConfigured={igSecretConfigured}
               onClear={() => handleClearIgSecret('INSTAGRAM_APP_SECRET')}
               t={t}
+              required
+              error={igShowErrors ? igErrors.INSTAGRAM_APP_SECRET?.message : undefined}
             />
             <TextField
               id="INSTAGRAM_VERIFY_TOKEN"
@@ -742,7 +874,8 @@ export default function ChannelConfig() {
               placeholder={t('channels.instagram.placeholders.verifyToken')}
               type="password"
               register={instagramForm.register('INSTAGRAM_VERIFY_TOKEN')}
-              error={instagramForm.formState.errors.INSTAGRAM_VERIFY_TOKEN}
+              error={igShowErrors ? igErrors.INSTAGRAM_VERIFY_TOKEN : undefined}
+              required
             />
             <TextField
               id="INSTAGRAM_API_VERSION"
@@ -763,13 +896,21 @@ export default function ChannelConfig() {
 
         {/* Evolution Tab */}
         <TabsContent value="evolution" className="mt-4">
-          <ChannelFormCard onSubmit={evolutionForm.handleSubmit(onSubmitEvolution)} saving={savingEvolution} t={t}>
+          <ChannelFormCard
+            onSubmit={evolutionForm.handleSubmit(onSubmitEvolution)}
+            saving={savingEvolution}
+            canSubmit={evolutionForm.formState.isValid}
+            saveError={evoSaveError}
+            onDismissError={() => setEvoSaveError(null)}
+            t={t}
+          >
             <TextField
               id="EVOLUTION_API_URL"
               label={t('channels.evolution.fields.apiUrl')}
               placeholder={t('channels.evolution.placeholders.apiUrl')}
               register={evolutionForm.register('EVOLUTION_API_URL')}
-              error={evolutionForm.formState.errors.EVOLUTION_API_URL}
+              error={evoShowErrors ? evoErrors.EVOLUTION_API_URL : undefined}
+              required
             />
             <SecretField<EvolutionFormData>
               fieldName="EVOLUTION_ADMIN_SECRET"
@@ -781,19 +922,29 @@ export default function ChannelConfig() {
               secretConfigured={evoSecretConfigured}
               onClear={() => handleClearEvoSecret('EVOLUTION_ADMIN_SECRET')}
               t={t}
+              required
+              error={evoShowErrors ? evoErrors.EVOLUTION_ADMIN_SECRET?.message : undefined}
             />
           </ChannelFormCard>
         </TabsContent>
 
         {/* Evolution Go Tab */}
         <TabsContent value="evolution_go" className="mt-4">
-          <ChannelFormCard onSubmit={evolutionGoForm.handleSubmit(onSubmitEvolutionGo)} saving={savingEvolutionGo} t={t}>
+          <ChannelFormCard
+            onSubmit={evolutionGoForm.handleSubmit(onSubmitEvolutionGo)}
+            saving={savingEvolutionGo}
+            canSubmit={evolutionGoForm.formState.isValid}
+            saveError={evoGoSaveError}
+            onDismissError={() => setEvoGoSaveError(null)}
+            t={t}
+          >
             <TextField
               id="EVOLUTION_GO_API_URL"
               label={t('channels.evolutionGo.fields.apiUrl')}
               placeholder={t('channels.evolutionGo.placeholders.apiUrl')}
               register={evolutionGoForm.register('EVOLUTION_GO_API_URL')}
-              error={evolutionGoForm.formState.errors.EVOLUTION_GO_API_URL}
+              error={evoGoShowErrors ? evoGoErrors.EVOLUTION_GO_API_URL : undefined}
+              required
             />
             <SecretField<EvolutionGoFormData>
               fieldName="EVOLUTION_GO_ADMIN_SECRET"
@@ -805,13 +956,15 @@ export default function ChannelConfig() {
               secretConfigured={evoGoSecretConfigured}
               onClear={() => handleClearEvoGoSecret('EVOLUTION_GO_ADMIN_SECRET')}
               t={t}
+              required
+              error={evoGoShowErrors ? evoGoErrors.EVOLUTION_GO_ADMIN_SECRET?.message : undefined}
             />
             <TextField
               id="EVOLUTION_GO_INSTANCE_ID"
               label={t('channels.evolutionGo.fields.instanceId')}
               placeholder={t('channels.evolutionGo.placeholders.instanceId')}
               register={evolutionGoForm.register('EVOLUTION_GO_INSTANCE_ID')}
-              error={evolutionGoForm.formState.errors.EVOLUTION_GO_INSTANCE_ID}
+              error={evoGoShowErrors ? evoGoErrors.EVOLUTION_GO_INSTANCE_ID : undefined}
             />
             <SecretField<EvolutionGoFormData>
               fieldName="EVOLUTION_GO_INSTANCE_SECRET"
@@ -829,20 +982,29 @@ export default function ChannelConfig() {
 
         {/* Twitter Tab */}
         <TabsContent value="twitter" className="mt-4">
-          <ChannelFormCard onSubmit={twitterForm.handleSubmit(onSubmitTwitter)} saving={savingTwitter} t={t}>
+          <ChannelFormCard
+            onSubmit={twitterForm.handleSubmit(onSubmitTwitter)}
+            saving={savingTwitter}
+            canSubmit={twitterForm.formState.isValid}
+            saveError={twSaveError}
+            onDismissError={() => setTwSaveError(null)}
+            t={t}
+          >
             <TextField
               id="TWITTER_APP_ID"
               label={t('channels.twitter.fields.appId')}
               placeholder={t('channels.twitter.placeholders.appId')}
               register={twitterForm.register('TWITTER_APP_ID')}
-              error={twitterForm.formState.errors.TWITTER_APP_ID}
+              error={twShowErrors ? twErrors.TWITTER_APP_ID : undefined}
+              required
             />
             <TextField
               id="TWITTER_CONSUMER_KEY"
               label={t('channels.twitter.fields.consumerKey')}
               placeholder={t('channels.twitter.placeholders.consumerKey')}
               register={twitterForm.register('TWITTER_CONSUMER_KEY')}
-              error={twitterForm.formState.errors.TWITTER_CONSUMER_KEY}
+              error={twShowErrors ? twErrors.TWITTER_CONSUMER_KEY : undefined}
+              required
             />
             <SecretField<TwitterFormData>
               fieldName="TWITTER_CONSUMER_SECRET"
@@ -854,13 +1016,16 @@ export default function ChannelConfig() {
               secretConfigured={twSecretConfigured}
               onClear={() => handleClearTwSecret('TWITTER_CONSUMER_SECRET')}
               t={t}
+              required
+              error={twShowErrors ? twErrors.TWITTER_CONSUMER_SECRET?.message : undefined}
             />
             <TextField
               id="TWITTER_ENVIRONMENT"
               label={t('channels.twitter.fields.environment')}
               placeholder={t('channels.twitter.placeholders.environment')}
               register={twitterForm.register('TWITTER_ENVIRONMENT')}
-              error={twitterForm.formState.errors.TWITTER_ENVIRONMENT}
+              error={twShowErrors ? twErrors.TWITTER_ENVIRONMENT : undefined}
+              required
             />
           </ChannelFormCard>
         </TabsContent>

--- a/src/pages/Customer/Channels/NewChannel/index.tsx
+++ b/src/pages/Customer/Channels/NewChannel/index.tsx
@@ -59,6 +59,9 @@ export default function NewChannel() {
     hasEvolutionGoConfig,
     canFB,
     canWpCloud,
+    canIG,
+    canEmailGoogle,
+    canEmailMicrosoft,
     config,
   } = useChannelForm();
 
@@ -76,11 +79,11 @@ export default function NewChannel() {
               ...provider,
               description:
                 provider.id === 'google'
-                  ? typeof config.googleOAuthClientId === 'string' && config.googleOAuthClientId
+                  ? canEmailGoogle
                     ? t('newChannel.providers.gmail.description')
                     : t('newChannel.messages.googleOAuthNotConfigured')
                   : provider.id === 'microsoft'
-                  ? typeof config.azureAppId === 'string' && config.azureAppId
+                  ? canEmailMicrosoft
                     ? t('newChannel.providers.outlook.description')
                     : t('newChannel.messages.microsoftOAuthNotConfigured')
                   : provider.description,
@@ -89,7 +92,7 @@ export default function NewChannel() {
         }
         return channel;
       }),
-    [config, t],
+    [canEmailGoogle, canEmailMicrosoft, t],
   );
 
   const handleGoBack = () => {
@@ -104,19 +107,31 @@ export default function NewChannel() {
       return toast.error(t('newChannel.messages.facebookConfigMissing'));
     }
     // Check if Instagram configuration is available
-    if (
-      channel.type === 'instagram' &&
-      !(typeof config.instagramAppId === 'string' && config.instagramAppId)
-    ) {
+    if (channel.type === 'instagram' && !canIG) {
       return toast.error(t('newChannel.messages.instagramConfigMissing'));
     }
     handleChannelSelect(channel);
   };
 
   const handleProviderSelectWithValidation = (provider: ProviderType) => {
-    // WhatsApp Cloud uses integrated component
-    if (selectedChannel?.type === 'whatsapp' && provider.id === 'whatsapp_cloud') {
-      if (!canWpCloud) return toast.error(t('newChannel.messages.whatsappCloudConfigMissing'));
+    if (selectedChannel?.type === 'whatsapp') {
+      if (provider.id === 'whatsapp_cloud' && !canWpCloud) {
+        return toast.error(t('newChannel.messages.whatsappCloudConfigMissing'));
+      }
+      if (provider.id === 'evolution' && !hasEvolutionConfig) {
+        return toast.error(t('newChannel.channelGrid.notConfiguredTooltip'));
+      }
+      if (provider.id === 'evolution_go' && !hasEvolutionGoConfig) {
+        return toast.error(t('newChannel.channelGrid.notConfiguredTooltip'));
+      }
+    }
+    if (selectedChannel?.type === 'email') {
+      if (provider.id === 'google' && !canEmailGoogle) {
+        return toast.error(t('newChannel.channelGrid.notConfiguredTooltip'));
+      }
+      if (provider.id === 'microsoft' && !canEmailMicrosoft) {
+        return toast.error(t('newChannel.channelGrid.notConfiguredTooltip'));
+      }
     }
     handleProviderSelect(provider);
   };
@@ -270,7 +285,11 @@ export default function NewChannel() {
             onFormChange={(key, value) => updateForm({ [key]: value })}
             hasEvolutionConfig={hasEvolutionConfig}
             hasEvolutionGoConfig={hasEvolutionGoConfig}
-            canFB={canFB}
+            // CloudWhatsappForm's FB Embedded Signup initializes the SDK with
+            // wpAppId/wpApiVersion and logs in with wpWhatsappConfigId — so this
+            // button is gated by WhatsApp config, not Facebook. Prop name kept
+            // as canFB for backward compat inside the form components.
+            canFB={canWpCloud}
             onWhatsappCloudSuccess={data => {
               const createdId = data?.id ?? data?.payload?.id;
               toast.success(t('newChannel.success.channelCreated'));
@@ -337,6 +356,7 @@ export default function NewChannel() {
               channels={channelTypes}
               onChannelSelect={handleChannelSelectWithValidation}
               canFB={canFB}
+              canIG={canIG}
             />
           </>
 
@@ -349,22 +369,27 @@ export default function NewChannel() {
               channelType={selectedChannel?.type || 'whatsapp'}
               providers={selectedChannel?.providers || []}
               isDisabled={providerId => {
-                if (providerId === 'whatsapp_cloud') return !canWpCloud;
+                if (selectedChannel?.type === 'whatsapp') {
+                  if (providerId === 'whatsapp_cloud') return !canWpCloud;
+                  if (providerId === 'evolution') return !hasEvolutionConfig;
+                  if (providerId === 'evolution_go') return !hasEvolutionGoConfig;
+                }
                 if (selectedChannel?.type === 'email') {
-                  if (providerId === 'google')
-                    return !(
-                      typeof config.googleOAuthClientId === 'string' && config.googleOAuthClientId
-                    );
-                  if (providerId === 'microsoft')
-                    return !(typeof config.azureAppId === 'string' && config.azureAppId);
+                  if (providerId === 'google') return !canEmailGoogle;
+                  if (providerId === 'microsoft') return !canEmailMicrosoft;
                 }
                 return false;
               }}
               disabledTooltip={providerId => {
-                if (providerId === 'whatsapp_cloud' && !canWpCloud) {
-                  return t('newChannel.channelGrid.notConfiguredTooltip');
-                }
-                return undefined;
+                const gated =
+                  (selectedChannel?.type === 'whatsapp' &&
+                    ((providerId === 'whatsapp_cloud' && !canWpCloud) ||
+                      (providerId === 'evolution' && !hasEvolutionConfig) ||
+                      (providerId === 'evolution_go' && !hasEvolutionGoConfig))) ||
+                  (selectedChannel?.type === 'email' &&
+                    ((providerId === 'google' && !canEmailGoogle) ||
+                      (providerId === 'microsoft' && !canEmailMicrosoft)));
+                return gated ? t('newChannel.channelGrid.notConfiguredTooltip') : undefined;
               }}
               onProviderSelect={handleProviderSelectWithValidation}
               onBack={handleGoBack}


### PR DESCRIPTION
- ChannelConfig schemas enforce required essentials per integration with mode:'onChange'; Save disabled while invalid; inline errors only render after the first submit attempt (formState.submitCount>0).
- SecretField gains an error prop and a sentinel so secrets already stored in the DB satisfy required validation without exposing or retransmitting the value; buildPayload maps the sentinel back to null on save.
- Replace save-error toast with a persistent, selectable inline banner in ChannelFormCard so the admin can copy the backend error text.
- Invalidate the GlobalConfig cache after each save and broadcast to listeners so the channel creation flow reflects hasXxxConfig changes without a manual reload.
- useChannelForm reads hasFacebook/hasWhatsapp/hasInstagram/hasTwitter from the backend booleans; email/google and email/microsoft stay on their existing string gates.
- CloudWhatsappForm:
  - SDK effect now depends on wpAppId/wpApiVersion so it waits for the GlobalConfig response before calling FB.init.
  - Drop script.crossOrigin='anonymous' on the SDK script tag here, in FacebookChannelForm and in AuthorizationBanners; Facebook's CDN does not emit the CORS headers it requires and the script failed to load.
  - The FB embedded-signup button on NewChannel is now gated by the WhatsApp config (canWpCloud), because the SDK initializes with wpAppId/wpApiVersion and logs in with wpWhatsappConfigId.
- Add generic i18n keys: common:validation.required (6 locales), channels.dismissError for the banner close button, and cloudWhatsappForm.facebookIntegration.loadingSDK.
- WhatsAppForm under components/integrations/forms keeps two fields marked required as documentation for when that orphan directory is adopted; no page renders it today.