### PR TITLE
feat(frontend): Chatwoot-style global search panel (EVO-969)

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -44,6 +44,7 @@ import GlobalSearchPanel from '../search/GlobalSearchPanel';
 import { BaseFilter } from '@/types/core';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useDebounce } from '@/hooks/useDebounce';
+import chatService from '@/services/chat/chatService';
 import type {
   SearchConversationResult,
   SearchContactResult,
@@ -176,7 +177,7 @@ const ChatSidebar = ({
 
   const handleSelectConversation = useCallback(
     (item: SearchConversationResult) => {
-      navigate(`/conversations/${item.display_id}`);
+      navigate(`/conversations/${item.id}`);
       onSearchChange('');
       setIsSearchPanelOpen(false);
     },
@@ -193,14 +194,25 @@ const ChatSidebar = ({
   );
 
   const handleSelectMessage = useCallback(
-    (item: SearchMessageResult) => {
-      if (item.conversation_id != null) {
-        navigate(`/conversations/${item.conversation_id}`, {
-          state: { scrollToMessageId: item.id },
-        });
-      }
-      onSearchChange('');
+    async (item: SearchMessageResult) => {
       setIsSearchPanelOpen(false);
+      onSearchChange('');
+
+      if (item.conversation_id == null) return;
+
+      try {
+        const raw = await chatService.getConversation(String(item.conversation_id));
+        const envelope = raw as { data?: { uuid?: string; id?: string }; uuid?: string; id?: string } | null;
+        const conv = envelope?.data?.id ? envelope.data : envelope;
+        const uuid = conv?.uuid || conv?.id;
+        if (uuid) {
+          navigate(`/conversations/${uuid}`, {
+            state: { scrollToMessageId: item.id },
+          });
+        }
+      } catch (error) {
+        console.error('Failed to load conversation from message result:', error);
+      }
     },
     [navigate, onSearchChange],
   );

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -31,6 +31,7 @@ import {
   Pin,
   Archive,
 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useChatContext } from '@/contexts/chat/ChatContext';
 import { Conversation, ConversationFilter } from '@/types/chat/api';
 import { formatConversationTime, formatDetailedTime } from '@/utils/time/timeHelpers';
@@ -39,8 +40,15 @@ import { NoConversations } from '../empty-states';
 import ContactAvatar from '../contact/ContactAvatar';
 import ConversationBadges from '../conversation/ConversationBadges';
 import ConversationsFilter from '../conversation/ConversationsFilter';
+import GlobalSearchPanel from '../search/GlobalSearchPanel';
 import { BaseFilter } from '@/types/core';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useDebounce } from '@/hooks/useDebounce';
+import type {
+  SearchConversationResult,
+  SearchContactResult,
+  SearchMessageResult,
+} from '@/types/chat/search';
 
 interface ChatSidebarProps {
   mobileView: 'list' | 'chat';
@@ -149,13 +157,53 @@ const ChatSidebar = ({
     }
   }, [filters.state.activeFilters, conversationFilters]);
 
-  // Debounce da busca para nÃ£o sobrecarregar a API
-  // const debouncedSearchTerm = useDebounce(searchInput, 500);
+  const navigate = useNavigate();
+  const [isSearchPanelOpen, setIsSearchPanelOpen] = useState(false);
+  const debouncedSearchTerm = useDebounce(searchInput, 500);
 
-  // Apply search with debounce
   const handleSearchChange = (value: string) => {
     onSearchChange(value);
+    if (value.trim().length > 0) {
+      setIsSearchPanelOpen(true);
+    }
   };
+
+  const handleSearchFocus = () => {
+    if (searchInput.trim().length > 0) {
+      setIsSearchPanelOpen(true);
+    }
+  };
+
+  const handleSelectConversation = useCallback(
+    (item: SearchConversationResult) => {
+      navigate(`/conversations/${item.display_id}`);
+      onSearchChange('');
+      setIsSearchPanelOpen(false);
+    },
+    [navigate, onSearchChange],
+  );
+
+  const handleSelectContact = useCallback(
+    (item: SearchContactResult) => {
+      navigate(`/contacts/${item.id}`);
+      onSearchChange('');
+      setIsSearchPanelOpen(false);
+    },
+    [navigate, onSearchChange],
+  );
+
+  const handleSelectMessage = useCallback(
+    (item: SearchMessageResult) => {
+      if (item.conversation_id != null) {
+        navigate(`/conversations/${item.conversation_id}`, {
+          state: { scrollToMessageId: item.id },
+        });
+      }
+      onSearchChange('');
+      setIsSearchPanelOpen(false);
+    },
+    [navigate, onSearchChange],
+  );
 
   const handleApplyFilters = async (newFilters: BaseFilter[]) => {
     setConversationFilters(newFilters);
@@ -517,7 +565,17 @@ const ChatSidebar = ({
             placeholder={t('chatSidebar.searchPlaceholder')}
             value={searchInput}
             onChange={e => handleSearchChange(e.target.value)}
+            onFocus={handleSearchFocus}
             className="pl-10"
+          />
+          <GlobalSearchPanel
+            isOpen={isSearchPanelOpen && searchInput.trim().length > 0}
+            searchTerm={debouncedSearchTerm}
+            rawInputValue={searchInput}
+            onClose={() => setIsSearchPanelOpen(false)}
+            onSelectConversation={handleSelectConversation}
+            onSelectContact={handleSelectContact}
+            onSelectMessage={handleSelectMessage}
           />
         </div>
 

--- a/src/components/chat/search/GlobalSearchPanel.spec.tsx
+++ b/src/components/chat/search/GlobalSearchPanel.spec.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GlobalSearchPanel from './GlobalSearchPanel';
+import type { UseGlobalSearchResult } from '@/hooks/chat/useGlobalSearch';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+});
+
+const stableT = (key: string) => key;
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: stableT }),
+}));
+
+const mockUseGlobalSearch = vi.fn<[string], UseGlobalSearchResult>();
+
+vi.mock('@/hooks/chat/useGlobalSearch', () => ({
+  __esModule: true,
+  default: (term: string) => mockUseGlobalSearch(term),
+  useGlobalSearch: (term: string) => mockUseGlobalSearch(term),
+}));
+
+const buildResult = (overrides: Partial<UseGlobalSearchResult> = {}): UseGlobalSearchResult => ({
+  status: 'success',
+  error: null,
+  conversations: [],
+  contacts: [],
+  messages: [],
+  isEmpty: false,
+  term: 'acme',
+  ...overrides,
+});
+
+const conversation = {
+  id: 'c-1',
+  display_id: 123,
+  created_at: 0,
+  message: { id: 1, content: 'hello world', message_type: 0, content_type: 'text', source_id: null, inbox_id: 1, conversation_id: 123, created_at: 0 },
+  contact: { id: 1, name: 'Acme Contact', email: null, phone_number: null, identifier: null },
+  inbox: { id: 1, name: 'Website' },
+  agent: null,
+  additional_attributes: {},
+};
+
+const contact = {
+  id: 42,
+  name: 'Acme Contact',
+  email: 'acme@example.com',
+  phone_number: null,
+  identifier: null,
+};
+
+const message = {
+  id: 999,
+  content: 'Acme mentioned here',
+  message_type: 0,
+  content_type: 'text',
+  source_id: null,
+  inbox_id: 1,
+  conversation_id: 123,
+  created_at: 0,
+  sender: { id: 5, name: 'Operator', type: 'user', available_name: 'Operator' },
+  inbox: { id: 1, name: 'Website' },
+};
+
+describe('GlobalSearchPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGlobalSearch.mockReturnValue(buildResult());
+  });
+
+  const baseProps = {
+    isOpen: true,
+    searchTerm: 'acme',
+    rawInputValue: 'acme',
+    onClose: vi.fn(),
+    onSelectConversation: vi.fn(),
+    onSelectContact: vi.fn(),
+    onSelectMessage: vi.fn(),
+  };
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(<GlobalSearchPanel {...baseProps} isOpen={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows loading state', () => {
+    mockUseGlobalSearch.mockReturnValue(buildResult({ status: 'loading' }));
+    render(<GlobalSearchPanel {...baseProps} />);
+    expect(screen.getByText('globalSearch.loading')).toBeInTheDocument();
+  });
+
+  it('shows error state with custom error message', () => {
+    mockUseGlobalSearch.mockReturnValue(
+      buildResult({ status: 'error', error: 'boom' }),
+    );
+    render(<GlobalSearchPanel {...baseProps} />);
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('shows "noResults" empty state on successful empty search', () => {
+    mockUseGlobalSearch.mockReturnValue(
+      buildResult({ status: 'success', isEmpty: true }),
+    );
+    render(<GlobalSearchPanel {...baseProps} />);
+    expect(screen.getByText('globalSearch.noResults')).toBeInTheDocument();
+  });
+
+  it('renders three sections when all entity types have results', () => {
+    mockUseGlobalSearch.mockReturnValue(
+      buildResult({
+        conversations: [conversation],
+        contacts: [contact],
+        messages: [message],
+      }),
+    );
+    render(<GlobalSearchPanel {...baseProps} />);
+
+    expect(screen.getByText('globalSearch.sections.conversations')).toBeInTheDocument();
+    expect(screen.getByText('globalSearch.sections.contacts')).toBeInTheDocument();
+    expect(screen.getByText('globalSearch.sections.messages')).toBeInTheDocument();
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(3);
+    expect(options[0].textContent).toContain('Acme Contact');
+    expect(options[0].textContent).toContain('#123');
+    expect(options[1].textContent).toContain('acme@example.com');
+    expect(options[2].textContent).toContain('Acme mentioned here');
+  });
+
+  it('invokes onSelectConversation and onClose when a conversation result is clicked', async () => {
+    mockUseGlobalSearch.mockReturnValue(buildResult({ conversations: [conversation] }));
+    const props = { ...baseProps, onSelectConversation: vi.fn(), onClose: vi.fn() };
+    render(<GlobalSearchPanel {...props} />);
+
+    await userEvent.click(screen.getByRole('option'));
+
+    expect(props.onSelectConversation).toHaveBeenCalledWith(conversation);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('invokes onSelectContact and onClose when a contact result is clicked', async () => {
+    mockUseGlobalSearch.mockReturnValue(buildResult({ contacts: [contact] }));
+    const props = { ...baseProps, onSelectContact: vi.fn(), onClose: vi.fn() };
+    render(<GlobalSearchPanel {...props} />);
+
+    await userEvent.click(screen.getByRole('option'));
+
+    expect(props.onSelectContact).toHaveBeenCalledWith(contact);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('invokes onSelectMessage and onClose when a message result is clicked', async () => {
+    mockUseGlobalSearch.mockReturnValue(buildResult({ messages: [message] }));
+    const props = { ...baseProps, onSelectMessage: vi.fn(), onClose: vi.fn() };
+    render(<GlobalSearchPanel {...props} />);
+
+    await userEvent.click(screen.getByRole('option'));
+
+    expect(props.onSelectMessage).toHaveBeenCalledWith(message);
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when the user presses Escape', () => {
+    const props = { ...baseProps, onClose: vi.fn() };
+    render(<GlobalSearchPanel {...props} />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('limits each section to 5 results', () => {
+    const manyConversations = Array.from({ length: 8 }, (_, i) => ({
+      ...conversation,
+      id: `c-${i}`,
+      display_id: 100 + i,
+      contact: { ...conversation.contact!, id: i + 1, name: `Contact ${i}` },
+    }));
+    mockUseGlobalSearch.mockReturnValue(buildResult({ conversations: manyConversations }));
+    render(<GlobalSearchPanel {...baseProps} />);
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(5);
+  });
+});

--- a/src/components/chat/search/GlobalSearchPanel.spec.tsx
+++ b/src/components/chat/search/GlobalSearchPanel.spec.tsx
@@ -177,6 +177,36 @@ describe('GlobalSearchPanel', () => {
     expect(props.onClose).toHaveBeenCalled();
   });
 
+  it('calls onClose when the user clicks outside the panel', () => {
+    const props = { ...baseProps, onClose: vi.fn() };
+    const { container } = render(
+      <>
+        <div data-testid="outside">outside</div>
+        <GlobalSearchPanel {...props} />
+      </>,
+    );
+
+    const outside = container.querySelector('[data-testid="outside"]') as HTMLElement;
+    fireEvent.mouseDown(outside);
+
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('shows per-section empty fallback when only some sections have results', () => {
+    mockUseGlobalSearch.mockReturnValue(
+      buildResult({
+        conversations: [conversation],
+        contacts: [],
+        messages: [],
+      }),
+    );
+    render(<GlobalSearchPanel {...baseProps} />);
+
+    expect(screen.queryByText('globalSearch.sections.conversationsEmpty')).not.toBeInTheDocument();
+    expect(screen.getByText('globalSearch.sections.contactsEmpty')).toBeInTheDocument();
+    expect(screen.getByText('globalSearch.sections.messagesEmpty')).toBeInTheDocument();
+  });
+
   it('limits each section to 5 results', () => {
     const manyConversations = Array.from({ length: 8 }, (_, i) => ({
       ...conversation,

--- a/src/components/chat/search/GlobalSearchPanel.tsx
+++ b/src/components/chat/search/GlobalSearchPanel.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef } from 'react';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandList,
+} from '@evoapi/design-system';
+import { Loader2 } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import useGlobalSearch from '@/hooks/chat/useGlobalSearch';
+import SearchResultConversation from './SearchResultConversation';
+import SearchResultContact from './SearchResultContact';
+import SearchResultMessage from './SearchResultMessage';
+import type {
+  SearchConversationResult,
+  SearchContactResult,
+  SearchMessageResult,
+} from '@/types/chat/search';
+
+const SECTION_DISPLAY_LIMIT = 5;
+
+interface Props {
+  isOpen: boolean;
+  searchTerm: string;
+  rawInputValue: string;
+  onClose: () => void;
+  onSelectConversation: (item: SearchConversationResult) => void;
+  onSelectContact: (item: SearchContactResult) => void;
+  onSelectMessage: (item: SearchMessageResult) => void;
+}
+
+export default function GlobalSearchPanel({
+  isOpen,
+  searchTerm,
+  rawInputValue,
+  onClose,
+  onSelectConversation,
+  onSelectContact,
+  onSelectMessage,
+}: Props) {
+  const { t } = useLanguage('chat');
+  const panelRef = useRef<HTMLDivElement>(null);
+  const { status, error, conversations, contacts, messages, isEmpty, term } =
+    useGlobalSearch(searchTerm);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKey);
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const hasAnyResult =
+    conversations.length > 0 || contacts.length > 0 || messages.length > 0;
+
+  const limitedConversations = conversations.slice(0, SECTION_DISPLAY_LIMIT);
+  const limitedContacts = contacts.slice(0, SECTION_DISPLAY_LIMIT);
+  const limitedMessages = messages.slice(0, SECTION_DISPLAY_LIMIT);
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute top-full left-0 right-0 mt-1 z-50 rounded-md border bg-popover text-popover-foreground shadow-lg overflow-hidden"
+      role="dialog"
+      aria-label={t('globalSearch.ariaLabel')}
+    >
+      <Command shouldFilter={false} className="max-h-[60vh]">
+        {status === 'loading' && (
+          <div className="flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground border-b">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            <span>{t('globalSearch.loading')}</span>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="px-3 py-2 text-sm text-destructive border-b">
+            {error || t('globalSearch.error')}
+          </div>
+        )}
+
+        {status === 'idle' && rawInputValue.trim().length > 0 && rawInputValue.trim().length < 2 && (
+          <div className="px-3 py-4 text-sm text-muted-foreground text-center">
+            {t('globalSearch.typeMoreHint')}
+          </div>
+        )}
+
+        {status === 'idle' && rawInputValue.trim().length === 0 && (
+          <div className="px-3 py-4 text-sm text-muted-foreground text-center">
+            {t('globalSearch.emptyHint')}
+          </div>
+        )}
+
+        <CommandList>
+          {status === 'success' && isEmpty && (
+            <CommandEmpty>{t('globalSearch.noResults')}</CommandEmpty>
+          )}
+
+          {hasAnyResult && limitedConversations.length > 0 && (
+            <CommandGroup heading={t('globalSearch.sections.conversations')}>
+              {limitedConversations.map(item => (
+                <SearchResultConversation
+                  key={`conv-${item.id}`}
+                  item={item}
+                  query={term}
+                  onSelect={result => {
+                    onSelectConversation(result);
+                    onClose();
+                  }}
+                />
+              ))}
+            </CommandGroup>
+          )}
+
+          {hasAnyResult && limitedContacts.length > 0 && (
+            <CommandGroup heading={t('globalSearch.sections.contacts')}>
+              {limitedContacts.map(item => (
+                <SearchResultContact
+                  key={`contact-${item.id}`}
+                  item={item}
+                  query={term}
+                  onSelect={result => {
+                    onSelectContact(result);
+                    onClose();
+                  }}
+                />
+              ))}
+            </CommandGroup>
+          )}
+
+          {hasAnyResult && limitedMessages.length > 0 && (
+            <CommandGroup heading={t('globalSearch.sections.messages')}>
+              {limitedMessages.map(item => (
+                <SearchResultMessage
+                  key={`msg-${item.id}`}
+                  item={item}
+                  query={term}
+                  onSelect={result => {
+                    onSelectMessage(result);
+                    onClose();
+                  }}
+                />
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+  );
+}

--- a/src/components/chat/search/GlobalSearchPanel.tsx
+++ b/src/components/chat/search/GlobalSearchPanel.tsx
@@ -69,9 +69,6 @@ export default function GlobalSearchPanel({
 
   if (!isOpen) return null;
 
-  const hasAnyResult =
-    conversations.length > 0 || contacts.length > 0 || messages.length > 0;
-
   const limitedConversations = conversations.slice(0, SECTION_DISPLAY_LIMIT);
   const limitedContacts = contacts.slice(0, SECTION_DISPLAY_LIMIT);
   const limitedMessages = messages.slice(0, SECTION_DISPLAY_LIMIT);
@@ -114,52 +111,68 @@ export default function GlobalSearchPanel({
             <CommandEmpty>{t('globalSearch.noResults')}</CommandEmpty>
           )}
 
-          {hasAnyResult && limitedConversations.length > 0 && (
-            <CommandGroup heading={t('globalSearch.sections.conversations')}>
-              {limitedConversations.map(item => (
-                <SearchResultConversation
-                  key={`conv-${item.id}`}
-                  item={item}
-                  query={term}
-                  onSelect={result => {
-                    onSelectConversation(result);
-                    onClose();
-                  }}
-                />
-              ))}
-            </CommandGroup>
-          )}
+          {status === 'success' && !isEmpty && (
+            <>
+              <CommandGroup heading={t('globalSearch.sections.conversations')}>
+                {limitedConversations.length === 0 ? (
+                  <div className="px-3 py-2 text-xs text-muted-foreground">
+                    {t('globalSearch.sections.conversationsEmpty')}
+                  </div>
+                ) : (
+                  limitedConversations.map(item => (
+                    <SearchResultConversation
+                      key={`conv-${item.id}`}
+                      item={item}
+                      query={term}
+                      onSelect={result => {
+                        onSelectConversation(result);
+                        onClose();
+                      }}
+                    />
+                  ))
+                )}
+              </CommandGroup>
 
-          {hasAnyResult && limitedContacts.length > 0 && (
-            <CommandGroup heading={t('globalSearch.sections.contacts')}>
-              {limitedContacts.map(item => (
-                <SearchResultContact
-                  key={`contact-${item.id}`}
-                  item={item}
-                  query={term}
-                  onSelect={result => {
-                    onSelectContact(result);
-                    onClose();
-                  }}
-                />
-              ))}
-            </CommandGroup>
-          )}
+              <CommandGroup heading={t('globalSearch.sections.contacts')}>
+                {limitedContacts.length === 0 ? (
+                  <div className="px-3 py-2 text-xs text-muted-foreground">
+                    {t('globalSearch.sections.contactsEmpty')}
+                  </div>
+                ) : (
+                  limitedContacts.map(item => (
+                    <SearchResultContact
+                      key={`contact-${item.id}`}
+                      item={item}
+                      query={term}
+                      onSelect={result => {
+                        onSelectContact(result);
+                        onClose();
+                      }}
+                    />
+                  ))
+                )}
+              </CommandGroup>
 
-          {hasAnyResult && limitedMessages.length > 0 && (
-            <CommandGroup heading={t('globalSearch.sections.messages')}>
-              {limitedMessages.map(item => (
-                <SearchResultMessage
-                  key={`msg-${item.id}`}
-                  item={item}
-                  query={term}
-                  onSelect={result => {
-                    onSelectMessage(result);
-                    onClose();
-                  }}
-                />
-              ))}
-            </CommandGroup>
+              <CommandGroup heading={t('globalSearch.sections.messages')}>
+                {limitedMessages.length === 0 ? (
+                  <div className="px-3 py-2 text-xs text-muted-foreground">
+                    {t('globalSearch.sections.messagesEmpty')}
+                  </div>
+                ) : (
+                  limitedMessages.map(item => (
+                    <SearchResultMessage
+                      key={`msg-${item.id}`}
+                      item={item}
+                      query={term}
+                      onSelect={result => {
+                        onSelectMessage(result);
+                        onClose();
+                      }}
+                    />
+                  ))
+                )}
+              </CommandGroup>
+            </>
           )}
         </CommandList>
       </Command>

--- a/src/components/chat/search/SearchResultContact.tsx
+++ b/src/components/chat/search/SearchResultContact.tsx
@@ -1,0 +1,32 @@
+import { CommandItem } from '@evoapi/design-system';
+import { User } from 'lucide-react';
+import type { SearchContactResult } from '@/types/chat/search';
+import { highlightMatch } from './searchHighlight';
+
+interface Props {
+  item: SearchContactResult;
+  query: string;
+  onSelect: (item: SearchContactResult) => void;
+}
+
+export default function SearchResultContact({ item, query, onSelect }: Props) {
+  const secondary = item.email || item.phone_number || item.identifier || '';
+
+  return (
+    <CommandItem
+      value={`contact-${item.id}`}
+      onSelect={() => onSelect(item)}
+      className="flex items-start gap-3 py-2 cursor-pointer"
+    >
+      <User className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="font-medium truncate">{highlightMatch(item.name, query)}</div>
+        {secondary && (
+          <p className="text-xs text-muted-foreground truncate">
+            {highlightMatch(secondary, query)}
+          </p>
+        )}
+      </div>
+    </CommandItem>
+  );
+}

--- a/src/components/chat/search/SearchResultConversation.tsx
+++ b/src/components/chat/search/SearchResultConversation.tsx
@@ -1,0 +1,40 @@
+import { CommandItem } from '@evoapi/design-system';
+import { MessageSquare } from 'lucide-react';
+import type { SearchConversationResult } from '@/types/chat/search';
+import { highlightMatch } from './searchHighlight';
+
+interface Props {
+  item: SearchConversationResult;
+  query: string;
+  onSelect: (item: SearchConversationResult) => void;
+}
+
+export default function SearchResultConversation({ item, query, onSelect }: Props) {
+  const contactName = item.contact?.name ?? 'Unknown contact';
+  const snippet = item.message?.content ?? '';
+  const inboxName = item.inbox?.name;
+
+  return (
+    <CommandItem
+      value={`conversation-${item.id}`}
+      onSelect={() => onSelect(item)}
+      className="flex items-start gap-3 py-2 cursor-pointer"
+    >
+      <MessageSquare className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-medium truncate">{highlightMatch(contactName, query)}</span>
+          <span className="text-xs text-muted-foreground shrink-0">#{item.display_id}</span>
+        </div>
+        {snippet && (
+          <p className="text-xs text-muted-foreground truncate">{highlightMatch(snippet, query)}</p>
+        )}
+        {inboxName && (
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            {inboxName}
+          </span>
+        )}
+      </div>
+    </CommandItem>
+  );
+}

--- a/src/components/chat/search/SearchResultMessage.tsx
+++ b/src/components/chat/search/SearchResultMessage.tsx
@@ -1,0 +1,36 @@
+import { CommandItem } from '@evoapi/design-system';
+import { MessageCircle } from 'lucide-react';
+import type { SearchMessageResult } from '@/types/chat/search';
+import { highlightMatch } from './searchHighlight';
+
+interface Props {
+  item: SearchMessageResult;
+  query: string;
+  onSelect: (item: SearchMessageResult) => void;
+}
+
+export default function SearchResultMessage({ item, query, onSelect }: Props) {
+  const senderName = item.sender?.available_name || item.sender?.name || 'Unknown';
+  const inboxName = item.inbox?.name;
+  const content = item.content ?? '';
+
+  return (
+    <CommandItem
+      value={`message-${item.id}`}
+      onSelect={() => onSelect(item)}
+      className="flex items-start gap-3 py-2 cursor-pointer"
+    >
+      <MessageCircle className="h-4 w-4 mt-0.5 text-muted-foreground shrink-0" />
+      <div className="min-w-0 flex-1">
+        {content && (
+          <p className="text-sm line-clamp-2">{highlightMatch(content, query)}</p>
+        )}
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="truncate">{senderName}</span>
+          {item.conversation_id != null && <span>· #{item.conversation_id}</span>}
+          {inboxName && <span className="truncate">· {inboxName}</span>}
+        </div>
+      </div>
+    </CommandItem>
+  );
+}

--- a/src/components/chat/search/searchHighlight.tsx
+++ b/src/components/chat/search/searchHighlight.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export const highlightMatch = (text: string | null | undefined, query: string): React.ReactNode => {
+  if (!text) return null;
+  const trimmed = query.trim();
+  if (!trimmed) return text;
+
+  const escaped = trimmed.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`(${escaped})`, 'ig');
+  const parts = text.split(regex);
+
+  return parts.map((part, index) =>
+    regex.test(part) ? (
+      <mark key={index} className="bg-primary/20 text-inherit rounded px-0.5">
+        {part}
+      </mark>
+    ) : (
+      <React.Fragment key={index}>{part}</React.Fragment>
+    ),
+  );
+};

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -148,7 +148,10 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
           return null;
         }
 
-        const conversation = response as unknown as Conversation;
+        const envelope = response as unknown as {
+          data?: Conversation;
+        } & Partial<Conversation>;
+        const conversation = (envelope?.data?.id ? envelope.data : envelope) as unknown as Conversation;
 
         // Validar se conversation é válida
         if (!conversation || !conversation.id) {

--- a/src/hooks/chat/useGlobalSearch.ts
+++ b/src/hooks/chat/useGlobalSearch.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import searchService from '@/services/chat/searchService';
+import type {
+  SearchAllResult,
+  SearchConversationResult,
+  SearchContactResult,
+  SearchMessageResult,
+} from '@/types/chat/search';
+
+const MIN_QUERY_LENGTH = 2;
+
+export type GlobalSearchStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UseGlobalSearchResult {
+  status: GlobalSearchStatus;
+  error: string | null;
+  conversations: SearchConversationResult[];
+  contacts: SearchContactResult[];
+  messages: SearchMessageResult[];
+  isEmpty: boolean;
+  term: string;
+}
+
+const EMPTY_RESULT: SearchAllResult = {
+  conversations: [],
+  contacts: [],
+  messages: [],
+};
+
+export const useGlobalSearch = (searchTerm: string): UseGlobalSearchResult => {
+  const [status, setStatus] = useState<GlobalSearchStatus>('idle');
+  const [result, setResult] = useState<SearchAllResult>(EMPTY_RESULT);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const cancelInFlight = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const term = searchTerm.trim();
+
+    if (term.length < MIN_QUERY_LENGTH) {
+      cancelInFlight();
+      setStatus('idle');
+      setResult(EMPTY_RESULT);
+      setError(null);
+      return;
+    }
+
+    cancelInFlight();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setStatus('loading');
+    setError(null);
+
+    searchService
+      .searchAll({ q: term, page: 1 }, controller.signal)
+      .then(data => {
+        if (controller.signal.aborted) return;
+        setResult({
+          conversations: data.conversations ?? [],
+          contacts: data.contacts ?? [],
+          messages: data.messages ?? [],
+        });
+        setStatus('success');
+      })
+      .catch(err => {
+        if (axios.isCancel(err) || err?.name === 'CanceledError' || err?.name === 'AbortError') {
+          return;
+        }
+        if (controller.signal.aborted) return;
+        const message = err instanceof Error ? err.message : 'Search failed';
+        setError(message);
+        setStatus('error');
+        setResult(EMPTY_RESULT);
+      });
+
+    return () => {
+      controller.abort();
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+      }
+    };
+  }, [searchTerm, cancelInFlight]);
+
+  const isEmpty =
+    status === 'success' &&
+    result.conversations.length === 0 &&
+    result.contacts.length === 0 &&
+    result.messages.length === 0;
+
+  return {
+    status,
+    error,
+    conversations: result.conversations,
+    contacts: result.contacts,
+    messages: result.messages,
+    isEmpty,
+    term: searchTerm.trim(),
+  };
+};
+
+export default useGlobalSearch;

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -917,7 +917,10 @@
     "sections": {
       "conversations": "Conversations",
       "contacts": "Contacts",
-      "messages": "Messages"
+      "messages": "Messages",
+      "conversationsEmpty": "No conversations found",
+      "contactsEmpty": "No contacts found",
+      "messagesEmpty": "No messages found"
     }
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -906,5 +906,18 @@
     "success": {
       "sent": "Template sent successfully!"
     }
+  },
+  "globalSearch": {
+    "ariaLabel": "Global search",
+    "loading": "Searching...",
+    "error": "Search failed. Try again.",
+    "noResults": "No results found",
+    "emptyHint": "Type to search conversations, contacts, and messages",
+    "typeMoreHint": "Type at least 2 characters",
+    "sections": {
+      "conversations": "Conversations",
+      "contacts": "Contacts",
+      "messages": "Messages"
+    }
   }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -894,7 +894,10 @@
     "sections": {
       "conversations": "Conversas",
       "contacts": "Contatos",
-      "messages": "Mensagens"
+      "messages": "Mensagens",
+      "conversationsEmpty": "Nenhuma conversa encontrada",
+      "contactsEmpty": "Nenhum contato encontrado",
+      "messagesEmpty": "Nenhuma mensagem encontrada"
     }
   }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -883,5 +883,18 @@
     "success": {
       "sent": "Template enviado com sucesso!"
     }
+  },
+  "globalSearch": {
+    "ariaLabel": "Busca global",
+    "loading": "Buscando...",
+    "error": "Erro ao buscar. Tente novamente.",
+    "noResults": "Nenhum resultado encontrado",
+    "emptyHint": "Digite para buscar conversas, contatos e mensagens",
+    "typeMoreHint": "Digite pelo menos 2 caracteres",
+    "sections": {
+      "conversations": "Conversas",
+      "contacts": "Contatos",
+      "messages": "Mensagens"
+    }
   }
 }

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -6,7 +6,6 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useChatContext } from '@/contexts/chat/ChatContext';
 import { usePermissions } from '@/contexts/PermissionsContext';
 
-import { useDebounce } from '../../../hooks/useDebounce';
 import { useLanguage } from '@/hooks/useLanguage';
 
 // Hooks customizados
@@ -68,7 +67,7 @@ const Chat = () => {
   const chatContext = useChatContext();
   // Explicitly type conversations to ensure TypeScript recognizes it has 'state'
   const conversations = chatContext.conversations;
-  const { messages, filters, selectedConversation, selectedMessages } = chatContext;
+  const { messages, selectedConversation, selectedMessages } = chatContext;
 
   // 🔒 RACE CONDITION FIX: Ref para rastrear última conversa carregada
   const lastLoadedConversationRef = useRef<string | null>(null);
@@ -102,9 +101,6 @@ const Chat = () => {
   // Dashboard Apps state (lazy loaded, not auto-fetched)
   const [dashboardApps] = useState<DashboardApp[]>([]);
   const [activeTab, setActiveTab] = useState<string>('chat');
-
-  // Debounce da busca para não sobrecarregar a API
-  const debouncedSearchTerm = useDebounce(searchInput, 500);
 
   // Hooks customizados para lógica de negócio
   const conversationHandlers = useConversationHandlers();
@@ -205,26 +201,6 @@ const Chat = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversations.state.selectedConversationId]); // Removido 'messages' para evitar loop
-
-  // Apply search with debounce
-  useEffect(() => {
-    // 🔒 PROTEÇÃO: Só aplicar busca se o usuário realmente digitou algo
-    // Se searchInput ainda está vazio (valor inicial), não fazer nada
-
-    // Só aplicar busca se o usuário interagiu com o campo de busca
-    if (debouncedSearchTerm === undefined || debouncedSearchTerm === '') {
-      return; // Ignorar busca vazia inicial
-    }
-
-    filters.applySearch(
-      debouncedSearchTerm,
-      () => {},
-      error => {
-        console.error('Search error:', error);
-      },
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedSearchTerm]); // Removido 'filters' para evitar loop
 
   // Sincronizar conversa selecionada com URL com debounce
   useEffect(() => {

--- a/src/services/chat/searchService.spec.ts
+++ b/src/services/chat/searchService.spec.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import searchService from './searchService';
+import api from '@/services/core/api';
+
+vi.mock('@/services/core/api', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/retry/retryHelper', () => ({
+  withRetry: <T>(op: () => Promise<T>) => op(),
+}));
+
+describe('searchService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const samplePayload = {
+    conversations: [{ id: 'c-1', display_id: 123 }],
+    contacts: [{ id: 1, name: 'Acme' }],
+    messages: [{ id: 10, content: 'hello' }],
+  };
+
+  it('searchAll hits /search with q + page and unwraps the payload envelope', async () => {
+    const getMock = vi.mocked(api.get);
+    getMock.mockResolvedValue({ data: { payload: samplePayload } } as never);
+
+    const result = await searchService.searchAll({ q: 'acme', page: 2 });
+
+    expect(getMock).toHaveBeenCalledWith('/search', {
+      params: { q: 'acme', page: 2 },
+      signal: undefined,
+    });
+    expect(result).toEqual(samplePayload);
+  });
+
+  it('defaults page to 1 when not provided', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { payload: samplePayload } } as never);
+
+    await searchService.searchAll({ q: 'x' });
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/search',
+      expect.objectContaining({ params: { q: 'x', page: 1 } }),
+    );
+  });
+
+  it('searchConversations hits /search/conversations and unwraps payload', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: { payload: { conversations: samplePayload.conversations } },
+    } as never);
+
+    const result = await searchService.searchConversations({ q: 'acme' });
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/search/conversations',
+      expect.objectContaining({ params: { q: 'acme', page: 1 } }),
+    );
+    expect(result.conversations).toEqual(samplePayload.conversations);
+  });
+
+  it('searchContacts hits /search/contacts and unwraps payload', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: { payload: { contacts: samplePayload.contacts } },
+    } as never);
+
+    const result = await searchService.searchContacts({ q: 'acme' });
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/search/contacts',
+      expect.objectContaining({ params: { q: 'acme', page: 1 } }),
+    );
+    expect(result.contacts).toEqual(samplePayload.contacts);
+  });
+
+  it('searchMessages hits /search/messages and unwraps payload', async () => {
+    vi.mocked(api.get).mockResolvedValue({
+      data: { payload: { messages: samplePayload.messages } },
+    } as never);
+
+    const result = await searchService.searchMessages({ q: 'hello' });
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/search/messages',
+      expect.objectContaining({ params: { q: 'hello', page: 1 } }),
+    );
+    expect(result.messages).toEqual(samplePayload.messages);
+  });
+
+  it('forwards the AbortSignal to axios', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: { payload: samplePayload } } as never);
+
+    const controller = new AbortController();
+    await searchService.searchAll({ q: 'acme' }, controller.signal);
+
+    expect(api.get).toHaveBeenCalledWith(
+      '/search',
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  it('returns the response data as-is when the payload envelope is absent', async () => {
+    vi.mocked(api.get).mockResolvedValue({ data: samplePayload } as never);
+
+    const result = await searchService.searchAll({ q: 'acme' });
+
+    expect(result).toEqual(samplePayload);
+  });
+
+  it('rejects when the underlying request fails', async () => {
+    vi.mocked(api.get).mockRejectedValue(new Error('network down'));
+
+    await expect(searchService.searchAll({ q: 'acme' })).rejects.toThrow('network down');
+  });
+});

--- a/src/services/chat/searchService.ts
+++ b/src/services/chat/searchService.ts
@@ -1,0 +1,78 @@
+import api from '@/services/core/api';
+import { withRetry } from '@/utils/retry/retryHelper';
+import type {
+  SearchAllResult,
+  SearchConversationsResult,
+  SearchContactsResult,
+  SearchMessagesResult,
+  SearchRequestParams,
+} from '@/types/chat/search';
+
+interface ChatwootPayloadEnvelope<T> {
+  payload: T;
+}
+
+const unwrap = <T>(data: unknown): T => {
+  const envelope = data as ChatwootPayloadEnvelope<T> | T;
+  if (envelope && typeof envelope === 'object' && 'payload' in envelope) {
+    return (envelope as ChatwootPayloadEnvelope<T>).payload;
+  }
+  return envelope as T;
+};
+
+class SearchService {
+  async searchAll(
+    params: SearchRequestParams,
+    signal?: AbortSignal,
+  ): Promise<SearchAllResult> {
+    return withRetry(async () => {
+      const response = await api.get('/search', {
+        params: { q: params.q, page: params.page ?? 1 },
+        signal,
+      });
+      return unwrap<SearchAllResult>(response.data);
+    });
+  }
+
+  async searchConversations(
+    params: SearchRequestParams,
+    signal?: AbortSignal,
+  ): Promise<SearchConversationsResult> {
+    return withRetry(async () => {
+      const response = await api.get('/search/conversations', {
+        params: { q: params.q, page: params.page ?? 1 },
+        signal,
+      });
+      return unwrap<SearchConversationsResult>(response.data);
+    });
+  }
+
+  async searchContacts(
+    params: SearchRequestParams,
+    signal?: AbortSignal,
+  ): Promise<SearchContactsResult> {
+    return withRetry(async () => {
+      const response = await api.get('/search/contacts', {
+        params: { q: params.q, page: params.page ?? 1 },
+        signal,
+      });
+      return unwrap<SearchContactsResult>(response.data);
+    });
+  }
+
+  async searchMessages(
+    params: SearchRequestParams,
+    signal?: AbortSignal,
+  ): Promise<SearchMessagesResult> {
+    return withRetry(async () => {
+      const response = await api.get('/search/messages', {
+        params: { q: params.q, page: params.page ?? 1 },
+        signal,
+      });
+      return unwrap<SearchMessagesResult>(response.data);
+    });
+  }
+}
+
+export const searchService = new SearchService();
+export default searchService;

--- a/src/types/chat/search.ts
+++ b/src/types/chat/search.ts
@@ -1,0 +1,76 @@
+import type { Inbox } from './api';
+
+export type SearchScope = 'all' | 'conversations' | 'contacts' | 'messages';
+
+export interface SearchContactResult {
+  id: number | string;
+  name: string;
+  email: string | null;
+  phone_number: string | null;
+  identifier: string | null;
+}
+
+export interface SearchMessageSender {
+  id: number;
+  name: string;
+  type: string;
+  available_name?: string;
+  avatar_url?: string;
+  availability_status?: string;
+  thumbnail?: string;
+}
+
+export interface SearchMessageResult {
+  id: number | string;
+  content: string | null;
+  message_type: number;
+  content_type: string;
+  source_id: string | null;
+  inbox_id: number;
+  conversation_id: number | null;
+  created_at: number;
+  sender?: SearchMessageSender | null;
+  inbox?: Pick<Inbox, 'id' | 'name'> | null;
+}
+
+export interface SearchConversationAgent {
+  id: number;
+  name: string;
+  email?: string;
+  available_name?: string;
+  avatar_url?: string;
+}
+
+export interface SearchConversationResult {
+  id: string;
+  display_id: number;
+  created_at: number;
+  message: SearchMessageResult | null;
+  contact: SearchContactResult | null;
+  inbox: Pick<Inbox, 'id' | 'name'> | null;
+  agent: SearchConversationAgent | null;
+  additional_attributes: Record<string, unknown>;
+}
+
+export interface SearchAllResult {
+  conversations: SearchConversationResult[];
+  contacts: SearchContactResult[];
+  messages: SearchMessageResult[];
+}
+
+export interface SearchConversationsResult {
+  conversations: SearchConversationResult[];
+}
+
+export interface SearchContactsResult {
+  contacts: SearchContactResult[];
+}
+
+export interface SearchMessagesResult {
+  messages: SearchMessageResult[];
+}
+
+export interface SearchRequestParams {
+  q: string;
+  page?: number;
+}


### PR DESCRIPTION
## Summary
- New global search panel anchored below the chat-sidebar input, querying conversations, contacts, and messages via the existing Rails `Api::V1::SearchController` (`/search`, `/search/conversations`, `/search/contacts`, `/search/messages`).
- Replaces the old sidebar-input conversation-filter behavior (the dead `applySearch` useEffect with empty `onSuccess` callback) with a dedicated `cmdk`-based panel grouping results by entity type.
- Backend was already in place — no Rails changes.

## Security
- AuthZ is backend-enforced via `SearchService#accessable_inbox_ids` scoping; frontend reuses the shared `api` axios instance (auth headers attached via interceptors).
- No `dangerouslySetInnerHTML`. Match highlighting splits the string and wraps matches in `<mark>` elements.
- Regex metacharacters in the user query are escaped before constructing the highlight regex.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm lint src/components/chat/search src/hooks/chat/useGlobalSearch.ts src/services/chat/searchService.ts src/components/chat/chat-sidebar/ChatSidebar.tsx src/pages/Customer/Chat/Chat.tsx` — clean
- `pnpm exec vitest run src/services/chat/searchService.spec.ts` — 8 passing
- `pnpm exec vitest run src/components/chat/search/GlobalSearchPanel.spec.tsx` — 12 passing
- `pnpm exec vitest run src/contexts/chat/ConversationsContext.spec.tsx` — 3 passing (no regression)
- Manual smoke: typed in search, saw 3 sections (conversations/contacts/messages), clicked results of each type, ESC and outside-click closed the panel.

## Changed Files
- `src/types/chat/search.ts` (new)
- `src/services/chat/searchService.ts` (new) + `.spec.ts`
- `src/hooks/chat/useGlobalSearch.ts` (new)
- `src/components/chat/search/GlobalSearchPanel.tsx` (new) + `.spec.tsx`
- `src/components/chat/search/SearchResult{Conversation,Contact,Message}.tsx` (new)
- `src/components/chat/search/searchHighlight.tsx` (new)
- `src/components/chat/chat-sidebar/ChatSidebar.tsx` (wire panel + navigation handlers)
- `src/pages/Customer/Chat/Chat.tsx` (remove dead applySearch useEffect + unused imports)
- `src/contexts/chat/ConversationsContext.tsx` (unwrap `{success, data, meta}` envelope in `loadSpecificConversation`)
- `src/i18n/locales/{pt-BR,en}/chat.json` (add `globalSearch.*` keys)

## Linked Issue
- [EVO-969](https://linear.app/evoai/issue/EVO-969/implement-chatwoot-style-global-search-panel-conversations-contacts)