### PR TITLE
fix(frontend): open conversation when clicking pipeline card (EVO-1007)

### DIFF
--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -1188,9 +1188,15 @@ export default function PipelineKanban() {
                           onDragStart={() => handleDragStart(item)}
                           onDragEnd={handleDragEnd}
                           onClick={() => {
-                            if (!isDraggingRef.current && Date.now() > suppressClickUntilRef.current) {
-                              handleEditItem(item);
+                            if (isDraggingRef.current || Date.now() <= suppressClickUntilRef.current) {
+                              return;
                             }
+                            const conversationUuid = item.conversation?.uuid;
+                            if (conversationUuid) {
+                              navigate(`/conversations/${conversationUuid}`);
+                              return;
+                            }
+                            handleEditItem(item);
                           }}
                         >
                           {/* Card Options Menu */}

--- a/src/types/analytics/pipelines.ts
+++ b/src/types/analytics/pipelines.ts
@@ -234,6 +234,7 @@ export interface PipelineItem {
   };
   conversation?: {
     id: string;
+    uuid?: string;
     display_id: string;
     status: string;
     priority?: string | null;


### PR DESCRIPTION
## Summary

- Pipeline kanban cards now navigate to `/conversations/<uuid>` when clicked.
- Items without a conversation (lead / orphan) keep the existing edit-modal fallback.
- Drag-suppression refs are preserved so drag-and-drop does not fire navigation.
- Edit access stays available via the card's overflow (`⋮`) menu.

## Validation

- `pnpm exec tsc -b --noEmit` — no new errors in the changed files (pre-existing errors in unrelated files remain).
- `pnpm lint` — no new errors in the changed files.
- `pnpm exec vitest run src/components/pipelines/PipelineItemCard.spec.tsx src/components/chat/contact-sidebar/PipelineManagement.spec.tsx` — 9 tests passing.
- Manual smoke (dev): clicking a card with a conversation navigates to the conversation; clicking a lead/orphan card opens the edit modal; drag-and-drop does not navigate; `⋮` → Edit still opens the edit modal; `/conversations` continues to render messages (no chat regression).

## Changed Files

- `src/pages/Customer/Pipelines/PipelineKanban.tsx`
- `src/types/analytics/pipelines.ts`

## Linked Issue

- EVO-1007 — https://linear.app/evoai/issue/EVO-1007

## Related PRs

- Backend: https://github.com/EvolutionAPI/evo-ai-crm-community/pull/43

## Summary by Sourcery

Route pipeline kanban card clicks to conversation pages when available while retaining existing edit-modal behavior as a fallback.

New Features:
- Open the associated conversation view when clicking a pipeline card linked to a conversation.

Enhancements:
- Preserve drag-suppression logic when introducing conversation navigation from pipeline cards.
- Extend analytics pipeline item types to include an optional conversation UUID used for navigation.