### PR TITLE
test(EVO-1012): regression spec for contact avatar field priority

### DIFF
--- a/src/components/chat/contact/ContactAvatar.spec.tsx
+++ b/src/components/chat/contact/ContactAvatar.spec.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ContactAvatar from './ContactAvatar';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/components/channels/ChannelIcon', () => ({
+  default: () => <span data-testid="channel-icon" />,
+}));
+
+// Radix Avatar gates AvatarImage behind a loading-state check that does not
+// resolve in jsdom. Replace it with primitives so the assertions can target the
+// field-priority logic in ContactAvatar.tsx, which is what EVO-1012 needs to
+// regression-pin (a rename like `thumbnail` → `avatar_thumb` in the API would
+// silently break the conversation list, header, sidebar, and /contacts pages).
+vi.mock('@evoapi/design-system/avatar', () => ({
+  Avatar: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="avatar-root" className={className}>
+      {children}
+    </div>
+  ),
+  AvatarImage: ({ src, alt }: { src?: string; alt?: string }) =>
+    src ? <img data-testid="avatar-image" src={src} alt={alt ?? ''} /> : null,
+  AvatarFallback: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="avatar-fallback" className={className}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@evoapi/design-system/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('ContactAvatar (EVO-1012)', () => {
+  it('renders avatar_url when present (priority 1)', () => {
+    render(
+      <ContactAvatar
+        contact={{ id: '1', name: 'Jane Doe', avatar_url: 'https://cdn.example.com/avatar.jpg' }}
+      />,
+    );
+
+    const img = screen.getByTestId('avatar-image');
+    expect(img).toHaveAttribute('src', 'https://cdn.example.com/avatar.jpg');
+  });
+
+  it('falls back to thumbnail (backend ContactSerializer field) when avatar_url is missing', () => {
+    render(
+      <ContactAvatar
+        contact={{
+          id: '2',
+          name: 'John Doe',
+          avatar_url: null,
+          thumbnail: 'https://cdn.example.com/from-thumbnail.jpg',
+        }}
+      />,
+    );
+
+    const img = screen.getByTestId('avatar-image');
+    expect(img).toHaveAttribute('src', 'https://cdn.example.com/from-thumbnail.jpg');
+  });
+
+  it('falls back to avatar field as a last resort', () => {
+    render(
+      <ContactAvatar
+        contact={{
+          id: '3',
+          name: 'Bob',
+          avatar_url: null,
+          thumbnail: null,
+          avatar: 'https://cdn.example.com/from-avatar.jpg',
+        }}
+      />,
+    );
+
+    const img = screen.getByTestId('avatar-image');
+    expect(img).toHaveAttribute('src', 'https://cdn.example.com/from-avatar.jpg');
+  });
+
+  it('skips <img> entirely when no avatar field is populated and shows initials fallback', () => {
+    render(
+      <ContactAvatar
+        contact={{ id: '4', name: 'Alice Smith', avatar_url: null, thumbnail: null, avatar: null }}
+      />,
+    );
+
+    expect(screen.queryByTestId('avatar-image')).toBeNull();
+    expect(screen.getByTestId('avatar-fallback')).toHaveTextContent('AS');
+  });
+
+  it('skips <img> when contact is null', () => {
+    render(<ContactAvatar contact={null} />);
+
+    expect(screen.queryByTestId('avatar-image')).toBeNull();
+  });
+
+  it('renders the channel icon badge when channelType is provided', () => {
+    render(
+      <ContactAvatar
+        contact={{ id: '5', name: 'Channel User', avatar_url: 'https://cdn.example.com/x.jpg' }}
+        channelType="Channel::Whatsapp"
+        channelProvider="evolution"
+      />,
+    );
+
+    expect(screen.getByTestId('channel-icon')).toBeInTheDocument();
+  });
+});

--- a/src/utils/chat/avatarHelpers.spec.ts
+++ b/src/utils/chat/avatarHelpers.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { getContactAvatarUrl } from './avatarHelpers';
+
+describe('getContactAvatarUrl', () => {
+  it('returns undefined for null/undefined contact', () => {
+    expect(getContactAvatarUrl(null)).toBeUndefined();
+    expect(getContactAvatarUrl(undefined)).toBeUndefined();
+  });
+
+  it('prioritizes avatar_url over thumbnail and avatar', () => {
+    expect(
+      getContactAvatarUrl({
+        avatar_url: 'https://cdn.example.com/a.jpg',
+        thumbnail: 'https://cdn.example.com/b.jpg',
+        avatar: 'https://cdn.example.com/c.jpg',
+      }),
+    ).toBe('https://cdn.example.com/a.jpg');
+  });
+
+  // EVO-1012: backend ContactSerializer emits `thumbnail`, not `avatar_url`. The
+  // helper must consume `thumbnail` when avatar_url is absent so /contacts and
+  // conversation surfaces render the WhatsApp profile picture consistently.
+  it('falls back to thumbnail when avatar_url is missing', () => {
+    expect(
+      getContactAvatarUrl({
+        thumbnail: 'https://cdn.example.com/from-thumbnail.jpg',
+      }),
+    ).toBe('https://cdn.example.com/from-thumbnail.jpg');
+  });
+
+  it('falls back to avatar (absolute URL) when avatar_url and thumbnail are missing', () => {
+    expect(
+      getContactAvatarUrl({ avatar: 'https://cdn.example.com/from-avatar.jpg' }),
+    ).toBe('https://cdn.example.com/from-avatar.jpg');
+  });
+
+  it('returns avatar path as-is when it starts with /', () => {
+    expect(getContactAvatarUrl({ avatar: '/uploads/avatar.jpg' })).toBe(
+      '/uploads/avatar.jpg',
+    );
+  });
+
+  it('prefixes /uploads/ when avatar is a bare relative filename', () => {
+    expect(getContactAvatarUrl({ avatar: 'avatar.jpg' })).toBe('/uploads/avatar.jpg');
+  });
+
+  it('returns undefined when no avatar field is populated', () => {
+    expect(
+      getContactAvatarUrl({ avatar_url: null, thumbnail: null, avatar: null }),
+    ).toBeUndefined();
+    expect(getContactAvatarUrl({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Locks in the contract between `getContactAvatarUrl` and the backend `ContactSerializer`, which now emits `thumbnail` on the main contact payload. The helper must keep its `avatar_url` > `thumbnail` > `avatar` fallback order so `/contatos` and the chat surfaces (list row, header, sidebar, individual contact view) render the WhatsApp profile picture consistently.

No production code change is required on the frontend — the existing `ContactAvatar` component and `getContactAvatarUrl` already honor the right field order. This is regression coverage to keep that contract stable across refactors.

## Validation

- `pnpm exec vitest run src/utils/chat/avatarHelpers.spec.ts` — 7 tests passed
- `pnpm exec eslint src/utils/chat/avatarHelpers.spec.ts` — clean
- Manual end-to-end test: backend now ships `thumbnail`, helper consumes it, `/contatos` shows the WhatsApp profile picture for contacts whose avatar was successfully attached on the backend.

## Changed Files

- `src/utils/chat/avatarHelpers.spec.ts`

## Linked Issue

- https://linear.app/evoai/issue/EVO-1012/contact-avatar-not-loading-on-conversation-chat-and-contacts-screen

## Related PRs

- Backend: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/28

## Summary by Sourcery

Tests:
- Add a new avatar helper spec to validate the fallback order across avatar_url, thumbnail, and avatar fields.