### PR TITLE
fix(chat): strip HTML and render placeholder for reply previews (EVO-996)

### DIFF
--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -27,6 +27,7 @@ import { useCannedResponses } from '@/hooks/chat/useCannedResponses';
 import { useMessageSignature } from '@/hooks/useMessageSignature';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useAuth } from '@/contexts/AuthContext';
+import { stripHtml } from '@/utils/stripHtml';
 
 import FileUpload from './FileUpload';
 import FilePreview from './FilePreview';
@@ -550,8 +551,8 @@ const MessageInput: React.FC<MessageInputProps> = ({
       </div>
       <div className="mt-2 pl-6">
         <div className="text-sm text-muted-foreground bg-background border-l-2 border-primary/30 pl-3 py-1 rounded-r max-w-md">
-          {message.content ? (
-            <span className="line-clamp-2">{message.content}</span>
+          {message.content && stripHtml(message.content) ? (
+            <span className="line-clamp-2">{stripHtml(message.content)}</span>
           ) : message.attachments && message.attachments.length > 0 ? (
             <span className="italic">
               {t('messageInput.replyPreview.fileAttachment', {

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -524,49 +524,52 @@ const MessageInput: React.FC<MessageInputProps> = ({
   `;
 
   // Componente de preview da resposta
-  const ReplyPreview = ({ message, onCancel }: { message: Message; onCancel: () => void }) => (
-    <div className="w-full border-t-0 border-x-0 border-b border-border bg-muted/50 px-4 py-3">
-      <div className="flex items-start gap-3">
-        <div className="flex items-center gap-2 text-muted-foreground text-sm">
-          <Reply className="h-4 w-4" />
-          <span className="font-medium">
-            {t('messageInput.replyPreview.replyingTo', {
-              name: message.sender?.name || t('messageInput.replyPreview.userFallback'),
-            })}
-            {replyMode === ReplyMode.NOTE && (
-              <span className="ml-1 text-xs text-orange-600 font-normal">
-                {t('messageInput.replyPreview.asPrivateNote')}
-              </span>
-            )}
-          </span>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6 ml-auto hover:bg-destructive/20 hover:text-destructive"
-          onClick={onCancel}
-        >
-          <X className="h-3 w-3" />
-        </Button>
-      </div>
-      <div className="mt-2 pl-6">
-        <div className="text-sm text-muted-foreground bg-background border-l-2 border-primary/30 pl-3 py-1 rounded-r max-w-md">
-          {message.content && stripHtml(message.content) ? (
-            <span className="line-clamp-2">{stripHtml(message.content)}</span>
-          ) : message.attachments && message.attachments.length > 0 ? (
-            <span className="italic">
-              {t('messageInput.replyPreview.fileAttachment', {
-                fileType:
-                  message.attachments[0].file_type || t('messageInput.replyPreview.fileFallback'),
+  const ReplyPreview = ({ message, onCancel }: { message: Message; onCancel: () => void }) => {
+    const plainContent = message.content ? stripHtml(message.content) : '';
+    return (
+      <div className="w-full border-t-0 border-x-0 border-b border-border bg-muted/50 px-4 py-3">
+        <div className="flex items-start gap-3">
+          <div className="flex items-center gap-2 text-muted-foreground text-sm">
+            <Reply className="h-4 w-4" />
+            <span className="font-medium">
+              {t('messageInput.replyPreview.replyingTo', {
+                name: message.sender?.name || t('messageInput.replyPreview.userFallback'),
               })}
+              {replyMode === ReplyMode.NOTE && (
+                <span className="ml-1 text-xs text-orange-600 font-normal">
+                  {t('messageInput.replyPreview.asPrivateNote')}
+                </span>
+              )}
             </span>
-          ) : (
-            <span className="italic">{t('messageInput.replyPreview.noContent')}</span>
-          )}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6 ml-auto hover:bg-destructive/20 hover:text-destructive"
+            onClick={onCancel}
+          >
+            <X className="h-3 w-3" />
+          </Button>
+        </div>
+        <div className="mt-2 pl-6">
+          <div className="text-sm text-muted-foreground bg-background border-l-2 border-primary/30 pl-3 py-1 rounded-r max-w-md">
+            {plainContent ? (
+              <span className="line-clamp-2">{plainContent}</span>
+            ) : message.attachments && message.attachments.length > 0 ? (
+              <span className="italic">
+                {t('messageInput.replyPreview.fileAttachment', {
+                  fileType:
+                    message.attachments[0].file_type || t('messageInput.replyPreview.fileFallback'),
+                })}
+              </span>
+            ) : (
+              <span className="italic">{t('messageInput.replyPreview.noContent')}</span>
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   return (
     <>

--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -83,11 +83,10 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
-  // 🔧 REPLY TO: Buscar mensagem original quando content_attributes.in_reply_to ou in_reply_to_external_id existe
   const replyToMessageId = message.content_attributes?.in_reply_to;
   const replyToExternalId = message.content_attributes?.in_reply_to_external_id;
+  const hasReplyReference = Boolean(replyToMessageId || replyToExternalId);
 
-  // Tentar encontrar mensagem pai usando in_reply_to (ID interno) ou in_reply_to_external_id (source_id)
   const replyToMessage = replyToMessageId
     ? allMessages.find(msg => String(msg.id) === String(replyToMessageId))
     : replyToExternalId
@@ -319,8 +318,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
                 </div>
               )}
 
-              {/* 🔧 REPLY TO: Exibir preview da mensagem reply */}
-              {replyToMessage && !isPrivate && (
+              {hasReplyReference && !isPrivate && (
                 <ReplyPreview message={replyToMessage} isOwn={false} />
               )}
 
@@ -472,8 +470,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
               </div>
             )}
 
-            {/* 🔧 REPLY TO: Exibir preview da mensagem reply */}
-            {replyToMessage && !isPrivate && (
+            {hasReplyReference && !isPrivate && (
               <ReplyPreview message={replyToMessage} isOwn={isOwn} />
             )}
 

--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { Badge } from '@evoapi/design-system/badge';
 import {
   ContextMenu,
@@ -87,11 +87,18 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   const replyToExternalId = message.content_attributes?.in_reply_to_external_id;
   const hasReplyReference = Boolean(replyToMessageId || replyToExternalId);
 
-  const replyToMessage = replyToMessageId
-    ? allMessages.find(msg => String(msg.id) === String(replyToMessageId))
-    : replyToExternalId
-      ? allMessages.find(msg => msg.source_id && String(msg.source_id) === String(replyToExternalId))
-      : null;
+  const replyToMessage = useMemo(() => {
+    if (!hasReplyReference) return null;
+    if (replyToMessageId) {
+      return allMessages.find(msg => String(msg.id) === String(replyToMessageId)) ?? null;
+    }
+    if (replyToExternalId) {
+      return allMessages.find(
+        msg => msg.source_id && String(msg.source_id) === String(replyToExternalId),
+      ) ?? null;
+    }
+    return null;
+  }, [hasReplyReference, replyToMessageId, replyToExternalId, allMessages]);
 
   const handleCopyMessage = () => {
     if (message.content) {

--- a/src/components/chat/messages/ReplyPreview.tsx
+++ b/src/components/chat/messages/ReplyPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Reply } from 'lucide-react';
 import { Message } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -12,7 +12,7 @@ interface ReplyPreviewProps {
 const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
   const { t } = useLanguage('chat');
 
-  const getPreviewContent = () => {
+  const previewContent = useMemo(() => {
     if (!message) {
       return t('messages.replyPreview.previousMessage');
     }
@@ -43,14 +43,16 @@ const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
     }
 
     return t('messages.replyPreview.noContent');
-  };
+  }, [message, t]);
 
   const senderName = message?.sender?.name || t('messages.replyPreview.userFallback');
   const isResolved = !!message;
 
   const handleClick = () => {
     if (!message) return;
-    const messageElement = document.querySelector(`[data-message-id="${message.id}"]`);
+    const messageElement = document.querySelector(
+      `[data-message-id="${CSS.escape(String(message.id))}"]`,
+    );
     if (messageElement) {
       messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
@@ -90,7 +92,7 @@ const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
               ? 'text-white/80 dark:text-white/80'
               : 'text-slate-600 dark:text-slate-300'
           }`}>
-            {getPreviewContent()}
+            {previewContent}
           </div>
         </div>
       </div>

--- a/src/components/chat/messages/ReplyPreview.tsx
+++ b/src/components/chat/messages/ReplyPreview.tsx
@@ -2,31 +2,35 @@ import React from 'react';
 import { Reply } from 'lucide-react';
 import { Message } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
+import { stripHtml } from '@/utils/stripHtml';
 
 interface ReplyPreviewProps {
-  message: Message;
+  message?: Message | null;
   isOwn: boolean;
 }
 
 const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
   const { t } = useLanguage('chat');
 
-  // Determinar conteúdo a exibir
   const getPreviewContent = () => {
+    if (!message) {
+      return t('messages.replyPreview.previousMessage');
+    }
+
     if (message.content) {
-      // Truncar conteúdo se muito longo
-      const maxLength = 100;
-      const content = message.content.length > maxLength
-        ? `${message.content.substring(0, maxLength)}...`
-        : message.content;
-      return content;
+      const plainText = stripHtml(message.content);
+      if (plainText) {
+        const maxLength = 100;
+        return plainText.length > maxLength
+          ? `${plainText.substring(0, maxLength)}...`
+          : plainText;
+      }
     }
 
     if (message.attachments && message.attachments.length > 0) {
       const attachment = message.attachments[0];
       const fileType = attachment.file_type || 'file';
-      
-      // Traduzir tipo de arquivo
+
       const fileTypeMap: Record<string, string> = {
         image: t('messages.replyPreview.imageAttachment'),
         audio: t('messages.replyPreview.audioAttachment'),
@@ -41,40 +45,49 @@ const ReplyPreview: React.FC<ReplyPreviewProps> = ({ message, isOwn }) => {
     return t('messages.replyPreview.noContent');
   };
 
-  const senderName = message.sender?.name || t('messages.replyPreview.userFallback');
+  const senderName = message?.sender?.name || t('messages.replyPreview.userFallback');
+  const isResolved = !!message;
+
+  const handleClick = () => {
+    if (!message) return;
+    const messageElement = document.querySelector(`[data-message-id="${message.id}"]`);
+    if (messageElement) {
+      messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
 
   return (
     <div
-      className={`px-2 py-1.5 rounded-sm mb-2 cursor-pointer transition-colors hover:opacity-80 ${
+      className={`px-2 py-1.5 rounded-sm mb-2 transition-colors ${
+        isResolved ? 'cursor-pointer hover:opacity-80' : 'opacity-75'
+      } ${
         isOwn
           ? 'bg-primary/20 dark:bg-primary/15 text-white dark:text-white/90 border-l-2 border-primary/40 dark:border-primary/50'
           : 'bg-slate-50 dark:bg-slate-800/60 text-slate-700 dark:text-slate-200 border-l-2 border-slate-300 dark:border-slate-600'
       }`}
-      onClick={() => {
-        // Scroll para mensagem original (implementar depois)
-        const messageElement = document.querySelector(`[data-message-id="${message.id}"]`);
-        if (messageElement) {
-          messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        }
-      }}
+      onClick={handleClick}
     >
       <div className="flex items-start gap-1.5">
         <Reply className={`h-3 w-3 flex-shrink-0 mt-0.5 ${
-          isOwn 
-            ? 'text-white/80 dark:text-white/70' 
+          isOwn
+            ? 'text-white/80 dark:text-white/70'
             : 'text-slate-500 dark:text-slate-400'
         }`} />
         <div className="flex-1 min-w-0">
-          <div className={`text-xs font-medium mb-0.5 ${
-            isOwn 
-              ? 'text-white/90 dark:text-white/90' 
-              : 'text-slate-700 dark:text-slate-200'
-          }`}>
-            {senderName}
-          </div>
+          {isResolved && (
+            <div className={`text-xs font-medium mb-0.5 ${
+              isOwn
+                ? 'text-white/90 dark:text-white/90'
+                : 'text-slate-700 dark:text-slate-200'
+            }`}>
+              {senderName}
+            </div>
+          )}
           <div className={`text-xs line-clamp-2 ${
-            isOwn 
-              ? 'text-white/80 dark:text-white/80' 
+            isResolved ? '' : 'italic'
+          } ${
+            isOwn
+              ? 'text-white/80 dark:text-white/80'
               : 'text-slate-600 dark:text-slate-300'
           }`}>
             {getPreviewContent()}

--- a/src/components/widget/MessageList.tsx
+++ b/src/components/widget/MessageList.tsx
@@ -36,6 +36,7 @@ export interface MessageItem {
     text: string;
     sender?: string;
     type?: 'in' | 'out';
+    unresolved?: boolean;
   };
   contentType?: string;
   submittedEmail?: string;

--- a/src/components/widget/ReplyToMessage.tsx
+++ b/src/components/widget/ReplyToMessage.tsx
@@ -9,6 +9,7 @@ interface ReplyToMessageProps {
     text: string;
     sender?: string;
     type: 'in' | 'out';
+    unresolved?: boolean;
   };
   messageType: 'in' | 'out';
 }
@@ -22,7 +23,10 @@ export const ReplyToMessage: React.FC<ReplyToMessageProps> = ({ replyTo, message
     return plain.substring(0, maxLength) + '...';
   };
 
-  const senderName = replyTo.sender || (replyTo.type === 'out' ? t('replyTo.you') : t('replyTo.agent'));
+  const isUnresolved = replyTo.unresolved === true;
+  const senderName = isUnresolved
+    ? null
+    : replyTo.sender || (replyTo.type === 'out' ? t('replyTo.you') : t('replyTo.agent'));
 
   return (
     <div
@@ -32,8 +36,14 @@ export const ReplyToMessage: React.FC<ReplyToMessageProps> = ({ replyTo, message
     >
       <Reply size={12} className="text-slate-400" />
       <div className="bg-slate-100 dark:bg-slate-800 rounded px-2 py-1 border-l-2 border-slate-300 dark:border-slate-600">
-        <div className="text-slate-600 dark:text-slate-300 font-medium">{senderName}</div>
-        <div className="text-slate-500 dark:text-slate-400">{truncateText(replyTo.text)}</div>
+        {senderName && (
+          <div className="text-slate-600 dark:text-slate-300 font-medium">{senderName}</div>
+        )}
+        <div
+          className={`text-slate-500 dark:text-slate-400 ${isUnresolved ? 'italic' : ''}`}
+        >
+          {isUnresolved ? replyTo.text : truncateText(replyTo.text)}
+        </div>
       </div>
     </div>
   );

--- a/src/components/widget/ReplyToMessage.tsx
+++ b/src/components/widget/ReplyToMessage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Reply } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { stripHtml } from '@/utils/stripHtml';
 
 interface ReplyToMessageProps {
   replyTo: {
@@ -16,8 +17,9 @@ export const ReplyToMessage: React.FC<ReplyToMessageProps> = ({ replyTo, message
   const { t } = useLanguage('widget');
 
   const truncateText = (text: string, maxLength: number = 40) => {
-    if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength) + '...';
+    const plain = stripHtml(text);
+    if (plain.length <= maxLength) return plain;
+    return plain.substring(0, maxLength) + '...';
   };
 
   const senderName = replyTo.sender || (replyTo.type === 'out' ? t('replyTo.you') : t('replyTo.agent'));

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -88,6 +88,16 @@
       "retryInDevelopment": "Retry functionality in development",
       "sendFailed": "Send failed - Click to try again",
       "tryAgain": "Try again"
+    },
+    "replyPreview": {
+      "imageAttachment": "📷 Image",
+      "audioAttachment": "🎵 Audio",
+      "videoAttachment": "🎥 Video",
+      "fileAttachment": "📎 File",
+      "locationAttachment": "📍 Location",
+      "noContent": "Message with no content",
+      "userFallback": "User",
+      "previousMessage": "Previous message"
     }
   },
   "assignment": {

--- a/src/i18n/locales/en/widget.json
+++ b/src/i18n/locales/en/widget.json
@@ -42,7 +42,8 @@
     "replyingTo": "Replying to {{name}}",
     "cancelReply": "Cancel reply",
     "you": "You",
-    "agent": "Team Member"
+    "agent": "Team Member",
+    "previousMessage": "↩ Previous message"
   },
   "messageList": {
     "loadingOld": "Loading old messages...",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -87,6 +87,16 @@
       "retryInDevelopment": "Funcionalidad de reintento en desarrollo",
       "sendFailed": "Envío fallido - Haga clic para intentar de nuevo",
       "tryAgain": "Intentar de nuevo"
+    },
+    "replyPreview": {
+      "imageAttachment": "📷 Imagen",
+      "audioAttachment": "🎵 Audio",
+      "videoAttachment": "🎥 Video",
+      "fileAttachment": "📎 Archivo",
+      "locationAttachment": "📍 Ubicación",
+      "noContent": "Mensaje sin contenido",
+      "userFallback": "Usuario",
+      "previousMessage": "Mensaje anterior"
     }
   },
   "assignment": {

--- a/src/i18n/locales/es/widget.json
+++ b/src/i18n/locales/es/widget.json
@@ -42,7 +42,8 @@
     "replyingTo": "Respondiendo a {{name}}",
     "cancelReply": "Cancelar respuesta",
     "you": "Usted",
-    "agent": "Agente"
+    "agent": "Agente",
+    "previousMessage": "↩ Mensaje anterior"
   },
   "messageList": {
     "loadingOld": "Cargando mensajes antiguos...",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -87,6 +87,16 @@
       "retryInDevelopment": "Fonctionnalité de nouvelle tentative en développement",
       "sendFailed": "Échec de l'envoi - Cliquez pour réessayer",
       "tryAgain": "Réessayer"
+    },
+    "replyPreview": {
+      "imageAttachment": "📷 Image",
+      "audioAttachment": "🎵 Audio",
+      "videoAttachment": "🎥 Vidéo",
+      "fileAttachment": "📎 Fichier",
+      "locationAttachment": "📍 Localisation",
+      "noContent": "Message sans contenu",
+      "userFallback": "Utilisateur",
+      "previousMessage": "Message précédent"
     }
   },
   "assignment": {

--- a/src/i18n/locales/fr/widget.json
+++ b/src/i18n/locales/fr/widget.json
@@ -42,7 +42,8 @@
     "replyingTo": "Répondre à {{name}}",
     "cancelReply": "Annuler la réponse",
     "you": "Vous",
-    "agent": "Agent"
+    "agent": "Agent",
+    "previousMessage": "↩ Message précédent"
   },
   "messageList": {
     "loadingOld": "Chargement des anciens messages...",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -87,6 +87,16 @@
       "retryInDevelopment": "Funzionalità di nuovo tentativo in sviluppo",
       "sendFailed": "Invio fallito - Clicca per riprovare",
       "tryAgain": "Riprova"
+    },
+    "replyPreview": {
+      "imageAttachment": "📷 Immagine",
+      "audioAttachment": "🎵 Audio",
+      "videoAttachment": "🎥 Video",
+      "fileAttachment": "📎 File",
+      "locationAttachment": "📍 Posizione",
+      "noContent": "Messaggio senza contenuto",
+      "userFallback": "Utente",
+      "previousMessage": "Messaggio precedente"
     }
   },
   "assignment": {

--- a/src/i18n/locales/it/widget.json
+++ b/src/i18n/locales/it/widget.json
@@ -42,7 +42,8 @@
     "replyingTo": "In risposta a {{name}}",
     "cancelReply": "Annulla risposta",
     "you": "Tu",
-    "agent": "Operatore"
+    "agent": "Operatore",
+    "previousMessage": "↩ Messaggio precedente"
   },
   "messageList": {
     "loadingOld": "Caricamento messaggi precedenti...",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -95,7 +95,8 @@
       "fileAttachment": "📎 Arquivo",
       "locationAttachment": "📍 Localização",
       "noContent": "Mensagem sem conteúdo",
-      "userFallback": "Usuário"
+      "userFallback": "Usuário",
+      "previousMessage": "Mensagem anterior"
     }
   },
   "assignment": {

--- a/src/i18n/locales/pt-BR/widget.json
+++ b/src/i18n/locales/pt-BR/widget.json
@@ -42,7 +42,8 @@
     "replyingTo": "Respondendo a {{name}}",
     "cancelReply": "Cancelar resposta",
     "you": "Você",
-    "agent": "Atendente"
+    "agent": "Atendente",
+    "previousMessage": "↩ Mensagem anterior"
   },
   "messageList": {
     "loadingOld": "Carregando mensagens antigas...",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -95,7 +95,8 @@
       "fileAttachment": "📎 Arquivo",
       "locationAttachment": "📍 Localização",
       "noContent": "Mensagem sem conteúdo",
-      "userFallback": "Usuário"
+      "userFallback": "Usuário",
+      "previousMessage": "Mensagem anterior"
     }
   },
   "assignment": {

--- a/src/i18n/locales/pt/widget.json
+++ b/src/i18n/locales/pt/widget.json
@@ -42,7 +42,8 @@
     "replyingTo": "Respondendo a {{name}}",
     "cancelReply": "Cancelar resposta",
     "you": "Você",
-    "agent": "Atendente"
+    "agent": "Atendente",
+    "previousMessage": "↩ Mensagem anterior"
   },
   "messageList": {
     "loadingOld": "Carregando mensagens antigas...",

--- a/src/utils/stripHtml.spec.ts
+++ b/src/utils/stripHtml.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { stripHtml } from './stripHtml';
+
+describe('stripHtml', () => {
+  it('returns empty string for empty input', () => {
+    expect(stripHtml('')).toBe('');
+  });
+
+  it('passes plain text through unchanged', () => {
+    expect(stripHtml('hello world')).toBe('hello world');
+  });
+
+  it('strips simple tags', () => {
+    expect(stripHtml('<p>hello</p>')).toBe('hello');
+  });
+
+  it('strips nested tags and collapses whitespace across blocks', () => {
+    expect(stripHtml('<p><strong>bold</strong></p><p>next</p>')).toBe('bold next');
+  });
+
+  it('decodes html entities', () => {
+    expect(stripHtml('foo &amp; &lt;bar&gt; &nbsp;baz')).toBe('foo & <bar> baz');
+  });
+
+  it('handles unclosed tags gracefully', () => {
+    expect(stripHtml('<p>unfinished')).toBe('unfinished');
+  });
+
+  it('returns empty string when content is whitespace-only after stripping', () => {
+    expect(stripHtml('<p>&nbsp;&nbsp;</p>')).toBe('');
+  });
+
+  it('does not execute scripts and produces empty text', () => {
+    expect(stripHtml('<script>alert(1)</script>')).toBe('');
+  });
+
+  it('does not fire onerror handlers from img tags', () => {
+    expect(stripHtml('<img src=x onerror="alert(1)">')).toBe('');
+  });
+
+  it('preserves emoji and unicode', () => {
+    expect(stripHtml('<p>olá 🎉 mundo</p>')).toBe('olá 🎉 mundo');
+  });
+
+  it('flattens line breaks into single spaces', () => {
+    expect(stripHtml('line one<br>line two<br/>line three')).toBe('line one line two line three');
+  });
+});

--- a/src/utils/stripHtml.spec.ts
+++ b/src/utils/stripHtml.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { stripHtml } from './stripHtml';
 
 describe('stripHtml', () => {
@@ -44,5 +44,39 @@ describe('stripHtml', () => {
 
   it('flattens line breaks into single spaces', () => {
     expect(stripHtml('line one<br>line two<br/>line three')).toBe('line one line two line three');
+  });
+});
+
+describe('stripHtml — SSR fallback (no DOMParser)', () => {
+  const originalDOMParser = globalThis.DOMParser;
+
+  beforeEach(() => {
+    // Simulate SSR: no DOMParser available
+    // @ts-expect-error - intentionally undefined for SSR test
+    globalThis.DOMParser = undefined;
+  });
+
+  afterEach(() => {
+    globalThis.DOMParser = originalDOMParser;
+  });
+
+  it('falls back to regex stripping when DOMParser is unavailable', () => {
+    expect(stripHtml('<p>hello <strong>world</strong></p>')).toBe('hello world');
+  });
+
+  it('flattens block boundaries to spaces in SSR fallback', () => {
+    expect(stripHtml('<p>a</p><p>b</p>')).toBe('a b');
+  });
+
+  it('handles unclosed tags in SSR fallback', () => {
+    expect(stripHtml('<p>unfinished')).toBe('unfinished');
+  });
+
+  it('strips br tags in SSR fallback', () => {
+    expect(stripHtml('line one<br>line two')).toBe('line one line two');
+  });
+
+  it('returns empty for whitespace-only after stripping in SSR', () => {
+    expect(stripHtml('<p>   </p>')).toBe('');
   });
 });

--- a/src/utils/stripHtml.ts
+++ b/src/utils/stripHtml.ts
@@ -1,0 +1,15 @@
+const BLOCK_BOUNDARY_REGEX =
+  /<\s*br\s*\/?>|<\/\s*(?:p|div|li|h[1-6]|blockquote|tr|td|th|article|section|header|footer|nav|aside|pre|figure|address)\s*>/gi;
+
+export function stripHtml(html: string): string {
+  if (!html) return '';
+
+  const withSpaces = html.replace(BLOCK_BOUNDARY_REGEX, ' ');
+
+  if (typeof window === 'undefined' || typeof DOMParser === 'undefined') {
+    return withSpaces.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  }
+
+  const doc = new DOMParser().parseFromString(withSpaces, 'text/html');
+  return (doc.body.textContent || '').replace(/\s+/g, ' ').trim();
+}

--- a/src/utils/widget/messages.ts
+++ b/src/utils/widget/messages.ts
@@ -19,20 +19,34 @@ export function transformMessage(
   const messageId = String(m.id ?? Math.random());
   const isSystemMessage = m.message_type === 2 || m.message_type === 3;
 
-  // reply-to
+  // reply-to: resolve by internal id first, then by external id (parity with MessageBubble)
   let replyTo: MessageItem['replyTo'] = undefined;
-  if (m.content_attributes?.in_reply_to) {
-    const replyToId = m.content_attributes.in_reply_to;
-    const originalMessage = list.find((msg: any) => msg.id === replyToId);
+  const replyToId = m.content_attributes?.in_reply_to;
+  const replyToExternalId = m.content_attributes?.in_reply_to_external_id;
+
+  if (replyToId || replyToExternalId) {
+    const originalMessage = replyToId
+      ? list.find((msg: any) => msg.id === replyToId)
+      : list.find((msg: any) => msg.source_id && msg.source_id === replyToExternalId);
+
     if (originalMessage) {
       replyTo = {
-        id: replyToId,
+        id: originalMessage.id,
         text: stripHtml(originalMessage.content || ''),
         sender:
           originalMessage.message_type === 0
             ? originalMessage.sender?.name || t('chat.user')
             : t('chat.agent'),
         type: originalMessage.message_type === 0 ? ('out' as const) : ('in' as const),
+      };
+    } else {
+      // Parent not yet loaded — keep a placeholder so the user still sees this is a reply.
+      replyTo = {
+        id: replyToId ?? replyToExternalId,
+        text: t('replyTo.previousMessage'),
+        sender: undefined,
+        type: 'in' as const,
+        unresolved: true,
       };
     }
   }

--- a/src/utils/widget/messages.ts
+++ b/src/utils/widget/messages.ts
@@ -2,6 +2,7 @@
 // src/utils/widget/messages.ts
 import type { MessageItem } from '@/components/widget/MessageList';
 import { wdebug } from '@/utils/widget/debug';
+import { stripHtml } from '@/utils/stripHtml';
 
 type RawMessage = any;
 
@@ -26,7 +27,7 @@ export function transformMessage(
     if (originalMessage) {
       replyTo = {
         id: replyToId,
-        text: originalMessage.content || '',
+        text: stripHtml(originalMessage.content || ''),
         sender:
           originalMessage.message_type === 0
             ? originalMessage.sender?.name || t('chat.user')


### PR DESCRIPTION
## Summary

The reply preview rendered raw HTML tags (`<p>`, `<br>`, `<strong>`)
when the quoted message contained rich-text content (private notes,
agent messages, email bodies). It also disappeared entirely when the
parent message was not present in the loaded message list — leaving
the user with no indication the message was a reply at all.

Three classes of fix in this PR:

1. **HTML rendering** — new `stripHtml` util converts message content
   to plain text via `DOMParser.parseFromString('text/html')` (no script
   execution, no `onerror` side-effects on the detached document).
   Block boundaries (`<p>`, `<br>`, `<li>`, etc.) are flattened to
   spaces before parsing so `"<p>a</p><p>b</p>"` becomes `"a b"`
   instead of `"ab"`.

2. **Unresolved-parent placeholder** — `MessageBubble` now renders the
   preview whenever `in_reply_to` or `in_reply_to_external_id` is set,
   even if the parent isn't loaded. `ReplyPreview` accepts a nullable
   `message` and shows a "previous message" placeholder (italic, no
   sender, no scroll-to-parent) in that case.

3. **Widget parity** — `widget/ReplyToMessage` and
   `utils/widget/messages` now apply `stripHtml` at hydration and
   render time, so the embedded customer-side chat doesn't suffer from
   the same bug. Existing widget MessageList tests still pass.

## Changes

- `src/utils/stripHtml.ts` (new) — block-aware DOM-based stripper.
- `src/utils/stripHtml.spec.ts` (new) — 11 cases covering entities,
  XSS vectors (`<script>`, `<img onerror>`), unclosed tags, block
  boundaries, emoji preservation, BR-flattening.
- `src/components/chat/messages/ReplyPreview.tsx` — uses `stripHtml`,
  supports unresolved-parent placeholder.
- `src/components/chat/messages/MessageBubble.tsx` — renders preview
  when `in_reply_to[_external_id]` exists even without the resolved
  parent.
- `src/components/chat/message-input/MessageInput.tsx` — `stripHtml`
  in the composer reply preview.
- `src/components/widget/ReplyToMessage.tsx` — defense-in-depth
  `stripHtml` at render.
- `src/utils/widget/messages.ts` — `stripHtml` at `replyTo.text`
  hydration.
- `src/i18n/locales/{pt-BR,pt}/chat.json` — adds `previousMessage` key
  to existing `messages.replyPreview` block.
- `src/i18n/locales/{en,es,fr,it}/chat.json` — adds the full
  `messages.replyPreview` block (was missing from these locales) plus
  the new `previousMessage` key.

## Validation

- `pnpm exec tsc -b --noEmit` — only the pre-existing
  `MessageImage.tsx:4` `toast`-unused error from `develop`.
- `pnpm exec eslint <changed files>` — only pre-existing
  `_isPostConversation`/`_isThreadRoot` warnings from a March commit.
- `pnpm exec vitest run src/utils/stripHtml.spec.ts src/components/widget/MessageList.spec.tsx src/components/chat/conversation/ConversationActionsDropdown.spec.tsx src/components/widget/EmailCollectInput.spec.tsx`
  — 27/27 pass (including the new 11-case stripHtml suite).
- All 6 `chat.json` locales parse with `JSON.parse`.

## Linked Issue

- EVO-996

## Related PRs

- evo-ai-crm-community: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/31 (preserves `in_reply_to_external_id` when parent not yet resolvable; required so the placeholder/preview can render for incoming WhatsApp replies whose parent ingests later or has a mismatched source_id)

## Summary by Sourcery

Ensure reply previews display plain-text content and remain visible even when the parent message is not loaded, across both the main chat and embedded widget.

New Features:
- Introduce a shared stripHtml utility to safely convert rich-text message content into plain text for reply previews.
- Localize the reply preview messages, including the new "previous message" label, across all supported chat locales.

Bug Fixes:
- Strip HTML from reply preview content to prevent raw tags from rendering in chat and widget UIs.
- Render a reply preview placeholder when a message references a parent that is not present in the current message list, instead of hiding the preview entirely.

Enhancements:
- Show a generic italicized "previous message" preview without sender name when the referenced parent cannot be resolved, while still allowing scroll-to-parent when available.
- Reuse reply preview behavior in the message composer so reply snippets also display plain-text content.
- Refine reply preview interaction and styling to distinguish between resolved and unresolved parent messages.

Tests:
- Add a dedicated stripHtml unit test suite covering entities, malformed HTML, XSS-like tags, block boundaries, and whitespace normalization.