### PR TITLE
fix(frontend): fail open to setup wizard when /setup/status is unreachable (EVO-971)

### DIFF
--- a/src/contexts/GlobalConfigContext.spec.tsx
+++ b/src/contexts/GlobalConfigContext.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
+import { setupService } from '@/services/setup/setupService';
 import {
   GlobalConfigProvider,
   useGlobalConfig,
@@ -99,6 +100,28 @@ describe('GlobalConfigContext', () => {
 
       expect(parsed).toHaveProperty('setupRequired');
       expect(parsed).toHaveProperty('setupLoading');
+    });
+  });
+
+  // EVO-971: when the /setup/status call fails (e.g. auth-service still warming
+  // up on first `docker compose up`), the frontend must default to showing the
+  // setup wizard rather than stranding the user on /login with no way to
+  // bootstrap. Bootstrap itself rejects double-init, so this is safe.
+  it('defaults setupRequired=true when /setup/status fails', async () => {
+    vi.mocked(setupService.getStatus).mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    mockApi.get.mockResolvedValueOnce({ data: {} });
+
+    render(
+      <GlobalConfigProvider>
+        <ConfigDisplay />
+      </GlobalConfigProvider>,
+    );
+
+    await waitFor(() => {
+      const configEl = screen.getByTestId('config');
+      const parsed = JSON.parse(configEl.textContent || '{}');
+      expect(parsed.setupRequired).toBe(true);
+      expect(parsed.setupLoading).toBe(false);
     });
   });
 });

--- a/src/contexts/GlobalConfigContext.tsx
+++ b/src/contexts/GlobalConfigContext.tsx
@@ -81,9 +81,15 @@ export const fetchSetupStatus = async (): Promise<boolean> => {
     const status = await setupService.getStatus();
     setupRequiredCache = status.status === 'inactive';
     return setupRequiredCache;
-  } catch {
-    setupRequiredCache = false;
-    return false;
+  } catch (e) {
+    // Fail open to the setup wizard so a transient backend outage during
+    // first boot (auth-service still warming up, migrations running, etc.)
+    // doesn't strand the user on /login with no way to bootstrap.
+    // The bootstrap endpoint itself rejects with AlreadyBootstrappedError
+    // if setup was already completed, so this is safe for healthy installs.
+    // Do not cache the failure — the next render retries.
+    console.warn('[GlobalConfig] /setup/status failed, defaulting setupRequired=true', e);
+    return true;
   }
 };
 


### PR DESCRIPTION
## Summary
Fresh `docker compose up` frequently had the SPA render before auth-service finished booting. `fetchSetupStatus` caught the failed call and silently cached `setupRequired = false`, sending the user to `/login` with **no way to create the first admin** — the very scenario `/setup` is meant to handle. Community users hit this repeatedly and the only known workaround was `docker compose down -v`.

## Fix
- Default `setupRequired = true` when the status call fails so the wizard is shown and the user can bootstrap. `SetupBootstrapService` already rejects double-init via `AlreadyBootstrappedError`, so this is safe on healthy installs.
- Do not cache a failure — the next render retries. Healthy installs that hit a transient failure auto-recover back to `/login` on refresh once auth-service is up.

## Verification
- Stopped auth-service, opened frontend in anonymous window:
  - `GET /setup/status` → `ERR_CONNECTION_REFUSED`
  - Console: `[GlobalConfig] /setup/status failed, defaulting setupRequired=true`
  - Landed on `/setup` (before fix: trapped on `/login`)
- Restarted auth-service, refresh: `/setup/status` → `304` (status active), landed on `/login` — healthy flow intact.

## Validation
- `pnpm exec tsc -b --noEmit` → clean
- `pnpm exec vitest run src/contexts/GlobalConfigContext.spec.tsx` → 3/3 passed (new test covers the fail-open path)

## Related PRs
- Auth: https://github.com/EvolutionAPI/evo-auth-service-community/pull/8

## Linked Issue
- [EVO-971](https://linear.app/evoai/issue/EVO-971)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
