### PR TITLE
fix(frontend): load account labels into conversation filter options (EVO-1001)

### DIFF
--- a/src/hooks/chat/useFilterOptions.ts
+++ b/src/hooks/chat/useFilterOptions.ts
@@ -2,9 +2,11 @@ import { useState, useEffect } from 'react';
 import InboxesService from '@/services/channels/inboxesService';
 import chatService from '@/services/chat/chatService';
 import { contactsService } from '@/services/contacts/contactsService';
+import { labelsService } from '@/services/contacts/labelsService';
 import { Inbox } from '@/types/channels/inbox';
 import type { Pipeline } from '@/types/chat/api';
 import type { Contact } from '@/types/contacts/contact';
+import type { Label } from '@/types/settings';
 
 interface FilterOption {
   label: string;
@@ -50,12 +52,14 @@ export const useFilterOptions = (params: UseFilterOptionsParams = {}): FilterOpt
       setOptions(prev => ({ ...prev, loading: true, error: null }));
 
       try {
-        // ✅ Carregar inboxes, pipelines e contatos (primeiros 100 por atividade)
-        const [inboxesResponse, pipelinesResponse, contactsResponse] = await Promise.allSettled([
-          InboxesService.list(),
-          chatService.getAvailablePipelines(),
-          contactsService.getContacts({ per_page: 100, sort: 'last_activity_at', order: 'desc' }),
-        ]);
+        // ✅ Carregar inboxes, pipelines, contatos e labels em paralelo
+        const [inboxesResponse, pipelinesResponse, contactsResponse, labelsResponse] =
+          await Promise.allSettled([
+            InboxesService.list(),
+            chatService.getAvailablePipelines(),
+            contactsService.getContacts({ per_page: 100, sort: 'last_activity_at', order: 'desc' }),
+            labelsService.getLabels(),
+          ]);
 
         // ✅ Processar inboxes
         const inboxes: Array<{ label: string; value: string }> = [];
@@ -91,9 +95,21 @@ export const useFilterOptions = (params: UseFilterOptionsParams = {}): FilterOpt
           }
         }
 
-        // ❌ Teams e Labels temporariamente vazios (APIs não implementadas no chatService)
         const teams: FilterOption[] = [];
         const labels: FilterOption[] = [];
+        if (labelsResponse.status === 'fulfilled') {
+          const labelsData = labelsResponse.value?.data ?? [];
+          if (Array.isArray(labelsData)) {
+            // Value = label.title to match filter_service#tag_filter_query, which
+            // compares against tags.name. Using label.id (UUID) here would never hit.
+            labels.push(
+              ...labelsData.map((label: Label) => ({
+                label: label.title,
+                value: label.title,
+              })),
+            );
+          }
+        }
 
         const contacts: FilterOption[] = [];
         if (contactsResponse.status === 'fulfilled') {
@@ -131,6 +147,9 @@ export const useFilterOptions = (params: UseFilterOptionsParams = {}): FilterOpt
         }
         if (contactsResponse.status === 'rejected') {
           console.warn('Erro ao carregar contatos:', contactsResponse.reason);
+        }
+        if (labelsResponse.status === 'rejected') {
+          console.warn('Erro ao carregar labels:', labelsResponse.reason);
         }
       } catch (error) {
         console.error('Erro ao carregar opções de filtro:', error);

--- a/src/hooks/chat/useFilterOptions.ts
+++ b/src/hooks/chat/useFilterOptions.ts
@@ -52,13 +52,15 @@ export const useFilterOptions = (params: UseFilterOptionsParams = {}): FilterOpt
       setOptions(prev => ({ ...prev, loading: true, error: null }));
 
       try {
-        // ✅ Carregar inboxes, pipelines, contatos e labels em paralelo
+        // ✅ Carregar inboxes, pipelines, contatos e labels em paralelo.
+        // Labels: per_page: 200 evita truncamento silencioso para contas com
+        // mais de 20 labels (default da paginação do /labels endpoint).
         const [inboxesResponse, pipelinesResponse, contactsResponse, labelsResponse] =
           await Promise.allSettled([
             InboxesService.list(),
             chatService.getAvailablePipelines(),
             contactsService.getContacts({ per_page: 100, sort: 'last_activity_at', order: 'desc' }),
-            labelsService.getLabels(),
+            labelsService.getLabels({ per_page: 200 }),
           ]);
 
         // ✅ Processar inboxes

--- a/src/services/contacts/labelsService.ts
+++ b/src/services/contacts/labelsService.ts
@@ -3,8 +3,8 @@ import { extractData, extractResponse } from '@/utils/apiHelpers';
 import { LabelsResponse, LabelResponse, LabelDeleteResponse, Label } from '@/types/settings';
 
 class LabelsService {
-  async getLabels(): Promise<LabelsResponse> {
-    const response = await api.get('/labels');
+  async getLabels(params?: { per_page?: number; page?: number }): Promise<LabelsResponse> {
+    const response = await api.get('/labels', { params });
     return extractResponse<Label>(response) as LabelsResponse;
   }
 


### PR DESCRIPTION
## Summary

Populates the `Label` option set in the conversation-list filter panel so users can actually filter by their own labels. Pairs with the backend PR that fixes `tags.name` storage and rendering — see *Related PRs* below.

## Changes

- `src/hooks/chat/useFilterOptions.ts` — calls `labelsService.getLabels()` alongside inboxes, pipelines and contacts via `Promise.allSettled`, then maps each `Label` to `{ label: label.title, value: label.title }`. `value` is the title (not the UUID) so filter payloads align with `filter_service#tag_filter_query`, which compares against `tags.name`. A rejected label request is logged as a warning and treated the same as today's empty-list behaviour; it does not break the rest of the filter panel.

## Validation

- `pnpm exec tsc -b --noEmit` — clean
- `npx eslint src/hooks/chat/useFilterOptions.ts` — clean (the repo-wide `pnpm lint` reports pre-existing offenses in unrelated files, all outside this PR's scope)

## Changed Files

- `src/hooks/chat/useFilterOptions.ts`

## Linked Issue

- EVO-1001 — https://linear.app/evoai/issue/EVO-1001

## Related PRs

- Backend counterpart: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/14

## Summary by Sourcery

Populate conversation filter options with user-defined labels fetched alongside other filter data.

New Features:
- Enable label-based filtering in the conversation list by loading available labels into the filter options.

Bug Fixes:
- Ensure label filter values align with backend tag filtering by using label titles instead of UUIDs.

Enhancements:
- Handle label fetch failures gracefully without blocking other filter options and log them as warnings.