### PR TITLE
fix(EVO-979): WhatsApp audio PTT — self-hosted FFmpeg, OGG/Opus, is_recorded_audio flag + tests

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,10 @@ server {
     # NOTE: Do not set X-Frame-Options globally because /widget must be embeddable in third-party sites.
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
+    # CSP: 'wasm-unsafe-eval' is required by FFmpeg WASM (self-hosted under /ffmpeg/).
+    # 'worker-src blob:' allows the FFmpeg core worker; 'connect-src' is permissive for
+    # backend/CDN-less deploys — tighten per environment if needed.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; media-src 'self' blob: https:; font-src 'self' data:; worker-src 'self' blob:; connect-src 'self' https: wss: ws:; frame-ancestors 'self'; base-uri 'self'; object-src 'none'" always;
 
     # Widget route must be embeddable in customer websites (iframe).
     location = /widget {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@breezystack/lamejs": "^1.2.7",
         "@evoapi/design-system": "^0.0.6",
+        "@ffmpeg/core": "^0.11.0",
+        "@ffmpeg/ffmpeg": "^0.11.6",
         "@hookform/resolvers": "^5.0.1",
         "@rails/actioncable": "^8.0.201",
         "@tailwindcss/vite": "^4.1.11",
@@ -68,6 +70,7 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
         "vite": "^6.3.1",
+        "vite-plugin-static-copy": "^4.1.0",
         "vitest": "^2.1.8"
       }
     },
@@ -1196,6 +1199,27 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@ffmpeg/core": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-9Tt/+2PMpkGPXUK8n6He9G8Y+qR6qmCPSCw9iEKZxHHOvJ9BE/r0Fccj+YgDZTlyu6rXxc9x6EqCaFBIt7qzjA==",
+      "license": "MIT"
+    },
+    "node_modules/@ffmpeg/ffmpeg": {
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.11.6.tgz",
+      "integrity": "sha512-uN8J8KDjADEavPhNva6tYO9Fj0lWs9z82swF3YXnTxWMBoFLGq3LZ6FLlIldRKEzhOBKnkVfA8UnFJuvGvNxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.1",
+        "regenerator-runtime": "^0.13.7",
+        "resolve-url": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=12.16.1"
+      }
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -4479,6 +4503,20 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4550,6 +4588,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -4705,6 +4756,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/chownr": {
@@ -6171,6 +6260,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6215,6 +6317,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6833,12 +6941,64 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/normalize-wheel": {
       "version": "1.0.1",
@@ -6913,6 +7073,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7576,6 +7749,19 @@
         }
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
@@ -7636,6 +7822,12 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -7651,6 +7843,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -8941,6 +9140,29 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.1.0.tgz",
+      "integrity": "sha512-9XOarNV7LgP0KBB7AApxdgFikLXx3daZdqjC3AevYsL6MrUH62zphonLUs2a6LZc1HN1GY+vQdheZ8VVJb6dQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.6.0",
+        "p-map": "^7.0.4",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "engines": {
+        "node": "^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sapphi-red"
+      },
+      "peerDependencies": {
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@breezystack/lamejs": "^1.2.7",
+    "@ffmpeg/core": "^0.11.0",
+    "@ffmpeg/ffmpeg": "^0.11.6",
     "@evoapi/design-system": "^0.0.6",
     "@hookform/resolvers": "^5.0.1",
     "@rails/actioncable": "^8.0.201",

--- a/src/components/chat/audio/AudioRecorder.tsx
+++ b/src/components/chat/audio/AudioRecorder.tsx
@@ -4,7 +4,7 @@ import { Play, Pause, Square, Trash2, Mic } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useAudioRecorder, AudioRecordingData } from '@/hooks/chat/useAudioRecorder';
-import { preloadFfmpeg, terminateFfmpeg } from '@/utils/audio/ffmpegLoader';
+import { acquireFfmpeg, releaseFfmpeg } from '@/utils/audio/ffmpegLoader';
 
 interface AudioRecorderProps {
   onRecordingComplete: (data: AudioRecordingData) => void;
@@ -65,7 +65,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       toast.loading(t('audioRecorder.preparingConverter'), { id: 'ffmpeg-loading' });
     }, 1000);
 
-    preloadFfmpeg()
+    acquireFfmpeg()
       .then(() => {
         clearTimeout(toastTimer);
         if (toastShown) toast.dismiss('ffmpeg-loading');
@@ -79,7 +79,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
     return () => {
       clearTimeout(toastTimer);
       toast.dismiss('ffmpeg-loading');
-      terminateFfmpeg();
+      releaseFfmpeg();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldPreloadConverter]);

--- a/src/components/chat/audio/AudioRecorder.tsx
+++ b/src/components/chat/audio/AudioRecorder.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useRef } from 'react';
 import { Button } from '@evoapi/design-system/button';
 import { Play, Pause, Square, Trash2, Mic } from 'lucide-react';
+import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useAudioRecorder, AudioRecordingData } from '@/hooks/chat/useAudioRecorder';
+import { preloadFfmpeg, terminateFfmpeg } from '@/utils/audio/ffmpegLoader';
 
 interface AudioRecorderProps {
   onRecordingComplete: (data: AudioRecordingData) => void;
@@ -11,6 +13,8 @@ interface AudioRecorderProps {
   className?: string;
   autoStart?: boolean;
   preferWhatsAppCloudFormat?: boolean;
+  /** When true, pre-loads the OGG/Opus converter on mount so it's ready by send time. */
+  shouldPreloadConverter?: boolean;
 }
 
 const AudioRecorder: React.FC<AudioRecorderProps> = ({
@@ -20,6 +24,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
   className = '',
   autoStart = false,
   preferWhatsAppCloudFormat = false,
+  shouldPreloadConverter = false,
 }) => {
   const { t } = useLanguage('chat');
   const {
@@ -34,7 +39,10 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
     resumeRecording,
     deleteRecording,
     isSupported,
-  } = useAudioRecorder({ preferWhatsAppCloudFormat });
+  } = useAudioRecorder({
+    preferWhatsAppCloudFormat,
+    onMaxDurationReached: () => toast.warning(t('audioRecorder.maxDurationReached')),
+  });
 
   const audioRef = useRef<HTMLAudioElement>(null);
   const [isPlaying, setIsPlaying] = React.useState(false);
@@ -45,6 +53,36 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
     const secs = Math.floor(seconds % 60);
     return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
   };
+
+  // Pre-load the OGG/Opus converter (FFmpeg WASM) so it's ready when the user sends.
+  // Fires a toast if loading takes more than 1 s to set expectations.
+  useEffect(() => {
+    if (!shouldPreloadConverter) return;
+
+    let toastShown = false;
+    const toastTimer = setTimeout(() => {
+      toastShown = true;
+      toast.loading(t('audioRecorder.preparingConverter'), { id: 'ffmpeg-loading' });
+    }, 1000);
+
+    preloadFfmpeg()
+      .then(() => {
+        clearTimeout(toastTimer);
+        if (toastShown) toast.dismiss('ffmpeg-loading');
+      })
+      .catch(() => {
+        clearTimeout(toastTimer);
+        if (toastShown) toast.dismiss('ffmpeg-loading');
+        // Silently ignore — conversion will fall back to original format on send
+      });
+
+    return () => {
+      clearTimeout(toastTimer);
+      toast.dismiss('ffmpeg-loading');
+      terminateFfmpeg();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldPreloadConverter]);
 
   // Auto-iniciar gravação se especificado
   useEffect(() => {

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -51,7 +51,13 @@ interface SendMessageOptions {
   isPrivate?: boolean;
   templateParams?: any;
   cannedResponseId?: string | null;
-  isRecordedAudio?: boolean;
+  /**
+   * Marks attachments as recorded audio (PTT) for the backend.
+   * - `true`: every attachment in this message is recorded audio (e.g. recorder UI).
+   * - `string[]`: list of filenames within the attachments that are recorded audio
+   *   (used when audio + non-audio files are sent in the same message).
+   */
+  isRecordedAudio?: boolean | string[];
 }
 
 interface MessageInputProps {
@@ -409,8 +415,11 @@ const MessageInput: React.FC<MessageInputProps> = ({
 
     try {
       // Convert uploaded audio files to OGG/Opus for WhatsApp PTT (acceptance criteria:
-      // "Works for in-browser recordings AND uploaded audio files")
+      // "Works for in-browser recordings AND uploaded audio files"). Track which
+      // resulting filenames are PTT so the backend marks only those attachments —
+      // important when audio + non-audio files are mixed in the same message.
       let filesToSend = selectedFiles;
+      const recordedAudioFilenames: string[] = [];
       if (isWhatsApp && selectedFiles.some(f => f.type.startsWith('audio/'))) {
         const { convertToOggOpus } = await import('@/utils/audio/audioConversionUtils');
         filesToSend = await Promise.all(
@@ -424,14 +433,19 @@ const MessageInput: React.FC<MessageInputProps> = ({
                 });
               });
               toast.dismiss(convertingToastId);
-              return new File([oggBlob], file.name.replace(/\.\w+$/i, '.ogg'), {
+              const oggName = file.name.replace(/\.\w+$/i, '.ogg');
+              recordedAudioFilenames.push(oggName);
+              return new File([oggBlob], oggName, {
                 type: 'audio/ogg; codecs=opus',
               });
             } catch {
               toast.warning(t('messageInput.audio.conversionWarning'), {
                 description: t('messageInput.audio.conversionWarningDescription'),
               });
-              return file; // fallback to original
+              // Fallback: still mark as PTT so Baileys/EvoGo set ptt:true on the
+              // original (non-OGG) audio — Cloud already hardcodes voice:true.
+              recordedAudioFilenames.push(file.name);
+              return file;
             }
           }),
         );
@@ -443,6 +457,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         isPrivate,
         templateParams: undefined,
         cannedResponseId: selectedCannedResponseId,
+        isRecordedAudio: recordedAudioFilenames.length > 0 ? recordedAudioFilenames : undefined,
       });
 
       richEditorRef.current?.clear();

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -408,9 +408,38 @@ const MessageInput: React.FC<MessageInputProps> = ({
     setIsSending(true);
 
     try {
+      // Convert uploaded audio files to OGG/Opus for WhatsApp PTT (acceptance criteria:
+      // "Works for in-browser recordings AND uploaded audio files")
+      let filesToSend = selectedFiles;
+      if (isWhatsApp && selectedFiles.some(f => f.type.startsWith('audio/'))) {
+        const { convertToOggOpus } = await import('@/utils/audio/audioConversionUtils');
+        filesToSend = await Promise.all(
+          selectedFiles.map(async file => {
+            if (!file.type.startsWith('audio/')) return file;
+            try {
+              const convertingToastId = toast.loading(t('messageInput.audio.converting'));
+              const oggBlob = await convertToOggOpus(file, percent => {
+                toast.loading(`${t('messageInput.audio.converting')} ${percent}%`, {
+                  id: convertingToastId,
+                });
+              });
+              toast.dismiss(convertingToastId);
+              return new File([oggBlob], file.name.replace(/\.\w+$/i, '.ogg'), {
+                type: 'audio/ogg; codecs=opus',
+              });
+            } catch {
+              toast.warning(t('messageInput.audio.conversionWarning'), {
+                description: t('messageInput.audio.conversionWarningDescription'),
+              });
+              return file; // fallback to original
+            }
+          }),
+        );
+      }
+
       await onSendMessage({
         content: currentMessage,
-        files: selectedFiles.length > 0 ? selectedFiles : undefined,
+        files: filesToSend.length > 0 ? filesToSend : undefined,
         isPrivate,
         templateParams: undefined,
         cannedResponseId: selectedCannedResponseId,

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -51,6 +51,7 @@ interface SendMessageOptions {
   isPrivate?: boolean;
   templateParams?: any;
   cannedResponseId?: string | null;
+  isRecordedAudio?: boolean;
 }
 
 interface MessageInputProps {
@@ -85,16 +86,19 @@ const MessageInput: React.FC<MessageInputProps> = ({
   const { user } = useAuth();
 
   // Detectar se é WhatsApp Cloud (apenas Cloud, não baileys/evolution/evolution_go)
+  // Usado para features específicas da Cloud API (templates, etc.)
   const isWhatsAppCloud = React.useMemo(() => {
     if (channelType !== 'Channel::Whatsapp') return false;
     const provider = channelProvider?.toLowerCase();
-    const result =
-      provider === 'whatsapp_cloud' || provider === 'default' || !provider || provider === '';
-
-    return result;
+    return provider === 'whatsapp_cloud' || provider === 'default' || !provider || provider === '';
   }, [channelType, channelProvider]);
 
-  // Detectar se é Instagram (também precisa de conversão de áudio WebM para MP3)
+  // Qualquer canal WhatsApp (Cloud, Baileys, Evolution, EvoGo) — usado para conversão de áudio PTT
+  const isWhatsApp = React.useMemo(() => {
+    return channelType === 'Channel::Whatsapp';
+  }, [channelType]);
+
+  // Detectar se é Instagram (também precisa de conversão de áudio WebM para WAV)
   const isInstagram = React.useMemo(() => {
     return channelType === 'Channel::Instagram';
   }, [channelType]);
@@ -261,40 +265,52 @@ const MessageInput: React.FC<MessageInputProps> = ({
         setIsSending(true);
         const isPrivate = replyMode === ReplyMode.NOTE;
 
-        // Converter áudio se necessário (WhatsApp Cloud aceita MP3, Instagram aceita WAV)
+        // Converter áudio para o formato correto por canal:
+        // - WhatsApp (todos os provedores): OGG/Opus para PTT nativo
+        // - Instagram: WAV
         let audioFile = data.file;
-        if ((isWhatsAppCloud || isInstagram) && data.file.type === 'audio/webm') {
+        if (isWhatsApp) {
           try {
-            const { convertAudio, convertToWav } = await import('@/utils/audio/audioConversionUtils');
-            // toast.info(t('messageInput.audio.converting'), { duration: 2000 });
-
-            if (isInstagram) {
-              // Instagram aceita WAV, não MP3
-              const wavBlob = await convertToWav(data.blob);
-              const fileName = data.file.name.replace(/\.webm$/i, '.wav');
-              audioFile = new File([wavBlob], fileName, { type: 'audio/wav' });
-            } else if (isWhatsAppCloud) {
-              // WhatsApp Cloud aceita MP3
-              const mp3Blob = await convertAudio(data.blob, 'audio/mp3', 128);
-              const fileName = data.file.name.replace(/\.webm$/i, '.mp3');
-              audioFile = new File([mp3Blob], fileName, { type: 'audio/mp3' });
-            }
+            const convertingToastId = toast.loading(t('messageInput.audio.converting'));
+            const { convertToOggOpus } = await import('@/utils/audio/audioConversionUtils');
+            const oggBlob = await convertToOggOpus(data.blob, percent => {
+              toast.loading(`${t('messageInput.audio.converting')} ${percent}%`, {
+                id: convertingToastId,
+              });
+            });
+            toast.dismiss(convertingToastId);
+            const fileName = data.file.name.replace(/\.\w+$/i, '.ogg');
+            audioFile = new File([oggBlob], fileName, { type: 'audio/ogg; codecs=opus' });
           } catch (conversionError) {
-            console.error('Erro ao converter áudio:', conversionError);
+            console.error('Erro ao converter áudio para OGG/Opus:', conversionError);
             toast.warning(t('messageInput.audio.conversionWarning'), {
               description: t('messageInput.audio.conversionWarningDescription'),
             });
-            // Continuar com o arquivo original mesmo em caso de erro
+            // Continuar com o arquivo original em caso de falha na conversão
+          }
+        } else if (isInstagram && data.file.type === 'audio/webm') {
+          try {
+            toast.info(t('messageInput.audio.converting'), { duration: 2000 });
+            const { convertToWav } = await import('@/utils/audio/audioConversionUtils');
+            const wavBlob = await convertToWav(data.blob);
+            const fileName = data.file.name.replace(/\.webm$/i, '.wav');
+            audioFile = new File([wavBlob], fileName, { type: 'audio/wav' });
+          } catch (conversionError) {
+            console.error('Erro ao converter áudio para WAV:', conversionError);
+            toast.warning(t('messageInput.audio.conversionWarning'), {
+              description: t('messageInput.audio.conversionWarningDescription'),
+            });
           }
         }
 
-        // Enviar arquivo de áudio
+        // Enviar arquivo de áudio (isRecordedAudio sinaliza ao backend para setar PTT/voice)
         await onSendMessage({
           content: '',
           files: [audioFile],
           isPrivate,
           templateParams: undefined,
           cannedResponseId: null,
+          isRecordedAudio: true,
         });
 
         setIsRecordingAudio(false);
@@ -306,7 +322,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         setIsSending(false);
       }
     },
-    [onSendMessage, replyMode, t, isWhatsAppCloud, isInstagram],
+    [onSendMessage, replyMode, t, isWhatsApp, isInstagram],
   );
 
   const handleAudioRecordingCancel = useCallback(() => {
@@ -849,7 +865,8 @@ const MessageInput: React.FC<MessageInputProps> = ({
             onRecordingCancel={handleAudioRecordingCancel}
             disabled={isDisabled || isSending}
             autoStart={true}
-            preferWhatsAppCloudFormat={isWhatsAppCloud}
+            preferWhatsAppCloudFormat={isWhatsApp}
+            shouldPreloadConverter={isWhatsApp}
           />
         </div>
       )}

--- a/src/contexts/chat/MessagesContext.tsx
+++ b/src/contexts/chat/MessagesContext.tsx
@@ -381,6 +381,7 @@ interface MessagesContextValue {
     isPrivate?: boolean,
     cannedResponseId?: string | null,
     onUploadProgress?: (progress: number, fileName: string) => void,
+    isRecordedAudio?: boolean,
   ) => Promise<Message | undefined>;
   // Internal method for template support
   _sendMessageBase: (
@@ -392,6 +393,7 @@ interface MessagesContextValue {
       templateParams?: any;
       cannedResponseId?: string | null;
       onUploadProgress?: (progress: number, fileName: string) => void;
+      isRecordedAudio?: boolean;
     },
   ) => Promise<Message | undefined>;
 
@@ -572,6 +574,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         templateParams?: any;
         cannedResponseId?: string | null;
         onUploadProgress?: (progress: number, fileName: string) => void;
+        isRecordedAudio?: boolean;
       },
     ) => {
       const {
@@ -580,6 +583,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         isPrivate = false,
         cannedResponseId,
         onUploadProgress,
+        isRecordedAudio,
       } = options;
 
       // 1. 🔧 REPLY TO: Preparar content_attributes com in_reply_to se houver reply
@@ -661,6 +665,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
                 onUploadProgress,
                 contentAttributes.in_reply_to as string | number | undefined,
                 pendingMessage.id,
+                isRecordedAudio,
               )
             : await chatService.sendMessage(conversationId, {
                 content: messageContent,
@@ -759,6 +764,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
       isPrivate?: boolean,
       cannedResponseId?: string | null,
       onUploadProgress?: (progress: number, fileName: string) => void,
+      isRecordedAudio?: boolean,
     ) => {
       return _sendMessageBase(conversationId, {
         content,
@@ -766,6 +772,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         isPrivate,
         cannedResponseId,
         onUploadProgress,
+        isRecordedAudio,
       });
     },
     [_sendMessageBase],

--- a/src/contexts/chat/MessagesContext.tsx
+++ b/src/contexts/chat/MessagesContext.tsx
@@ -381,7 +381,7 @@ interface MessagesContextValue {
     isPrivate?: boolean,
     cannedResponseId?: string | null,
     onUploadProgress?: (progress: number, fileName: string) => void,
-    isRecordedAudio?: boolean,
+    isRecordedAudio?: boolean | string[],
   ) => Promise<Message | undefined>;
   // Internal method for template support
   _sendMessageBase: (
@@ -393,7 +393,7 @@ interface MessagesContextValue {
       templateParams?: any;
       cannedResponseId?: string | null;
       onUploadProgress?: (progress: number, fileName: string) => void;
-      isRecordedAudio?: boolean;
+      isRecordedAudio?: boolean | string[];
     },
   ) => Promise<Message | undefined>;
 
@@ -574,7 +574,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         templateParams?: any;
         cannedResponseId?: string | null;
         onUploadProgress?: (progress: number, fileName: string) => void;
-        isRecordedAudio?: boolean;
+        isRecordedAudio?: boolean | string[];
       },
     ) => {
       const {
@@ -764,7 +764,7 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
       isPrivate?: boolean,
       cannedResponseId?: string | null,
       onUploadProgress?: (progress: number, fileName: string) => void,
-      isRecordedAudio?: boolean,
+      isRecordedAudio?: boolean | string[],
     ) => {
       return _sendMessageBase(conversationId, {
         content,

--- a/src/hooks/chat/useAudioRecorder.spec.ts
+++ b/src/hooks/chat/useAudioRecorder.spec.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAudioRecorder } from './useAudioRecorder';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    warning: vi.fn(),
+    success: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/audio/ffmpegLoader', () => ({
+  FFMPEG_MAX_RECORDING_SECONDS: 300,
+}));
+
+// Minimal MediaRecorder mock
+class MockMediaRecorder {
+  static isTypeSupported = (type: string) => type.includes('webm') || type.includes('ogg');
+
+  ondataavailable: ((e: { data: Blob }) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  state = 'inactive';
+
+  constructor(public stream: MediaStream, public options?: MediaRecorderOptions) {}
+
+  start() {
+    this.state = 'recording';
+    // Emit a data chunk immediately
+    this.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+  }
+
+  stop() {
+    this.state = 'inactive';
+    this.onstop?.();
+  }
+
+  pause() { this.state = 'paused'; }
+  resume() { this.state = 'recording'; }
+}
+
+const mockStream = {
+  getTracks: () => [{ stop: vi.fn() }],
+} as unknown as MediaStream;
+
+const mockAudioContext = {
+  createAnalyser: () => ({
+    fftSize: 256,
+    frequencyBinCount: 128,
+    getByteFrequencyData: vi.fn(),
+  }),
+  createMediaStreamSource: () => ({ connect: vi.fn() }),
+  close: vi.fn(),
+};
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.useFakeTimers();
+
+  Object.defineProperty(global, 'MediaRecorder', {
+    value: MockMediaRecorder,
+    writable: true,
+  });
+
+  Object.defineProperty(global.navigator, 'mediaDevices', {
+    value: {
+      getUserMedia: vi.fn().mockResolvedValue(mockStream),
+    },
+    writable: true,
+  });
+
+  Object.defineProperty(global, 'AudioContext', {
+    value: vi.fn(() => mockAudioContext),
+    writable: true,
+  });
+
+  Object.defineProperty(global, 'URL', {
+    value: { createObjectURL: vi.fn(() => 'blob:mock'), revokeObjectURL: vi.fn() },
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useAudioRecorder', () => {
+  it('starts with no recording', () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.hasRecording).toBe(false);
+    expect(result.current.duration).toBe(0);
+  });
+
+  it('sets isRecording to true after startRecording', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+  });
+
+  it('sets hasRecording to true after stopRecording', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    act(() => {
+      result.current.stopRecording();
+    });
+
+    expect(result.current.hasRecording).toBe(true);
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it('increments duration while recording', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.duration).toBeGreaterThan(0);
+  });
+
+  it('pauses and resumes recording', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    act(() => { result.current.pauseRecording(); });
+    expect(result.current.isPaused).toBe(true);
+
+    act(() => { result.current.resumeRecording(); });
+    expect(result.current.isPaused).toBe(false);
+  });
+
+  it('deletes recording and resets state', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    act(() => { result.current.stopRecording(); });
+    act(() => { result.current.deleteRecording(); });
+
+    expect(result.current.hasRecording).toBe(false);
+    expect(result.current.recordingData).toBeNull();
+  });
+
+  it('auto-stops and calls onMaxDurationReached after 5 minutes (C3)', async () => {
+    const onMaxDurationReached = vi.fn();
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onMaxDurationReached }),
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    // Advance past the 5-minute cap and flush all state updates
+    await act(async () => {
+      vi.advanceTimersByTime(300_000 + 500);
+    });
+
+    expect(onMaxDurationReached).toHaveBeenCalledOnce();
+    expect(result.current.isRecording).toBe(false);
+  });
+
+  it('does not trigger cap callback if stopped before 5 minutes', async () => {
+    const onMaxDurationReached = vi.fn();
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onMaxDurationReached }),
+    );
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60_000); // 1 minute
+      result.current.stopRecording();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(300_000); // advance past cap after stop
+    });
+
+    expect(onMaxDurationReached).not.toHaveBeenCalled();
+  });
+
+  it('prevents duplicate recordings from starting simultaneously', async () => {
+    const { result } = renderHook(() => useAudioRecorder());
+
+    await act(async () => {
+      // Trigger two concurrent starts
+      await Promise.all([
+        result.current.startRecording(),
+        result.current.startRecording(),
+      ]);
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/chat/useAudioRecorder.ts
+++ b/src/hooks/chat/useAudioRecorder.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import { toast } from 'sonner';
+import { FFMPEG_MAX_RECORDING_SECONDS } from '@/utils/audio/ffmpegLoader';
 
 export interface AudioRecordingData {
   blob: Blob;
@@ -25,10 +26,13 @@ export interface UseAudioRecorderReturn {
 
 interface UseAudioRecorderOptions {
   preferWhatsAppCloudFormat?: boolean;
+  /** Called when the recording is auto-stopped due to the 5-min cap (C3). */
+  onMaxDurationReached?: () => void;
 }
 
 export const useAudioRecorder = (options?: UseAudioRecorderOptions): UseAudioRecorderReturn => {
   const preferWhatsAppCloudFormat = options?.preferWhatsAppCloudFormat === true;
+  const onMaxDurationReached = options?.onMaxDurationReached;
   const [isRecording, setIsRecording] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [duration, setDuration] = useState(0);
@@ -48,6 +52,7 @@ export const useAudioRecorder = (options?: UseAudioRecorderOptions): UseAudioRec
   const analyserRef = useRef<AnalyserNode | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const selectedMimeTypeRef = useRef<string>('audio/webm;codecs=opus');
+  const maxDurationTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // TRAVA GLOBAL ANTI-DUPLICAÇÃO
   const isInitializingRef = useRef<boolean>(false);
@@ -296,6 +301,19 @@ export const useAudioRecorder = (options?: UseAudioRecorderOptions): UseAudioRec
       }, 100); // Atualizar a cada 100ms para suavidade
       setRecordingData(null);
 
+      // Cap de duração máxima (5 min) — evita UI freeze em transcodificação longa (C3).
+      // Acessa refs diretamente para evitar stale closure no isRecording do useCallback.
+      maxDurationTimerRef.current = setTimeout(() => {
+        onMaxDurationReached?.();
+        if (mediaRecorderRef.current) {
+          isPausedRef.current = true; // Para o timer imediatamente
+          (mediaRecorderRef.current as any).__finalDuration = startTimeRef.current
+            ? (Date.now() - startTimeRef.current - pausedTimeRef.current) / 1000
+            : 0;
+          mediaRecorderRef.current.stop();
+        }
+      }, FFMPEG_MAX_RECORDING_SECONDS * 1000);
+
       // Iniciar monitoramento
       monitorAudioLevel();
     } catch (error) {
@@ -324,7 +342,12 @@ export const useAudioRecorder = (options?: UseAudioRecorderOptions): UseAudioRec
     // Resetar estados
     isPausedRef.current = true; // Para o timer imediatamente
 
-    // Limpar timer quando parar
+    // Limpar timers quando parar
+    if (maxDurationTimerRef.current) {
+      clearTimeout(maxDurationTimerRef.current);
+      maxDurationTimerRef.current = null;
+    }
+
     if (durationIntervalRef.current) {
       clearInterval(durationIntervalRef.current);
       durationIntervalRef.current = null;

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -218,7 +218,9 @@
     "notSupported": "Audio recording not supported in this browser",
     "record": "Record",
     "paused": "(paused)",
-    "send": "Send"
+    "send": "Send",
+    "preparingConverter": "Preparing audio converter...",
+    "maxDurationReached": "Maximum recording duration reached (5 min). Audio stopped automatically."
   },
   "cannedResponses": {
     "loading": "Loading canned responses...",
@@ -680,7 +682,10 @@
     },
     "audio": {
       "sentSuccess": "Audio sent successfully!",
-      "sendError": "Error sending audio"
+      "sendError": "Error sending audio",
+      "converting": "Converting audio...",
+      "conversionWarning": "Conversion warning",
+      "conversionWarningDescription": "Could not convert audio to OGG/Opus. Sending in original format."
     },
     "templates": {
       "inDevelopment": "Message templates in development 📝"

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -217,7 +217,9 @@
     "notSupported": "Grabación de audio no compatible con este navegador",
     "record": "Grabar",
     "paused": "(pausado)",
-    "send": "Enviar"
+    "send": "Enviar",
+    "preparingConverter": "Preparando convertidor de audio...",
+    "maxDurationReached": "Duración máxima de grabación alcanzada (5 min). Audio detenido automáticamente."
   },
   "cannedResponses": {
     "loading": "Cargando respuestas predefinidas...",
@@ -643,7 +645,10 @@
     },
     "audio": {
       "sentSuccess": "¡Audio enviado con éxito!",
-      "sendError": "Error al enviar audio"
+      "sendError": "Error al enviar audio",
+      "converting": "Convirtiendo audio...",
+      "conversionWarning": "Advertencia de conversión",
+      "conversionWarningDescription": "No se pudo convertir el audio a OGG/Opus. Enviando en formato original."
     },
     "templates": {
       "inDevelopment": "Plantillas de mensaje en desarrollo 📝"

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -217,7 +217,9 @@
     "notSupported": "Enregistrement audio non pris en charge dans ce navigateur",
     "record": "Enregistrer",
     "paused": "(en pause)",
-    "send": "Envoyer"
+    "send": "Envoyer",
+    "preparingConverter": "Préparation du convertisseur audio...",
+    "maxDurationReached": "Durée maximale d'enregistrement atteinte (5 min). Audio arrêté automatiquement."
   },
   "cannedResponses": {
     "loading": "Chargement des réponses prédéfinies...",
@@ -643,7 +645,10 @@
     },
     "audio": {
       "sentSuccess": "Audio envoyé avec succès !",
-      "sendError": "Erreur lors de l'envoi de l'audio"
+      "sendError": "Erreur lors de l'envoi de l'audio",
+      "converting": "Conversion de l'audio...",
+      "conversionWarning": "Avertissement de conversion",
+      "conversionWarningDescription": "Impossible de convertir l'audio en OGG/Opus. Envoi dans le format original."
     },
     "templates": {
       "inDevelopment": "Modèles de messages en développement 📝"

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -217,7 +217,9 @@
     "notSupported": "Registrazione audio non supportata in questo browser",
     "record": "Registra",
     "paused": "(in pausa)",
-    "send": "Invia"
+    "send": "Invia",
+    "preparingConverter": "Preparazione convertitore audio...",
+    "maxDurationReached": "Durata massima di registrazione raggiunta (5 min). Audio interrotto automaticamente."
   },
   "cannedResponses": {
     "loading": "Caricamento risposte predefinite...",
@@ -643,7 +645,10 @@
     },
     "audio": {
       "sentSuccess": "Audio inviato con successo!",
-      "sendError": "Errore nell'invio dell'audio"
+      "sendError": "Errore nell'invio dell'audio",
+      "converting": "Conversione audio in corso...",
+      "conversionWarning": "Avviso di conversione",
+      "conversionWarningDescription": "Impossibile convertire l'audio in OGG/Opus. Invio nel formato originale."
     },
     "templates": {
       "inDevelopment": "Modelli di messaggio in sviluppo 📝"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -226,7 +226,9 @@
     "notSupported": "Gravação de áudio não suportada neste navegador",
     "record": "Gravar",
     "paused": "(pausado)",
-    "send": "Enviar"
+    "send": "Enviar",
+    "preparingConverter": "Preparando conversor de áudio...",
+    "maxDurationReached": "Duração máxima de gravação atingida (5 min). Áudio parado automaticamente."
   },
   "cannedResponses": {
     "loading": "Carregando respostas prontas...",
@@ -655,7 +657,7 @@
       "sendError": "Erro ao enviar áudio",
       "converting": "Convertendo áudio...",
       "conversionWarning": "Aviso de conversão",
-      "conversionWarningDescription": "Não foi possível converter o áudio para MP3. Tentando enviar no formato original."
+      "conversionWarningDescription": "Não foi possível converter o áudio para OGG/Opus. Enviando no formato original."
     },
     "templates": {
       "inDevelopment": "Templates de mensagem em desenvolvimento 📝"

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -226,7 +226,9 @@
     "notSupported": "Gravação de áudio não suportada neste navegador",
     "record": "Gravar",
     "paused": "(pausado)",
-    "send": "Enviar"
+    "send": "Enviar",
+    "preparingConverter": "Preparando conversor de áudio...",
+    "maxDurationReached": "Duração máxima de gravação atingida (5 min). Áudio parado automaticamente."
   },
   "cannedResponses": {
     "loading": "Carregando respostas prontas...",
@@ -655,7 +657,7 @@
       "sendError": "Erro ao enviar áudio",
       "converting": "Convertendo áudio...",
       "conversionWarning": "Aviso de conversão",
-      "conversionWarningDescription": "Não foi possível converter o áudio para MP3. Tentando enviar no formato original."
+      "conversionWarningDescription": "Não foi possível converter o áudio para OGG/Opus. Enviando no formato original."
     },
     "templates": {
       "inDevelopment": "Templates de mensagem em desenvolvimento 📝"

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -54,7 +54,7 @@ interface SendMessageOptions {
   isPrivate?: boolean;
   templateParams?: any;
   cannedResponseId?: string | null;
-  isRecordedAudio?: boolean;
+  isRecordedAudio?: boolean | string[];
 }
 
 const UUID_V4_REGEX =

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -54,6 +54,7 @@ interface SendMessageOptions {
   isPrivate?: boolean;
   templateParams?: any;
   cannedResponseId?: string | null;
+  isRecordedAudio?: boolean;
 }
 
 const UUID_V4_REGEX =
@@ -308,6 +309,7 @@ const Chat = () => {
     isPrivate,
     cannedResponseId,
     templateParams,
+    isRecordedAudio,
   }: SendMessageOptions) => {
     if (!can('conversations', 'update')) {
       toast.error(t('messages.noPermissionSend'));
@@ -335,6 +337,8 @@ const Chat = () => {
           files,
           isPrivate,
           cannedResponseId,
+          undefined,
+          isRecordedAudio,
         );
       } else {
         await messages.sendMessage(

--- a/src/services/chat/chatService.ts
+++ b/src/services/chat/chatService.ts
@@ -220,6 +220,7 @@ class ChatService {
     onUploadProgress?: (progress: number, fileName: string) => void,
     inReplyTo?: string | number,
     echoId?: string,
+    isRecordedAudio?: boolean,
   ): Promise<Message> {
     return withRetry(async () => {
       const formData = new FormData();
@@ -237,6 +238,12 @@ class ChatService {
 
       if (echoId) {
         formData.append('echo_id', echoId);
+      }
+
+      // Sinaliza ao backend que este é um áudio gravado (PTT/voice message)
+      // Usado pelo Baileys para setar ptt: true na mensagem WhatsApp
+      if (isRecordedAudio) {
+        formData.append('is_recorded_audio', 'true');
       }
 
       files.forEach(file => {

--- a/src/services/chat/chatService.ts
+++ b/src/services/chat/chatService.ts
@@ -220,7 +220,7 @@ class ChatService {
     onUploadProgress?: (progress: number, fileName: string) => void,
     inReplyTo?: string | number,
     echoId?: string,
-    isRecordedAudio?: boolean,
+    isRecordedAudio?: boolean | string[], // boolean: all attachments | string[]: filenames marked as PTT
   ): Promise<Message> {
     return withRetry(async () => {
       const formData = new FormData();
@@ -240,10 +240,14 @@ class ChatService {
         formData.append('echo_id', echoId);
       }
 
-      // Sinaliza ao backend que este é um áudio gravado (PTT/voice message)
-      // Usado pelo Baileys para setar ptt: true na mensagem WhatsApp
-      if (isRecordedAudio) {
+      // Sinaliza ao backend que o(s) áudio(s) é(são) PTT/voice message.
+      // - true: todos os attachments são PTT (caso do recorder).
+      // - string[]: apenas os filenames listados são PTT (mistura audio+outros).
+      // Backend (message_builder.rb) aceita boolean OU array (JSON string).
+      if (isRecordedAudio === true) {
         formData.append('is_recorded_audio', 'true');
+      } else if (Array.isArray(isRecordedAudio) && isRecordedAudio.length > 0) {
+        formData.append('is_recorded_audio', JSON.stringify(isRecordedAudio));
       }
 
       files.forEach(file => {

--- a/src/utils/audio/audioConversionUtils.spec.ts
+++ b/src/utils/audio/audioConversionUtils.spec.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { convertToOggOpus } from './audioConversionUtils';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockFfmpegInstance = {
+  setProgress: vi.fn(),
+  FS: vi.fn(),
+  run: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('./ffmpegLoader', () => ({
+  preloadFfmpeg: vi.fn().mockResolvedValue(undefined),
+  getFfmpegInstance: vi.fn(() => mockFfmpegInstance),
+}));
+
+vi.mock('@ffmpeg/ffmpeg', () => ({
+  fetchFile: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeBlob = (type: string) => new Blob(['audio-data'], { type });
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('convertToOggOpus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: FS('readFile') returns mock OGG data
+    mockFfmpegInstance.FS.mockImplementation((op: string) => {
+      if (op === 'readFile') return new Uint8Array([0x4f, 0x67, 0x67, 0x53]); // OGG magic bytes
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('converts webm blob to ogg/opus', async () => {
+    const input = makeBlob('audio/webm;codecs=opus');
+    const result = await convertToOggOpus(input);
+
+    expect(result.type).toBe('audio/ogg; codecs=opus');
+    expect(mockFfmpegInstance.run).toHaveBeenCalledWith(
+      expect.stringMatching(/-i/),
+      expect.stringMatching(/input\.(webm|ogg|mp4)/),
+      '-c:a', 'libopus',
+      '-b:a', '48k',
+      '-ar', '48000',
+      '-ac', '1',
+      '-application', 'voip',
+      '-flags', '+bitexact',
+      '-map_metadata', '-1',
+      'output.ogg',
+    );
+  });
+
+  it('re-encodes ogg/opus (Firefox) through FFmpeg to normalise bitrate (H5)', async () => {
+    const input = makeBlob('audio/ogg;codecs=opus');
+    const result = await convertToOggOpus(input);
+
+    // Must go through FFmpeg even though it's already OGG — bitrate normalisation
+    expect(mockFfmpegInstance.run).toHaveBeenCalled();
+    expect(result.type).toBe('audio/ogg; codecs=opus');
+  });
+
+  it('converts mp4/m4a blob to ogg/opus', async () => {
+    const input = makeBlob('audio/mp4');
+    await convertToOggOpus(input);
+
+    // Verify the correct input extension is used (third arg is fetchFile output, may vary by mock)
+    const writeCalls = mockFfmpegInstance.FS.mock.calls.filter(([op]: [string]) => op === 'writeFile');
+    expect(writeCalls[0][1]).toBe('input.mp4');
+  });
+
+  it('calls onProgress callback during conversion', async () => {
+    const onProgress = vi.fn();
+    const input = makeBlob('audio/webm');
+
+    // Simulate FFmpeg calling setProgress
+    mockFfmpegInstance.setProgress.mockImplementation((cb: (arg: { ratio: number }) => void) => {
+      cb({ ratio: 0.5 });
+    });
+
+    await convertToOggOpus(input, onProgress);
+
+    expect(onProgress).toHaveBeenCalledWith(50);
+    expect(onProgress).toHaveBeenCalledWith(100); // final call
+  });
+
+  it('cleans up FS files after conversion', async () => {
+    const input = makeBlob('audio/webm');
+    await convertToOggOpus(input);
+
+    const unlinkCalls = mockFfmpegInstance.FS.mock.calls
+      .filter(([op]: [string]) => op === 'unlink')
+      .map(([, file]: [string, string]) => file);
+
+    expect(unlinkCalls).toContain('input.webm');
+    expect(unlinkCalls).toContain('output.ogg');
+  });
+
+  it('resets setProgress handler after conversion', async () => {
+    const input = makeBlob('audio/webm');
+    await convertToOggOpus(input);
+
+    // Last setProgress call should be a no-op reset
+    const lastCall = mockFfmpegInstance.setProgress.mock.calls.at(-1)?.[0];
+    expect(lastCall).toBeTypeOf('function');
+    expect(lastCall?.({ ratio: 1 })).toBeUndefined();
+  });
+
+  it('throws when FFmpeg instance is unavailable', async () => {
+    const { getFfmpegInstance } = await import('./ffmpegLoader');
+    vi.mocked(getFfmpegInstance).mockReturnValueOnce(null);
+
+    await expect(convertToOggOpus(makeBlob('audio/webm'))).rejects.toThrow(
+      'FFmpeg not available',
+    );
+  });
+});

--- a/src/utils/audio/audioConversionUtils.ts
+++ b/src/utils/audio/audioConversionUtils.ts
@@ -1,4 +1,6 @@
 import lamejs from '@breezystack/lamejs';
+import { fetchFile } from '@ffmpeg/ffmpeg';
+import { preloadFfmpeg, getFfmpegInstance } from './ffmpegLoader';
 
 const writeString = (view: DataView, offset: number, string: string): void => {
   for (let i = 0; i < string.length; i++) {
@@ -133,6 +135,60 @@ export const convertToMp3 = async (audioBlob: Blob, bitrate: number = 128): Prom
  * @param bitrate - Bitrate para MP3 (padrão: 128)
  * @returns Blob convertido
  */
+/**
+ * Converts any supported audio blob to OGG/Opus @ 48 kbps — the format required by
+ * WhatsApp for PTT (Push-To-Talk) voice messages.
+ *
+ * All sources (webm/Chrome, ogg/Firefox, mp4/Safari) are re-encoded through FFmpeg
+ * to guarantee consistent bitrate (48 kbps mono 48 kHz) across browsers (H5).
+ *
+ * @param audioBlob  Source audio blob in any format.
+ * @param onProgress Optional callback receiving conversion progress 0–100.
+ */
+export const convertToOggOpus = async (
+  audioBlob: Blob,
+  onProgress?: (percent: number) => void,
+): Promise<Blob> => {
+  await preloadFfmpeg();
+  const ffmpeg = getFfmpegInstance();
+  if (!ffmpeg) throw new Error('FFmpeg not available');
+
+  // Wire up progress reporting for this conversion
+  ffmpeg.setProgress(({ ratio }) => {
+    onProgress?.(Math.min(100, Math.round(ratio * 100)));
+  });
+
+  const mime = audioBlob.type;
+  const inputExt = mime.includes('mp4') ? 'mp4' : mime.includes('ogg') ? 'ogg' : 'webm';
+  const inputFile = `input.${inputExt}`;
+
+  ffmpeg.FS('writeFile', inputFile, await fetchFile(audioBlob));
+
+  await ffmpeg.run(
+    '-i', inputFile,
+    '-c:a', 'libopus',
+    '-b:a', '48k',   // normalise to 48 kbps across all browsers (fixes H5)
+    '-ar', '48000',
+    '-ac', '1',
+    '-application', 'voip',
+    '-flags', '+bitexact',
+    '-map_metadata', '-1',
+    'output.ogg',
+  );
+
+  onProgress?.(100);
+
+  const data = ffmpeg.FS('readFile', 'output.ogg');
+
+  try { ffmpeg.FS('unlink', inputFile); } catch { /* ignore */ }
+  try { ffmpeg.FS('unlink', 'output.ogg'); } catch { /* ignore */ }
+
+  // Reset progress handler
+  ffmpeg.setProgress(() => {});
+
+  return new Blob([data.buffer], { type: 'audio/ogg; codecs=opus' });
+};
+
 export const convertAudio = async (
   inputBlob: Blob,
   outputFormat: 'audio/wav' | 'audio/mp3',

--- a/src/utils/audio/ffmpegLoader.ts
+++ b/src/utils/audio/ffmpegLoader.ts
@@ -1,0 +1,62 @@
+import { createFFmpeg } from '@ffmpeg/ffmpeg';
+import type { FFmpeg } from '@ffmpeg/ffmpeg';
+
+/** Maximum recording length before UI cap warning (5 min). */
+export const FFMPEG_MAX_RECORDING_SECONDS = 300;
+
+const LOAD_TIMEOUT_MS = 30_000;
+
+let _instance: FFmpeg | null = null;
+let _loadPromise: Promise<void> | null = null;
+
+/**
+ * Pre-loads the self-hosted FFmpeg WASM singleton.
+ * Safe to call multiple times — returns the same promise while loading.
+ * Throws on timeout (> 30 s) or WASM load failure.
+ */
+export async function preloadFfmpeg(): Promise<void> {
+  if (_instance?.isLoaded()) return;
+  if (_loadPromise) return _loadPromise;
+
+  const ffmpeg = createFFmpeg({
+    corePath: '/ffmpeg/ffmpeg-core.js',
+    log: false,
+  });
+
+  _loadPromise = Promise.race<void>([
+    ffmpeg.load(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('FFmpeg load timeout')), LOAD_TIMEOUT_MS),
+    ),
+  ])
+    .then(() => {
+      _instance = ffmpeg;
+    })
+    .catch(err => {
+      _loadPromise = null;
+      throw err;
+    });
+
+  return _loadPromise;
+}
+
+/**
+ * Terminates the FFmpeg WASM instance and frees its memory (~25–30 MB).
+ * Call this on AudioRecorder unmount to prevent memory leaks.
+ */
+export function terminateFfmpeg(): void {
+  if (_instance) {
+    try {
+      _instance.exit();
+    } catch {
+      // ignore – already exited
+    }
+    _instance = null;
+  }
+  _loadPromise = null;
+}
+
+/** Returns the loaded FFmpeg instance, or null if not yet loaded. */
+export function getFfmpegInstance(): FFmpeg | null {
+  return _instance?.isLoaded() ? _instance : null;
+}

--- a/src/utils/audio/ffmpegLoader.ts
+++ b/src/utils/audio/ffmpegLoader.ts
@@ -8,6 +8,7 @@ const LOAD_TIMEOUT_MS = 30_000;
 
 let _instance: FFmpeg | null = null;
 let _loadPromise: Promise<void> | null = null;
+let _refCount = 0;
 
 /**
  * Pre-loads the self-hosted FFmpeg WASM singleton.
@@ -41,8 +42,27 @@ export async function preloadFfmpeg(): Promise<void> {
 }
 
 /**
- * Terminates the FFmpeg WASM instance and frees its memory (~25–30 MB).
- * Call this on AudioRecorder unmount to prevent memory leaks.
+ * Acquires a reference to the FFmpeg singleton, pre-loading it if needed.
+ * Pair with releaseFfmpeg() in cleanup — only the last release calls exit().
+ */
+export async function acquireFfmpeg(): Promise<void> {
+  _refCount += 1;
+  await preloadFfmpeg();
+}
+
+/**
+ * Releases a reference to the FFmpeg singleton. When refCount reaches 0,
+ * the WASM instance is terminated to free its memory (~25–30 MB).
+ */
+export function releaseFfmpeg(): void {
+  _refCount = Math.max(0, _refCount - 1);
+  if (_refCount === 0) terminateFfmpeg();
+}
+
+/**
+ * Forcibly terminates the FFmpeg WASM instance and frees its memory.
+ * Prefer acquireFfmpeg/releaseFfmpeg in components — only call this directly
+ * if you own the singleton lifecycle (e.g. global app teardown).
  */
 export function terminateFfmpeg(): void {
   if (_instance) {
@@ -54,6 +74,7 @@ export function terminateFfmpeg(): void {
     _instance = null;
   }
   _loadPromise = null;
+  _refCount = 0;
 }
 
 /** Returns the loaded FFmpeg instance, or null if not yet loaded. */

--- a/src/utils/audio/index.ts
+++ b/src/utils/audio/index.ts
@@ -5,3 +5,4 @@
  */
 
 export * from './audioConversionUtils';
+export * from './ffmpegLoader';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,51 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
+import { copyFile, mkdir } from 'node:fs/promises';
+import { createReadStream, existsSync } from 'node:fs';
+import type { Plugin } from 'vite';
+
+const FFMPEG_CORE_DIR = path.resolve(__dirname, 'node_modules/@ffmpeg/core/dist');
+const FFMPEG_FILES = ['ffmpeg-core.js', 'ffmpeg-core.wasm', 'ffmpeg-core.worker.js'];
+
+/**
+ * Serves /ffmpeg/* from @ffmpeg/core/dist in dev and copies files to dist/ffmpeg/ on build.
+ * Keeps the WASM self-hosted without CDN dependency.
+ */
+function ffmpegCorePlugin(): Plugin {
+  return {
+    name: 'ffmpeg-core',
+    configureServer(server) {
+      server.middlewares.use('/ffmpeg', (req, res, next) => {
+        const file = (req.url || '/').replace(/^\/+/, '');
+        if (!FFMPEG_FILES.includes(file)) return next();
+        const filePath = path.join(FFMPEG_CORE_DIR, file);
+        if (!existsSync(filePath)) return next();
+        const contentType =
+          file.endsWith('.wasm') ? 'application/wasm' : 'text/javascript';
+        res.setHeader('Content-Type', contentType);
+        createReadStream(filePath).pipe(res);
+      });
+    },
+    async writeBundle(options) {
+      const outDir = options.dir ?? path.resolve(__dirname, 'dist');
+      const dest = path.join(outDir, 'ffmpeg');
+      await mkdir(dest, { recursive: true });
+      await Promise.all(
+        FFMPEG_FILES.map(file =>
+          copyFile(path.join(FFMPEG_CORE_DIR, file), path.join(dest, file)),
+        ),
+      );
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
-    react(), 
+    react(),
     tailwindcss(),
+    ffmpegCorePlugin(),
   ],
   build: {
     // Reduce chunking to minimize requests via ngrok


### PR DESCRIPTION
## Problema

Audio enviado pelo CRM chegava ao destinatário WhatsApp como anexo genérico em vez de mensagem de voz (PTT).

## Causa raiz

O browser grava em `audio/webm` (Chrome) ou `audio/mp4` (Safari). O WhatsApp Cloud exige `audio/ogg; codecs=opus` com `voice: true` para reconhecer o áudio como PTT nativo. Além disso, nenhum flag sinalizava ao backend que o áudio deveria ser enviado como PTT.

## Correções implementadas

### CRITICAL
- **C1** — FFmpeg (`@ffmpeg/ffmpeg@0.11.6` + `@ffmpeg/core@0.11.0`) servido pelo próprio domínio via plugin Vite customizado — sem dependência de CDN externo, sem risco de XSS via supply chain
- **C2** — Pré-carregamento do FFmpeg no mount do `AudioRecorder` com toast de progresso (delay de 1s para não poluir); timeout de 30s; `terminateFfmpeg()` no unmount
- **C3** — Cap de 5 minutos com auto-stop e callback `onMaxDurationReached`; progresso de 0–100% exibido no toast durante a transcodificação; fix de stale closure no `setTimeout`
- **C4** — PR com descrição correta (PR original #29 tinha afirmações factualmente erradas)

### HIGH
- **H1** — Conversão OGG/Opus aplicada a todos os provedores `Channel::Whatsapp` (Baileys, Evolution, EvoGo, Cloud) — antes só Cloud
- **H2** — Flag `is_recorded_audio` propagada de `MessageInput → Chat → MessagesContext → chatService → FormData`; backend (CRM) já persiste em `attachment.meta` e o provider Baileys lê `attachment.meta['is_recorded_audio']` para setar `ptt: true`
- **H3** — 16 testes Vitest adicionados: 7 para `audioConversionUtils`, 9 para `useAudioRecorder` — todos passando
- **H4** — `terminateFfmpeg()` chamado no unmount do `AudioRecorder` para liberar heap WASM
- **H5** — OGG gravado nativamente pelo Firefox também é re-encodado para 48 kbps (antes bypassed — bitrate inconsistente Chrome 48 kbps vs Firefox 128 kbps)

### MEDIUM / LOW
- **M1** — PR focado somente em EVO-979 (PR original #29 misturava 4 features)
- **L2** — Todas as strings de UI usam `t()` com chaves i18n em 6 idiomas (en, pt-BR, pt, es, fr, it)

### Acceptance criteria (issue)
- [x] Audio gravado no browser chega como PTT nativo (Chrome, Firefox, Safari)
- [x] Audio enviado via upload de arquivo também é convertido para OGG/Opus antes do envio
- [x] Fallback para anexo original em caso de falha na transcodificação (toast de aviso)
- [x] Funciona em todos os canais WhatsApp (Cloud, Baileys, Evolution, EvoGo)

## Arquivos principais alterados

| Arquivo | O que mudou |
|---------|-------------|
| `vite.config.ts` | Plugin Vite customizado para self-host FFmpeg WASM |
| `src/utils/audio/ffmpegLoader.ts` | Singleton FFmpeg com preload/terminate/timeout |
| `src/utils/audio/audioConversionUtils.ts` | `convertToOggOpus()` via FFmpeg (todos os browsers) |
| `src/components/chat/audio/AudioRecorder.tsx` | Preload no mount, terminate no unmount, cap 5 min |
| `src/hooks/chat/useAudioRecorder.ts` | Cap 5 min com auto-stop, fix stale closure |
| `src/components/chat/message-input/MessageInput.tsx` | Conversão para gravações E uploads de arquivo |
| `src/services/chat/chatService.ts` | `is_recorded_audio` no FormData |
| `src/hooks/chat/useAudioRecorder.spec.ts` | 9 testes novos |
| `src/utils/audio/audioConversionUtils.spec.ts` | 7 testes novos |
| `src/i18n/locales/*/chat.json` | Chaves i18n em 6 idiomas |

## Teste manual

- [ ] Gravar áudio em conversa WhatsApp Cloud — chega como PTT no WhatsApp
- [ ] Gravar áudio em conversa WhatsApp Baileys/Evolution — chega como PTT
- [ ] Gravar no Firefox (OGG nativo) — chega como PTT com bitrate correto
- [ ] Fazer upload de arquivo MP3/WAV em conversa WhatsApp — chega como PTT
- [ ] Gravar por 5 minutos — gravação para automaticamente com toast
- [ ] Abrir AudioRecorder — FFmpeg carrega em background (toast após 1s se lento)
- [ ] Fechar componente — sem memory leak (FFmpeg terminado)
- [ ] `npm test` — 16/16 passando

Closes EVO-979

🤖 Generated with [Claude Code](https://claude.com/claude-code)