### PR TITLE
fix(frontend): scope 401 force-logout to auth-invalidation codes (EVO-1000)

### DIFF
--- a/src/services/core/api.ts
+++ b/src/services/core/api.ts
@@ -11,6 +11,18 @@ const api = axios.create({
   },
 });
 
+// Mirrors the auth-invalidation codes declared in
+// app/models/concerns/api_error_codes.rb on the backend. Only these warrant
+// killing the session on a 401 response.
+const AUTH_INVALIDATION_ERROR_CODES = new Set<string>([
+  'UNAUTHORIZED',
+  'INVALID_TOKEN',
+  'TOKEN_EXPIRED',
+  'MISSING_TOKEN',
+  'INVALID_CREDENTIALS',
+  'SESSION_EXPIRED',
+]);
+
 let isRefreshing = false;
 let isTerminatingSession = false;
 let failedQueue: Array<{
@@ -137,6 +149,23 @@ api.interceptors.response.use(
       const isUnreadCountEndpoint = error.config?.url?.includes('/unread_count');
 
       if (isUnreadCountEndpoint) {
+        return Promise.reject(error);
+      }
+
+      // The backend uses ApiErrorCodes (see app/models/concerns/api_error_codes.rb)
+      // and returns business-logic errors with their own code even when the HTTP
+      // status is 401. Only treat the response as a session-invalidation 401 when
+      // the body is missing a code or carries a known auth-invalidation code —
+      // otherwise the global interceptor would log the user out on validation /
+      // permission errors that mistakenly use 401.
+      const errorCode = (
+        error.response?.data as { error?: { code?: string } } | undefined
+      )?.error?.code;
+      const isAuthInvalidationCode =
+        !errorCode ||
+        AUTH_INVALIDATION_ERROR_CODES.has(errorCode);
+
+      if (!isAuthInvalidationCode) {
         return Promise.reject(error);
       }
 


### PR DESCRIPTION
## Summary

The axios response interceptor in `src/services/core/api.ts` invalidated the user's session on **every** 401 (other than `/unread_count`). Backend endpoints that mistakenly returned 401 for business-logic failures — e.g., the team-member create flow handled in the paired CRM PR — therefore killed the admin's session mid-flow.

Before calling `terminateSession()`, the interceptor now reads `error.response.data.error.code` and only invalidates the session when the code matches one of the auth-invalidation codes the backend publishes via `app/models/concerns/api_error_codes.rb`:

- `UNAUTHORIZED`
- `INVALID_TOKEN`
- `TOKEN_EXPIRED`
- `MISSING_TOKEN`
- `INVALID_CREDENTIALS`
- `SESSION_EXPIRED`

If the response body has no `code` at all, the legacy logout behaviour is preserved (older endpoints without `ApiErrorCodes` still trigger session termination, so this change does not regress anything that already works).

This is defence-in-depth: the team-member endpoint is fixed at the source by the CRM PR (now returns 422 with `VALIDATION_ERROR`), but any other endpoint that mistakenly returns a business 401 will no longer log the user out as a side effect.

## Validation

- `pnpm exec tsc -b --noEmit` — clean
- `npx eslint src/services/core/api.ts` — clean
- Manually reproduced and confirmed by the reporter: admin stays logged in throughout the team-creation + add-members flow.

## Changed Files

- `src/services/core/api.ts`

## Linked Issue

- EVO-1000 — https://linear.app/evoai/issue/EVO-1000

## Related PRs

- Backend counterpart: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/24

## Summary by Sourcery

Bug Fixes:
- Prevent user sessions from being terminated on 401 responses that represent business-logic or validation errors by requiring a known auth-invalidation error code before forcing logout.