### PR TITLE
fix(frontend): stop hiding unapproved WhatsApp Cloud templates (EVO-1002)

### DIFF
--- a/src/components/chat/message-template/TemplatesPicker.spec.tsx
+++ b/src/components/chat/message-template/TemplatesPicker.spec.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { MessageTemplate } from '@/types/channels/inbox';
+import TemplatesPicker from './TemplatesPicker';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const approved: MessageTemplate = {
+  id: 'approved-1',
+  name: 'ini_approved',
+  content: 'Olá',
+  language: 'pt_BR',
+  category: 'UTILITY',
+  status: 'APPROVED',
+};
+
+const approvedViaSettings: MessageTemplate = {
+  id: 'approved-2',
+  name: 'ini_settings',
+  content: 'Olá',
+  language: 'pt_BR',
+  category: 'UTILITY',
+  settings: { status: 'APPROVED' },
+};
+
+const pendingImplicit: MessageTemplate = {
+  id: 'pending-1',
+  name: 'ini_conversa',
+  content: 'Olá',
+  language: 'pt_BR',
+  category: 'UTILITY',
+  settings: {},
+};
+
+const pendingExplicit: MessageTemplate = {
+  id: 'pending-2',
+  name: 'ini_pending',
+  content: 'Olá',
+  language: 'pt_BR',
+  category: 'UTILITY',
+  status: 'PENDING',
+};
+
+const rejected: MessageTemplate = {
+  id: 'rejected-1',
+  name: 'ini_rejected',
+  content: 'Olá',
+  language: 'pt_BR',
+  category: 'UTILITY',
+  status: 'REJECTED',
+};
+
+const withImageHeader: MessageTemplate = {
+  id: 'image-1',
+  name: 'ini_media',
+  content: 'Olá',
+  language: 'pt_BR',
+  category: 'MARKETING',
+  status: 'APPROVED',
+  components: { header: { type: 'HEADER', format: 'IMAGE' } },
+};
+
+describe('TemplatesPicker', () => {
+  it('renders every template as clickable when isWhatsAppCloud=false regardless of status', () => {
+    const onSelect = vi.fn();
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud={false}
+        templates={[approved, pendingImplicit, rejected]}
+        onSelect={onSelect}
+      />,
+    );
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(3);
+    buttons.forEach(b => expect(b).not.toBeDisabled());
+
+    fireEvent.click(screen.getByText('ini_conversa'));
+    expect(onSelect).toHaveBeenCalledWith(pendingImplicit);
+  });
+
+  it('renders approved template (top-level status) clickable when isWhatsAppCloud=true', () => {
+    const onSelect = vi.fn();
+    render(
+      <TemplatesPicker isWhatsAppCloud templates={[approved]} onSelect={onSelect} />,
+    );
+    const btn = screen.getByRole('button', { name: /ini_approved/ });
+    expect(btn).not.toBeDisabled();
+    fireEvent.click(btn);
+    expect(onSelect).toHaveBeenCalledWith(approved);
+  });
+
+  it('renders approved via settings.status fallback when isWhatsAppCloud=true', () => {
+    const onSelect = vi.fn();
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud
+        templates={[approvedViaSettings]}
+        onSelect={onSelect}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: /ini_settings/ });
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('renders missing-status as visible + disabled + pending badge when isWhatsAppCloud=true', () => {
+    const onSelect = vi.fn();
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud
+        templates={[pendingImplicit]}
+        onSelect={onSelect}
+      />,
+    );
+
+    const btn = screen.getByRole('button', { name: /ini_conversa/ });
+    expect(btn).toBeDisabled();
+    expect(
+      screen.getByText('messageTemplates.picker.status.pending'),
+    ).toBeTruthy();
+
+    fireEvent.click(btn);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('renders explicit PENDING status with pending badge and disabled', () => {
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud
+        templates={[pendingExplicit]}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: /ini_pending/ })).toBeDisabled();
+    expect(
+      screen.getByText('messageTemplates.picker.status.pending'),
+    ).toBeTruthy();
+  });
+
+  it('renders REJECTED with rejected badge and disabled', () => {
+    render(
+      <TemplatesPicker isWhatsAppCloud templates={[rejected]} onSelect={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /ini_rejected/ })).toBeDisabled();
+    expect(
+      screen.getByText('messageTemplates.picker.status.rejected'),
+    ).toBeTruthy();
+  });
+
+  it('excludes templates with unsupported header format (IMAGE/VIDEO/DOCUMENT) entirely', () => {
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud
+        templates={[withImageHeader, approved]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText('ini_media')).toBeNull();
+    expect(screen.getByText('ini_approved')).toBeTruthy();
+  });
+
+  it('search filter narrows visible set by name over approved + pending', () => {
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud
+        templates={[approved, pendingImplicit]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText(
+      'messageTemplates.picker.searchPlaceholder',
+    );
+    fireEvent.change(searchInput, { target: { value: 'conversa' } });
+
+    expect(screen.getByText('ini_conversa')).toBeTruthy();
+    expect(screen.queryByText('ini_approved')).toBeNull();
+  });
+
+  it('empty-state appears only when search yields zero results', () => {
+    render(
+      <TemplatesPicker
+        isWhatsAppCloud
+        templates={[approved]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const searchInput = screen.getByPlaceholderText(
+      'messageTemplates.picker.searchPlaceholder',
+    );
+    fireEvent.change(searchInput, { target: { value: 'zzznothing' } });
+
+    expect(
+      screen.getByText(/messageTemplates\.picker\.noTemplatesFound/),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/chat/message-template/TemplatesPicker.tsx
+++ b/src/components/chat/message-template/TemplatesPicker.tsx
@@ -1,10 +1,15 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Input } from '@evoapi/design-system/input';
 import { Card } from '@evoapi/design-system/card';
 import { Search } from 'lucide-react';
 import type { MessageTemplate } from '@/types/channels/inbox';
 
 import { useLanguage } from '@/hooks/useLanguage';
+import {
+  getStatusBadgeKey,
+  hasUnsupportedFormat,
+  isTemplateSendable,
+} from './templateStatus';
 
 interface TemplatesPickerProps {
   isWhatsAppCloud?: boolean;
@@ -16,38 +21,24 @@ const TemplatesPicker: React.FC<TemplatesPickerProps> = ({ isWhatsAppCloud, temp
   const { t } = useLanguage('chat');
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Filter approved templates without unsupported formats
-  const UNSUPPORTED_FORMATS = ['DOCUMENT', 'IMAGE', 'VIDEO'];
-  const approvedTemplates = templates.filter((template: MessageTemplate) => {
-    if (!isWhatsAppCloud) {
-      return true;
-    }
+  const visibleTemplates = useMemo(
+    () =>
+      isWhatsAppCloud
+        ? templates.filter(template => !hasUnsupportedFormat(template))
+        : templates,
+    [templates, isWhatsAppCloud],
+  );
 
-    const status = template?.settings?.status;
-    if (!status) return false;
-
-    if ((status as string).toLowerCase() !== 'approved') return false;
-    if (template.components) {
-      // Handle both object format (WhatsApp Cloud) and array format (legacy)
-      const hasUnsupportedFormat = Array.isArray(template.components)
-        ? template.components.some(c => c.format && UNSUPPORTED_FORMATS.includes(c.format))
-        : (template.components?.header?.format && UNSUPPORTED_FORMATS.includes(template.components.header.format)) || false;
-      if (hasUnsupportedFormat) return false;
-    }
-    return true;
-  });
-
-  // Filtrar por busca
   const filteredTemplates = useMemo(() => {
     if (!searchQuery.trim()) {
-      return approvedTemplates;
+      return visibleTemplates;
     }
 
     const query = searchQuery.toLowerCase();
-    return approvedTemplates.filter(template =>
-      template.name.toLowerCase().includes(query)
+    return visibleTemplates.filter(template =>
+      template.name.toLowerCase().includes(query),
     );
-  }, [approvedTemplates, searchQuery]);
+  }, [visibleTemplates, searchQuery]);
 
 
   return (
@@ -68,32 +59,56 @@ const TemplatesPicker: React.FC<TemplatesPickerProps> = ({ isWhatsAppCloud, temp
       <Card className="max-h-[300px] overflow-y-auto border border-border">
         <div className="p-2 space-y-2">
           {filteredTemplates.length > 0 ? (
-            filteredTemplates.map((template, index) => (
-              <div key={template.id || index}>
-                <button
-                  onClick={() => onSelect(template)}
-                  className="w-full text-left p-3 rounded-lg hover:bg-accent transition-colors"
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <p className="text-sm font-medium">{template.name}</p>
-                    <span className="inline-block px-2 py-1 text-xs bg-muted rounded-md">
-                      {t('messageTemplates.picker.labels.language')}: {template.language}
-                    </span>
-                  </div>
+            filteredTemplates.map((template, index) => {
+              const isEnabled = isWhatsAppCloud ? isTemplateSendable(template) : true;
+              const badgeKey = isWhatsAppCloud ? getStatusBadgeKey(template) : null;
+              const showBadge = badgeKey !== null && badgeKey !== 'approved';
 
-                  <div>
-                    <p className="text-xs font-medium text-muted-foreground mb-1">
-                      {t('messageTemplates.picker.labels.category')}
-                    </p>
-                    <p className="text-xs">{template.category}</p>
-                  </div>
-                </button>
+              return (
+                <div key={template.id || index}>
+                  <button
+                    type="button"
+                    onClick={() => isEnabled && onSelect(template)}
+                    disabled={!isEnabled}
+                    title={
+                      !isEnabled
+                        ? t('messageTemplates.picker.status.disabledTooltip')
+                        : undefined
+                    }
+                    className={`w-full text-left p-3 rounded-lg transition-colors ${
+                      isEnabled
+                        ? 'hover:bg-accent cursor-pointer'
+                        : 'opacity-60 cursor-not-allowed'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium">{template.name}</p>
+                        {showBadge && (
+                          <span className="inline-block px-2 py-0.5 text-xs rounded-md bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+                            {t(`messageTemplates.picker.status.${badgeKey}`)}
+                          </span>
+                        )}
+                      </div>
+                      <span className="inline-block px-2 py-1 text-xs bg-muted rounded-md">
+                        {t('messageTemplates.picker.labels.language')}: {template.language}
+                      </span>
+                    </div>
 
-                {index < filteredTemplates.length - 1 && (
-                  <div className="border-b border-border my-2 mx-3" />
-                )}
-              </div>
-            ))
+                    <div>
+                      <p className="text-xs font-medium text-muted-foreground mb-1">
+                        {t('messageTemplates.picker.labels.category')}
+                      </p>
+                      <p className="text-xs">{template.category}</p>
+                    </div>
+                  </button>
+
+                  {index < filteredTemplates.length - 1 && (
+                    <div className="border-b border-border my-2 mx-3" />
+                  )}
+                </div>
+              );
+            })
           ) : (
             <div className="p-4 text-center text-sm text-muted-foreground">
               {t('messageTemplates.picker.noTemplatesFound')}{' '}

--- a/src/components/chat/message-template/templateStatus.spec.ts
+++ b/src/components/chat/message-template/templateStatus.spec.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageTemplate } from '@/types/channels/inbox';
+import {
+  UNSUPPORTED_FORMATS,
+  getStatusBadgeKey,
+  getTemplateStatus,
+  hasUnsupportedFormat,
+  isTemplateApproved,
+  isTemplateSendable,
+} from './templateStatus';
+
+const base: MessageTemplate = {
+  name: 'ini_conversa',
+  content: 'Olá, tudo bem?',
+  language: 'pt_BR',
+};
+
+describe('getTemplateStatus', () => {
+  it('reads top-level status and normalizes to lowercase', () => {
+    expect(getTemplateStatus({ ...base, status: 'APPROVED' })).toBe('approved');
+    expect(getTemplateStatus({ ...base, status: 'PENDING' })).toBe('pending');
+  });
+
+  it('falls back to settings.status when top-level is missing', () => {
+    expect(
+      getTemplateStatus({ ...base, settings: { status: 'APPROVED' } }),
+    ).toBe('approved');
+  });
+
+  it('prefers top-level status over settings.status', () => {
+    expect(
+      getTemplateStatus({
+        ...base,
+        status: 'REJECTED',
+        settings: { status: 'APPROVED' },
+      }),
+    ).toBe('rejected');
+  });
+
+  it('returns undefined when neither source has a status', () => {
+    expect(getTemplateStatus({ ...base, settings: {} })).toBeUndefined();
+    expect(getTemplateStatus({ ...base })).toBeUndefined();
+  });
+});
+
+describe('isTemplateApproved', () => {
+  it('returns true only when normalized status is "approved"', () => {
+    expect(isTemplateApproved({ ...base, status: 'APPROVED' })).toBe(true);
+    expect(isTemplateApproved({ ...base, settings: { status: 'approved' } })).toBe(true);
+  });
+
+  it('returns false for any non-approved status and for missing status', () => {
+    expect(isTemplateApproved({ ...base, status: 'PENDING' })).toBe(false);
+    expect(isTemplateApproved({ ...base, status: 'REJECTED' })).toBe(false);
+    expect(isTemplateApproved({ ...base })).toBe(false);
+    expect(isTemplateApproved({ ...base, settings: {} })).toBe(false);
+  });
+});
+
+describe('hasUnsupportedFormat', () => {
+  it('returns false when components is absent', () => {
+    expect(hasUnsupportedFormat({ ...base })).toBe(false);
+  });
+
+  it('detects unsupported header formats in object-shaped components', () => {
+    for (const format of UNSUPPORTED_FORMATS) {
+      expect(
+        hasUnsupportedFormat({
+          ...base,
+          components: { header: { type: 'HEADER', format } },
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it('allows TEXT header format in object-shaped components', () => {
+    expect(
+      hasUnsupportedFormat({
+        ...base,
+        components: { header: { type: 'HEADER', format: 'TEXT' } },
+      }),
+    ).toBe(false);
+  });
+
+  it('detects unsupported formats in array-shaped components', () => {
+    expect(
+      hasUnsupportedFormat({
+        ...base,
+        components: [
+          { type: 'BODY', text: 'hello' },
+          { type: 'HEADER', format: 'IMAGE' },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('allows array-shaped components without media header', () => {
+    expect(
+      hasUnsupportedFormat({
+        ...base,
+        components: [{ type: 'BODY', text: 'hello' }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('isTemplateSendable', () => {
+  it('requires approved + no unsupported format', () => {
+    expect(
+      isTemplateSendable({ ...base, status: 'APPROVED' }),
+    ).toBe(true);
+
+    expect(
+      isTemplateSendable({
+        ...base,
+        status: 'APPROVED',
+        components: { header: { type: 'HEADER', format: 'IMAGE' } },
+      }),
+    ).toBe(false);
+
+    expect(
+      isTemplateSendable({ ...base, status: 'PENDING' }),
+    ).toBe(false);
+
+    expect(isTemplateSendable({ ...base })).toBe(false);
+  });
+});
+
+describe('getStatusBadgeKey', () => {
+  it('maps each normalized status to its key', () => {
+    expect(getStatusBadgeKey({ ...base, status: 'APPROVED' })).toBe('approved');
+    expect(getStatusBadgeKey({ ...base, status: 'PENDING' })).toBe('pending');
+    expect(getStatusBadgeKey({ ...base, status: 'REJECTED' })).toBe('rejected');
+    expect(getStatusBadgeKey({ ...base, status: 'PAUSED' })).toBe('paused');
+    expect(getStatusBadgeKey({ ...base, status: 'INACTIVE' })).toBe('inactive');
+  });
+
+  it('treats missing status as pending (locally-created, awaiting sync)', () => {
+    expect(getStatusBadgeKey({ ...base, settings: {} })).toBe('pending');
+    expect(getStatusBadgeKey({ ...base })).toBe('pending');
+  });
+
+  it('returns "unknown" for unrecognized status values', () => {
+    expect(
+      getStatusBadgeKey({
+        ...base,
+        settings: { status: 'SOMETHING_ELSE' },
+      }),
+    ).toBe('unknown');
+  });
+});

--- a/src/components/chat/message-template/templateStatus.ts
+++ b/src/components/chat/message-template/templateStatus.ts
@@ -1,0 +1,59 @@
+import type { MessageTemplate, MessageTemplateComponent } from '@/types/channels/inbox';
+
+export const UNSUPPORTED_FORMATS = ['DOCUMENT', 'IMAGE', 'VIDEO'] as const;
+
+export type TemplateStatusKey =
+  | 'approved'
+  | 'pending'
+  | 'rejected'
+  | 'paused'
+  | 'inactive'
+  | 'unknown';
+
+export const getTemplateStatus = (template: MessageTemplate): string | undefined => {
+  const fromSettings = (template.settings as Record<string, unknown> | undefined)?.status;
+  const raw = (template.status ?? fromSettings) as string | undefined;
+  return raw?.toLowerCase();
+};
+
+export const isTemplateApproved = (template: MessageTemplate): boolean =>
+  getTemplateStatus(template) === 'approved';
+
+export const hasUnsupportedFormat = (template: MessageTemplate): boolean => {
+  if (!template.components) return false;
+
+  if (Array.isArray(template.components)) {
+    return template.components.some(
+      (c: MessageTemplateComponent) =>
+        !!c.format &&
+        (UNSUPPORTED_FORMATS as readonly string[]).includes(c.format),
+    );
+  }
+
+  const headerFormat = (template.components as Record<string, MessageTemplateComponent | undefined>)
+    ?.header?.format;
+  return !!headerFormat && (UNSUPPORTED_FORMATS as readonly string[]).includes(headerFormat);
+};
+
+export const isTemplateSendable = (template: MessageTemplate): boolean =>
+  isTemplateApproved(template) && !hasUnsupportedFormat(template);
+
+export const getStatusBadgeKey = (template: MessageTemplate): TemplateStatusKey => {
+  const status = getTemplateStatus(template);
+  switch (status) {
+    case 'approved':
+      return 'approved';
+    case 'pending':
+      return 'pending';
+    case 'rejected':
+      return 'rejected';
+    case 'paused':
+      return 'paused';
+    case 'inactive':
+      return 'inactive';
+    case undefined:
+      return 'pending';
+    default:
+      return 'unknown';
+  }
+};

--- a/src/components/contacts/StartConversationModal.spec.tsx
+++ b/src/components/contacts/StartConversationModal.spec.tsx
@@ -1,0 +1,190 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Contact, ContactableInboxes } from '@/types/contacts';
+import type { MessageTemplate } from '@/types/channels/inbox';
+import StartConversationModal from './StartConversationModal';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockGetContactableInboxes = vi.fn();
+vi.mock('@/services/contacts', () => ({
+  contactsService: {
+    getContactableInboxes: (...args: unknown[]) => mockGetContactableInboxes(...args),
+  },
+}));
+
+const mockGetTemplates = vi.fn();
+vi.mock('@/services/channels/messageTemplatesService', () => ({
+  default: {
+    getTemplates: (...args: unknown[]) => mockGetTemplates(...args),
+  },
+}));
+
+vi.mock('@/services/conversations', () => ({
+  conversationAPI: {
+    createConversation: vi.fn(),
+  },
+}));
+
+const contact: Contact = {
+  id: 'contact-1',
+  name: 'Cliente Teste',
+  type: 'person',
+  email: '',
+  phone_number: '+5531900000000',
+  thumbnail: '',
+  avatar: '',
+  avatar_url: '',
+  tax_id: '',
+  website: '',
+  industry: '',
+  created_at: '',
+  updated_at: '',
+  availability_status: 'offline',
+  blocked: false,
+  custom_attributes: {},
+  additional_attributes: {},
+  contact_inboxes: [],
+};
+
+const whatsappCloudInbox: ContactableInboxes = {
+  id: '101',
+  channel_id: 'ch-101',
+  name: 'evolution-suporte',
+  channel_type: 'Channel::Whatsapp',
+  enable_auto_assignment: true,
+  greeting_enabled: false,
+  greeting_message: '',
+  working_hours_enabled: false,
+  out_of_office_message: null,
+  timezone: 'America/Sao_Paulo',
+  enable_email_collect: false,
+  csat_survey_enabled: false,
+  allow_messages_after_resolved: true,
+  auto_assignment_config: {},
+  sender_name_type: 'friendly',
+  business_name: null,
+  avatar_url: '',
+  created_at: 0,
+  updated_at: 0,
+  available: true,
+  can_create_conversation: true,
+  source_id: '+5531900000000',
+  channel: { provider: 'whatsapp_cloud' } as unknown as ContactableInboxes['channel'],
+};
+
+const localPendingTemplate: MessageTemplate = {
+  id: 'tpl-1',
+  name: 'ini_conversa',
+  content: 'Olá, tudo bem?',
+  language: 'pt_BR',
+  category: 'UTILITY',
+  template_type: 'text',
+  settings: {},
+  components: [{ text: 'Olá, tudo bem?', type: 'BODY' }],
+  variables: [],
+  active: true,
+};
+
+const approvedTemplate: MessageTemplate = {
+  id: 'tpl-2',
+  name: 'welcome',
+  content: 'Bem-vindo',
+  language: 'pt_BR',
+  category: 'MARKETING',
+  template_type: 'text',
+  settings: { status: 'APPROVED' },
+  components: [{ text: 'Bem-vindo', type: 'BODY' }],
+  variables: [],
+  active: true,
+};
+
+describe('StartConversationModal — template filtering (EVO-1002)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a pending locally-created template in the selector with a pending badge', async () => {
+    mockGetContactableInboxes.mockResolvedValue([whatsappCloudInbox]);
+    mockGetTemplates.mockResolvedValue({ data: [localPendingTemplate] });
+
+    render(
+      <StartConversationModal open onOpenChange={vi.fn()} contact={contact} />,
+    );
+
+    // The template name is eventually rendered in the selector.
+    await waitFor(() => {
+      expect(screen.getByText('ini_conversa')).toBeTruthy();
+    });
+
+    // The "Pendente" badge copy (i18n key) is rendered alongside the name.
+    expect(
+      screen.getByText('startConversation.templates.statusBadge.pending'),
+    ).toBeTruthy();
+
+    // The "noApproved" warning fires because no template is sendable.
+    expect(
+      screen.getByText(
+        content => typeof content === 'string' && content.includes('startConversation.templates.noApproved'),
+      ),
+    ).toBeTruthy();
+  });
+
+  it('shows the "noneForInbox" warning when the backend returns zero templates', async () => {
+    mockGetContactableInboxes.mockResolvedValue([whatsappCloudInbox]);
+    mockGetTemplates.mockResolvedValue({ data: [] });
+
+    render(
+      <StartConversationModal open onOpenChange={vi.fn()} contact={contact} />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          content =>
+            typeof content === 'string' &&
+            content.includes('startConversation.templates.noneForInbox'),
+        ),
+      ).toBeTruthy();
+    });
+
+    expect(
+      screen.queryByText(
+        content =>
+          typeof content === 'string' &&
+          content.includes('startConversation.templates.noApproved'),
+      ),
+    ).toBeNull();
+  });
+
+  it('does not render the noApproved warning when an approved template exists', async () => {
+    mockGetContactableInboxes.mockResolvedValue([whatsappCloudInbox]);
+    mockGetTemplates.mockResolvedValue({
+      data: [approvedTemplate, localPendingTemplate],
+    });
+
+    render(
+      <StartConversationModal open onOpenChange={vi.fn()} contact={contact} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('welcome')).toBeTruthy();
+    });
+
+    // The pending template is still visible in the list.
+    expect(screen.getByText('ini_conversa')).toBeTruthy();
+
+    // No approved-gate warning because there IS an approved template.
+    expect(
+      screen.queryByText(
+        content =>
+          typeof content === 'string' &&
+          content.includes('startConversation.templates.noApproved'),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/components/contacts/StartConversationModal.tsx
+++ b/src/components/contacts/StartConversationModal.tsx
@@ -25,6 +25,11 @@ import { conversationAPI } from '@/services/conversations';
 import MessageTemplateService from '@/services/channels/messageTemplatesService';
 import { MessageTemplate } from '@/types/channels/inbox';
 import { ConversationCreateData } from '@/types/chat/api';
+import {
+  getStatusBadgeKey,
+  hasUnsupportedFormat,
+  isTemplateSendable,
+} from '../chat/message-template/templateStatus';
 
 interface StartConversationModalProps {
   open: boolean;
@@ -95,45 +100,37 @@ export default function StartConversationModal({
     }
   }, [contact.id]);
 
-  const loadMessageTemplate = useCallback(async () => {
-    if (!selectedInboxId) return;
+  const loadMessageTemplate = useCallback(
+    async (inboxId: string, cloudInbox: boolean, isCancelled: () => boolean) => {
+      setLoadingTemplates(true);
+      try {
+        const response = await MessageTemplateService.getTemplates(inboxId);
 
-    setLoadingTemplates(true);
-    try {
-      const response = await MessageTemplateService.getTemplates(selectedInboxId);
+        if (isCancelled()) return;
 
-      const templates = response?.data || [];
+        const templates = response?.data || [];
 
-      if (!isWhatsAppCloud) {
-        setMessageTemplate(templates);
-        return;
-      }
-
-      // Filter approved templates without unsupported formats
-      const UNSUPPORTED_FORMATS = ['DOCUMENT', 'IMAGE', 'VIDEO'];
-      const approvedTemplates = templates.filter((template: MessageTemplate) => {
-        const status = template?.settings?.status;
-        if (!status) return false;
-
-        if ((status as string).toLowerCase() !== 'approved') return false;
-        if (template.components) {
-          // Handle both object format (WhatsApp Cloud) and array format (legacy)
-          const hasUnsupportedFormat = Array.isArray(template.components)
-            ? template.components.some(c => c.format && UNSUPPORTED_FORMATS.includes(c.format))
-            : (template.components?.header?.format && UNSUPPORTED_FORMATS.includes(template.components.header.format)) || false;
-          if (hasUnsupportedFormat) return false;
+        if (!cloudInbox) {
+          setMessageTemplate(templates);
+          return;
         }
-        return true;
-      });
 
-      setMessageTemplate(approvedTemplates);
-    } catch (error) {
-      console.error('Error loading templates:', error);
-      setMessageTemplate([]);
-    } finally {
-      setLoadingTemplates(false);
-    }
-  }, [selectedInboxId, isWhatsAppCloud]);
+        // Keep pending/unknown templates visible so the user can see why the flow
+        // is blocked. Submit-time guard still requires isTemplateSendable(t).
+        const visible = templates.filter(template => !hasUnsupportedFormat(template));
+        setMessageTemplate(visible);
+      } catch (error) {
+        if (isCancelled()) return;
+        console.error('Error loading templates:', error);
+        setMessageTemplate([]);
+      } finally {
+        if (!isCancelled()) {
+          setLoadingTemplates(false);
+        }
+      }
+    },
+    [],
+  );
 
   // Load available inboxes when modal opens
   useEffect(() => {
@@ -144,21 +141,23 @@ export default function StartConversationModal({
 
   // Load templates when inbox is selected
   useEffect(() => {
-    if (selectedInboxId) {
-      loadMessageTemplate();
-      // Only auto-enable template if it's WhatsApp Cloud (requires template)
-      if (isWhatsAppCloud) {
-        setUseTemplate(true);
-      } else {
-        // For other channels, start with template disabled to allow free message
-        setUseTemplate(false);
-      }
-    } else {
-      setUseTemplate(false);
-    }
-
     setMessageTemplate([]);
     setSelectedTemplate(null);
+
+    if (!selectedInboxId) {
+      setUseTemplate(false);
+      return;
+    }
+
+    // Only auto-enable template if it's WhatsApp Cloud (requires template)
+    setUseTemplate(isWhatsAppCloud);
+
+    let cancelled = false;
+    loadMessageTemplate(selectedInboxId, isWhatsAppCloud, () => cancelled);
+
+    return () => {
+      cancelled = true;
+    };
   }, [selectedInboxId, loadMessageTemplate, isWhatsAppCloud]);
 
   const getChannelIcon = (channelType: string) => {
@@ -212,8 +211,8 @@ export default function StartConversationModal({
     // Validate based on mode
     if (!selectedInboxId) return;
 
-    // WhatsApp Cloud requires template
-    if (isWhatsAppCloud && !selectedTemplate) return;
+    // WhatsApp Cloud requires a Meta-approved template.
+    if (isWhatsAppCloud && !(selectedTemplate && isTemplateSendable(selectedTemplate))) return;
 
     // WhatsApp with template mode requires template selected
     if (isWhatsAppInbox && useTemplate && !selectedTemplate) return;
@@ -405,15 +404,24 @@ export default function StartConversationModal({
             )}
           </div>
 
-          {/* WhatsApp Cloud requires template */}
-          {isWhatsAppCloud && messageTemplates.length === 0 && !loadingTemplates && (
+          {/* WhatsApp Cloud requires a Meta-approved template. Two warning states. */}
+          {isWhatsAppCloud && !loadingTemplates && messageTemplates.length === 0 && (
             <div className="p-3 rounded-md border border-orange-200 bg-orange-50 dark:bg-orange-950/20 dark:border-orange-800">
               <p className="text-sm text-orange-700 dark:text-orange-400">
-                ⚠️ WhatsApp Cloud requer um template aprovado para iniciar a conversa. Nenhum
-                template disponível foi encontrado.
+                ⚠️ {t('startConversation.templates.noneForInbox')}
               </p>
             </div>
           )}
+          {isWhatsAppCloud &&
+            !loadingTemplates &&
+            messageTemplates.length > 0 &&
+            messageTemplates.every(tpl => !isTemplateSendable(tpl)) && (
+              <div className="p-3 rounded-md border border-amber-200 bg-amber-50 dark:bg-amber-950/20 dark:border-amber-800">
+                <p className="text-sm text-amber-700 dark:text-amber-400">
+                  ⚠️ {t('startConversation.templates.noApproved')}
+                </p>
+              </div>
+            )}
 
           {/* Template Selection */}
           {/* Always show template toggle for non-WhatsApp Cloud, even if no templates */}
@@ -421,10 +429,10 @@ export default function StartConversationModal({
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
-                  <Label>{'Usar Template'}</Label>
+                  <Label>{t('startConversation.toggle.label')}</Label>
                   {isWhatsAppCloud && (
                     <p className="text-xs text-muted-foreground mt-1">
-                      WhatsApp Cloud Requer template para iniciar conversa
+                      {t('startConversation.toggle.cloudRequires')}
                     </p>
                   )}
                 </div>
@@ -442,7 +450,9 @@ export default function StartConversationModal({
                     }}
                     disabled={loadingTemplates}
                   >
-                    {useTemplate ? 'Usando Template' : 'Usar Template'}
+                    {useTemplate
+                      ? t('startConversation.toggle.using')
+                      : t('startConversation.toggle.label')}
                   </Button>
                 )}
               </div>
@@ -452,8 +462,7 @@ export default function StartConversationModal({
                   {messageTemplates.length === 0 ? (
                     <div className="p-3 rounded-md border border-yellow-200 bg-yellow-50 dark:bg-yellow-950/20 dark:border-yellow-800">
                       <p className="text-sm text-yellow-700 dark:text-yellow-400">
-                        ⚠️ Nenhum template disponível. Desative "Usar Template" para enviar uma
-                        mensagem livre.
+                        ⚠️ {t('startConversation.templates.noneForInbox')}
                       </p>
                     </div>
                   ) : !selectedTemplate ? (
@@ -503,6 +512,12 @@ export default function StartConversationModal({
                             previewText = bodyComponent?.text || template.content || '';
                           }
 
+                          const cloudBadgeKey = isWhatsAppCloud
+                            ? getStatusBadgeKey(template)
+                            : null;
+                          const showCloudBadge =
+                            cloudBadgeKey !== null && cloudBadgeKey !== 'approved';
+
                           return (
                             <div
                               key={template.id}
@@ -519,7 +534,16 @@ export default function StartConversationModal({
                                 setTemplateParams(params);
                               }}
                             >
-                              <div className="font-medium text-sm">{template.name}</div>
+                              <div className="flex items-center gap-2">
+                                <div className="font-medium text-sm">{template.name}</div>
+                                {showCloudBadge && (
+                                  <Badge variant="outline" className="text-xs">
+                                    {t(
+                                      `startConversation.templates.statusBadge.${cloudBadgeKey}`,
+                                    )}
+                                  </Badge>
+                                )}
+                              </div>
                               <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
                                 {previewText}
                               </div>
@@ -544,6 +568,12 @@ export default function StartConversationModal({
                           Trocar Template
                         </Button>
                       </div>
+
+                      {isWhatsAppCloud && !isTemplateSendable(selectedTemplate) && (
+                        <p className="text-xs text-amber-700 dark:text-amber-400 mt-1">
+                          {t('startConversation.templates.pendingSelectedHint')}
+                        </p>
+                      )}
 
                       {/* Template Variables */}
                       {Object.keys(templateParams).length > 0 && (
@@ -678,8 +708,9 @@ export default function StartConversationModal({
                 loading ||
                   !selectedInboxId ||
                   availableInboxes.length === 0 ||
-                  // WhatsApp Cloud requires template
-                  (isWhatsAppCloud && !selectedTemplate) ||
+                  // WhatsApp Cloud requires a Meta-approved template
+                  (isWhatsAppCloud &&
+                    !(selectedTemplate && isTemplateSendable(selectedTemplate))) ||
                   // WhatsApp with template mode requires template selected
                   (isWhatsAppInbox && useTemplate && !selectedTemplate) ||
                   // WhatsApp with template and variables requires all params filled

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -896,6 +896,15 @@
         "language": "Language",
         "templateBody": "Template Body",
         "category": "Category"
+      },
+      "status": {
+        "approved": "Approved",
+        "pending": "Awaiting approval",
+        "rejected": "Rejected",
+        "paused": "Paused",
+        "inactive": "Inactive",
+        "unknown": "Unknown status",
+        "disabledTooltip": "Templates must be approved by Meta before they can be sent. Open the inbox settings to sync."
       }
     },
     "parser": {

--- a/src/i18n/locales/en/contacts.json
+++ b/src/i18n/locales/en/contacts.json
@@ -638,6 +638,24 @@
       "noChannels": "No channels available for this contact"
     },
     "unavailable": "Unavailable",
+    "templates": {
+      "noneForInbox": "No templates registered for this inbox. Create one in the inbox settings.",
+      "noApproved": "No Meta-approved templates yet. The templates listed are awaiting approval and cannot be sent.",
+      "pendingSelectedHint": "This template has not been approved by Meta yet and cannot be used to start the conversation.",
+      "statusBadge": {
+        "approved": "Approved",
+        "pending": "Pending",
+        "rejected": "Rejected",
+        "paused": "Paused",
+        "inactive": "Inactive",
+        "unknown": "Unknown"
+      }
+    },
+    "toggle": {
+      "label": "Use Template",
+      "cloudRequires": "WhatsApp Cloud requires a template to start the conversation",
+      "using": "Using Template"
+    },
     "actions": {
       "cancel": "Cancel",
       "send": "Start Conversation",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -847,6 +847,15 @@
         "language": "Idioma",
         "templateBody": "Contenido de la Plantilla",
         "category": "Categoría"
+      },
+      "status": {
+        "approved": "Aprobada",
+        "pending": "Esperando aprobación",
+        "rejected": "Rechazada",
+        "paused": "Pausada",
+        "inactive": "Inactiva",
+        "unknown": "Estado desconocido",
+        "disabledTooltip": "Las plantillas deben ser aprobadas por Meta antes de poder enviarse. Abre la configuración del inbox para sincronizar."
       }
     },
     "parser": {

--- a/src/i18n/locales/es/contacts.json
+++ b/src/i18n/locales/es/contacts.json
@@ -630,6 +630,24 @@
       "noChannels": "Ningún canal disponible para este contacto"
     },
     "unavailable": "No disponible",
+    "templates": {
+      "noneForInbox": "No hay plantillas registradas para este inbox. Crea una en la configuración del inbox.",
+      "noApproved": "Aún no hay plantillas aprobadas por Meta. Las plantillas listadas están esperando aprobación y no pueden enviarse.",
+      "pendingSelectedHint": "Esta plantilla aún no ha sido aprobada por Meta y no puede usarse para iniciar la conversación.",
+      "statusBadge": {
+        "approved": "Aprobada",
+        "pending": "Pendiente",
+        "rejected": "Rechazada",
+        "paused": "Pausada",
+        "inactive": "Inactiva",
+        "unknown": "Desconocido"
+      }
+    },
+    "toggle": {
+      "label": "Usar Plantilla",
+      "cloudRequires": "WhatsApp Cloud requiere una plantilla para iniciar la conversación",
+      "using": "Usando Plantilla"
+    },
     "actions": {
       "cancel": "Cancelar",
       "send": "Iniciar Conversación",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -847,6 +847,15 @@
         "language": "Langue",
         "templateBody": "Contenu du Modèle",
         "category": "Catégorie"
+      },
+      "status": {
+        "approved": "Approuvé",
+        "pending": "En attente d'approbation",
+        "rejected": "Rejeté",
+        "paused": "En pause",
+        "inactive": "Inactif",
+        "unknown": "Statut inconnu",
+        "disabledTooltip": "Les modèles doivent être approuvés par Meta avant d'être envoyés. Ouvrez les paramètres de la boîte de réception pour synchroniser."
       }
     },
     "parser": {

--- a/src/i18n/locales/fr/contacts.json
+++ b/src/i18n/locales/fr/contacts.json
@@ -630,6 +630,24 @@
       "noChannels": "Aucun canal disponible pour ce contact"
     },
     "unavailable": "Indisponible",
+    "templates": {
+      "noneForInbox": "Aucun modèle enregistré pour cette boîte de réception. Créez-en un dans les paramètres de la boîte de réception.",
+      "noApproved": "Aucun modèle approuvé par Meta pour l'instant. Les modèles listés sont en attente d'approbation et ne peuvent pas être envoyés.",
+      "pendingSelectedHint": "Ce modèle n'a pas encore été approuvé par Meta et ne peut pas être utilisé pour démarrer la conversation.",
+      "statusBadge": {
+        "approved": "Approuvé",
+        "pending": "En attente",
+        "rejected": "Rejeté",
+        "paused": "En pause",
+        "inactive": "Inactif",
+        "unknown": "Inconnu"
+      }
+    },
+    "toggle": {
+      "label": "Utiliser un Modèle",
+      "cloudRequires": "WhatsApp Cloud nécessite un modèle pour démarrer la conversation",
+      "using": "Utilisation du Modèle"
+    },
     "actions": {
       "cancel": "Annuler",
       "send": "Démarrer la Conversation",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -847,6 +847,15 @@
         "language": "Lingua",
         "templateBody": "Contenuto del Modello",
         "category": "Categoria"
+      },
+      "status": {
+        "approved": "Approvato",
+        "pending": "In attesa di approvazione",
+        "rejected": "Rifiutato",
+        "paused": "In pausa",
+        "inactive": "Inattivo",
+        "unknown": "Stato sconosciuto",
+        "disabledTooltip": "I modelli devono essere approvati da Meta prima di poter essere inviati. Apri le impostazioni dell'inbox per sincronizzare."
       }
     },
     "parser": {

--- a/src/i18n/locales/it/contacts.json
+++ b/src/i18n/locales/it/contacts.json
@@ -630,6 +630,24 @@
       "noChannels": "Nessun canale disponibile per questo contatto"
     },
     "unavailable": "Non disponibile",
+    "templates": {
+      "noneForInbox": "Nessun modello registrato per questa inbox. Creane uno nelle impostazioni dell'inbox.",
+      "noApproved": "Nessun modello approvato da Meta. I modelli elencati sono in attesa di approvazione e non possono essere inviati.",
+      "pendingSelectedHint": "Questo modello non è ancora stato approvato da Meta e non può essere usato per avviare la conversazione.",
+      "statusBadge": {
+        "approved": "Approvato",
+        "pending": "In attesa",
+        "rejected": "Rifiutato",
+        "paused": "In pausa",
+        "inactive": "Inattivo",
+        "unknown": "Sconosciuto"
+      }
+    },
+    "toggle": {
+      "label": "Usa Modello",
+      "cloudRequires": "WhatsApp Cloud richiede un modello per avviare la conversazione",
+      "using": "Modello in Uso"
+    },
     "actions": {
       "cancel": "Annulla",
       "send": "Avvia Conversazione",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -873,6 +873,15 @@
         "language": "Idioma",
         "templateBody": "Conteúdo do Template",
         "category": "Categoria"
+      },
+      "status": {
+        "approved": "Aprovado",
+        "pending": "Aguardando aprovação",
+        "rejected": "Reprovado",
+        "paused": "Pausado",
+        "inactive": "Inativo",
+        "unknown": "Status desconhecido",
+        "disabledTooltip": "Templates precisam ser aprovados pela Meta antes de serem enviados. Acesse as configurações do inbox para sincronizar."
       }
     },
     "parser": {

--- a/src/i18n/locales/pt-BR/contacts.json
+++ b/src/i18n/locales/pt-BR/contacts.json
@@ -638,6 +638,24 @@
       "noChannels": "Nenhum canal disponível para este contato"
     },
     "unavailable": "Indisponível",
+    "templates": {
+      "noneForInbox": "Não há templates cadastrados para este inbox. Crie um template nas configurações.",
+      "noApproved": "Nenhum template aprovado pela Meta. Os templates listados aguardam aprovação e não podem ser enviados ainda.",
+      "pendingSelectedHint": "Este template ainda não foi aprovado pela Meta e não pode ser usado para iniciar a conversa.",
+      "statusBadge": {
+        "approved": "Aprovado",
+        "pending": "Pendente",
+        "rejected": "Reprovado",
+        "paused": "Pausado",
+        "inactive": "Inativo",
+        "unknown": "Desconhecido"
+      }
+    },
+    "toggle": {
+      "label": "Usar Template",
+      "cloudRequires": "WhatsApp Cloud requer template para iniciar conversa",
+      "using": "Usando Template"
+    },
     "actions": {
       "cancel": "Cancelar",
       "send": "Iniciar Conversa",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -866,6 +866,15 @@
         "language": "Idioma",
         "templateBody": "Conteúdo do Template",
         "category": "Categoria"
+      },
+      "status": {
+        "approved": "Aprovado",
+        "pending": "A aguardar aprovação",
+        "rejected": "Rejeitado",
+        "paused": "Pausado",
+        "inactive": "Inativo",
+        "unknown": "Estado desconhecido",
+        "disabledTooltip": "Os templates precisam de ser aprovados pela Meta antes de serem enviados. Aceda às definições da caixa de entrada para sincronizar."
       }
     },
     "parser": {

--- a/src/i18n/locales/pt/contacts.json
+++ b/src/i18n/locales/pt/contacts.json
@@ -638,6 +638,24 @@
       "noChannels": "Nenhum canal disponível para este contato"
     },
     "unavailable": "Indisponível",
+    "templates": {
+      "noneForInbox": "Não há templates registados para esta caixa de entrada. Crie um nas definições da caixa de entrada.",
+      "noApproved": "Nenhum template aprovado pela Meta. Os templates listados aguardam aprovação e não podem ser enviados ainda.",
+      "pendingSelectedHint": "Este template ainda não foi aprovado pela Meta e não pode ser usado para iniciar a conversa.",
+      "statusBadge": {
+        "approved": "Aprovado",
+        "pending": "Pendente",
+        "rejected": "Rejeitado",
+        "paused": "Pausado",
+        "inactive": "Inativo",
+        "unknown": "Desconhecido"
+      }
+    },
+    "toggle": {
+      "label": "Usar Template",
+      "cloudRequires": "WhatsApp Cloud requer template para iniciar conversa",
+      "using": "A usar Template"
+    },
     "actions": {
       "cancel": "Cancelar",
       "send": "Iniciar Conversa",


### PR DESCRIPTION
## Summary

- Extract a shared `templateStatus.ts` utility (`getTemplateStatus`, `isTemplateApproved`, `isTemplateSendable`, `hasUnsupportedFormat`, `getStatusBadgeKey`) consumed by both modals; reads `template.status` with fallback to `template.settings?.status` (case-insensitive).
- `TemplatesPicker.tsx` now renders pending/rejected/unknown templates with a status badge and `disabled` state instead of hiding them. Approved templates remain clickable.
- `StartConversationModal.tsx` stops silently dropping non-approved templates; displays them with a status badge, adds i18n-ized warning copy for the two real states ("no templates at all" vs "no approved templates"), and shows a hint when a pending template is selected. Submit guard preserved: Meta approval still required to initiate conversations (no behavior change for the Meta constraint).
- i18n keys added across all six locales (`en`, `es`, `fr`, `it`, `pt`, `pt-BR`) under `messageTemplates.picker.status.*` and `startConversation.templates.*` / `startConversation.toggle.*`.

## Root cause (corrigindo a hipótese da issue)

The Linear issue attributed the bug to the envelope `{ success, data, meta }` not being unwrapped — following the EVO-969 pattern. **That hypothesis is incorrect.** Evidence:
- `messageTemplatesService.ts:133` already calls `extractResponse<MessageTemplate>(response)`.
- `MessageTemplateModal.tsx:74` and `StartConversationModal.tsx:105` read the unwrapped `response?.data` correctly.

The real cause was a filter (duplicated in both modals) that required `template.settings.status?.toLowerCase() === 'approved'` for WhatsApp Cloud. Locally-created templates with `settings: {}` (status only populated on Meta sync) were silently dropped.

Pairs with backend PR: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/new/davidson/evo-1002-message-templates-modal-shows-empty-state-despite-api (optional, adds `status` top-level in `#serialized`; frontend already handles both shapes).

## Adversarial review — fixes applied

- **F1 (Critical):** Race on rapid inbox switch — added cancellation guard to the template-load effect.
- **F4 (High):** Submit button now shows `disabled` visual state when no approved template is selected (previously silently `return`ed).
- **F9 (Medium):** `visibleTemplates` short-circuits when `!isWhatsAppCloud` (don't apply unsupported-format filter to non-Cloud channels, preserving prior behavior).
- **F10 (Low, backend PR):** Defensive `settings.is_a?(Hash)` guard on serializer.

## Deferred (follow-up)

- **F3:** Pre-existing hardcoded PT strings in the "Iniciar Conversa" template selector (`"Selecione um Template"`, `"Trocar Template"`, `"Preencha as Variáveis"`, `"Template de email visual"`). Not in scope for EVO-1002; tracked as follow-up.
- **F6:** Provider detection uses negative list (`!['baileys','evolution','evolution_go']`); consider inverting to explicit allowlist in a follow-up.
- **F7:** `<div onClick>` cards in the template selector need proper `<button role>` + keyboard support (pre-existing accessibility debt).

## Test plan

- [x] `src/components/chat/message-template/templateStatus.spec.ts` — 15 unit tests covering status sources, normalization, format detection, and badge keys.
- [x] `src/components/chat/message-template/TemplatesPicker.spec.tsx` — 9 tests covering status permutations × `isWhatsAppCloud`, search filter, empty state.
- [x] `src/components/contacts/StartConversationModal.spec.tsx` — 3 integration tests covering the bug scenario (pending local template visible with badge), empty backend, and mixed approved+pending.
- [x] Full frontend suite: `173 passed / 0 failed`.
- [ ] Manual QA: WhatsApp Cloud inbox with locally-created unsynced template → visible with "Aguardando aprovação" badge, disabled; approved template → clickable and submit enabled; non-Cloud channel → unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update WhatsApp Cloud template handling to show non-approved templates with status badges while still enforcing Meta approval for sending, and centralize template status logic in a shared utility.

New Features:
- Display WhatsApp Cloud templates in pending or rejected states with badges and disabled interactions instead of hiding them in the template selector and start conversation modal.

Bug Fixes:
- Fix WhatsApp Cloud flows dropping locally-created templates without status by no longer filtering strictly to approved templates in the frontend and instead blocking only at send time.

Enhancements:
- Introduce a shared templateStatus utility for status normalization, sendability checks, and unsupported format detection reused by template picker and start conversation modal.
- Improve UX in the start conversation modal with clearer warnings for missing or non-approved templates and a visible disabled state for the submit button when no sendable template is selected.

Tests:
- Add unit tests for templateStatus utilities covering status precedence, normalization, and media format handling.
- Add tests for TemplatesPicker to cover WhatsApp Cloud status permutations, search filtering, and unsupported format exclusion.
- Add integration tests for StartConversationModal to validate visibility and warnings for pending and approved templates in WhatsApp Cloud flows.