### PR TITLE
fix(EVO-997): remove non-functional delete contact option from actions menu

### DIFF
--- a/src/components/contacts/ContactCard.tsx
+++ b/src/components/contacts/ContactCard.tsx
@@ -1,6 +1,6 @@
 import { useLanguage } from '@/hooks/useLanguage';
 import { Button, Card, CardContent } from '@evoapi/design-system';
-import { Edit, MessageSquare, Trash2, Activity, Eye } from 'lucide-react';
+import { Edit, MessageSquare, Activity, Eye } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
 import ContactStatusBadge from './ContactStatusBadge';
@@ -13,7 +13,6 @@ type ContactCardProps = {
   onViewDetails?: (contact: Contact) => void;
   onStartConversation?: (contact: Contact) => void;
   onEdit?: (contact: Contact) => void;
-  onDelete?: (contact: Contact) => void;
   onViewEvents?: (contact: Contact) => void;
 };
 
@@ -22,7 +21,6 @@ export default function ContactCard({
   onViewDetails,
   onStartConversation,
   onEdit,
-  onDelete,
   onViewEvents,
 }: ContactCardProps) {
   const { t } = useLanguage('contacts');
@@ -117,18 +115,6 @@ export default function ContactCard({
             title={t('card.actions.edit')}
           >
             <Edit className="h-4 w-4" />
-          </Button>
-          <div className="w-px bg-sidebar-border" />
-          <Button
-            variant="ghost"
-            className="rounded-none h-12 px-3 text-red-500 hover:text-red-400 hover:bg-red-500/10"
-            onClick={e => {
-              e.stopPropagation();
-              onDelete?.(contact);
-            }}
-            title={t('card.actions.delete')}
-          >
-            <Trash2 className="h-4 w-4" />
           </Button>
         </div>
       </CardContent>

--- a/src/components/contacts/ContactsTable.tsx
+++ b/src/components/contacts/ContactsTable.tsx
@@ -1,5 +1,5 @@
 import { useLanguage } from '@/hooks/useLanguage';
-import { MessageSquare, Edit, Trash2, Users, Activity } from 'lucide-react';
+import { MessageSquare, Edit, Users, Activity } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import { BaseTable, TableColumn, TableAction } from '@/components/base';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
@@ -16,7 +16,6 @@ interface ContactsTableProps {
   onContactClick: (contact: Contact) => void;
   onStartConversation: (contact: Contact) => void;
   onEditContact: (contact: Contact) => void;
-  onDeleteContact: (contact: Contact) => void;
   onViewEvents?: (contact: Contact) => void;
   onCreateContact?: () => void;
   sortBy?: string;
@@ -32,7 +31,6 @@ export default function ContactsTable({
   onContactClick,
   onStartConversation,
   onEditContact,
-  onDeleteContact,
   onViewEvents,
   onCreateContact,
   sortBy,
@@ -130,12 +128,6 @@ export default function ContactsTable({
       label: t('table.actions.edit'),
       icon: <Edit className="h-4 w-4" />,
       onClick: onEditContact,
-    },
-    {
-      label: t('table.actions.delete'),
-      icon: <Trash2 className="h-4 w-4" />,
-      onClick: onDeleteContact,
-      variant: 'destructive' as const,
     },
   ];
 

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -69,8 +69,6 @@ export default function Contacts() {
   const { can, isReady: permissionsReady } = useUserPermissions();
   const [state, setState] = useState<ContactsState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
-  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [contactToDelete, setContactToDelete] = useState<Contact | null>(null);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [editingContact, setEditingContact] = useState<Contact | null>(null);
@@ -469,11 +467,6 @@ export default function Contacts() {
     setContactModalOpen(true);
   };
 
-  const handleDeleteContact = (contact: Contact) => {
-    setContactToDelete(contact);
-    setDeleteDialogOpen(true);
-  };
-
   const handleStartConversation = (contact: Contact) => {
     setConversationContact(contact);
     setConversationModalOpen(true);
@@ -576,31 +569,6 @@ export default function Contacts() {
       toast.error(errorMessage);
     } finally {
       setState(prev => ({ ...prev, loading: { ...prev.loading, export: false } }));
-    }
-  };
-
-  // Confirm delete single contact
-  const confirmDeleteContact = async () => {
-    if (!contactToDelete) return;
-
-    setState(prev => ({ ...prev, loading: { ...prev.loading, delete: true } }));
-
-    try {
-      await contactsService.deleteContact(contactToDelete.id);
-      toast.success(t('messages.deleteSuccess'));
-
-      // Refresh the list
-      loadContacts();
-
-      setDeleteDialogOpen(false);
-      setContactToDelete(null);
-    } catch (error) {
-      console.error('Error deleting contact:', error);
-      
-      const errorMessage = extractError(error).message;
-      toast.error(errorMessage);
-    } finally {
-      setState(prev => ({ ...prev, loading: { ...prev.loading, delete: false } }));
     }
   };
 
@@ -825,7 +793,6 @@ export default function Contacts() {
                 onViewDetails={handleContactClick}
                 onStartConversation={handleStartConversation}
                 onEdit={handleEditContact}
-                onDelete={handleDeleteContact}
                 onViewEvents={handleViewEvents}
               />
             ))}
@@ -846,7 +813,6 @@ export default function Contacts() {
             onContactClick={handleContactClick}
             onStartConversation={handleStartConversation}
             onEditContact={handleEditContact}
-            onDeleteContact={handleDeleteContact}
             onViewEvents={handleViewEvents}
             onCreateContact={handleCreateContact}
             sortBy={state.sortBy}
@@ -883,36 +849,6 @@ export default function Contacts() {
           />
         </div>
       )}
-
-      {/* Delete Contact Dialog */}
-      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('dialog.deleteContact.title')}</DialogTitle>
-            <DialogDescription>
-              {t('dialog.deleteContact.description', { name: contactToDelete?.name })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setDeleteDialogOpen(false)}
-              disabled={state.loading.delete}
-            >
-              {t('dialog.deleteContact.cancel')}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={confirmDeleteContact}
-              disabled={state.loading.delete}
-            >
-              {state.loading.delete
-                ? t('dialog.deleteContact.deleting')
-                : t('dialog.deleteContact.confirm')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       {/* Bulk Delete Dialog */}
       <Dialog open={bulkDeleteDialogOpen} onOpenChange={setBulkDeleteDialogOpen}>


### PR DESCRIPTION
## Summary

- Remove the 'Delete contact' button from `ContactCard` (grid view) and `ContactsTable` (table view) action menus
- Clean up related state (`deleteDialogOpen`, `contactToDelete`), handlers (`handleDeleteContact`, `confirmDeleteContact`), and confirmation dialog in `Contacts.tsx`
- Bulk delete and backend `destroy` endpoint are unaffected

## Test plan

- [ ] Navigate to Contacts page
- [ ] **Grid view**: hover a contact card → confirm delete (trash) button is gone
- [ ] **Table view**: open row actions menu (3-dot) → confirm "Delete contact" option is absent
- [ ] Bulk delete (checkbox selection + toolbar) still works normally

Closes: EVO-997

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove single-contact delete actions from contacts grid and table views and associated UI state, while keeping bulk delete functionality intact.

Bug Fixes:
- Remove non-functional per-contact delete option from contact cards and table row actions menus to prevent broken delete flows.

Enhancements:
- Simplify Contacts page state and handlers by removing unused single-contact delete dialog logic and props from contact components.