### PR TITLE
feat(EVO-989): add per-stage automation rules UI

### DIFF
--- a/src/components/pipelines/EditStageModal.tsx
+++ b/src/components/pipelines/EditStageModal.tsx
@@ -22,8 +22,10 @@ import {
   TabsTrigger,
 } from '@evoapi/design-system';
 import { PipelineStage } from '@/types/analytics';
+import type { StageAutomationRule } from '@/types/analytics/pipelines';
 import { LocalAttributeDefinition, LocalAttributeDefinitionPayload } from '@/types/pipelines/localAttributeDefinition';
 import PipelineStageCustomAttributes from './PipelineStageCustomAttributes';
+import StageAutomationRules from './StageAutomationRules';
 
 // Cores predefinidas para as etapas
 const getStageColors = (t: (key: string) => string) => [
@@ -39,6 +41,11 @@ const getStageColors = (t: (key: string) => string) => [
   { value: '#6B7280', label: t('editStage.colors.gray') },
 ];
 
+interface Agent {
+  id: string;
+  name: string;
+}
+
 interface EditStageModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -47,12 +54,14 @@ interface EditStageModalProps {
     name: string;
     color: string;
     stage_type: string;
-    automation_rules?: { description?: string };
+    automation_rules?: { description?: string; rules?: StageAutomationRule[] };
     custom_fields?: Record<string, unknown> & {
       attributes?: string[];
     };
   }) => void;
   loading: boolean;
+  stages?: PipelineStage[];
+  agents?: Agent[];
 }
 
 export default function EditStageModal({
@@ -61,6 +70,8 @@ export default function EditStageModal({
   stage,
   onSubmit,
   loading,
+  stages = [],
+  agents = [],
 }: EditStageModalProps) {
   const { t } = useLanguage('pipelines');
   const [name, setName] = useState('');
@@ -68,6 +79,7 @@ export default function EditStageModal({
   const [stageType, setStageType] = useState('active');
   const [description, setDescription] = useState('');
   const [customAttributes, setCustomAttributes] = useState<Record<string, unknown>>({});
+  const [automationRules, setAutomationRules] = useState<StageAutomationRule[]>([]);
 
   const stageColors = getStageColors(t);
 
@@ -78,6 +90,7 @@ export default function EditStageModal({
       setColor(stage.color);
       setStageType(stage.stage_type || 'active');
       setDescription(stage.automation_rules?.description || stage.description || '');
+      setAutomationRules(stage.automation_rules?.rules || []);
       // Load attributes array from custom_fields.attributes
       // Structure: custom_fields = { attributes: ["key1", "key2", ...] }
       const attributesArray = (stage.custom_fields?.attributes as string[]) || [];
@@ -108,10 +121,9 @@ export default function EditStageModal({
   const handleSubmit = () => {
     if (!name.trim() || !stage) return;
     
-    const automationRules: { description?: string } = {};
-    if (description) {
-      automationRules.description = description;
-    }
+    const automationRulesPayload: { description?: string; rules?: StageAutomationRule[] } = {};
+    if (description) automationRulesPayload.description = description;
+    if (automationRules.length > 0) automationRulesPayload.rules = automationRules;
     
     const attributeKeys = Object.keys(customAttributes);
     const attributeDefinitions = Object.entries(customAttributes).reduce(
@@ -139,7 +151,7 @@ export default function EditStageModal({
       name: name.trim(),
       color,
       stage_type: stageType,
-      automation_rules: Object.keys(automationRules).length > 0 ? automationRules : undefined,
+      automation_rules: Object.keys(automationRulesPayload).length > 0 ? automationRulesPayload : undefined,
       custom_fields: attributeKeys.length > 0
         ? {
             ...existingCustomFields,
@@ -167,8 +179,9 @@ export default function EditStageModal({
         </DialogHeader>
 
         <Tabs defaultValue="details" className="flex-1 flex flex-col min-h-0">
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className="grid w-full grid-cols-3">
             <TabsTrigger value="details">{t('editStage.details')}</TabsTrigger>
+            <TabsTrigger value="automation">{t('editStage.automation')}</TabsTrigger>
             <TabsTrigger value="attributes">{t('editStage.customAttributes')}</TabsTrigger>
           </TabsList>
 
@@ -269,6 +282,17 @@ export default function EditStageModal({
               </div>
             </div>
           </div>
+          </TabsContent>
+
+          <TabsContent value="automation" className="py-4 overflow-y-auto flex-1">
+            <StageAutomationRules
+              rules={automationRules}
+              onChange={setAutomationRules}
+              disabled={loading}
+              currentStageId={stage?.id}
+              stages={stages}
+              agents={agents}
+            />
           </TabsContent>
 
           <TabsContent value="attributes" className="py-4 overflow-y-auto flex-1">

--- a/src/components/pipelines/StageAutomationRules.tsx
+++ b/src/components/pipelines/StageAutomationRules.tsx
@@ -1,0 +1,269 @@
+import { useRef, useEffect, useState } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
+import {
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+} from '@evoapi/design-system';
+import { PlusIcon, TrashIcon } from 'lucide-react';
+import type { StageAutomationRule, StageAutomationTrigger, StageAutomationAction } from '@/types/analytics/pipelines';
+import type { PipelineStage } from '@/types/analytics';
+
+interface Agent {
+  id: string;
+  name: string;
+}
+
+interface StageAutomationRulesProps {
+  rules: StageAutomationRule[];
+  onChange: (rules: StageAutomationRule[]) => void;
+  disabled?: boolean;
+  currentStageId?: string;
+  stages?: PipelineStage[];
+  agents?: Agent[];
+}
+
+const EMPTY_RULE: StageAutomationRule = {
+  trigger: 'label_added',
+  trigger_value: '',
+  action: 'move_to_stage',
+  action_value: '',
+};
+
+const CONVERSATION_STATUSES = ['open', 'resolved', 'pending', 'snoozed'] as const;
+
+function generateKey() {
+  return `rule-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export default function StageAutomationRules({
+  rules,
+  onChange,
+  disabled = false,
+  currentStageId,
+  stages = [],
+  agents = [],
+}: StageAutomationRulesProps) {
+  const { t } = useLanguage('pipelines');
+
+  const [keys, setKeys] = useState<string[]>(() => rules.map(() => generateKey()));
+  const prevLengthRef = useRef(rules.length);
+
+  useEffect(() => {
+    if (rules.length !== prevLengthRef.current) {
+      if (rules.length > prevLengthRef.current) {
+        setKeys(prev => [...prev, generateKey()]);
+      } else {
+        setKeys(prev => prev.slice(0, rules.length));
+      }
+      prevLengthRef.current = rules.length;
+    }
+  }, [rules.length]);
+
+  const addRule = () => onChange([...rules, { ...EMPTY_RULE }]);
+
+  const removeRule = (index: number) => onChange(rules.filter((_, i) => i !== index));
+
+  const updateRule = (index: number, patch: Partial<StageAutomationRule>) => {
+    onChange(rules.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  };
+
+  const otherStages = stages.filter(s => s.id !== currentStageId);
+
+  const renderTriggerValue = (rule: StageAutomationRule, index: number) => {
+    if (rule.trigger === 'custom_attribute_updated') return null;
+
+    if (rule.trigger === 'conversation_status_changed') {
+      return (
+        <Select
+          value={rule.trigger_value || ''}
+          onValueChange={v => updateRule(index, { trigger_value: v })}
+          disabled={disabled}
+        >
+          <SelectTrigger className="flex-1">
+            <SelectValue placeholder={t('stageAutomation.anyValue')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">{t('stageAutomation.anyValue')}</SelectItem>
+            {CONVERSATION_STATUSES.map(s => (
+              <SelectItem key={s} value={s}>
+                {t(`kanban.search.status.${s}`) || s}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+
+    return (
+      <Input
+        className="flex-1"
+        placeholder={t('stageAutomation.labelNamePlaceholder')}
+        value={rule.trigger_value}
+        onChange={e => updateRule(index, { trigger_value: e.target.value })}
+        disabled={disabled}
+      />
+    );
+  };
+
+  const renderActionValue = (rule: StageAutomationRule, index: number) => {
+    if (rule.action === 'move_to_stage') {
+      return (
+        <Select
+          value={rule.action_value || ''}
+          onValueChange={v => updateRule(index, { action_value: v })}
+          disabled={disabled}
+        >
+          <SelectTrigger className="flex-1">
+            <SelectValue placeholder={t('stageAutomation.selectStage')} />
+          </SelectTrigger>
+          <SelectContent>
+            {otherStages.length === 0 ? (
+              <SelectItem value="" disabled>{t('stageAutomation.noOtherStages')}</SelectItem>
+            ) : (
+              otherStages.map(s => (
+                <SelectItem key={s.id} value={s.id}>
+                  <span className="flex items-center gap-2">
+                    <span
+                      className="w-3 h-3 rounded-full inline-block shrink-0"
+                      style={{ backgroundColor: s.color }}
+                    />
+                    {s.name}
+                  </span>
+                </SelectItem>
+              ))
+            )}
+          </SelectContent>
+        </Select>
+      );
+    }
+
+    if (rule.action === 'assign_agent') {
+      return (
+        <Select
+          value={rule.action_value || ''}
+          onValueChange={v => updateRule(index, { action_value: v })}
+          disabled={disabled}
+        >
+          <SelectTrigger className="flex-1">
+            <SelectValue placeholder={t('stageAutomation.selectAgent')} />
+          </SelectTrigger>
+          <SelectContent>
+            {agents.length === 0 ? (
+              <SelectItem value="" disabled>{t('stageAutomation.noAgents')}</SelectItem>
+            ) : (
+              agents.map(a => (
+                <SelectItem key={a.id} value={a.id}>
+                  {a.name}
+                </SelectItem>
+              ))
+            )}
+          </SelectContent>
+        </Select>
+      );
+    }
+
+    return (
+      <Input
+        className="flex-1"
+        placeholder={t('stageAutomation.labelNamePlaceholder')}
+        value={rule.action_value}
+        onChange={e => updateRule(index, { action_value: e.target.value })}
+        disabled={disabled}
+      />
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-base font-semibold">{t('stageAutomation.title')}</h3>
+        <p className="text-sm text-muted-foreground mt-1">{t('stageAutomation.description')}</p>
+      </div>
+
+      {rules.length === 0 && (
+        <p className="text-sm text-muted-foreground py-4 text-center border border-dashed rounded-lg">
+          {t('stageAutomation.noRules')}
+        </p>
+      )}
+
+      <div className="space-y-3">
+        {rules.map((rule, index) => (
+          <div key={keys[index] ?? index} className="border rounded-lg p-3 space-y-3 bg-muted/30">
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                {t('stageAutomation.rule')} {index + 1}
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => removeRule(index)}
+                disabled={disabled}
+                className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+              >
+                <TrashIcon className="w-3.5 h-3.5" />
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground font-medium">{t('stageAutomation.when')}</p>
+              <div className="flex gap-2">
+                <Select
+                  value={rule.trigger}
+                  onValueChange={v => updateRule(index, { trigger: v as StageAutomationTrigger, trigger_value: '' })}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="label_added">{t('stageAutomation.triggers.label_added')}</SelectItem>
+                    <SelectItem value="conversation_status_changed">{t('stageAutomation.triggers.conversation_status_changed')}</SelectItem>
+                    <SelectItem value="custom_attribute_updated">{t('stageAutomation.triggers.custom_attribute_updated')}</SelectItem>
+                  </SelectContent>
+                </Select>
+                {renderTriggerValue(rule, index)}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-xs text-muted-foreground font-medium">{t('stageAutomation.then')}</p>
+              <div className="flex gap-2">
+                <Select
+                  value={rule.action}
+                  onValueChange={v => updateRule(index, { action: v as StageAutomationAction, action_value: '' })}
+                  disabled={disabled}
+                >
+                  <SelectTrigger className="w-[200px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="move_to_stage">{t('stageAutomation.actions.move_to_stage')}</SelectItem>
+                    <SelectItem value="assign_agent">{t('stageAutomation.actions.assign_agent')}</SelectItem>
+                    <SelectItem value="apply_label">{t('stageAutomation.actions.apply_label')}</SelectItem>
+                  </SelectContent>
+                </Select>
+                {renderActionValue(rule, index)}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={addRule}
+        disabled={disabled}
+        className="w-full"
+      >
+        <PlusIcon className="w-4 h-4 mr-2" />
+        {t('stageAutomation.addRule')}
+      </Button>
+    </div>
+  );
+}

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -381,10 +381,36 @@
     "saving": "Saving...",
     "save": "Save Changes"
   },
+  "stageAutomation": {
+    "title": "Automation Rules",
+    "description": "Define rules that automatically trigger actions when specific events occur in this stage.",
+    "noRules": "No automation rules configured. Click \"Add Rule\" to get started.",
+    "addRule": "Add Rule",
+    "rule": "Rule",
+    "when": "When",
+    "then": "Then",
+    "anyValue": "Any",
+    "labelNamePlaceholder": "Label name...",
+    "selectStage": "Select stage...",
+    "selectAgent": "Select agent...",
+    "noOtherStages": "No other stages available",
+    "noAgents": "No agents available",
+    "triggers": {
+      "label_added": "Label added",
+      "conversation_status_changed": "Conversation status changed",
+      "custom_attribute_updated": "Custom attribute updated"
+    },
+    "actions": {
+      "move_to_stage": "Move to stage",
+      "assign_agent": "Assign agent",
+      "apply_label": "Apply label"
+    }
+  },
   "editStage": {
     "title": "Edit Stage",
     "description": "Edit the information of this stage of the pipeline.",
     "details": "Details",
+    "automation": "Automation",
     "customAttributes": "Attributes",
     "attributesDescription": "Configure attributes for this stage",
     "name": "Stage Name",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -342,10 +342,36 @@
     "saving": "Guardando...",
     "save": "Guardar Cambios"
   },
+  "stageAutomation": {
+    "title": "Reglas de Automatización",
+    "description": "Define reglas que disparan acciones automáticamente cuando ocurren eventos en esta etapa.",
+    "noRules": "No hay reglas configuradas. Haz clic en \"Agregar Regla\" para comenzar.",
+    "addRule": "Agregar Regla",
+    "rule": "Regla",
+    "when": "Cuando",
+    "then": "Entonces",
+    "anyValue": "Cualquiera",
+    "labelNamePlaceholder": "Nombre de la etiqueta...",
+    "selectStage": "Seleccionar etapa...",
+    "selectAgent": "Seleccionar agente...",
+    "noOtherStages": "No hay otras etapas disponibles",
+    "noAgents": "No hay agentes disponibles",
+    "triggers": {
+      "label_added": "Etiqueta agregada",
+      "conversation_status_changed": "Estado de conversación cambiado",
+      "custom_attribute_updated": "Atributo personalizado actualizado"
+    },
+    "actions": {
+      "move_to_stage": "Mover a etapa",
+      "assign_agent": "Asignar agente",
+      "apply_label": "Aplicar etiqueta"
+    }
+  },
   "editStage": {
     "title": "Editar Etapa",
     "description": "Edite la información de esta etapa del pipeline.",
     "details": "Detalles",
+    "automation": "Automatización",
     "customAttributes": "Atributos",
     "attributesDescription": "Configure atributos para esta etapa",
     "name": "Nombre de la Etapa",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -343,10 +343,36 @@
     "saving": "Enregistrement...",
     "save": "Enregistrer les Modifications"
   },
+  "stageAutomation": {
+    "title": "Règles d'Automatisation",
+    "description": "Définissez des règles qui déclenchent des actions automatiquement lorsque des événements se produisent dans cette étape.",
+    "noRules": "Aucune règle configurée. Cliquez sur \"Ajouter une règle\" pour commencer.",
+    "addRule": "Ajouter une règle",
+    "rule": "Règle",
+    "when": "Quand",
+    "then": "Alors",
+    "anyValue": "Tout",
+    "labelNamePlaceholder": "Nom de l'étiquette...",
+    "selectStage": "Sélectionner une étape...",
+    "selectAgent": "Sélectionner un agent...",
+    "noOtherStages": "Aucune autre étape disponible",
+    "noAgents": "Aucun agent disponible",
+    "triggers": {
+      "label_added": "Étiquette ajoutée",
+      "conversation_status_changed": "Statut de conversation modifié",
+      "custom_attribute_updated": "Attribut personnalisé mis à jour"
+    },
+    "actions": {
+      "move_to_stage": "Déplacer vers l'étape",
+      "assign_agent": "Assigner un agent",
+      "apply_label": "Appliquer une étiquette"
+    }
+  },
   "editStage": {
     "title": "Modifier l'Étape",
     "description": "Modifiez les informations de cette étape du pipeline.",
     "details": "Détails",
+    "automation": "Automatisation",
     "customAttributes": "Attributs",
     "attributesDescription": "Configurez les attributs pour cette étape",
     "name": "Nom de l'Étape",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -342,10 +342,36 @@
     "saving": "Salvataggio...",
     "save": "Salva Modifiche"
   },
+  "stageAutomation": {
+    "title": "Regole di Automazione",
+    "description": "Definisci regole che attivano azioni automaticamente quando si verificano eventi in questa fase.",
+    "noRules": "Nessuna regola configurata. Clicca su \"Aggiungi Regola\" per iniziare.",
+    "addRule": "Aggiungi Regola",
+    "rule": "Regola",
+    "when": "Quando",
+    "then": "Allora",
+    "anyValue": "Qualsiasi",
+    "labelNamePlaceholder": "Nome dell'etichetta...",
+    "selectStage": "Seleziona fase...",
+    "selectAgent": "Seleziona agente...",
+    "noOtherStages": "Nessun'altra fase disponibile",
+    "noAgents": "Nessun agente disponibile",
+    "triggers": {
+      "label_added": "Etichetta aggiunta",
+      "conversation_status_changed": "Stato conversazione modificato",
+      "custom_attribute_updated": "Attributo personalizzato aggiornato"
+    },
+    "actions": {
+      "move_to_stage": "Sposta alla fase",
+      "assign_agent": "Assegna agente",
+      "apply_label": "Applica etichetta"
+    }
+  },
   "editStage": {
     "title": "Modifica Fase",
     "description": "Modifica le informazioni di questa fase della pipeline.",
     "details": "Dettagli",
+    "automation": "Automazione",
     "customAttributes": "Attributi",
     "attributesDescription": "Configura attributi per questa fase",
     "name": "Nome della Fase",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -381,10 +381,36 @@
     "saving": "Salvando...",
     "save": "Salvar Alterações"
   },
+  "stageAutomation": {
+    "title": "Regras de Automação",
+    "description": "Defina regras que disparam ações automaticamente quando eventos ocorrem nesta etapa.",
+    "noRules": "Nenhuma regra configurada. Clique em \"Adicionar Regra\" para começar.",
+    "addRule": "Adicionar Regra",
+    "rule": "Regra",
+    "when": "Quando",
+    "then": "Então",
+    "anyValue": "Qualquer",
+    "labelNamePlaceholder": "Nome da etiqueta...",
+    "selectStage": "Selecionar etapa...",
+    "selectAgent": "Selecionar agente...",
+    "noOtherStages": "Nenhuma outra etapa disponível",
+    "noAgents": "Nenhum agente disponível",
+    "triggers": {
+      "label_added": "Etiqueta adicionada",
+      "conversation_status_changed": "Status da conversa alterado",
+      "custom_attribute_updated": "Atributo personalizado atualizado"
+    },
+    "actions": {
+      "move_to_stage": "Mover para etapa",
+      "assign_agent": "Atribuir agente",
+      "apply_label": "Aplicar etiqueta"
+    }
+  },
   "editStage": {
     "title": "Editar Etapa",
     "description": "Edite as informações desta etapa do pipeline.",
     "details": "Detalhes",
+    "automation": "Automação",
     "customAttributes": "Atributos",
     "attributesDescription": "Configure atributos para este estágio",
     "name": "Nome da Etapa",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -369,10 +369,36 @@
     "saving": "Salvando...",
     "save": "Salvar Alterações"
   },
+  "stageAutomation": {
+    "title": "Regras de Automação",
+    "description": "Defina regras que disparam ações automaticamente quando eventos ocorrem nesta etapa.",
+    "noRules": "Nenhuma regra configurada. Clique em \"Adicionar Regra\" para começar.",
+    "addRule": "Adicionar Regra",
+    "rule": "Regra",
+    "when": "Quando",
+    "then": "Então",
+    "anyValue": "Qualquer",
+    "labelNamePlaceholder": "Nome da etiqueta...",
+    "selectStage": "Selecionar etapa...",
+    "selectAgent": "Selecionar agente...",
+    "noOtherStages": "Nenhuma outra etapa disponível",
+    "noAgents": "Nenhum agente disponível",
+    "triggers": {
+      "label_added": "Etiqueta adicionada",
+      "conversation_status_changed": "Estado da conversa alterado",
+      "custom_attribute_updated": "Atributo personalizado atualizado"
+    },
+    "actions": {
+      "move_to_stage": "Mover para etapa",
+      "assign_agent": "Atribuir agente",
+      "apply_label": "Aplicar etiqueta"
+    }
+  },
   "editStage": {
     "title": "Editar Etapa",
     "description": "Edite as informações desta etapa do pipeline.",
     "details": "Detalhes",
+    "automation": "Automação",
     "customAttributes": "Atributos",
     "attributesDescription": "Configure atributos para este estágio",
     "name": "Nome da Etapa",

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -1611,6 +1611,8 @@ export default function PipelineKanban() {
         stage={stageToEdit}
         onSubmit={handleUpdateStage}
         loading={isEditingStage}
+        stages={stages}
+        agents={uniqueAssignees}
       />
 
       {/* Delete Stage Modal */}

--- a/src/types/analytics/pipelines.ts
+++ b/src/types/analytics/pipelines.ts
@@ -1,6 +1,16 @@
 import type { PaginatedResponse, StandardResponse, PaginationMeta } from '@/types/core';
 import type { Contact } from '@/types/contacts';
 
+export type StageAutomationTrigger = 'label_added' | 'conversation_status_changed' | 'custom_attribute_updated';
+export type StageAutomationAction = 'move_to_stage' | 'assign_agent' | 'apply_label';
+
+export interface StageAutomationRule {
+  trigger: StageAutomationTrigger;
+  trigger_value: string;
+  action: StageAutomationAction;
+  action_value: string;
+}
+
 export interface PipelinesResponse extends PaginatedResponse<Pipeline> {}
 
 export interface PipelineResponse extends StandardResponse<Pipeline> {}
@@ -68,6 +78,7 @@ export interface PipelineStage {
   stage_type?: string;
   automation_rules?: {
     description?: string;
+    rules?: StageAutomationRule[];
   };
   custom_fields?: Record<string, unknown> & {
     attributes?: string[]; // Array of attribute keys created at stage level


### PR DESCRIPTION
## Summary

- Adds an **Automation** tab to the Edit Stage modal in the Kanban pipeline view
- Users can configure trigger→action rules per stage (e.g. "when label `urgent` is added → move to Stage B")
- Full i18n support across all 6 locales

## Changes

### New files
- `src/components/pipelines/StageAutomationRules.tsx` — rule editor component with add/remove; stable React keys via `useState + generateKey()`; conditional rendering for trigger_value (status dropdown vs text input) and action_value (stage select vs agent select vs label input)

### Modified files
- `src/components/pipelines/EditStageModal.tsx` — new "Automation" tab (3-tab grid); state initialized from `stage.automation_rules.rules`; accepts `stages` and `agents` props
- `src/pages/Customer/Pipelines/PipelineKanban.tsx` — passes `stages` and `agents` to `EditStageModal`
- `src/types/analytics/pipelines.ts` — `StageAutomationRule`, `StageAutomationTrigger`, `StageAutomationAction` types; updated `PipelineStage.automation_rules`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/pipelines.json` — `stageAutomation` section added to all 6 locales

## How to test

1. Go to any pipeline in Kanban view
2. Click **Edit** on a stage
3. Switch to the **Automation** tab
4. Add a rule: `Label added` → `urgent` → `Move to stage` → (select another stage)
5. Save and add label `urgent` to a conversation in that stage
6. The conversation should move automatically after a few seconds (async job)

## Linear

Closes [EVO-989](https://linear.app/evoai/issue/EVO-989)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add per-stage automation rule configuration to pipeline stages via a new Automation tab in the Edit Stage modal, with supporting types, data wiring, and localization.

New Features:
- Introduce a StageAutomationRules UI component for configuring trigger-action automation rules per pipeline stage.
- Add an Automation tab to the Edit Stage modal to manage automation descriptions and rule lists.
- Define typed trigger and action enums and rule structures for stage automation in analytics pipeline types.

Enhancements:
- Wire pipeline stages and agent lists into the Edit Stage modal so automation rules can reference other stages and agents.
- Extend existing stage automation metadata to persist both descriptions and structured rule definitions.
- Add localized copy for stage automation UI across all supported locales.