### PR TITLE
ci: also build and publish develop images for staging

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Build & Publish Docker Image
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     tags: ["v*.*.*"]
 
 permissions:
@@ -99,6 +99,8 @@ jobs:
             TAGS="${IMAGE}:${VERSION},${IMAGE}:latest"
           elif [[ "${GH_REF}" == refs/heads/main ]]; then
             TAGS="${IMAGE}:latest,${IMAGE}:main-${SHA_SHORT}"
+          elif [[ "${GH_REF}" == refs/heads/develop ]]; then
+            TAGS="${IMAGE}:develop,${IMAGE}:develop-${SHA_SHORT}"
           fi
 
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- Extend `docker-publish.yml` to also trigger on pushes to `develop`.
- Publish two tags from develop pushes: `develop` (moving tag, always latest of develop) and `develop-<sha>` (immutable per-commit tag).
- No change to `main` or `v*.*.*` behavior — additive only.

Mirrors the tagging pattern already in use by the monorepo's `gateway-publish.yml` (see `EvolutionAPI/evo-crm-community` repo).

## Motivation

Staging environments currently have no pre-merge image to pull: develop builds never publish. This blocks smoke-testing before the next main release and creates pressure to merge straight to main for anything that needs validation in a real cluster.

## Test plan

- [ ] Merge to develop → workflow runs → Docker Hub gets `:develop` and `:develop-<sha>` tags.
- [ ] Merge to main → workflow runs → `:latest` and `:main-<sha>` (unchanged).
- [ ] Tag `v*.*.*` → `:<version>` and `:latest` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable Docker image builds and publishes from both main and develop branches, adding develop-specific tagging while preserving existing main and release tag behavior.

Build:
- Trigger the docker-publish workflow on pushes to the develop branch in addition to main.
- Publish develop branch images with both a moving :develop tag and an immutable :develop-<sha> tag alongside existing main and version tag schemes.