### PR TITLE
fix(notifications): fix desktop push, bell empty state, audio unlock and permission flow

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.0.1
         version: 5.2.2(react-hook-form@7.68.0(react@19.2.1))
+      '@icons-pack/react-simple-icons':
+        specifier: ^13.13.0
+        version: 13.13.0(react@19.2.1)
       '@rails/actioncable':
         specifier: ^8.0.201
         version: 8.1.100
@@ -141,6 +144,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22.16.0
         version: 22.19.1
@@ -720,6 +726,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@icons-pack/react-simple-icons@13.13.0':
+    resolution: {integrity: sha512-B5HhQMIpcSH4z8IZ8HFhD59CboHceKYMpPC9kAwGyKntvPdyJJv26DLu4Z1wAjcCLyrJhf11tMhiQGom9Rxb9g==}
+    engines: {node: '>=24', pnpm: '>=10'}
+    peerDependencies:
+      react: ^16.13 || ^17 || ^18 || ^19
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1640,6 +1652,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3095,8 +3113,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  unlayer-types@1.395.0:
-    resolution: {integrity: sha512-2tb1IuEBa11ZUXueDtYCHc7PqV3WbAoBmEpNWjgE4WZclSk4sW0P41KKpa6NswdoP8UfFd18aV+oQJhz467NcA==}
+  unlayer-types@1.405.0:
+    resolution: {integrity: sha512-KbrpkUDRnjCkF1HO7Ap1oiIl7xvqgUf5Du9erC5TiJODwPk3c6XO/wypycSSqu0V+05v1CfmvwmD9icDqXSkNg==}
 
   update-browserslist-db@1.2.2:
     resolution: {integrity: sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==}
@@ -3814,6 +3832,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@icons-pack/react-simple-icons@13.13.0(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4692,6 +4714,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@types/aria-query@5.0.4': {}
 
@@ -5870,7 +5896,7 @@ snapshots:
   react-email-editor@1.7.11(react@19.2.1):
     dependencies:
       react: 19.2.1
-      unlayer-types: 1.395.0
+      unlayer-types: 1.405.0
 
   react-hook-form@7.68.0(react@19.2.1):
     dependencies:
@@ -6169,7 +6195,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  unlayer-types@1.395.0: {}
+  unlayer-types@1.405.0: {}
 
   update-browserslist-db@1.2.2(browserslist@4.28.1):
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,8 @@ function App() {
       'touchstart',
     ];
     const unlock = () => unlockAudioContext();
+    // `once: true` removes the listener automatically after first fire,
+    // so no manual cleanup is needed for these.
     gestureEvents.forEach(evt => window.addEventListener(evt, unlock, { once: true }));
 
     // visibilitychange does not count as a user gesture, but when the tab
@@ -51,7 +53,6 @@ function App() {
     document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
-      gestureEvents.forEach(evt => window.removeEventListener(evt, unlock));
       document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,12 +31,28 @@ function ThemedToaster() {
 
 function App() {
   useEffect(() => {
+    // Try to unlock the AudioContext on the widest possible range of user
+    // interactions so notification sounds work even if the user never clicked
+    // or typed before switching tabs (the original EVO-977 scenario).
+    const gestureEvents: Array<keyof WindowEventMap> = [
+      'click',
+      'keydown',
+      'pointerdown',
+      'touchstart',
+    ];
     const unlock = () => unlockAudioContext();
-    window.addEventListener('click', unlock, { once: true });
-    window.addEventListener('keydown', unlock, { once: true });
+    gestureEvents.forEach(evt => window.addEventListener(evt, unlock, { once: true }));
+
+    // visibilitychange does not count as a user gesture, but when the tab
+    // becomes visible again the browser usually allows resume() — try it.
+    const onVisibility = () => {
+      if (!document.hidden) unlockAudioContext();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
     return () => {
-      window.removeEventListener('click', unlock);
-      window.removeEventListener('keydown', unlock);
+      gestureEvents.forEach(evt => window.removeEventListener(evt, unlock));
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import AppRouter from './routes';
 import { AuthProvider } from './contexts/AuthContext';
 import { DarkModeProvider } from './contexts/ThemeContext';
@@ -7,6 +8,7 @@ import { GlobalConfigProvider } from './contexts/GlobalConfigContext';
 import { NotificationsProvider } from './contexts/NotificationsContext';
 import { PermissionsProvider } from './contexts/PermissionsContext';
 import { UISettingsApplier } from './components/UISettingsApplier';
+import { unlockAudioContext } from '@/utils/audioNotificationUtils';
 
 import { Toaster } from '@evoapi/design-system';
 
@@ -28,6 +30,16 @@ function ThemedToaster() {
 }
 
 function App() {
+  useEffect(() => {
+    const unlock = () => unlockAudioContext();
+    window.addEventListener('click', unlock, { once: true });
+    window.addEventListener('keydown', unlock, { once: true });
+    return () => {
+      window.removeEventListener('click', unlock);
+      window.removeEventListener('keydown', unlock);
+    };
+  }, []);
+
   return (
     <AuthProvider>
       <DarkModeProvider>

--- a/src/components/chat/messages/MessageImage.tsx
+++ b/src/components/chat/messages/MessageImage.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Button } from '@evoapi/design-system/button';
 import { Download, ImageOff, ZoomIn, ZoomOut, X } from 'lucide-react';
-import { toast } from 'sonner';
 import { Attachment } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
 import { openAttachmentInNewTab } from '@/components/chat/messages/utils/openAttachmentInNewTab';

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -16,12 +16,16 @@ export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false);
   const { state, actions } = useNotifications();
 
-  // Fetch notifications every time the dropdown opens
+  // Fetch notifications every time the dropdown opens.
+  // `actions` is intentionally excluded from deps because it's a fresh object
+  // on every render of the provider — including it here would re-create the
+  // effect on every parent render and double-fetch on open.
   useEffect(() => {
     if (isOpen) {
       actions.fetchNotifications({ page: 1 });
     }
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   const unreadCount = state.meta.unreadCount;
 

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -17,15 +17,13 @@ export default function NotificationBell() {
   const { state, actions } = useNotifications();
 
   // Fetch notifications every time the dropdown opens.
-  // `actions` is intentionally excluded from deps because it's a fresh object
-  // on every render of the provider — including it here would re-create the
-  // effect on every parent render and double-fetch on open.
+  // `actions` is now memoized in the provider (deps=[]), so it's stable across
+  // renders and safe to include here without causing re-fetch loops.
   useEffect(() => {
     if (isOpen) {
       actions.fetchNotifications({ page: 1 });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isOpen, actions]);
 
   const unreadCount = state.meta.unreadCount;
 

--- a/src/components/layout/NotificationBell.tsx
+++ b/src/components/layout/NotificationBell.tsx
@@ -16,13 +16,12 @@ export default function NotificationBell() {
   const [isOpen, setIsOpen] = useState(false);
   const { state, actions } = useNotifications();
 
-
-  // Fetch notifications when dropdown is opened
+  // Fetch notifications every time the dropdown opens
   useEffect(() => {
-    if (isOpen && state.notifications.length === 0) {
+    if (isOpen) {
       actions.fetchNotifications({ page: 1 });
     }
-  }, [isOpen]); // Remover dependencies que causam loop
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const unreadCount = state.meta.unreadCount;
 

--- a/src/components/layout/NotificationPanel.tsx
+++ b/src/components/layout/NotificationPanel.tsx
@@ -29,23 +29,20 @@ export default function NotificationPanel({
   const { state, actions } = useNotifications();
   const [currentPage, setCurrentPage] = useState(1);
 
-  // Filter unread notifications
-  const unreadNotifications = useMemo(
-    () => state.notifications.filter(n => !n.read_at),
-    [state.notifications]
-  );
-
   const totalUnreadCount = state.meta.unreadCount;
+  const totalCount = state.meta.count;
 
-  // Paginate unread notifications
+  // Show all notifications (read + unread); the visual unread indicator is
+  // rendered by NotificationItem so the user can see history after marking
+  // everything as read (EVO-977 AC2).
   const paginatedNotifications = useMemo(() => {
     const startIndex = (currentPage - 1) * PAGE_SIZE;
     const endIndex = startIndex + PAGE_SIZE;
-    return unreadNotifications.slice(startIndex, endIndex);
-  }, [unreadNotifications, currentPage]);
+    return state.notifications.slice(startIndex, endIndex);
+  }, [state.notifications, currentPage]);
 
   // Pagination helpers
-  const totalPages = Math.ceil(totalUnreadCount / PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
   const isFirstPage = currentPage === 1;
   const isLastPage = currentPage >= totalPages;
 
@@ -138,13 +135,22 @@ export default function NotificationPanel({
       </div>
 
       {/* Notifications List */}
-      <div className="flex-1 overflow-y-auto">
-        {state.uiFlags.isFetching ? (
+      <div className="flex-1 overflow-y-auto relative">
+        {/* Stale-while-revalidate: keep showing the cached list while refetch
+            happens in the background. Only show full-screen loader when there
+            is no cached data yet. */}
+        {state.uiFlags.isFetching && paginatedNotifications.length > 0 && (
+          <div
+            className="absolute top-2 right-3 w-4 h-4 animate-spin rounded-full border-2 border-primary border-t-transparent z-10"
+            aria-label={t('notifications.panel.loading')}
+          />
+        )}
+        {state.uiFlags.isFetching && paginatedNotifications.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full p-8 text-center">
             <div className="w-8 h-8 animate-spin rounded-full border-2 border-primary border-t-transparent mb-4" />
             <p className="text-muted-foreground">{t('notifications.panel.loading')}</p>
           </div>
-        ) : totalUnreadCount === 0 || paginatedNotifications.length === 0 ? (
+        ) : paginatedNotifications.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full p-8 text-center">
             <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
               <ListCheck className="h-8 w-8 text-muted-foreground" />
@@ -167,7 +173,7 @@ export default function NotificationPanel({
       </div>
 
       {/* Pagination */}
-      {totalUnreadCount > 0 && totalPages > 1 && (
+      {totalCount > 0 && totalPages > 1 && (
         <div className="flex items-center justify-between p-4 border-t border-border">
           <div className="flex items-center gap-1">
             <Button

--- a/src/components/layout/NotificationPanel.tsx
+++ b/src/components/layout/NotificationPanel.tsx
@@ -144,7 +144,7 @@ export default function NotificationPanel({
             <div className="w-8 h-8 animate-spin rounded-full border-2 border-primary border-t-transparent mb-4" />
             <p className="text-muted-foreground">{t('notifications.panel.loading')}</p>
           </div>
-        ) : totalUnreadCount === 0 ? (
+        ) : totalUnreadCount === 0 || paginatedNotifications.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full p-8 text-center">
             <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center mb-4">
               <ListCheck className="h-8 w-8 text-muted-foreground" />

--- a/src/contexts/NotificationsContext.tsx
+++ b/src/contexts/NotificationsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { AxiosError } from 'axios';
 import notificationsService, { type Notification } from '@/services/notifications/NotificationsService';
 import { useAuth } from '@/contexts/AuthContext';
@@ -199,7 +199,7 @@ interface NotificationsContextType {
       status?: string;
       type?: string;
     }) => Promise<void>;
-    fetchUnreadCount: () => Promise<void>;
+    fetchUnreadCount: (opts?: { force?: boolean }) => Promise<void>;
     markAsRead: (notification: Notification) => Promise<void>;
     markAsUnread: (id: string) => Promise<void>;
     markAllAsRead: () => Promise<void>;
@@ -229,10 +229,19 @@ interface NotificationsProviderProps {
 const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(notificationsReducer, initialState);
   const { user } = useAuth();
-  const unreadCountRequestInFlightRef = React.useRef(false);
-  const unreadCountBlockedUntilRef = React.useRef(0);
+  const unreadCountRequestInFlightRef = useRef(false);
+  const unreadCountBlockedUntilRef = useRef(0);
 
-  const actions = {
+  // Mirror the latest state on a ref so memoized callbacks can read fresh values
+  // without re-creating themselves on every render. Fixes:
+  //  - HIGH-1: stale `actions` captured by WebSocket handlers with deps=[]
+  //  - HIGH-4: stale `state.meta.unreadCount` inside checkUnreadConversations
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  const actions = useMemo(() => ({
     fetchNotifications: async (params: { page?: number; status?: string; type?: string } = {}) => {
       dispatch({ type: 'SET_UI_FLAGS', payload: { isFetching: true } });
 
@@ -258,10 +267,12 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
       }
     },
 
-    fetchUnreadCount: async () => {
+    fetchUnreadCount: async (opts: { force?: boolean } = {}) => {
       const now = Date.now();
       if (unreadCountRequestInFlightRef.current) return;
-      if (unreadCountBlockedUntilRef.current > now) return;
+      // `force: true` bypasses the 401-backoff window so explicit reconciliation
+      // (e.g. after markAllAsRead) is never silently dropped.
+      if (!opts.force && unreadCountBlockedUntilRef.current > now) return;
 
       unreadCountRequestInFlightRef.current = true;
       dispatch({ type: 'SET_UI_FLAGS', payload: { isUpdatingUnreadCount: true } });
@@ -319,7 +330,8 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
         dispatch({ type: 'MARK_ALL_AS_READ' });
         // Reconcile with server: NotificationBell now refetches on every open,
         // so make sure the next fetch sees a consistent unread count.
-        await actions.fetchUnreadCount();
+        // Use `force: true` so a recent 401 backoff window doesn't silently skip this.
+        await actions.fetchUnreadCount({ force: true });
       } catch (error) {
         console.error('Error marking all notifications as read:', error);
         throw error;
@@ -351,7 +363,7 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
           dispatch({ type: 'SET_UNREAD_COUNT', payload: 0 });
         } else {
           // Remove only read notifications
-          const unreadNotifications = state.notifications.filter(n => !n.read_at);
+          const unreadNotifications = stateRef.current.notifications.filter(n => !n.read_at);
           dispatch({ type: 'SET_NOTIFICATIONS', payload: unreadNotifications });
           dispatch({ type: 'SET_META', payload: { count: unreadNotifications.length } });
         }
@@ -389,9 +401,12 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
     setFilters: (filters: Record<string, any>) => {
       dispatch({ type: 'SET_FILTERS', payload: filters });
     },
-  };
+  }), []);
+  // ^ deps=[] is safe: every read of `state` inside actions goes through stateRef.current,
+  // and dispatch/notificationsService/refs are stable references.
 
-  // Callbacks for WebSocket events (usando useCallback para evitar re-criação)
+  // Callbacks for WebSocket events — deps=[actions] is fine because `actions` is now
+  // memoized with deps=[], so it's stable across renders.
   const handleNotificationCreated = useCallback(
     (data: any) => {
       // Mapear dados do WebSocket para o formato Notification
@@ -476,10 +491,16 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
           });
           desktopNotification.onclick = () => {
             window.focus();
-            if (conversationId) {
-              window.location.assign(`/conversations/${conversationId}`);
-            }
             desktopNotification.close();
+            if (conversationId) {
+              // SPA navigation: pushState + popstate keeps WebSocket / contexts alive
+              // (vs. window.location.assign which forces a full reload).
+              const target = `/conversations/${conversationId}`;
+              if (window.location.pathname !== target) {
+                window.history.pushState({}, '', target);
+                window.dispatchEvent(new PopStateEvent('popstate'));
+              }
+            }
           };
         } catch {
           // Browser may block Notification constructor in certain contexts
@@ -510,9 +531,9 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
           if (isAssignedConversationNotification) {
             return true;
           }
-          // For other notification types, check if there are unread notifications
-          // Note: This is a simplified check - ideally we'd check specifically for assigned conversations
-          const hasUnread = state.meta.unreadCount > 0;
+          // Read unreadCount from the ref so back-to-back WebSocket events
+          // (which fire faster than React re-renders) see the freshest value.
+          const hasUnread = stateRef.current.meta.unreadCount > 0;
           return hasUnread;
         };
 
@@ -521,20 +542,20 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
         });
       }
     },
-    [state.meta.unreadCount, actions],
+    [actions],
   );
 
   const handleNotificationDeleted = useCallback((data: any) => {
     if (data.id) {
       actions.deleteNotification(data.id);
     }
-  }, []);
+  }, [actions]);
 
   const handleNotificationUpdated = useCallback((data: any) => {
     if (data.id) {
       actions.updateNotification(data.id, data);
     }
-  }, []);
+  }, [actions]);
 
   // Initialize global WebSocket connection for real-time notifications and messages
   const { isConnected } = useGlobalWebSocket({

--- a/src/contexts/NotificationsContext.tsx
+++ b/src/contexts/NotificationsContext.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
 import type { AxiosError } from 'axios';
-import notificationsService, { Notification } from '@/services/notifications/NotificationsService';
+import notificationsService, { type Notification } from '@/services/notifications/NotificationsService';
 import { useAuth } from '@/contexts/AuthContext';
 import { useGlobalWebSocket } from '@/hooks/useGlobalWebSocket';
-import { playNotificationSound, getAudioSettings } from '@/utils/audioNotificationUtils';
+import { playNotificationSound, getAudioSettings, unlockAudioContext } from '@/utils/audioNotificationUtils';
 
 interface NotificationsMeta {
   count: number;
@@ -451,6 +451,27 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
       if (isConversationOpen) {
         return; // Não tocar som nem mostrar notificação se a conversa está aberta
       }
+
+      // Fire browser desktop push notification when permission is granted and tab is inactive
+      if (
+        typeof window !== 'undefined' &&
+        'Notification' in window &&
+        Notification.permission === 'granted' &&
+        document.hidden
+      ) {
+        try {
+          const title = notification.push_message_title || 'Nova notificação';
+          new Notification(title, {
+            icon: '/favicon.ico',
+            tag: `notification-${notification.id}`,
+          });
+        } catch {
+          // Browser may block Notification constructor in certain contexts
+        }
+      }
+
+      // Unlock AudioContext on the WebSocket callback (counts as indirect user context in some browsers)
+      unlockAudioContext();
 
       // Play notification sound if enabled
       const audioSettings = getAudioSettings();

--- a/src/contexts/NotificationsContext.tsx
+++ b/src/contexts/NotificationsContext.tsx
@@ -3,7 +3,8 @@ import type { AxiosError } from 'axios';
 import notificationsService, { type Notification } from '@/services/notifications/NotificationsService';
 import { useAuth } from '@/contexts/AuthContext';
 import { useGlobalWebSocket } from '@/hooks/useGlobalWebSocket';
-import { playNotificationSound, getAudioSettings, unlockAudioContext } from '@/utils/audioNotificationUtils';
+import { playNotificationSound, getAudioSettings } from '@/utils/audioNotificationUtils';
+import i18n from '@/i18n/config';
 
 interface NotificationsMeta {
   count: number;
@@ -316,6 +317,9 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
       try {
         await notificationsService.markAllAsRead();
         dispatch({ type: 'MARK_ALL_AS_READ' });
+        // Reconcile with server: NotificationBell now refetches on every open,
+        // so make sure the next fetch sees a consistent unread count.
+        await actions.fetchUnreadCount();
       } catch (error) {
         console.error('Error marking all notifications as read:', error);
         throw error;
@@ -460,18 +464,27 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
         document.hidden
       ) {
         try {
-          const title = notification.push_message_title || 'Nova notificação';
-          new Notification(title, {
+          const title = notification.push_message_title || i18n.t('layout:notifications.push.fallbackTitle');
+          const assigneeName = notification.primary_actor_meta?.assignee?.name;
+          const body = assigneeName
+            ? i18n.t('layout:notifications.push.bodyWithAssignee', { name: assigneeName })
+            : undefined;
+          const desktopNotification = new Notification(title, {
             icon: '/favicon.ico',
             tag: `notification-${notification.id}`,
+            body,
           });
+          desktopNotification.onclick = () => {
+            window.focus();
+            if (conversationId) {
+              window.location.assign(`/conversations/${conversationId}`);
+            }
+            desktopNotification.close();
+          };
         } catch {
           // Browser may block Notification constructor in certain contexts
         }
       }
-
-      // Unlock AudioContext on the WebSocket callback (counts as indirect user context in some browsers)
-      unlockAudioContext();
 
       // Play notification sound if enabled
       const audioSettings = getAudioSettings();
@@ -503,12 +516,9 @@ const NotificationsProviderInner: React.FC<NotificationsProviderProps> = ({ chil
           return hasUnread;
         };
 
-        // Use setTimeout to ensure state is updated before checking
-        setTimeout(() => {
-          playNotificationSound(audioSettings, checkUnreadConversations).catch(error => {
-            console.error('❌ Error playing notification sound:', error);
-          });
-        }, 100);
+        playNotificationSound(audioSettings, checkUnreadConversations).catch(error => {
+          console.error('❌ Error playing notification sound:', error);
+        });
       }
     },
     [state.meta.unreadCount, actions],

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -24,12 +24,16 @@
       "noAssignee": "NA",
       "noContent": "No content"
     },
+    "push": {
+      "fallbackTitle": "New notification",
+      "bodyWithAssignee": "Assigned to {{name}}"
+    },
     "panel": {
-      "title": "Unread notifications",
+      "title": "Notifications",
       "markAllAsRead": "Mark all as read",
       "loading": "Loading notifications...",
       "emptyTitle": "You're all caught up!",
-      "emptyDescription": "You don't have any unread notifications at the moment.",
+      "emptyDescription": "You don't have any notifications at the moment.",
       "pagination": {
         "separator": " - "
       },

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -24,12 +24,16 @@
       "noAssignee": "NA",
       "noContent": "Sin contenido"
     },
+    "push": {
+      "fallbackTitle": "Nueva notificación",
+      "bodyWithAssignee": "Asignada a {{name}}"
+    },
     "panel": {
-      "title": "Notificaciones no leídas",
+      "title": "Notificaciones",
       "markAllAsRead": "Marcar todas como leídas",
       "loading": "Cargando notificaciones...",
       "emptyTitle": "¡Todo al día!",
-      "emptyDescription": "No tiene notificaciones no leídas en este momento.",
+      "emptyDescription": "No tiene notificaciones en este momento.",
       "pagination": {
         "separator": " - "
       },

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -24,12 +24,16 @@
       "noAssignee": "NA",
       "noContent": "Sans contenu"
     },
+    "push": {
+      "fallbackTitle": "Nouvelle notification",
+      "bodyWithAssignee": "Assignée à {{name}}"
+    },
     "panel": {
-      "title": "Notifications non lues",
+      "title": "Notifications",
       "markAllAsRead": "Tout marquer comme lu",
       "loading": "Chargement des notifications...",
       "emptyTitle": "Tout est à jour !",
-      "emptyDescription": "Vous n'avez aucune notification non lue pour le moment.",
+      "emptyDescription": "Vous n'avez aucune notification pour le moment.",
       "pagination": {
         "separator": " - "
       },

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -24,12 +24,16 @@
       "noAssignee": "NA",
       "noContent": "Nessun contenuto"
     },
+    "push": {
+      "fallbackTitle": "Nuova notifica",
+      "bodyWithAssignee": "Assegnata a {{name}}"
+    },
     "panel": {
-      "title": "Notifiche non lette",
+      "title": "Notifiche",
       "markAllAsRead": "Segna tutte come lette",
       "loading": "Caricamento notifiche...",
       "emptyTitle": "Tutto a posto!",
-      "emptyDescription": "Non hai notifiche non lette al momento.",
+      "emptyDescription": "Non hai notifiche al momento.",
       "pagination": {
         "separator": " - "
       },

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -24,12 +24,16 @@
       "noAssignee": "NA",
       "noContent": "Sem conteúdo"
     },
+    "push": {
+      "fallbackTitle": "Nova notificação",
+      "bodyWithAssignee": "Atribuída a {{name}}"
+    },
     "panel": {
-      "title": "Notificações não lidas",
+      "title": "Notificações",
       "markAllAsRead": "Marcar todas como lidas",
       "loading": "Carregando notificações...",
       "emptyTitle": "Tudo em dia!",
-      "emptyDescription": "Você não tem notificações não lidas no momento.",
+      "emptyDescription": "Você não tem notificações no momento.",
       "pagination": {
         "separator": " - "
       },

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -24,12 +24,16 @@
       "noAssignee": "NA",
       "noContent": "Sem conteúdo"
     },
+    "push": {
+      "fallbackTitle": "Nova notificação",
+      "bodyWithAssignee": "Atribuída a {{name}}"
+    },
     "panel": {
-      "title": "Notificações não lidas",
+      "title": "Notificações",
       "markAllAsRead": "Marcar todas como lidas",
       "loading": "Carregando notificações...",
       "emptyTitle": "Tudo em dia!",
-      "emptyDescription": "Você não tem notificações não lidas no momento.",
+      "emptyDescription": "Você não tem notificações no momento.",
       "pagination": {
         "separator": " - "
       },

--- a/src/pages/Shared/Profile/Profile.tsx
+++ b/src/pages/Shared/Profile/Profile.tsx
@@ -613,6 +613,11 @@ const Profile = () => {
       return;
     }
 
+    // Auto-request browser permission on first push enable
+    if (type === 'push' && value && 'Notification' in window && Notification.permission === 'default') {
+      await requestNotificationPermission();
+    }
+
     // Atualizar estado local primeiro (otimistic update)
     const notificationType = `${type}_notifications` as keyof typeof notificationSettings;
     const currentNotifications = notificationSettings[notificationType] as Record<string, boolean> | undefined;

--- a/src/pages/Shared/Profile/Profile.tsx
+++ b/src/pages/Shared/Profile/Profile.tsx
@@ -613,9 +613,17 @@ const Profile = () => {
       return;
     }
 
-    // Auto-request browser permission on first push enable
-    if (type === 'push' && value && 'Notification' in window && Notification.permission === 'default') {
-      await requestNotificationPermission();
+    // Auto-request browser permission on first push enable.
+    // If the user denies the prompt, abort: saving push=true while permission is
+    // 'denied' would silently store an unreachable subscription on the backend.
+    if (type === 'push' && value && 'Notification' in window) {
+      if (Notification.permission === 'default') {
+        await requestNotificationPermission();
+      }
+      if (Notification.permission !== 'granted') {
+        toast.error(t('notifications.browserPermission.denied'));
+        return;
+      }
     }
 
     // Atualizar estado local primeiro (otimistic update)
@@ -649,13 +657,6 @@ const Profile = () => {
 
       const emailFlags = settingsToFlags(updatedSettings.email_notifications, 'email');
       const pushFlags = settingsToFlags(updatedSettings.push_notifications, 'push');
-
-      console.log('📧 [Profile] Updating notification settings:', {
-        emailFlags,
-        pushFlags,
-        setting,
-        value,
-      });
 
       await notificationSettingsService.updateSettings({
         selected_email_flags: emailFlags,

--- a/src/utils/audioNotificationUtils.ts
+++ b/src/utils/audioNotificationUtils.ts
@@ -28,15 +28,17 @@ const getAudioContextClass = (): AudioContextClass | null => {
   return window.AudioContext || (window as unknown as { webkitAudioContext: AudioContextClass }).webkitAudioContext || null;
 };
 
-// Shared AudioContext — created once and reused to survive browser autoplay restrictions
-let sharedAudioContext: AudioContext | null = null;
-let audioContextUnlocked = false;
+// Shared AudioContext — created once and reused to survive browser autoplay restrictions.
+// The "unlocked" flag lives on the context itself (not module-global) so that recreating
+// the context after close() / HMR / suspend automatically requires a fresh unlock.
+type UnlockableAudioContext = AudioContext & { __unlocked?: boolean };
+let sharedAudioContext: UnlockableAudioContext | null = null;
 
-const getOrCreateAudioContext = (): AudioContext | null => {
+const getOrCreateAudioContext = (): UnlockableAudioContext | null => {
   const Ctx = getAudioContextClass();
   if (!Ctx) return null;
   if (!sharedAudioContext || sharedAudioContext.state === 'closed') {
-    sharedAudioContext = new Ctx();
+    sharedAudioContext = new Ctx() as UnlockableAudioContext;
   }
   return sharedAudioContext;
 };
@@ -47,17 +49,16 @@ const getOrCreateAudioContext = (): AudioContext | null => {
  * allowed by the browser's autoplay policy even when the tab is inactive.
  */
 export const unlockAudioContext = (): void => {
-  if (audioContextUnlocked) return;
   const ctx = getOrCreateAudioContext();
-  if (!ctx) return;
+  if (!ctx || ctx.__unlocked) return;
   if (ctx.state === 'suspended') {
     ctx.resume().then(() => {
-      audioContextUnlocked = true;
+      ctx.__unlocked = true;
     }).catch(() => {
       // Ignore — will retry on next user gesture
     });
   } else {
-    audioContextUnlocked = true;
+    ctx.__unlocked = true;
   }
 };
 
@@ -113,7 +114,9 @@ const playFileWithAudioContext = async (toneFile: string, tone: NotificationTone
     const source = ctx.createBufferSource();
     const gainNode = ctx.createGain();
     source.buffer = audioBuffer;
-    gainNode.gain.value = 0.5;
+    // Match oscillator fallback volume so user perception stays stable when the
+    // .mp3 path falls back to the synthesized tone.
+    gainNode.gain.value = 0.3;
     source.connect(gainNode);
     gainNode.connect(ctx.destination);
     source.start(0);
@@ -133,7 +136,6 @@ export const closeSharedAudioContext = (): void => {
     });
   }
   sharedAudioContext = null;
-  audioContextUnlocked = false;
 };
 
 let audioSettingsCache: AudioSettings | null = null;

--- a/src/utils/audioNotificationUtils.ts
+++ b/src/utils/audioNotificationUtils.ts
@@ -17,39 +17,106 @@ const TONE_FILES: Record<NotificationTone, string> = {
   ding: '/audio/notifications/ding.mp3',
   chime: '/audio/notifications/chime.mp3',
   bell: '/audio/notifications/bell.mp3',
-  notification: '/audio/notifications/ping.mp3', // Use ping.mp3 as default notification sound
+  notification: '/audio/notifications/ping.mp3',
   magic: '/audio/notifications/magic.mp3',
 };
 
-// Fallback: Use Web Audio API to generate simple tones if files don't exist
-const generateTone = (tone: NotificationTone): string => {
-  const AudioContextClass = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
-  const audioContext = new AudioContextClass();
-  const oscillator = audioContext.createOscillator();
-  const gainNode = audioContext.createGain();
+type AudioContextClass = typeof AudioContext;
 
-  oscillator.connect(gainNode);
-  gainNode.connect(audioContext.destination);
+const getAudioContextClass = (): AudioContextClass | null => {
+  if (typeof window === 'undefined') return null;
+  return window.AudioContext || (window as unknown as { webkitAudioContext: AudioContextClass }).webkitAudioContext || null;
+};
 
-  // Different frequencies for different tones
-  const frequencies: Record<NotificationTone, number> = {
-    ding: 800,
-    chime: 600,
-    bell: 400,
-    notification: 500,
-    magic: 700,
-  };
+// Shared AudioContext — created once and reused to survive browser autoplay restrictions
+let sharedAudioContext: AudioContext | null = null;
+let audioContextUnlocked = false;
 
-  oscillator.frequency.value = frequencies[tone];
-  oscillator.type = tone === 'bell' ? 'sine' : 'sine';
+const getOrCreateAudioContext = (): AudioContext | null => {
+  const Ctx = getAudioContextClass();
+  if (!Ctx) return null;
+  if (!sharedAudioContext || sharedAudioContext.state === 'closed') {
+    sharedAudioContext = new Ctx();
+  }
+  return sharedAudioContext;
+};
 
-  gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
-  gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.5);
+/**
+ * Must be called inside a user-gesture event handler (click, keydown, etc.).
+ * Resumes the shared AudioContext so that subsequent notification sounds are
+ * allowed by the browser's autoplay policy even when the tab is inactive.
+ */
+export const unlockAudioContext = (): void => {
+  if (audioContextUnlocked) return;
+  const ctx = getOrCreateAudioContext();
+  if (!ctx) return;
+  if (ctx.state === 'suspended') {
+    ctx.resume().then(() => {
+      audioContextUnlocked = true;
+    }).catch(() => {
+      // Ignore — will retry on next user gesture
+    });
+  } else {
+    audioContextUnlocked = true;
+  }
+};
 
-  oscillator.start(audioContext.currentTime);
-  oscillator.stop(audioContext.currentTime + 0.5);
+const playToneWithAudioContext = (tone: NotificationTone): void => {
+  const ctx = getOrCreateAudioContext();
+  if (!ctx) return;
 
-  return ''; // Return empty string as we're using Web Audio API directly
+  const resume = ctx.state === 'suspended' ? ctx.resume() : Promise.resolve();
+  resume.then(() => {
+    const frequencies: Record<NotificationTone, number> = {
+      ding: 800,
+      chime: 600,
+      bell: 400,
+      notification: 500,
+      magic: 700,
+    };
+
+    const oscillator = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+
+    oscillator.connect(gainNode);
+    gainNode.connect(ctx.destination);
+    oscillator.frequency.value = frequencies[tone];
+    oscillator.type = 'sine';
+    gainNode.gain.setValueAtTime(0.3, ctx.currentTime);
+    gainNode.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + 0.5);
+    oscillator.start(ctx.currentTime);
+    oscillator.stop(ctx.currentTime + 0.5);
+  }).catch(() => {
+    // AudioContext could not be resumed — browser is blocking audio
+  });
+};
+
+const playFileWithAudioContext = async (toneFile: string, tone: NotificationTone): Promise<void> => {
+  const ctx = getOrCreateAudioContext();
+  if (!ctx) {
+    playToneWithAudioContext(tone);
+    return;
+  }
+
+  try {
+    if (ctx.state === 'suspended') {
+      await ctx.resume();
+    }
+
+    const response = await fetch(toneFile);
+    const arrayBuffer = await response.arrayBuffer();
+    const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
+
+    const source = ctx.createBufferSource();
+    const gainNode = ctx.createGain();
+    source.buffer = audioBuffer;
+    gainNode.gain.value = 0.5;
+    source.connect(gainNode);
+    gainNode.connect(ctx.destination);
+    source.start(0);
+  } catch {
+    playToneWithAudioContext(tone);
+  }
 };
 
 let audioSettingsCache: AudioSettings | null = null;
@@ -72,7 +139,6 @@ export const getAudioSettings = (): AudioSettings => {
     console.error('Error loading audio settings:', error);
   }
 
-  // Default settings
   const defaults: AudioSettings = {
     enable_audio_alerts: false,
     notification_tone: 'ding',
@@ -115,64 +181,25 @@ export const playNotificationSound = async (
 ): Promise<void> => {
   const audioSettings = settings ? { ...getAudioSettings(), ...settings } : getAudioSettings();
 
-  // Check if audio alerts are enabled
   if (!audioSettings.enable_audio_alerts) {
     return;
   }
 
-  // Check condition: play only when tab is inactive
-  // If always_play_audio_alert is true, play regardless of tab state
   // If always_play_audio_alert is false, only play when tab is inactive
   if (!audioSettings.always_play_audio_alert && isTabActive()) {
     return;
   }
 
-  // Check condition: alert if unread assigned conversations exist
-  // This is an ADDITIONAL condition - if enabled, it requires unread conversations
-  // If disabled, it doesn't block the sound
   if (audioSettings.alert_if_unread_assigned_conversation_exist) {
     if (checkUnreadConversations) {
-      const hasUnread = checkUnreadConversations();
-      if (!hasUnread) {
-        return;
-      }
+      if (!checkUnreadConversations()) return;
     } else {
-      // If checkUnreadConversations is not provided but condition is enabled, don't play
       return;
     }
   }
 
   const toneFile = TONE_FILES[audioSettings.notification_tone];
-
-  try {
-    // Try to play audio file first
-    if (toneFile) {
-      const audio = new Audio(toneFile);
-      audio.volume = 0.5;
-
-      // Handle errors (file might not exist)
-      audio.onerror = () => {
-        // Fallback to generated tone
-        generateTone(audioSettings.notification_tone);
-      };
-
-      await audio.play().catch(() => {
-        // If play fails, try generated tone
-        generateTone(audioSettings.notification_tone);
-      });
-    } else {
-      // Use generated tone
-      generateTone(audioSettings.notification_tone);
-    }
-  } catch (error) {
-    console.error('Error playing notification sound:', error);
-    // Fallback to generated tone
-    try {
-      generateTone(audioSettings.notification_tone);
-    } catch (fallbackError) {
-      console.error('Error generating fallback tone:', fallbackError);
-    }
-  }
+  await playFileWithAudioContext(toneFile, audioSettings.notification_tone);
 };
 
 /**
@@ -180,36 +207,7 @@ export const playNotificationSound = async (
  */
 export const playNotificationSoundPreview = async (tone: NotificationTone): Promise<void> => {
   const toneFile = TONE_FILES[tone];
-
-  try {
-    // Try to play audio file first
-    if (toneFile) {
-      const audio = new Audio(toneFile);
-      audio.volume = 0.5;
-
-      // Handle errors (file might not exist)
-      audio.onerror = () => {
-        // Fallback to generated tone
-        generateTone(tone);
-      };
-
-      await audio.play().catch(() => {
-        // If play fails, try generated tone
-        generateTone(tone);
-      });
-    } else {
-      // Use generated tone
-      generateTone(tone);
-    }
-  } catch (error) {
-    console.error('Error playing notification sound preview:', error);
-    // Fallback to generated tone
-    try {
-      generateTone(tone);
-    } catch (fallbackError) {
-      console.error('Error generating fallback tone:', fallbackError);
-    }
-  }
+  await playFileWithAudioContext(toneFile, tone);
 };
 
 /**
@@ -218,4 +216,3 @@ export const playNotificationSoundPreview = async (tone: NotificationTone): Prom
 export const clearAudioSettingsCache = (): void => {
   audioSettingsCache = null;
 };
-

--- a/src/utils/audioNotificationUtils.ts
+++ b/src/utils/audioNotificationUtils.ts
@@ -104,6 +104,9 @@ const playFileWithAudioContext = async (toneFile: string, tone: NotificationTone
     }
 
     const response = await fetch(toneFile);
+    if (!response.ok) {
+      throw new Error(`Audio file fetch failed: ${response.status} ${toneFile}`);
+    }
     const arrayBuffer = await response.arrayBuffer();
     const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
 
@@ -114,9 +117,23 @@ const playFileWithAudioContext = async (toneFile: string, tone: NotificationTone
     source.connect(gainNode);
     gainNode.connect(ctx.destination);
     source.start(0);
-  } catch {
+  } catch (error) {
+    console.error('Error playing notification sound, falling back to oscillator tone:', error);
     playToneWithAudioContext(tone);
   }
+};
+
+/**
+ * Close and reset the shared AudioContext. Useful for tests and hot-reload.
+ */
+export const closeSharedAudioContext = (): void => {
+  if (sharedAudioContext && sharedAudioContext.state !== 'closed') {
+    sharedAudioContext.close().catch(() => {
+      // Ignore — context may already be closing
+    });
+  }
+  sharedAudioContext = null;
+  audioContextUnlocked = false;
 };
 
 let audioSettingsCache: AudioSettings | null = null;


### PR DESCRIPTION
## Summary

- **Desktop push never fired**: `new Notification(title)` is now dispatched when `Notification.permission === 'granted'` and the tab is inactive, inside `handleNotificationCreated`
- **Bell showed blank**: panel now shows the empty-state message when `paginatedNotifications.length === 0` (previously only when `unreadCount === 0`); bell also refetches on every open instead of only on first open
- **Audio blocked by autoplay policy**: replaced `new Audio()` + inline `new AudioContext()` with a shared `AudioContext` (`sharedAudioContext`) unlocked on first user gesture via `unlockAudioContext()`, called from `App.tsx` on `click`/`keydown` events
- **Permission dialog not triggered automatically**: `handleNotificationChange` in Profile now calls `requestNotificationPermission()` when the user enables a push type for the first time and `Notification.permission === 'default'`

## Validation

- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` — zero new errors
- `evo-ai-frontend-community: pnpm exec eslint [changed files]` — zero new errors
- `evo-ai-frontend-community: vitest run` — 26 suites pass, 1 pre-existing failure in ChannelConfig unrelated to this fix

## Changed Files

- `src/App.tsx`
- `src/utils/audioNotificationUtils.ts`
- `src/contexts/NotificationsContext.tsx`
- `src/components/layout/NotificationBell.tsx`
- `src/components/layout/NotificationPanel.tsx`
- `src/pages/Shared/Profile/Profile.tsx`

## Linked Issue

- EVO-977

## Summary by Sourcery

Improve desktop notification behavior and audio playback reliability across the app.

Bug Fixes:
- Ensure desktop push notifications are dispatched when browser permission is granted and the tab is inactive.
- Show the notifications panel empty state when there are no paginated notifications, not just when unread count is zero.
- Prevent notification sounds from being blocked by autoplay policies by reusing an unlocked shared AudioContext and triggering it via user gestures and WebSocket callbacks.
- Automatically request browser notification permission when a user enables push notifications for the first time.
- Refetch notifications every time the notification bell dropdown is opened to avoid stale data.

Enhancements:
- Refactor audio notification utilities to centralize AudioContext management and reuse both for live notifications and tone previews.