### PR TITLE
fix(frontend): show WhatsApp group sender name and media labels across chat UI

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -312,10 +312,49 @@ const ChatSidebar = ({
     return (tempDiv.textContent || tempDiv.innerText || '').trim();
   };
 
+  const attachmentLabel = (fileType?: string) => {
+    switch (fileType) {
+      case 'image':
+        return '📷 Foto';
+      case 'video':
+        return '🎥 Vídeo';
+      case 'audio':
+        return '🎵 Áudio';
+      case 'file':
+        return '📎 Documento';
+      case 'sticker':
+        return '💟 Figurinha';
+      case 'location':
+        return '📍 Localização';
+      case 'contact':
+        return '👤 Contato';
+      default:
+        return fileType ? `📎 ${fileType}` : '📎 Anexo';
+    }
+  };
+
   const getLastMessage = (conversation: Conversation) => {
     const msg = conversation.last_non_activity_message;
-    const cleanContent = stripHtml(msg?.processed_message_content || msg?.content || '');
-    return cleanContent.length > 60 ? cleanContent.substring(0, 60) + '...' : cleanContent;
+    const rawText = stripHtml(msg?.processed_message_content || msg?.content || '');
+    // Media-only messages (video/image/audio/file) come with empty content; surface
+    // a typed placeholder so the preview tells the operator what was sent. Try the
+    // attachment first, then fall back to content_attributes.media_type (set by the
+    // backend even when the attachment couldn't be downloaded — e.g. inline base64).
+    const firstAttachmentType = msg?.attachments?.[0]?.file_type;
+    const fallbackMediaType = msg?.content_attributes?.media_type as string | undefined;
+    const cleanContent =
+      rawText ||
+      (firstAttachmentType ? attachmentLabel(firstAttachmentType) : '') ||
+      (fallbackMediaType ? attachmentLabel(fallbackMediaType) : '');
+    // For WhatsApp group conversations the backend tags each incoming message with
+    // content_attributes.sender_name (the participant who actually spoke). Prepend
+    // that to the preview so the operator can attribute who said what.
+    const senderName =
+      msg && msg.message_type === 'incoming'
+        ? (msg.content_attributes?.sender_name as string | undefined)
+        : undefined;
+    const preview = senderName ? `${senderName}: ${cleanContent}` : cleanContent;
+    return preview.length > 60 ? preview.substring(0, 60) + '...' : preview;
   };
 
   // Render conversation context menu

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -34,6 +34,11 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useChatContext } from '@/contexts/chat/ChatContext';
 import { Conversation, ConversationFilter } from '@/types/chat/api';
+import {
+  attachmentLabel,
+  mediaTypeFromAttributes,
+  senderNameFromAttributes,
+} from '@/utils/chat/mediaLabels';
 import { formatConversationTime, formatDetailedTime } from '@/utils/time/timeHelpers';
 import { ConversationSkeleton } from '../loading-states';
 import { NoConversations } from '../empty-states';
@@ -312,46 +317,21 @@ const ChatSidebar = ({
     return (tempDiv.textContent || tempDiv.innerText || '').trim();
   };
 
-  const attachmentLabel = (fileType?: string) => {
-    switch (fileType) {
-      case 'image':
-        return '📷 Foto';
-      case 'video':
-        return '🎥 Vídeo';
-      case 'audio':
-        return '🎵 Áudio';
-      case 'file':
-        return '📎 Documento';
-      case 'sticker':
-        return '💟 Figurinha';
-      case 'location':
-        return '📍 Localização';
-      case 'contact':
-        return '👤 Contato';
-      default:
-        return fileType ? `📎 ${fileType}` : '📎 Anexo';
-    }
-  };
-
   const getLastMessage = (conversation: Conversation) => {
     const msg = conversation.last_non_activity_message;
     const rawText = stripHtml(msg?.processed_message_content || msg?.content || '');
-    // Media-only messages (video/image/audio/file) come with empty content; surface
-    // a typed placeholder so the preview tells the operator what was sent. Try the
-    // attachment first, then fall back to content_attributes.media_type (set by the
-    // backend even when the attachment couldn't be downloaded — e.g. inline base64).
+    // Media-only messages come with empty content; surface a typed placeholder.
+    // Prefer the attachment file_type; fall back to backend-tagged media_type.
     const firstAttachmentType = msg?.attachments?.[0]?.file_type;
-    const fallbackMediaType = msg?.content_attributes?.media_type as string | undefined;
+    const fallbackMediaType = mediaTypeFromAttributes(msg?.content_attributes);
     const cleanContent =
       rawText ||
       (firstAttachmentType ? attachmentLabel(firstAttachmentType) : '') ||
       (fallbackMediaType ? attachmentLabel(fallbackMediaType) : '');
-    // For WhatsApp group conversations the backend tags each incoming message with
-    // content_attributes.sender_name (the participant who actually spoke). Prepend
-    // that to the preview so the operator can attribute who said what.
+    // Group conversations: prepend the participant who actually spoke.
     const senderName =
       msg && msg.message_type === 'incoming'
-        ? (msg.content_attributes?.sender_name as string | undefined)
+        ? senderNameFromAttributes(msg.content_attributes)
         : undefined;
     const preview = senderName ? `${senderName}: ${cleanContent}` : cleanContent;
     return preview.length > 60 ? preview.substring(0, 60) + '...' : preview;

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -39,6 +39,11 @@ import { CannedResponsesList } from '../canned-responses';
 import { RichTextEditor, RichTextEditorRef } from '../rich-text-editor';
 
 import { ReplyMode, Message } from '@/types/chat/api';
+import {
+  attachmentI18nKey,
+  mediaTypeFromAttributes,
+  senderNameFromAttributes,
+} from '@/utils/chat/mediaLabels';
 import type { CannedResponse } from '@/types/knowledge';
 
 import { MessageTemplateModal } from '../message-template';
@@ -531,7 +536,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
           <span className="font-medium">
             {t('messageInput.replyPreview.replyingTo', {
               name:
-                (message.content_attributes?.sender_name as string | undefined) ||
+                senderNameFromAttributes(message.content_attributes) ||
                 message.sender?.name ||
                 t('messageInput.replyPreview.userFallback'),
             })}
@@ -557,16 +562,15 @@ const MessageInput: React.FC<MessageInputProps> = ({
             <span className="line-clamp-2">{message.content}</span>
           ) : message.attachments && message.attachments.length > 0 ? (
             <span className="italic">
-              {t('messageInput.replyPreview.fileAttachment', {
-                fileType:
-                  message.attachments[0].file_type || t('messageInput.replyPreview.fileFallback'),
-              })}
+              {t(`messageInput.replyPreview.${attachmentI18nKey(message.attachments[0].file_type)}`)}
             </span>
-          ) : message.content_attributes?.media_type ? (
+          ) : mediaTypeFromAttributes(message.content_attributes) ? (
             <span className="italic">
-              {t('messageInput.replyPreview.fileAttachment', {
-                fileType: message.content_attributes.media_type as string,
-              })}
+              {t(
+                `messageInput.replyPreview.${attachmentI18nKey(
+                  mediaTypeFromAttributes(message.content_attributes),
+                )}`,
+              )}
             </span>
           ) : (
             <span className="italic">{t('messageInput.replyPreview.noContent')}</span>

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -530,7 +530,10 @@ const MessageInput: React.FC<MessageInputProps> = ({
           <Reply className="h-4 w-4" />
           <span className="font-medium">
             {t('messageInput.replyPreview.replyingTo', {
-              name: message.sender?.name || t('messageInput.replyPreview.userFallback'),
+              name:
+                (message.content_attributes?.sender_name as string | undefined) ||
+                message.sender?.name ||
+                t('messageInput.replyPreview.userFallback'),
             })}
             {replyMode === ReplyMode.NOTE && (
               <span className="ml-1 text-xs text-orange-600 font-normal">
@@ -557,6 +560,12 @@ const MessageInput: React.FC<MessageInputProps> = ({
               {t('messageInput.replyPreview.fileAttachment', {
                 fileType:
                   message.attachments[0].file_type || t('messageInput.replyPreview.fileFallback'),
+              })}
+            </span>
+          ) : message.content_attributes?.media_type ? (
+            <span className="italic">
+              {t('messageInput.replyPreview.fileAttachment', {
+                fileType: message.content_attributes.media_type as string,
               })}
             </span>
           ) : (

--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -397,11 +397,8 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
       )}
 
       <div className={`${isThreadReply ? 'max-w-[calc(70%-2rem)]' : 'max-w-[70%]'} ${isOwn ? 'ml-auto' : ''}`}>
-        {/* 📛 Nome do remetente:
-            - Em conversa de grupo (backend WhatsApp anexa content_attributes.sender_name por mensagem),
-              renderiza o nome do participante em destaque acima da bolha.
-            - Em 1:1 cai no comportamento antigo (mostrar só em thread reply / sem avatar).
-        */}
+        {/* Em conversa de grupo o backend anexa content_attributes.sender_name por mensagem;
+            destaca o participante acima da bolha. Em 1:1, mantém o comportamento antigo. */}
         {!isOwn && (message.content_attributes?.sender_name || isThreadReply || !showAvatar) && (
           <div
             className={`text-xs mb-1 flex items-center gap-1.5 ${
@@ -410,11 +407,9 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
                 : 'text-muted-foreground'
             }`}
           >
-            {String(
-              message.content_attributes?.sender_name ||
-                message.sender?.name ||
-                t('messages.messageBubble.userFallback'),
-            )}
+            {message.content_attributes?.sender_name ||
+              message.sender?.name ||
+              t('messages.messageBubble.userFallback')}
           </div>
         )}
 

--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -397,10 +397,24 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
       )}
 
       <div className={`${isThreadReply ? 'max-w-[calc(70%-2rem)]' : 'max-w-[70%]'} ${isOwn ? 'ml-auto' : ''}`}>
-        {/* 📛 Nome: mostrar apenas para contatos (lado esquerdo) - sempre mostrar em replies */}
-        {!isOwn && (isThreadReply || !showAvatar) && (
-          <div className="text-xs mb-1 flex items-center gap-1.5 text-muted-foreground">
-            {message.sender?.name || t('messages.messageBubble.userFallback')}
+        {/* 📛 Nome do remetente:
+            - Em conversa de grupo (backend WhatsApp anexa content_attributes.sender_name por mensagem),
+              renderiza o nome do participante em destaque acima da bolha.
+            - Em 1:1 cai no comportamento antigo (mostrar só em thread reply / sem avatar).
+        */}
+        {!isOwn && (message.content_attributes?.sender_name || isThreadReply || !showAvatar) && (
+          <div
+            className={`text-xs mb-1 flex items-center gap-1.5 ${
+              message.content_attributes?.sender_name
+                ? 'font-medium text-primary'
+                : 'text-muted-foreground'
+            }`}
+          >
+            {String(
+              message.content_attributes?.sender_name ||
+                message.sender?.name ||
+                t('messages.messageBubble.userFallback'),
+            )}
           </div>
         )}
 

--- a/src/components/chat/messages/ReplyPreview.tsx
+++ b/src/components/chat/messages/ReplyPreview.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { Reply } from 'lucide-react';
 import { Message } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
+import {
+  attachmentI18nKey,
+  mediaTypeFromAttributes,
+  senderNameFromAttributes,
+} from '@/utils/chat/mediaLabels';
 
 interface ReplyPreviewProps {
   message: Message;
@@ -22,31 +27,22 @@ const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
       return content;
     }
 
-    const fileTypeMap: Record<string, string> = {
-      image: t('messages.replyPreview.imageAttachment'),
-      audio: t('messages.replyPreview.audioAttachment'),
-      video: t('messages.replyPreview.videoAttachment'),
-      file: t('messages.replyPreview.fileAttachment'),
-      location: t('messages.replyPreview.locationAttachment'),
-    };
-
     if (message.attachments && message.attachments.length > 0) {
       const fileType = message.attachments[0].file_type || 'file';
-      return fileTypeMap[fileType] || fileTypeMap.file;
+      return t(`messages.replyPreview.${attachmentI18nKey(fileType)}`);
     }
 
-    // Fallback: media message whose attachment didn't materialize (e.g. inline base64).
-    // Backend tags content_attributes.media_type so we can still surface the kind.
-    const mediaType = message.content_attributes?.media_type as string | undefined;
+    // Fallback: media message whose attachment didn't materialize (inline base64).
+    const mediaType = mediaTypeFromAttributes(message.content_attributes);
     if (mediaType) {
-      return fileTypeMap[mediaType] || fileTypeMap.file;
+      return t(`messages.replyPreview.${attachmentI18nKey(mediaType)}`);
     }
 
     return t('messages.replyPreview.noContent');
   };
 
   const senderName =
-    (message.content_attributes?.sender_name as string | undefined) ||
+    senderNameFromAttributes(message.content_attributes) ||
     message.sender?.name ||
     t('messages.replyPreview.userFallback');
 

--- a/src/components/chat/messages/ReplyPreview.tsx
+++ b/src/components/chat/messages/ReplyPreview.tsx
@@ -22,26 +22,33 @@ const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
       return content;
     }
 
-    if (message.attachments && message.attachments.length > 0) {
-      const attachment = message.attachments[0];
-      const fileType = attachment.file_type || 'file';
-      
-      // Traduzir tipo de arquivo
-      const fileTypeMap: Record<string, string> = {
-        image: t('messages.replyPreview.imageAttachment'),
-        audio: t('messages.replyPreview.audioAttachment'),
-        video: t('messages.replyPreview.videoAttachment'),
-        file: t('messages.replyPreview.fileAttachment'),
-        location: t('messages.replyPreview.locationAttachment'),
-      };
+    const fileTypeMap: Record<string, string> = {
+      image: t('messages.replyPreview.imageAttachment'),
+      audio: t('messages.replyPreview.audioAttachment'),
+      video: t('messages.replyPreview.videoAttachment'),
+      file: t('messages.replyPreview.fileAttachment'),
+      location: t('messages.replyPreview.locationAttachment'),
+    };
 
+    if (message.attachments && message.attachments.length > 0) {
+      const fileType = message.attachments[0].file_type || 'file';
       return fileTypeMap[fileType] || fileTypeMap.file;
+    }
+
+    // Fallback: media message whose attachment didn't materialize (e.g. inline base64).
+    // Backend tags content_attributes.media_type so we can still surface the kind.
+    const mediaType = message.content_attributes?.media_type as string | undefined;
+    if (mediaType) {
+      return fileTypeMap[mediaType] || fileTypeMap.file;
     }
 
     return t('messages.replyPreview.noContent');
   };
 
-  const senderName = message.sender?.name || t('messages.replyPreview.userFallback');
+  const senderName =
+    (message.content_attributes?.sender_name as string | undefined) ||
+    message.sender?.name ||
+    t('messages.replyPreview.userFallback');
 
   return (
     <div

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -692,7 +692,11 @@
       "asPrivateNote": "(as private note)",
       "fileAttachment": "📎 {{fileType}}",
       "fileFallback": "File",
-      "noContent": "Message with no content"
+      "noContent": "Message with no content",
+      "imageAttachment": "📷 Image",
+      "videoAttachment": "🎥 Video",
+      "audioAttachment": "🎵 Audio",
+      "locationAttachment": "📍 Location"
     },
     "signature": {
       "enable": "Enable signature",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -655,7 +655,11 @@
       "asPrivateNote": "(como nota privada)",
       "fileAttachment": "📎 {{fileType}}",
       "fileFallback": "Archivo",
-      "noContent": "Mensaje sin contenido"
+      "noContent": "Mensaje sin contenido",
+      "imageAttachment": "📷 Imagen",
+      "videoAttachment": "🎥 Vídeo",
+      "audioAttachment": "🎵 Audio",
+      "locationAttachment": "📍 Ubicación"
     },
     "signature": {
       "enable": "Habilitar firma",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -655,7 +655,11 @@
       "asPrivateNote": "(comme note privée)",
       "fileAttachment": "📎 {{fileType}}",
       "fileFallback": "Fichier",
-      "noContent": "Message sans contenu"
+      "noContent": "Message sans contenu",
+      "imageAttachment": "📷 Image",
+      "videoAttachment": "🎥 Vidéo",
+      "audioAttachment": "🎵 Audio",
+      "locationAttachment": "📍 Emplacement"
     },
     "signature": {
       "enable": "Activer la signature",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -655,7 +655,11 @@
       "asPrivateNote": "(come nota privata)",
       "fileAttachment": "📎 {{fileType}}",
       "fileFallback": "File",
-      "noContent": "Messaggio senza contenuto"
+      "noContent": "Messaggio senza contenuto",
+      "imageAttachment": "📷 Immagine",
+      "videoAttachment": "🎥 Video",
+      "audioAttachment": "🎵 Audio",
+      "locationAttachment": "📍 Posizione"
     },
     "signature": {
       "enable": "Abilita firma",

--- a/src/types/chat/api.ts
+++ b/src/types/chat/api.ts
@@ -81,6 +81,8 @@ export interface Conversation {
     message_type: MessageTypeValue;
     created_at: string;
     processed_message_content: string;
+    content_attributes?: Record<string, unknown>;
+    attachments?: Array<{ file_type: string }>;
     sender: {
       id: string;
       name: string;

--- a/src/types/chat/api.ts
+++ b/src/types/chat/api.ts
@@ -81,7 +81,7 @@ export interface Conversation {
     message_type: MessageTypeValue;
     created_at: string;
     processed_message_content: string;
-    content_attributes?: Record<string, unknown>;
+    content_attributes?: MessageContentAttributes;
     attachments?: Array<{ file_type: string }>;
     sender: {
       id: string;
@@ -186,11 +186,25 @@ export interface Attachment {
   meta?: Record<string, any>;
 }
 
+// Known fields the backend tags on `Message.content_attributes`. The shape stays
+// open (`Record<string, unknown>`) for forward compatibility, but these named
+// fields let consumers read them without unsafe `as string` casts.
+export interface MessageContentAttributes extends Record<string, unknown> {
+  sender_name?: string;
+  media_type?: 'image' | 'video' | 'audio' | 'file' | 'sticker' | 'location' | 'contact';
+  in_reply_to?: string | number;
+  in_reply_to_external_id?: string;
+  is_reaction?: boolean;
+  is_unsupported?: boolean;
+  deleted?: boolean;
+  external_created_at?: number;
+}
+
 // ===== MESSAGE =====
 export interface Message {
   id: string;
   content: string;
-  content_attributes: Record<string, unknown>;
+  content_attributes: MessageContentAttributes;
   content_type:
     | 'text'
     | 'input_email'

--- a/src/utils/chat/mediaLabels.ts
+++ b/src/utils/chat/mediaLabels.ts
@@ -1,0 +1,63 @@
+// Centralized media-type and attachment-label helpers used by the chat UI to
+// preview WhatsApp messages whose body is empty (media-only) and to render
+// reply previews consistently across MessageBubble, ChatSidebar, ReplyPreview
+// and MessageInput.
+//
+// The backend tags `content_attributes.media_type` even when the binary
+// attachment didn't materialize (e.g. inline base64 from Evolution Go), so we
+// fall back to it when `attachments[0].file_type` is absent.
+
+export type MediaType =
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'file'
+  | 'sticker'
+  | 'location'
+  | 'contact';
+
+const EMOJI_LABEL: Record<MediaType, string> = {
+  image: '📷 Foto',
+  video: '🎥 Vídeo',
+  audio: '🎵 Áudio',
+  file: '📎 Documento',
+  sticker: '💟 Figurinha',
+  location: '📍 Localização',
+  contact: '👤 Contato',
+};
+
+const isKnownMediaType = (value: unknown): value is MediaType =>
+  typeof value === 'string' && value in EMOJI_LABEL;
+
+export const attachmentLabel = (fileType?: string | null): string => {
+  if (!fileType) return '📎 Anexo';
+  return isKnownMediaType(fileType) ? EMOJI_LABEL[fileType] : `📎 ${fileType}`;
+};
+
+// i18n key fragment matching the existing `messages.replyPreview.*` translations.
+const I18N_KEY: Record<MediaType, string> = {
+  image: 'imageAttachment',
+  video: 'videoAttachment',
+  audio: 'audioAttachment',
+  file: 'fileAttachment',
+  sticker: 'fileAttachment',
+  location: 'locationAttachment',
+  contact: 'fileAttachment',
+};
+
+export const attachmentI18nKey = (fileType?: string | null): string =>
+  isKnownMediaType(fileType) ? I18N_KEY[fileType] : I18N_KEY.file;
+
+export const senderNameFromAttributes = (
+  attrs: Record<string, unknown> | undefined,
+): string | undefined => {
+  const value = attrs?.sender_name;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+export const mediaTypeFromAttributes = (
+  attrs: Record<string, unknown> | undefined,
+): MediaType | undefined => {
+  const value = attrs?.media_type;
+  return isKnownMediaType(value) ? value : undefined;
+};


### PR DESCRIPTION
## Summary

Companion to the backend group-ingestion fix. Render `content_attributes.sender_name` and `content_attributes.media_type` that the backend now ships with every WhatsApp group message, so operators can tell who said what and what kind of media was sent.

- **ChatSidebar conversation list preview**: prefix group-conversation preview with `<sender>:` and surface typed media labels (📷 Foto / 🎥 Vídeo / 🎵 Áudio / 📎 Documento / 💟 Figurinha / 📍 Localização) when content is empty.
- **MessageBubble**: show the participant name above each incoming bubble in group conversations (`text-primary font-medium`), preserving the original 1:1 behaviour.
- **ReplyPreview** (both inside the bubble and above the input): prefer `content_attributes.sender_name` instead of the group's contact name, with media_type fallback for media-only quoted messages.
- **Types**: extend `last_non_activity_message` with optional `content_attributes` and `attachments`.

## Validation

- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` — no new errors
- `evo-ai-frontend-community: pnpm test --run src/components/chat` — **45 tests, 0 failures**
- Manual end-to-end on a live Evolution Go channel: sender name renders in the conversation list preview, in the chat bubble, and in both reply previews; media-only messages render typed labels.

## Changed Files

- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/chat/messages/MessageBubble.tsx`
- `src/components/chat/messages/ReplyPreview.tsx`
- `src/components/chat/message-input/MessageInput.tsx`
- `src/types/chat/api.ts`

## Linked Issue

- Linear: [EVO-981](https://linear.app/evoai/issue/EVO-981)

## Related PRs

- Backend: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/29

## Summary by Sourcery

Render WhatsApp group sender names and media-type labels consistently across the chat UI using new backend-supplied content attributes.

New Features:
- Show sender names for incoming WhatsApp group messages in conversation previews, message bubbles, and reply previews using backend-provided content attributes.
- Display human-friendly media-type labels for media-only messages in the chat sidebar preview and reply previews, including fallback to backend media_type metadata when attachments are unavailable.

Enhancements:
- Extend chat API types to include optional content_attributes and attachments on last_non_activity_message to support richer display metadata in the frontend.