### PR TITLE
fix(frontend): allow removing team members + show members count + visual diff (EVO-1010)

### DIFF
--- a/src/i18n/locales/en/teams.json
+++ b/src/i18n/locales/en/teams.json
@@ -119,6 +119,9 @@
     "selectAtLeastOne": "Select at least one user",
     "usersAddedSuccess": "Users added successfully!",
     "addUsersError": "Error adding users",
+    "removeUsersSuccess": "Users removed successfully!",
+    "removeUsersError": "Error removing users",
+    "membersUpdated": "Team members updated successfully!",
     "permissionDenied": {
       "read": "No permission to view teams",
       "create": "No permission to create teams",
@@ -138,6 +141,7 @@
     "title": "Add Users - {{name}}",
     "subtitle": "Select the users you want to add to the team",
     "summary": "{{selected}} of {{total}} users selected",
+    "alreadyMemberBadge": "Member",
     "table": {
       "select": "Select",
       "user": "User",
@@ -179,6 +183,7 @@
     "selectAll": "Select All",
     "deselectAll": "Deselect All",
     "saving": "Saving...",
+    "save": "Save",
     "addUsers": "Add Users"
   }
 }

--- a/src/i18n/locales/es/teams.json
+++ b/src/i18n/locales/es/teams.json
@@ -119,6 +119,9 @@
     "selectAtLeastOne": "Seleccione al menos un usuario",
     "usersAddedSuccess": "¡Usuarios agregados con éxito!",
     "addUsersError": "Error al agregar usuarios",
+    "removeUsersSuccess": "¡Usuarios eliminados con éxito!",
+    "removeUsersError": "Error al eliminar usuarios",
+    "membersUpdated": "¡Miembros del equipo actualizados con éxito!",
     "permissionDenied": {
       "read": "Sin permiso para visualizar equipos",
       "create": "Sin permiso para crear equipos",
@@ -138,6 +141,7 @@
     "title": "Agregar Usuarios - {{name}}",
     "subtitle": "Seleccione los usuarios que desea agregar al equipo",
     "summary": "{{selected}} de {{total}} usuarios seleccionados",
+    "alreadyMemberBadge": "Miembro",
     "table": {
       "select": "Seleccionar",
       "user": "Usuario",
@@ -179,6 +183,7 @@
     "selectAll": "Seleccionar Todos",
     "deselectAll": "Desmarcar Todos",
     "saving": "Guardando...",
+    "save": "Guardar",
     "addUsers": "Agregar Usuarios"
   }
 }

--- a/src/i18n/locales/fr/teams.json
+++ b/src/i18n/locales/fr/teams.json
@@ -119,6 +119,9 @@
     "selectAtLeastOne": "Sélectionnez au moins un utilisateur",
     "usersAddedSuccess": "Utilisateurs ajoutés avec succès !",
     "addUsersError": "Erreur lors de l'ajout des utilisateurs",
+    "removeUsersSuccess": "Utilisateurs supprimés avec succès !",
+    "removeUsersError": "Erreur lors de la suppression des utilisateurs",
+    "membersUpdated": "Membres de l'équipe mis à jour avec succès !",
     "permissionDenied": {
       "read": "Pas de permission pour visualiser les équipes",
       "create": "Pas de permission pour créer des équipes",
@@ -138,6 +141,7 @@
     "title": "Ajouter des Utilisateurs - {{name}}",
     "subtitle": "Sélectionnez les utilisateurs que vous souhaitez ajouter à l'équipe",
     "summary": "{{selected}} sur {{total}} utilisateurs sélectionnés",
+    "alreadyMemberBadge": "Membre",
     "table": {
       "select": "Sélectionner",
       "user": "Utilisateur",
@@ -179,6 +183,7 @@
     "selectAll": "Tout Sélectionner",
     "deselectAll": "Tout Désélectionner",
     "saving": "Enregistrement en cours...",
+    "save": "Enregistrer",
     "addUsers": "Ajouter des Utilisateurs"
   }
 }

--- a/src/i18n/locales/it/teams.json
+++ b/src/i18n/locales/it/teams.json
@@ -119,6 +119,9 @@
     "selectAtLeastOne": "Seleziona almeno un utente",
     "usersAddedSuccess": "Utenti aggiunti con successo!",
     "addUsersError": "Errore durante l'aggiunta degli utenti",
+    "removeUsersSuccess": "Utenti rimossi con successo!",
+    "removeUsersError": "Errore durante la rimozione degli utenti",
+    "membersUpdated": "Membri del team aggiornati con successo!",
     "permissionDenied": {
       "read": "Permesso negato per visualizzare i team",
       "create": "Permesso negato per creare team",
@@ -138,6 +141,7 @@
     "title": "Aggiungi Utenti - {{name}}",
     "subtitle": "Seleziona gli utenti che desideri aggiungere al team",
     "summary": "{{selected}} di {{total}} utenti selezionati",
+    "alreadyMemberBadge": "Membro",
     "table": {
       "select": "Seleziona",
       "user": "Utente",
@@ -179,6 +183,7 @@
     "selectAll": "Seleziona Tutti",
     "deselectAll": "Deseleziona Tutti",
     "saving": "Salvataggio...",
+    "save": "Salva",
     "addUsers": "Aggiungi Utenti"
   }
 }

--- a/src/i18n/locales/pt-BR/teams.json
+++ b/src/i18n/locales/pt-BR/teams.json
@@ -119,6 +119,9 @@
     "selectAtLeastOne": "Selecione pelo menos um usuário",
     "usersAddedSuccess": "Usuários adicionados com sucesso!",
     "addUsersError": "Erro ao adicionar usuários",
+    "removeUsersSuccess": "Usuários removidos com sucesso!",
+    "removeUsersError": "Erro ao remover usuários",
+    "membersUpdated": "Membros do time atualizados com sucesso!",
     "permissionDenied": {
       "read": "Sem permissão para visualizar equipes",
       "create": "Sem permissão para criar equipes",
@@ -138,6 +141,7 @@
     "title": "Adicionar Usuários - {{name}}",
     "subtitle": "Selecione os usuários que deseja adicionar à equipe",
     "summary": "{{selected}} de {{total}} usuários selecionados",
+    "alreadyMemberBadge": "Membro",
     "table": {
       "select": "Selecionar",
       "user": "Usuário", 
@@ -179,6 +183,7 @@
     "selectAll": "Selecionar Todos",
     "deselectAll": "Desmarcar Todos",
     "saving": "Salvando...",
+    "save": "Salvar",
     "addUsers": "Adicionar Usuários"
   }
 }

--- a/src/i18n/locales/pt/teams.json
+++ b/src/i18n/locales/pt/teams.json
@@ -119,6 +119,9 @@
     "selectAtLeastOne": "Selecione pelo menos um usuário",
     "usersAddedSuccess": "Usuários adicionados com sucesso!",
     "addUsersError": "Erro ao adicionar usuários",
+    "removeUsersSuccess": "Usuários removidos com sucesso!",
+    "removeUsersError": "Erro ao remover usuários",
+    "membersUpdated": "Membros da equipa atualizados com sucesso!",
     "permissionDenied": {
       "read": "Sem permissão para visualizar equipes",
       "create": "Sem permissão para criar equipes",
@@ -138,6 +141,7 @@
     "title": "Adicionar Usuários - {{name}}",
     "subtitle": "Selecione os usuários que deseja adicionar à equipe",
     "summary": "{{selected}} de {{total}} usuários selecionados",
+    "alreadyMemberBadge": "Membro",
     "table": {
       "select": "Selecionar",
       "user": "Usuário", 
@@ -179,6 +183,7 @@
     "selectAll": "Selecionar Todos",
     "deselectAll": "Desmarcar Todos",
     "saving": "Salvando...",
+    "save": "Guardar",
     "addUsers": "Adicionar Usuários"
   }
 }

--- a/src/pages/Customer/Settings/Teams/AddUsers.tsx
+++ b/src/pages/Customer/Settings/Teams/AddUsers.tsx
@@ -1,15 +1,23 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
 import { toast } from 'sonner';
-import { Button, Checkbox, Avatar, AvatarFallback, AvatarImage } from '@evoapi/design-system';
-import { ArrowLeft, Users, UserPlus } from 'lucide-react';
+import { Badge, Button, Checkbox, Avatar, AvatarFallback, AvatarImage } from '@evoapi/design-system';
+import { ArrowLeft, Users, Save } from 'lucide-react';
 import BaseHeader from '@/components/base/BaseHeader';
 import BaseTable, { TableColumn } from '@/components/base/BaseTable';
 import TeamsService from '@/services/teams/teamsService';
 import type { Team } from '@/types/users';
 import { usersService } from '@/services/users';
 import type { User } from '@/types/users';
+
+// The team_members payload shape varies depending on which endpoint serialized
+// it (user_id is the canonical field, user.id and id show up in legacy
+// responses). Accept all three so the page works regardless of backend version.
+type TeamMembershipRow = { user_id?: string; user?: { id?: string }; id?: string };
+
+const extractMemberId = (row: TeamMembershipRow): string | undefined =>
+  row.user_id || row.user?.id || row.id;
 
 const AddUsers: React.FC = () => {
   const { t } = useLanguage('teams');
@@ -18,8 +26,8 @@ const AddUsers: React.FC = () => {
 
   const [team, setTeam] = useState<Team | null>(null);
   const [users, setUsers] = useState<User[]>([]);
-  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
-  const [savedUsers, setSavedUsers] = useState<string[]>([]);
+  const [originalMemberIds, setOriginalMemberIds] = useState<string[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -42,8 +50,11 @@ const AddUsers: React.FC = () => {
 
       setTeam(teamResponse);
       setUsers(usersResponse.data || []);
-      const existingMemberIds = membersResponse.map((m: any) => m.user_id || m.user?.id || m.id).filter(Boolean);
-      setSavedUsers(existingMemberIds);
+      const existingMemberIds = (membersResponse as unknown as TeamMembershipRow[])
+        .map(extractMemberId)
+        .filter((id): id is string => Boolean(id));
+      setOriginalMemberIds(existingMemberIds);
+      setSelectedIds(existingMemberIds);
     } catch (error) {
       console.error('Erro ao carregar dados:', error);
       toast.error(t('messages.loadDataError'));
@@ -54,37 +65,69 @@ const AddUsers: React.FC = () => {
   };
 
   const handleUserToggle = (userId: string) => {
-    setSelectedUsers(prev => {
-      if (prev.includes(userId)) {
-        return prev.filter(id => id !== userId);
-      } else {
-        return [...prev, userId];
-      }
-    });
+    setSelectedIds(prev =>
+      prev.includes(userId) ? prev.filter(id => id !== userId) : [...prev, userId],
+    );
   };
 
-  const handleSaveUsers = async () => {
-    if (!teamId || selectedUsers.length === 0) {
-      toast.error(t('messages.selectAtLeastOne'));
-      return;
-    }
+  const { addedIds, removedIds, hasPendingChanges } = useMemo(() => {
+    const original = new Set(originalMemberIds);
+    const selected = new Set(selectedIds);
+    const added = selectedIds.filter(id => !original.has(id));
+    const removed = originalMemberIds.filter(id => !selected.has(id));
+    return {
+      addedIds: added,
+      removedIds: removed,
+      hasPendingChanges: added.length > 0 || removed.length > 0,
+    };
+  }, [originalMemberIds, selectedIds]);
+
+  const handleSave = async () => {
+    if (!teamId || !hasPendingChanges) return;
 
     try {
       setIsSaving(true);
-      await TeamsService.addUsersToTeam(teamId, selectedUsers);
-      setSavedUsers(prev => [...new Set([...prev, ...selectedUsers])]);
-      setSelectedUsers([]);
-      toast.success(t('messages.usersAddedSuccess'));
+
+      const operations: Promise<unknown>[] = [];
+      if (addedIds.length > 0) {
+        operations.push(TeamsService.addUsersToTeam(teamId, addedIds));
+      }
+      if (removedIds.length > 0) {
+        operations.push(TeamsService.removeUsersFromTeam(teamId, removedIds));
+      }
+      await Promise.all(operations);
+
+      const refreshed = await TeamsService.getTeamMembers(teamId);
+      const refreshedMemberIds = (refreshed as unknown as TeamMembershipRow[])
+        .map(extractMemberId)
+        .filter((id): id is string => Boolean(id));
+      setOriginalMemberIds(refreshedMemberIds);
+      setSelectedIds(refreshedMemberIds);
+
+      // Toast tailored to which operation(s) ran. Both → membersUpdated.
+      if (addedIds.length > 0 && removedIds.length > 0) {
+        toast.success(t('messages.membersUpdated'));
+      } else if (addedIds.length > 0) {
+        toast.success(t('messages.usersAddedSuccess'));
+      } else {
+        toast.success(t('messages.removeUsersSuccess'));
+      }
     } catch (error) {
-      console.error('Erro ao adicionar usuários:', error);
-      toast.error(t('messages.addUsersError'));
+      console.error('Erro ao salvar membros:', error);
+      // Pick a contextual error label; falls back to add-error to keep parity
+      // with the previous behaviour when both operations were attempted.
+      if (removedIds.length > 0 && addedIds.length === 0) {
+        toast.error(t('messages.removeUsersError'));
+      } else {
+        toast.error(t('messages.addUsersError'));
+      }
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleGoBack = () => {
-    navigate('/settings/teams'); // Navigate back to teams list
+    navigate('/settings/teams');
   };
 
   const getUserInitials = (name: string) => {
@@ -122,13 +165,11 @@ const AddUsers: React.FC = () => {
     }
   };
 
-  const availableUsers = users.filter(u => !savedUsers.includes(u.id));
-
   const handleSelectAll = () => {
-    if (selectedUsers.length === availableUsers.length) {
-      setSelectedUsers([]);
+    if (selectedIds.length === users.length) {
+      setSelectedIds([]);
     } else {
-      setSelectedUsers(availableUsers.map(user => user.id));
+      setSelectedIds(users.map(user => user.id));
     }
   };
 
@@ -137,46 +178,52 @@ const AddUsers: React.FC = () => {
       key: 'select',
       label: t('addUsers.table.select'),
       width: '60px',
-      render: user => {
-        const alreadySaved = savedUsers.includes(user.id);
-        return (
-          <Checkbox
-            checked={alreadySaved || selectedUsers.includes(user.id)}
-            disabled={alreadySaved}
-            onCheckedChange={() => handleUserToggle(user.id)}
-            aria-label={`Selecionar ${user.name}`}
-          />
-        );
-      },
+      render: user => (
+        <Checkbox
+          checked={selectedIds.includes(user.id)}
+          onCheckedChange={() => handleUserToggle(user.id)}
+          aria-label={`Selecionar ${user.name}`}
+        />
+      ),
     },
     {
       key: 'user',
       label: t('addUsers.table.user'),
-      render: user => (
-        <div className="flex items-center gap-3">
-          <div className="relative">
-            <Avatar className="h-8 w-8">
-              {user.avatar_url || user.thumbnail ? (
-                <AvatarImage src={user.avatar_url || user.thumbnail} />
-              ) : null}
-              <AvatarFallback className="text-xs font-medium">
-                {getUserInitials(user.name)}
-              </AvatarFallback>
-            </Avatar>
-            <div
-              className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-background ${getStatusColor(
-                user.availability,
-              )}`}
-            />
+      render: user => {
+        const isMember = originalMemberIds.includes(user.id);
+        return (
+          <div className="flex items-center gap-3">
+            <div className="relative">
+              <Avatar className="h-8 w-8">
+                {user.avatar_url || user.thumbnail ? (
+                  <AvatarImage src={user.avatar_url || user.thumbnail} />
+                ) : null}
+                <AvatarFallback className="text-xs font-medium">
+                  {getUserInitials(user.name)}
+                </AvatarFallback>
+              </Avatar>
+              <div
+                className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-background ${getStatusColor(
+                  user.availability,
+                )}`}
+              />
+            </div>
+            <div>
+              <div className="flex items-center gap-2">
+                <p className="font-medium">{user.name}</p>
+                {isMember && (
+                  <Badge variant="secondary" className="text-xs">
+                    {t('addUsers.alreadyMemberBadge')}
+                  </Badge>
+                )}
+              </div>
+              <p className="text-sm text-muted-foreground capitalize">
+                {getStatusLabel(user.availability)}
+              </p>
+            </div>
           </div>
-          <div>
-            <p className="font-medium">{user.name}</p>
-            <p className="text-sm text-muted-foreground capitalize">
-              {getStatusLabel(user.availability)}
-            </p>
-          </div>
-        </div>
-      ),
+        );
+      },
     },
     {
       key: 'email',
@@ -237,30 +284,30 @@ const AddUsers: React.FC = () => {
         <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
           <div className="flex items-center gap-4">
             <p className="text-sm text-muted-foreground">
-              {t('addUsers.summary', { selected: selectedUsers.length, total: users.length })}
+              {t('addUsers.summary', { selected: selectedIds.length, total: users.length })}
             </p>
             <Button
               variant="outline"
               size="sm"
               onClick={handleSelectAll}
-              disabled={availableUsers.length === 0}
+              disabled={users.length === 0}
             >
-              {selectedUsers.length === availableUsers.length
+              {selectedIds.length === users.length
                 ? t('actions.deselectAll')
                 : t('actions.selectAll')}
             </Button>
           </div>
           <Button
-            onClick={handleSaveUsers}
-            disabled={selectedUsers.length === 0 || isSaving}
+            onClick={handleSave}
+            disabled={!hasPendingChanges || isSaving}
             className="min-w-[140px]"
           >
             {isSaving ? (
               t('actions.saving')
             ) : (
               <>
-                <UserPlus className="h-4 w-4 mr-2" />
-                {t('actions.addUsers')}
+                <Save className="h-4 w-4 mr-2" />
+                {t('actions.save')}
               </>
             )}
           </Button>

--- a/src/services/teams/teamsService.ts
+++ b/src/services/teams/teamsService.ts
@@ -122,6 +122,24 @@ const TeamsService = {
       throw error;
     }
   },
+
+  /**
+   * Remove users from team
+   *
+   * The collection-level DELETE consumes a `user_ids` body, mirroring the
+   * shape used by addUsersToTeam(POST). axios moves the body to `data` for
+   * DELETE requests.
+   */
+  async removeUsersFromTeam(teamId: string, userIds: string[]): Promise<void> {
+    try {
+      await api.delete(`/teams/${teamId}/team_members`, {
+        data: { user_ids: userIds },
+      });
+    } catch (error) {
+      console.error('TeamsService.removeUsersFromTeam error:', error);
+      throw error;
+    }
+  },
 };
 
 export default TeamsService;


### PR DESCRIPTION
## Summary

The team management page only allowed adding users — already-saved members had a `disabled` checkbox, and the page never invoked any remove endpoint. Combined with the team card always displaying `0 members` (the backend never serialized a count, fixed in the paired CRM PR), the feature was effectively read-once after creation.

The `AddUsers` page is now a unified "manage members" view:

- Single `selectedIds` state, initialised from the server-side membership snapshot (`originalMemberIds`). Checkboxes are always togglable; ticking adds, unticking removes.
- `handleSave` computes the diff against the snapshot:
  - `addedIds = selectedIds - originalMemberIds`
  - `removedIds = originalMemberIds - selectedIds`
  Each is dispatched to its own endpoint (`POST /team_members` and `DELETE /team_members`) in parallel. After the operations resolve, the snapshot is refetched so the next save uses fresh state. The Save button is disabled when there are no pending changes.
- Toast contextualised to which operation actually ran:
  - `messages.usersAddedSuccess` (add only)
  - `messages.removeUsersSuccess` (remove only)
  - `messages.membersUpdated` (mixed)
- Existing members get an `addUsers.alreadyMemberBadge` chip next to the name so the user can tell at a glance who is already in the team without relying on the (now togglable) checkbox.
- The save CTA is renamed from "Add Users" to "Save", with the `Save` icon, since the page now supports both directions of change.

`teamsService.removeUsersFromTeam` is added — DELETE `/teams/:id/team_members` with `user_ids` in the body, mirroring the POST shape (axios moves the body to `data` for DELETE).

The legacy `(m: any)` typing in the membership-id extraction paths is replaced by a small `TeamMembershipRow` structural type plus an `extractMemberId` helper, so both `loadData` and the post-save refetch share one nullable-safe code path.

i18n keys added in all six supported locales (`en`, `pt-BR`, `pt`, `es`, `fr`, `it`):
- `messages.removeUsersSuccess`
- `messages.removeUsersError`
- `messages.membersUpdated`
- `addUsers.alreadyMemberBadge`
- `actions.save`

## Validation

- `pnpm exec tsc -b --noEmit` — clean for files in scope (existing errors in `BrandIcon.tsx` and `MessageImage.tsx` predate this PR)
- `npx eslint src/pages/Customer/Settings/Teams/AddUsers.tsx src/services/teams/teamsService.ts` — clean (also removed a pre-existing `(m: any)` in `loadData` as part of the refactor)
- `node -e 'JSON.parse(...)'` on all six locale files — all parse cleanly
- Manually confirmed by the reporter: members count rendered on cards, badge visible, can both add and remove members in a single save and end up with the correct membership.

## Note for reviewers

The remove-member flow (DELETE `/teams/:id/team_members`) shares the controller with EVO-1000 (PR https://github.com/EvolutionAPI/evo-ai-crm-community/pull/24). The 401 / `map(&:to_i)` bug fixed there also affected the destroy action; remove-member only works end-to-end on `develop` once EVO-1000 lands. Until then, review on this branch can rely on the local merge or wait for EVO-1000 to merge first.

## Changed Files

- `src/pages/Customer/Settings/Teams/AddUsers.tsx`
- `src/services/teams/teamsService.ts`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/teams.json`

## Linked Issue

- EVO-1010 — https://linear.app/evoai/issue/EVO-1010

## Related PRs

- Backend counterpart: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/25
- EVO-1000 (paired bug, ships together):
  - Backend: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/24
  - Frontend: https://github.com/EvolutionAPI/evo-ai-frontend-community/pull/26

## Summary by Sourcery

Unify the team member management UI to support both adding and removing members in a single flow, wired to new add/remove endpoints and refreshed membership state.

New Features:
- Allow team members to be removed from a team via the AddUsers management page alongside adding new members.
- Display an inline badge for users who are already members of the team in the members list.
- Introduce a Save-based CTA for persisting membership changes instead of an add-only action.

Bug Fixes:
- Ensure team member selections reflect the actual saved membership by diffing against a server-sourced snapshot and refetching after save.
- Prevent no-op saves by disabling the Save action when there are no pending membership changes.

Enhancements:
- Share a typed helper for extracting member IDs from heterogeneous team_members payloads to support multiple backend response shapes.
- Improve the members table UX with consistent selection logic, full-list select/deselect, and contextual success/error toasts based on the operations performed.