### PR TITLE
fix(frontend): show real Meta approval status on template management table (EVO-1002 follow-up)

### DIFF
--- a/src/components/channels/settings/MessageTemplateForm.tsx
+++ b/src/components/channels/settings/MessageTemplateForm.tsx
@@ -46,6 +46,7 @@ import MessageTemplateService, {
 } from '@/services/channels/messageTemplatesService';
 import { TemplatePreview } from './TemplatePreview';
 import { MessageTemplate, TemplateFormData } from '@/types';
+import { getStatusBadgeKey } from '@/components/chat/message-template/templateStatus';
 
 interface MessageTemplateFormProps {
   inboxId: string;
@@ -636,36 +637,24 @@ const MessageTemplateForm: React.FC<MessageTemplateFormProps> = ({
     setShowDeleteConfirm(true);
   };
 
-  const getStatusBadge = (status?: string) => {
-    const statusConfig: Record<string, { color: string; text: string }> = {
-      APPROVED: {
-        color: 'bg-green-600 dark:bg-green-500 text-white',
-        text: t('settings.messageTemplates.status.approved'),
-      },
-      PENDING: {
-        color: 'bg-yellow-600 dark:bg-yellow-500 text-white',
-        text: t('settings.messageTemplates.status.pending'),
-      },
-      REJECTED: {
-        color: 'bg-red-600 dark:bg-red-500 text-white',
-        text: t('settings.messageTemplates.status.rejected'),
-      },
-      PAUSED: {
-        color: 'bg-gray-600 dark:bg-gray-500 text-white',
-        text: t('settings.messageTemplates.status.paused'),
-      },
-      ACTIVE: {
-        color: 'bg-green-600 dark:bg-green-500 text-white',
-        text: t('settings.messageTemplates.status.active'),
-      },
-      INACTIVE: {
-        color: 'bg-gray-600 dark:bg-gray-500 text-white',
-        text: t('settings.messageTemplates.status.inactive'),
-      },
+  const getStatusBadge = (template: MessageTemplate) => {
+    // Read from the canonical top-level `status` field, falling back to
+    // `settings.status` (populated by Meta sync on WhatsApp Cloud). Missing
+    // status means the template was created locally and never submitted
+    // upstream — render as "Aguardando aprovação", never as "Ativo" (which
+    // would reflect `active` — a different field).
+    const key = getStatusBadgeKey(template);
+    const styleByKey: Record<string, string> = {
+      approved: 'bg-green-600 dark:bg-green-500 text-white',
+      pending: 'bg-yellow-600 dark:bg-yellow-500 text-white',
+      rejected: 'bg-red-600 dark:bg-red-500 text-white',
+      paused: 'bg-gray-600 dark:bg-gray-500 text-white',
+      inactive: 'bg-gray-600 dark:bg-gray-500 text-white',
+      unknown: 'bg-gray-400 dark:bg-gray-600 text-white',
     };
-
-    const config = statusConfig[status || 'ACTIVE'] || statusConfig.ACTIVE;
-    return <Badge className={config.color}>{config.text}</Badge>;
+    const text = t(`settings.messageTemplates.status.${key}`);
+    const color = styleByKey[key] ?? styleByKey.unknown;
+    return <Badge className={color}>{text}</Badge>;
   };
 
   const getCategoryBadge = (category?: string) => {
@@ -821,7 +810,7 @@ const MessageTemplateForm: React.FC<MessageTemplateFormProps> = ({
                 <TableRow key={template.id}>
                   <TableCell className="font-medium">{template.name}</TableCell>
                   <TableCell>{getCategoryBadge(template.category)}</TableCell>
-                  <TableCell>{getStatusBadge(template.status)}</TableCell>
+                  <TableCell>{getStatusBadge(template)}</TableCell>
                   <TableCell>{template.language}</TableCell>
                   <TableCell>
                     {template.created_at

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -710,11 +710,12 @@
       },
       "status": {
         "approved": "Approved",
-        "pending": "Pending",
+        "pending": "Awaiting approval",
         "rejected": "Rejected",
         "paused": "Paused",
         "active": "Active",
-        "inactive": "Inactive"
+        "inactive": "Inactive",
+        "unknown": "Unknown status"
       },
       "preview": {
         "title": "Preview",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -692,11 +692,12 @@
       },
       "status": {
         "approved": "Aprobado",
-        "pending": "Pendiente",
+        "pending": "Esperando aprobación",
         "rejected": "Rechazado",
         "paused": "Pausado",
         "active": "Activo",
-        "inactive": "Inactivo"
+        "inactive": "Inactivo",
+        "unknown": "Estado desconocido"
       },
       "preview": {
         "title": "Vista Previa",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -669,11 +669,12 @@
       },
       "status": {
         "approved": "Approuvé",
-        "pending": "En Attente",
+        "pending": "En attente d'approbation",
         "rejected": "Rejeté",
         "paused": "En Pause",
         "active": "Actif",
-        "inactive": "Inactif"
+        "inactive": "Inactif",
+        "unknown": "Statut inconnu"
       },
       "preview": {
         "title": "Aperçu",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -669,11 +669,12 @@
       },
       "status": {
         "approved": "Approvato",
-        "pending": "In Attesa",
+        "pending": "In attesa di approvazione",
         "rejected": "Rifiutato",
         "paused": "In Pausa",
         "active": "Attivo",
-        "inactive": "Inattivo"
+        "inactive": "Inattivo",
+        "unknown": "Stato sconosciuto"
       },
       "preview": {
         "title": "Anteprima",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -709,11 +709,12 @@
       },
       "status": {
         "approved": "Aprovado",
-        "pending": "Pendente",
-        "rejected": "Rejeitado",
+        "pending": "Aguardando aprovação",
+        "rejected": "Reprovado",
         "paused": "Pausado",
         "active": "Ativo",
-        "inactive": "Inativo"
+        "inactive": "Inativo",
+        "unknown": "Status desconhecido"
       },
       "preview": {
         "title": "Visualização",

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -709,11 +709,12 @@
       },
       "status": {
         "approved": "Aprovado",
-        "pending": "Pendente",
+        "pending": "A aguardar aprovação",
         "rejected": "Rejeitado",
         "paused": "Pausado",
         "active": "Ativo",
-        "inactive": "Inativo"
+        "inactive": "Inativo",
+        "unknown": "Estado desconhecido"
       },
       "preview": {
         "title": "Visualização",


### PR DESCRIPTION
## Summary

- Rewrite `getStatusBadge` in `MessageTemplateForm.tsx` to use the shared `getStatusBadgeKey` utility introduced in #19. Reads `template.status` (top-level) with fallback to `template.settings?.status`, normalized to lower-case — same classification as the composer picker and "Iniciar Conversa" modal.
- Missing status now maps to `pending` ("Aguardando aprovação"), never silently falls back to `ACTIVE`.
- Add `unknown` i18n key to all six locale files (`en/es/fr/it/pt/pt-BR`) under `settings.messageTemplates.status.unknown` so unrecognized status values render a user-readable label instead of leaking the raw enum.
- Swap `"pending"` copy from "Pendente" to "Aguardando aprovação" across all locales to match the copy used in the picker and start-conversation warnings. Consistency across surfaces.

## Root cause

The previous `getStatusBadge(status?: string)` did `statusConfig[status || 'ACTIVE']`. When the backend returned `status: null` (default for locally-created templates before #10 merged / before upstream sync happens), the lookup fell through to the `ACTIVE` key → green "Ativo" badge. Users had no way to tell which templates were actually sendable vs. waiting on Meta approval.

Pairs with:
- https://github.com/EvolutionAPI/evo-auth-service-community/pull/5 — unblocks edit/delete of templates (403 fix).
- https://github.com/EvolutionAPI/evo-ai-crm-community/pull/12 — ensures `status` actually gets populated by submitting templates to Meta on create.

Together: create template → `PENDING` → badge reads "Aguardando aprovação" → Meta approves → next sync → badge reads "Aprovado" → template becomes sendable.

## Test plan

- [ ] Create a WhatsApp Cloud template → management table shows "Aguardando aprovação" (yellow badge), not "Ativo".
- [ ] Approved template (after Meta approval + sync) → "Aprovado" (green badge).
- [ ] Rejected template → "Reprovado" (red badge).
- [ ] Paused template → "Pausado" (gray badge).
- [ ] Rare/untracked status value → "Status desconhecido" (gray badge), no raw enum leaked.
- [ ] Picker (composer) and "Iniciar Conversa" modal keep identical classification (all three surfaces use `getStatusBadgeKey` now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align template status badge rendering in the message template management table with the shared status classification utility to reflect the real Meta approval state and avoid defaulting missing statuses to active.

Bug Fixes:
- Correct template status display when backend status is null or missing so pending templates no longer appear as active.
- Handle unknown or unexpected template status values with a dedicated user-facing label instead of showing raw enums.

Enhancements:
- Reuse the shared getStatusBadgeKey helper to ensure consistent status classification across template-related surfaces.
- Standardize status badge styling and copy, including an explicit "unknown" state, across all supported locales.