### PR TITLE
feat(frontend): build Automation Rules UI (EVO-1057)

### DIFF
--- a/src/components/automation/ActionRow.spec.tsx
+++ b/src/components/automation/ActionRow.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { useForm } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   automationRuleSchema,
@@ -22,18 +22,20 @@ const emptyFormData: AutomationFormData = {
 };
 
 function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
-  const { control } = useForm<AutomationRuleFormData>({
+  const methods = useForm<AutomationRuleFormData>({
     resolver: zodResolver(automationRuleSchema),
     defaultValues,
   });
   return (
-    <ActionRow
-      control={control}
-      index={0}
-      formData={emptyFormData}
-      onRemove={() => {}}
-      onActionChange={() => {}}
-    />
+    <FormProvider {...methods}>
+      <ActionRow
+        control={methods.control}
+        index={0}
+        formData={emptyFormData}
+        onRemove={() => {}}
+        onActionChange={() => {}}
+      />
+    </FormProvider>
   );
 }
 

--- a/src/components/automation/ActionRow.spec.tsx
+++ b/src/components/automation/ActionRow.spec.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  automationRuleSchema,
+  type AutomationRuleFormData,
+} from '@/pages/Customer/Automation/registries';
+import ActionRow from './ActionRow';
+import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+
+const emptyFormData: AutomationFormData = {
+  inboxes: [],
+  agents: [],
+  teams: [],
+  labels: [],
+  pipelines: [],
+  pipelineStages: [],
+  priorities: [],
+  statuses: [],
+  messageTypes: [],
+};
+
+function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
+  const { control } = useForm<AutomationRuleFormData>({
+    resolver: zodResolver(automationRuleSchema),
+    defaultValues,
+  });
+  return (
+    <ActionRow
+      control={control}
+      index={0}
+      formData={emptyFormData}
+      onRemove={() => {}}
+      onActionChange={() => {}}
+    />
+  );
+}
+
+describe('ActionRow', () => {
+  it('renders for a send_message action with the action select and remove button', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'send_message', action_params: ['hi'] }],
+    };
+    const { container } = render(<Wrapper defaultValues={defaults} />);
+    expect(container.querySelector('button[aria-label*="remove"]')).toBeTruthy();
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  it('renders the no-params placeholder for resolve_conversation', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'resolve_conversation', action_params: [] }],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+    expect(screen.getByText(/form\.fields\.actionRow\.noParams/)).toBeTruthy();
+  });
+});

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -221,12 +221,55 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
             const current = (field.value as Array<Record<string, unknown>>)?.[0] ?? {
               title: '',
             };
+            const setField = (key: string, value: unknown) =>
+              field.onChange([{ ...current, [key]: value }]);
             return (
-              <Input
-                value={(current.title as string) ?? ''}
-                onChange={(e) => field.onChange([{ ...current, title: e.target.value }])}
-                placeholder={t('form.fields.actionRow.params.create_pipeline_task')}
-              />
+              <div className="space-y-2">
+                <Input
+                  value={(current.title as string) ?? ''}
+                  onChange={(e) => setField('title', e.target.value)}
+                  placeholder={t('form.fields.actionRow.params.create_pipeline_task')}
+                />
+                <Textarea
+                  value={(current.description as string) ?? ''}
+                  onChange={(e) => setField('description', e.target.value)}
+                  placeholder={t('form.fields.actionRow.params.create_pipeline_task_description')}
+                  rows={2}
+                />
+                <div className="grid grid-cols-2 gap-2">
+                  <Input
+                    value={(current.task_type as string) ?? ''}
+                    onChange={(e) => setField('task_type', e.target.value)}
+                    placeholder={t('form.fields.actionRow.params.create_pipeline_task_type')}
+                  />
+                  <Input
+                    value={(current.priority as string) ?? ''}
+                    onChange={(e) => setField('priority', e.target.value)}
+                    placeholder={t('form.fields.actionRow.params.create_pipeline_task_priority')}
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Input
+                    type="number"
+                    value={
+                      current.assigned_to_id != null && current.assigned_to_id !== ''
+                        ? String(current.assigned_to_id)
+                        : ''
+                    }
+                    onChange={(e) => {
+                      const raw = e.target.value;
+                      const num = raw === '' ? undefined : Number(raw);
+                      setField('assigned_to_id', Number.isNaN(num) ? undefined : num);
+                    }}
+                    placeholder={t('form.fields.actionRow.params.create_pipeline_task_assignee')}
+                  />
+                  <Input
+                    value={(current.due_in as string) ?? ''}
+                    onChange={(e) => setField('due_in', e.target.value)}
+                    placeholder={t('form.fields.actionRow.params.create_pipeline_task_due_in')}
+                  />
+                </div>
+              </div>
             );
           }}
         />
@@ -239,9 +282,58 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
 
     case 'send_attachment':
       return (
-        <div className="text-xs text-muted-foreground">
-          {t('form.fields.actionRow.params.send_attachment_pending')}
-        </div>
+        <Controller
+          control={control}
+          name={`actions.${index}.action_params`}
+          render={({ field }) => {
+            const current = (field.value as Array<Record<string, unknown>>)?.[0] ?? {
+              attachment_ids: [] as Array<string | number>,
+            };
+            const ids = (current.attachment_ids as Array<string | number>) ?? [];
+            const inboxId = current.inbox_id;
+            const idsAsText = ids.join(', ');
+
+            const setIdsFromText = (raw: string) => {
+              const parsed = raw
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean)
+                .map((s) => (Number.isNaN(Number(s)) ? s : Number(s)));
+              field.onChange([{ ...current, attachment_ids: parsed }]);
+            };
+            const setInbox = (raw: string) => {
+              if (raw === '') {
+                const next = { ...current };
+                delete (next as Record<string, unknown>).inbox_id;
+                field.onChange([{ ...next, attachment_ids: ids }]);
+              } else {
+                const num = Number(raw);
+                field.onChange([
+                  {
+                    ...current,
+                    attachment_ids: ids,
+                    inbox_id: Number.isNaN(num) ? undefined : num,
+                  },
+                ]);
+              }
+            };
+            return (
+              <div className="space-y-2">
+                <Input
+                  value={idsAsText}
+                  onChange={(e) => setIdsFromText(e.target.value)}
+                  placeholder={t('form.fields.actionRow.params.send_attachment_ids')}
+                />
+                <Input
+                  type="number"
+                  value={inboxId != null ? String(inboxId) : ''}
+                  onChange={(e) => setInbox(e.target.value)}
+                  placeholder={t('form.fields.actionRow.params.send_attachment_inbox')}
+                />
+              </div>
+            );
+          }}
+        />
       );
 
     default:
@@ -281,10 +373,15 @@ function SelectParam({ control, index, options, placeholder, coerce = 'single' }
           <Select
             value={selectedValue}
             onValueChange={(value) => {
+              if (value === '') {
+                field.onChange(coerce === 'array' ? [] : [null]);
+                return;
+              }
               if (coerce === 'array') {
                 field.onChange([value]);
               } else {
-                const parsed = Number.isNaN(Number(value)) ? value : Number(value);
+                const asNumber = Number(value);
+                const parsed = Number.isFinite(asNumber) && value.trim() !== '' ? asNumber : value;
                 field.onChange([parsed]);
               }
             }}

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -14,7 +14,6 @@ import { Trash2 } from 'lucide-react';
 import {
   ALL_ACTION_NAMES,
   actionRegistry,
-  getDefaultActionForName,
   type AutomationRuleFormData,
 } from '@/pages/Customer/Automation/registries';
 import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
@@ -314,5 +313,3 @@ function asString(value: unknown, idx: number): string {
   }
   return '';
 }
-
-export { getDefaultActionForName };

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -1,0 +1,318 @@
+import { Controller, type Control, useWatch } from 'react-hook-form';
+import { useLanguage } from '@/hooks/useLanguage';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+  Textarea,
+  Button,
+} from '@evoapi/design-system';
+import { Trash2 } from 'lucide-react';
+import {
+  ALL_ACTION_NAMES,
+  actionRegistry,
+  getDefaultActionForName,
+  type AutomationRuleFormData,
+} from '@/pages/Customer/Automation/registries';
+import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+import type { AutomationActionType } from '@/types/automation';
+
+interface Props {
+  control: Control<AutomationRuleFormData>;
+  index: number;
+  formData: AutomationFormData;
+  onRemove: () => void;
+  onActionChange: (index: number, actionName: AutomationActionType) => void;
+}
+
+export default function ActionRow({
+  control,
+  index,
+  formData,
+  onRemove,
+  onActionChange,
+}: Props) {
+  const { t } = useLanguage('automation');
+  const actionName = useWatch({ control, name: `actions.${index}.action_name` });
+
+  return (
+    <div className="flex items-start gap-2 p-3 border rounded-md">
+      <div className="flex-1 grid grid-cols-2 gap-2">
+        <Controller
+          control={control}
+          name={`actions.${index}.action_name`}
+          render={({ field }) => (
+            <Select
+              value={field.value ?? ''}
+              onValueChange={(value) => {
+                onActionChange(index, value as AutomationActionType);
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t('form.fields.actionRow.action')} />
+              </SelectTrigger>
+              <SelectContent>
+                {ALL_ACTION_NAMES.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {t(actionRegistry[name].i18nKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+
+        <ActionParamsRenderer
+          control={control}
+          index={index}
+          actionName={actionName as AutomationActionType | undefined}
+          formData={formData}
+          t={t}
+        />
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onRemove}
+        aria-label={t('form.fields.actionRow.remove')}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
+interface ParamsProps {
+  control: Control<AutomationRuleFormData>;
+  index: number;
+  actionName: AutomationActionType | undefined;
+  formData: AutomationFormData;
+  t: (key: string) => string;
+}
+
+function ActionParamsRenderer({ control, index, actionName, formData, t }: ParamsProps) {
+  if (!actionName) {
+    return <div className="text-xs text-muted-foreground">{t('form.fields.actionRow.selectActionFirst')}</div>;
+  }
+
+  switch (actionName) {
+    case 'send_message':
+    case 'send_webhook_event':
+    case 'send_email_transcript':
+      return (
+        <Controller
+          control={control}
+          name={`actions.${index}.action_params`}
+          render={({ field }) => (
+            <Input
+              value={asString(field.value, 0)}
+              onChange={(e) => field.onChange([e.target.value])}
+              placeholder={t(`form.fields.actionRow.params.${actionName}`)}
+            />
+          )}
+        />
+      );
+
+    case 'assign_team':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.teams}
+          placeholder={t('form.fields.actionRow.params.assign_team')}
+        />
+      );
+
+    case 'assign_agent':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.agents}
+          placeholder={t('form.fields.actionRow.params.assign_agent')}
+        />
+      );
+
+    case 'add_label':
+    case 'remove_label':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.labels}
+          placeholder={t(`form.fields.actionRow.params.${actionName}`)}
+          coerce="array"
+        />
+      );
+
+    case 'change_priority':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.priorities}
+          placeholder={t('form.fields.actionRow.params.change_priority')}
+        />
+      );
+
+    case 'change_status':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.statuses}
+          placeholder={t('form.fields.actionRow.params.change_status')}
+        />
+      );
+
+    case 'assign_to_pipeline':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.pipelines}
+          placeholder={t('form.fields.actionRow.params.assign_to_pipeline')}
+        />
+      );
+
+    case 'update_pipeline_stage':
+      return (
+        <SelectParam
+          control={control}
+          index={index}
+          options={formData.pipelineStages}
+          placeholder={t('form.fields.actionRow.params.update_pipeline_stage')}
+        />
+      );
+
+    case 'send_email_to_team':
+      return (
+        <Controller
+          control={control}
+          name={`actions.${index}.action_params`}
+          render={({ field }) => {
+            const current = (field.value as Array<Record<string, unknown>>)?.[0] ?? {
+              team_ids: [],
+              message: '',
+            };
+            return (
+              <Textarea
+                value={(current.message as string) ?? ''}
+                onChange={(e) =>
+                  field.onChange([{ ...current, message: e.target.value }])
+                }
+                placeholder={t('form.fields.actionRow.params.send_email_to_team')}
+                rows={2}
+              />
+            );
+          }}
+        />
+      );
+
+    case 'create_pipeline_task':
+      return (
+        <Controller
+          control={control}
+          name={`actions.${index}.action_params`}
+          render={({ field }) => {
+            const current = (field.value as Array<Record<string, unknown>>)?.[0] ?? {
+              title: '',
+            };
+            return (
+              <Input
+                value={(current.title as string) ?? ''}
+                onChange={(e) => field.onChange([{ ...current, title: e.target.value }])}
+                placeholder={t('form.fields.actionRow.params.create_pipeline_task')}
+              />
+            );
+          }}
+        />
+      );
+
+    case 'mute_conversation':
+    case 'snooze_conversation':
+    case 'resolve_conversation':
+      return <div className="text-xs text-muted-foreground">{t('form.fields.actionRow.noParams')}</div>;
+
+    case 'send_attachment':
+      return (
+        <div className="text-xs text-muted-foreground">
+          {t('form.fields.actionRow.params.send_attachment_pending')}
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}
+
+interface SelectParamProps {
+  control: Control<AutomationRuleFormData>;
+  index: number;
+  options: { id: string | number; name: string }[];
+  placeholder: string;
+  coerce?: 'single' | 'array';
+}
+
+function SelectParam({ control, index, options, placeholder, coerce = 'single' }: SelectParamProps) {
+  return (
+    <Controller
+      control={control}
+      name={`actions.${index}.action_params`}
+      render={({ field }) => {
+        const current =
+          coerce === 'array'
+            ? Array.isArray(field.value) ? field.value : []
+            : Array.isArray(field.value) ? field.value[0] : null;
+
+        const selectedValue =
+          coerce === 'array'
+            ? (current as Array<string | number>)[0] !== undefined
+              ? String((current as Array<string | number>)[0])
+              : ''
+            : current != null
+              ? String(current)
+              : '';
+
+        return (
+          <Select
+            value={selectedValue}
+            onValueChange={(value) => {
+              if (coerce === 'array') {
+                field.onChange([value]);
+              } else {
+                const parsed = Number.isNaN(Number(value)) ? value : Number(value);
+                field.onChange([parsed]);
+              }
+            }}
+          >
+            <SelectTrigger>
+              <SelectValue placeholder={placeholder} />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((opt) => (
+                <SelectItem key={String(opt.id)} value={String(opt.id)}>
+                  {opt.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        );
+      }}
+    />
+  );
+}
+
+function asString(value: unknown, idx: number): string {
+  if (Array.isArray(value)) {
+    const v = value[idx];
+    return v == null ? '' : String(v);
+  }
+  return '';
+}
+
+export { getDefaultActionForName };

--- a/src/components/automation/ActionsBuilder.tsx
+++ b/src/components/automation/ActionsBuilder.tsx
@@ -34,6 +34,7 @@ export default function ActionsBuilder({ control, formData }: Props) {
           type="button"
           variant="outline"
           size="sm"
+          aria-label={t('form.fields.actions.addRow')}
           onClick={() => append(getDefaultActionForName('send_message'))}
         >
           <Plus className="h-4 w-4 mr-2" />

--- a/src/components/automation/ActionsBuilder.tsx
+++ b/src/components/automation/ActionsBuilder.tsx
@@ -1,0 +1,61 @@
+import { useFieldArray, type Control } from 'react-hook-form';
+import { useLanguage } from '@/hooks/useLanguage';
+import { Button } from '@evoapi/design-system';
+import { Plus } from 'lucide-react';
+import {
+  type AutomationRuleFormData,
+  getDefaultActionForName,
+} from '@/pages/Customer/Automation/registries';
+import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+import type { AutomationActionType } from '@/types/automation';
+import ActionRow from './ActionRow';
+
+interface Props {
+  control: Control<AutomationRuleFormData>;
+  formData: AutomationFormData;
+}
+
+export default function ActionsBuilder({ control, formData }: Props) {
+  const { t } = useLanguage('automation');
+  const { fields, append, remove, update } = useFieldArray({
+    control,
+    name: 'actions',
+  });
+
+  const handleActionChange = (index: number, actionName: AutomationActionType) => {
+    update(index, getDefaultActionForName(actionName));
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold">{t('form.fields.actions.label')}</h3>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => append(getDefaultActionForName('send_message'))}
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          {t('form.fields.actions.addRow')}
+        </Button>
+      </div>
+      {fields.length === 0 ? (
+        <p className="text-sm text-red-500">{t('form.fields.actions.empty')}</p>
+      ) : (
+        <div className="space-y-2">
+          {fields.map((field, index) => (
+            <ActionRow
+              key={field.id}
+              control={control}
+              index={index}
+              formData={formData}
+              onRemove={() => remove(index)}
+              onActionChange={handleActionChange}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/automation/AutomationsHeader.tsx
+++ b/src/components/automation/AutomationsHeader.tsx
@@ -1,0 +1,68 @@
+import { useLanguage } from '@/hooks/useLanguage';
+import { Button, Input } from '@evoapi/design-system';
+import { Plus, Search, Trash2 } from 'lucide-react';
+
+interface Props {
+  totalCount: number;
+  selectedCount: number;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  onNewAutomation: () => void;
+  onBulkDelete: () => void;
+  onClearSelection: () => void;
+  canCreate: boolean;
+  canDelete: boolean;
+}
+
+export default function AutomationsHeader({
+  totalCount,
+  selectedCount,
+  searchValue,
+  onSearchChange,
+  onNewAutomation,
+  onBulkDelete,
+  onClearSelection,
+  canCreate,
+  canDelete,
+}: Props) {
+  const { t } = useLanguage('automation');
+
+  return (
+    <div className="flex items-center justify-between gap-4 flex-wrap">
+      <div>
+        <h1 className="text-xl font-semibold">{t('page.title')}</h1>
+        <p className="text-sm text-muted-foreground">
+          {t('page.subtitle', { count: totalCount })}
+        </p>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={searchValue}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder={t('page.searchPlaceholder')}
+            className="pl-8 w-64"
+          />
+        </div>
+        {selectedCount > 0 && canDelete && (
+          <>
+            <Button variant="outline" onClick={onClearSelection}>
+              {t('page.clearSelection', { count: selectedCount })}
+            </Button>
+            <Button variant="destructive" onClick={onBulkDelete}>
+              <Trash2 className="h-4 w-4 mr-2" />
+              {t('page.bulkDelete')}
+            </Button>
+          </>
+        )}
+        {canCreate && (
+          <Button onClick={onNewAutomation}>
+            <Plus className="h-4 w-4 mr-2" />
+            {t('page.newAutomation')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/automation/AutomationsPagination.tsx
+++ b/src/components/automation/AutomationsPagination.tsx
@@ -1,0 +1,33 @@
+import BasePagination from '@/components/base/BasePagination';
+
+interface Props {
+  currentPage: number;
+  totalPages: number;
+  totalCount: number;
+  perPage: number;
+  onPageChange: (page: number) => void;
+  onPerPageChange: (perPage: number) => void;
+  loading?: boolean;
+}
+
+export default function AutomationsPagination({
+  currentPage,
+  totalPages,
+  totalCount,
+  perPage,
+  onPageChange,
+  onPerPageChange,
+  loading,
+}: Props) {
+  return (
+    <BasePagination
+      currentPage={currentPage}
+      totalPages={totalPages}
+      totalItems={totalCount}
+      itemsPerPage={perPage}
+      onPageChange={onPageChange}
+      onItemsPerPageChange={onPerPageChange}
+      disabled={loading}
+    />
+  );
+}

--- a/src/components/automation/AutomationsTable.tsx
+++ b/src/components/automation/AutomationsTable.tsx
@@ -1,0 +1,137 @@
+import { useLanguage } from '@/hooks/useLanguage';
+import { Badge } from '@evoapi/design-system';
+import { Edit, Trash2, Copy } from 'lucide-react';
+import type { AutomationRule } from '@/types/automation';
+import BaseTable, { type TableColumn, type TableAction } from '@/components/base/BaseTable';
+import { useDateFormat } from '@/hooks/useDateFormat';
+
+interface Props {
+  automations: AutomationRule[];
+  selected: AutomationRule[];
+  loading?: boolean;
+  onSelectionChange: (items: AutomationRule[]) => void;
+  onEdit: (rule: AutomationRule) => void;
+  onDelete: (rule: AutomationRule) => void;
+  onClone: (rule: AutomationRule) => void;
+  onCreate: () => void;
+  canEdit: boolean;
+  canDelete: boolean;
+  canClone: boolean;
+}
+
+export default function AutomationsTable({
+  automations,
+  selected,
+  loading,
+  onSelectionChange,
+  onEdit,
+  onDelete,
+  onClone,
+  onCreate,
+  canEdit,
+  canDelete,
+  canClone,
+}: Props) {
+  const { t } = useLanguage('automation');
+  const { formatDateTime } = useDateFormat();
+
+  const columns: TableColumn<AutomationRule>[] = [
+    {
+      key: 'name',
+      label: t('table.columns.name'),
+      sortable: true,
+      width: '300px',
+      render: (rule) => (
+        <div>
+          <div className="font-medium truncate">{rule.name}</div>
+          {rule.description && (
+            <div className="text-xs text-muted-foreground truncate">{rule.description}</div>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: 'event_name',
+      label: t('table.columns.event'),
+      width: '200px',
+      render: (rule) => (
+        <Badge variant="outline">{t(`form.fields.event.options.${rule.event_name}`)}</Badge>
+      ),
+    },
+    {
+      key: 'active',
+      label: t('table.columns.status'),
+      width: '120px',
+      render: (rule) => (
+        <Badge variant={rule.active ? 'default' : 'secondary'}>
+          {rule.active ? t('table.status.active') : t('table.status.inactive')}
+        </Badge>
+      ),
+    },
+    {
+      key: 'actions_count',
+      label: t('table.columns.actionsCount'),
+      width: '120px',
+      render: (rule) => (
+        <span className="text-sm text-muted-foreground">{rule.actions?.length ?? 0}</span>
+      ),
+    },
+    {
+      key: 'created_at',
+      label: t('table.columns.createdAt'),
+      sortable: true,
+      width: '180px',
+      render: (rule) => {
+        const ts = (rule as unknown as { created_at?: string; created_on?: number }).created_at;
+        const fallback = (rule as unknown as { created_on?: number }).created_on;
+        const value = ts ?? (fallback ? new Date(fallback).toISOString() : null);
+        return (
+          <div className="text-sm">
+            {value ? formatDateTime(value) : <span className="text-muted-foreground">—</span>}
+          </div>
+        );
+      },
+    },
+  ];
+
+  const actions: TableAction<AutomationRule>[] = [
+    {
+      label: t('table.actions.edit'),
+      icon: <Edit className="h-4 w-4" />,
+      onClick: onEdit,
+      show: () => canEdit,
+    },
+    {
+      label: t('table.actions.clone'),
+      icon: <Copy className="h-4 w-4" />,
+      onClick: onClone,
+      show: () => canClone,
+    },
+    {
+      label: t('table.actions.delete'),
+      icon: <Trash2 className="h-4 w-4" />,
+      onClick: onDelete,
+      variant: 'destructive',
+      show: () => canDelete,
+    },
+  ];
+
+  return (
+    <BaseTable
+      data={automations}
+      columns={columns}
+      actions={actions}
+      selectable
+      selectedItems={selected}
+      onSelectionChange={onSelectionChange}
+      loading={loading}
+      getRowKey={(rule) => rule.id}
+      emptyTitle={t('page.empty.title')}
+      emptyDescription={t('page.empty.description')}
+      emptyAction={{
+        label: t('page.empty.action'),
+        onClick: onCreate,
+      }}
+    />
+  );
+}

--- a/src/components/automation/ConditionRow.spec.tsx
+++ b/src/components/automation/ConditionRow.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { useForm } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   automationRuleSchema,
@@ -22,11 +22,15 @@ const emptyFormData: AutomationFormData = {
 };
 
 function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
-  const { control } = useForm<AutomationRuleFormData>({
+  const methods = useForm<AutomationRuleFormData>({
     resolver: zodResolver(automationRuleSchema),
     defaultValues,
   });
-  return <ConditionRow control={control} index={0} formData={emptyFormData} onRemove={() => {}} />;
+  return (
+    <FormProvider {...methods}>
+      <ConditionRow control={methods.control} index={0} formData={emptyFormData} onRemove={() => {}} />
+    </FormProvider>
+  );
 }
 
 describe('ConditionRow', () => {

--- a/src/components/automation/ConditionRow.spec.tsx
+++ b/src/components/automation/ConditionRow.spec.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  automationRuleSchema,
+  type AutomationRuleFormData,
+} from '@/pages/Customer/Automation/registries';
+import ConditionRow from './ConditionRow';
+import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+
+const emptyFormData: AutomationFormData = {
+  inboxes: [],
+  agents: [],
+  teams: [],
+  labels: [],
+  pipelines: [],
+  pipelineStages: [],
+  priorities: [],
+  statuses: [],
+  messageTypes: [],
+};
+
+function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
+  const { control } = useForm<AutomationRuleFormData>({
+    resolver: zodResolver(automationRuleSchema),
+    defaultValues,
+  });
+  return <ConditionRow control={control} index={0} formData={emptyFormData} onRemove={() => {}} />;
+}
+
+describe('ConditionRow', () => {
+  it('renders without crashing for an empty condition', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [
+        {
+          attribute_key: '',
+          filter_operator: 'equal_to',
+          query_operator: 'AND',
+          values: [],
+        },
+      ],
+      actions: [
+        {
+          action_name: 'send_message',
+          action_params: ['hello'],
+        },
+      ],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+    expect(screen.getByText(/form\.fields\.conditionRow\.attribute/)).toBeTruthy();
+  });
+});

--- a/src/components/automation/ConditionRow.tsx
+++ b/src/components/automation/ConditionRow.tsx
@@ -1,4 +1,5 @@
-import { Controller, type Control, useWatch } from 'react-hook-form';
+import { useEffect } from 'react';
+import { Controller, type Control, useWatch, useFormContext } from 'react-hook-form';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
   Select,
@@ -39,9 +40,20 @@ const optionLoaderToData: Record<string, keyof AutomationFormData> = {
 
 export default function ConditionRow({ control, index, formData, onRemove }: Props) {
   const { t } = useLanguage('automation');
+  const formCtx = useFormContext<AutomationRuleFormData>();
 
   const eventName = useWatch({ control, name: 'event_name' });
   const attributeKey = useWatch({ control, name: `conditions.${index}.attribute_key` });
+  const operator = useWatch({ control, name: `conditions.${index}.filter_operator` });
+  const currentValues = useWatch({ control, name: `conditions.${index}.values` });
+  const valueless = operator === 'is_present' || operator === 'is_not_present';
+
+  // Clear values when the operator goes valueless (avoids stale values being sent to the backend).
+  useEffect(() => {
+    if (valueless && Array.isArray(currentValues) && currentValues.length > 0) {
+      formCtx?.setValue(`conditions.${index}.values`, [], { shouldDirty: true });
+    }
+  }, [valueless, currentValues, index, formCtx]);
 
   const availableAttributes = eventName
     ? getAttributesForEvent(eventName)
@@ -103,6 +115,13 @@ export default function ConditionRow({ control, index, formData, onRemove }: Pro
           control={control}
           name={`conditions.${index}.values`}
           render={({ field }) => {
+            if (valueless) {
+              return (
+                <div className="flex items-center text-xs text-muted-foreground italic">
+                  {t('form.fields.conditionRow.noValueNeeded')}
+                </div>
+              );
+            }
             if (!descriptor || options.length === 0) {
               return (
                 <Input

--- a/src/components/automation/ConditionRow.tsx
+++ b/src/components/automation/ConditionRow.tsx
@@ -1,0 +1,147 @@
+import { Controller, type Control, useWatch } from 'react-hook-form';
+import { useLanguage } from '@/hooks/useLanguage';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Input,
+  Button,
+} from '@evoapi/design-system';
+import { Trash2 } from 'lucide-react';
+import {
+  type AutomationRuleFormData,
+  conditionAttributeRegistry,
+  getAttributeDescriptor,
+  getAttributesForEvent,
+} from '@/pages/Customer/Automation/registries';
+import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+
+interface Props {
+  control: Control<AutomationRuleFormData>;
+  index: number;
+  formData: AutomationFormData;
+  onRemove: () => void;
+}
+
+const optionLoaderToData: Record<string, keyof AutomationFormData> = {
+  pipelines: 'pipelines',
+  pipeline_stages: 'pipelineStages',
+  agents: 'agents',
+  teams: 'teams',
+  inboxes: 'inboxes',
+  labels: 'labels',
+  priorities: 'priorities',
+  statuses: 'statuses',
+  message_types: 'messageTypes',
+};
+
+export default function ConditionRow({ control, index, formData, onRemove }: Props) {
+  const { t } = useLanguage('automation');
+
+  const eventName = useWatch({ control, name: 'event_name' });
+  const attributeKey = useWatch({ control, name: `conditions.${index}.attribute_key` });
+
+  const availableAttributes = eventName
+    ? getAttributesForEvent(eventName)
+    : Object.values(conditionAttributeRegistry);
+
+  const descriptor = getAttributeDescriptor(attributeKey);
+
+  const optionsKey = descriptor?.optionLoaderKey
+    ? optionLoaderToData[descriptor.optionLoaderKey]
+    : undefined;
+  const options = optionsKey ? formData[optionsKey] : [];
+
+  return (
+    <div className="flex items-start gap-2 p-3 border rounded-md">
+      <div className="flex-1 grid grid-cols-3 gap-2">
+        <Controller
+          control={control}
+          name={`conditions.${index}.attribute_key`}
+          render={({ field }) => (
+            <Select value={field.value ?? ''} onValueChange={field.onChange}>
+              <SelectTrigger>
+                <SelectValue placeholder={t('form.fields.conditionRow.attribute')} />
+              </SelectTrigger>
+              <SelectContent>
+                {availableAttributes.map((attr) => (
+                  <SelectItem key={attr.attributeKey} value={attr.attributeKey}>
+                    {t(attr.i18nKey)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name={`conditions.${index}.filter_operator`}
+          render={({ field }) => (
+            <Select
+              value={field.value ?? ''}
+              onValueChange={field.onChange}
+              disabled={!descriptor}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t('form.fields.conditionRow.operator')} />
+              </SelectTrigger>
+              <SelectContent>
+                {descriptor?.operators.map((op) => (
+                  <SelectItem key={op} value={op}>
+                    {t(`form.fields.operators.${op}`)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name={`conditions.${index}.values`}
+          render={({ field }) => {
+            if (!descriptor || options.length === 0) {
+              return (
+                <Input
+                  type={descriptor?.dataType === 'number' ? 'number' : 'text'}
+                  value={Array.isArray(field.value) ? String(field.value[0] ?? '') : ''}
+                  onChange={(e) => field.onChange([e.target.value])}
+                  placeholder={t('form.fields.conditionRow.value')}
+                />
+              );
+            }
+            return (
+              <Select
+                value={Array.isArray(field.value) ? String(field.value[0] ?? '') : ''}
+                onValueChange={(v) => field.onChange([v])}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={t('form.fields.conditionRow.value')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {options.map((opt) => (
+                    <SelectItem key={String(opt.id)} value={String(opt.id)}>
+                      {opt.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            );
+          }}
+        />
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={onRemove}
+        aria-label={t('form.fields.conditionRow.remove')}
+      >
+        <Trash2 className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/automation/ConditionsBuilder.tsx
+++ b/src/components/automation/ConditionsBuilder.tsx
@@ -26,6 +26,7 @@ export default function ConditionsBuilder({ control, formData }: Props) {
           type="button"
           variant="outline"
           size="sm"
+          aria-label={t('form.fields.conditions.addRow')}
           onClick={() =>
             append({
               attribute_key: '',

--- a/src/components/automation/ConditionsBuilder.tsx
+++ b/src/components/automation/ConditionsBuilder.tsx
@@ -1,0 +1,59 @@
+import { useFieldArray, type Control } from 'react-hook-form';
+import { useLanguage } from '@/hooks/useLanguage';
+import { Button } from '@evoapi/design-system';
+import { Plus } from 'lucide-react';
+import type { AutomationRuleFormData } from '@/pages/Customer/Automation/registries';
+import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+import ConditionRow from './ConditionRow';
+
+interface Props {
+  control: Control<AutomationRuleFormData>;
+  formData: AutomationFormData;
+}
+
+export default function ConditionsBuilder({ control, formData }: Props) {
+  const { t } = useLanguage('automation');
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'conditions',
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold">{t('form.fields.conditions.label')}</h3>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            append({
+              attribute_key: '',
+              filter_operator: 'equal_to',
+              query_operator: 'AND',
+              values: [],
+            })
+          }
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          {t('form.fields.conditions.addRow')}
+        </Button>
+      </div>
+      {fields.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('form.fields.conditions.empty')}</p>
+      ) : (
+        <div className="space-y-2">
+          {fields.map((field, index) => (
+            <ConditionRow
+              key={field.id}
+              control={control}
+              index={index}
+              formData={formData}
+              onRemove={() => remove(index)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/automation/EventSelector.tsx
+++ b/src/components/automation/EventSelector.tsx
@@ -1,0 +1,50 @@
+import { Controller, type Control } from 'react-hook-form';
+import { useLanguage } from '@/hooks/useLanguage';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { ALL_PHASE_1_EVENTS, type AutomationRuleFormData } from '@/pages/Customer/Automation/registries';
+
+interface Props {
+  control: Control<AutomationRuleFormData>;
+  disabled?: boolean;
+}
+
+export default function EventSelector({ control, disabled }: Props) {
+  const { t } = useLanguage('automation');
+
+  return (
+    <Controller
+      control={control}
+      name="event_name"
+      render={({ field, fieldState }) => (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">{t('form.fields.event.label')}</label>
+          <Select
+            value={field.value ?? ''}
+            onValueChange={field.onChange}
+            disabled={disabled}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={t('form.fields.event.placeholder')} />
+            </SelectTrigger>
+            <SelectContent>
+              {ALL_PHASE_1_EVENTS.map((eventName) => (
+                <SelectItem key={eventName} value={eventName}>
+                  {t(`form.fields.event.options.${eventName}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {fieldState.error && (
+            <p className="text-sm text-red-500">{fieldState.error.message}</p>
+          )}
+        </div>
+      )}
+    />
+  );
+}

--- a/src/components/automation/index.ts
+++ b/src/components/automation/index.ts
@@ -1,0 +1,8 @@
+export { default as EventSelector } from './EventSelector';
+export { default as ConditionRow } from './ConditionRow';
+export { default as ConditionsBuilder } from './ConditionsBuilder';
+export { default as ActionRow } from './ActionRow';
+export { default as ActionsBuilder } from './ActionsBuilder';
+export { default as AutomationsHeader } from './AutomationsHeader';
+export { default as AutomationsTable } from './AutomationsTable';
+export { default as AutomationsPagination } from './AutomationsPagination';

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -17,6 +17,7 @@ import {
   Tags,
   TestTube,
   Wand,
+  Workflow,
   Settings,
   List,
   GraduationCap,
@@ -136,6 +137,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
     href: '/channels',
     icon: Layers,
     resource: 'channels',
+    action: 'read',
+  },
+  {
+    name: t('menu.customer.automation'),
+    href: '/automation',
+    icon: Workflow,
+    resource: 'automation_rules',
     action: 'read',
   },
   {

--- a/src/hooks/automation/index.ts
+++ b/src/hooks/automation/index.ts
@@ -1,0 +1,4 @@
+export { useAutomationFormData } from './useAutomationFormData';
+export type { AutomationFormData, AutomationFormDataOption } from './useAutomationFormData';
+export { useAutomationPermissions } from './useAutomationPermissions';
+export type { AutomationPermissions } from './useAutomationPermissions';

--- a/src/hooks/automation/useAutomationFormData.ts
+++ b/src/hooks/automation/useAutomationFormData.ts
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import { automationService } from '@/services/automation/automationService';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+export interface AutomationFormDataOption {
+  id: string | number;
+  name: string;
+}
+
+export interface AutomationFormData {
+  inboxes: AutomationFormDataOption[];
+  agents: AutomationFormDataOption[];
+  teams: AutomationFormDataOption[];
+  labels: AutomationFormDataOption[];
+  pipelines: AutomationFormDataOption[];
+  pipelineStages: AutomationFormDataOption[];
+  priorities: AutomationFormDataOption[];
+  statuses: AutomationFormDataOption[];
+  messageTypes: AutomationFormDataOption[];
+}
+
+const HARDCODED_PRIORITIES: AutomationFormDataOption[] = [
+  { id: 'low', name: 'low' },
+  { id: 'medium', name: 'medium' },
+  { id: 'high', name: 'high' },
+  { id: 'urgent', name: 'urgent' },
+];
+
+const HARDCODED_STATUSES: AutomationFormDataOption[] = [
+  { id: 'open', name: 'open' },
+  { id: 'resolved', name: 'resolved' },
+  { id: 'snoozed', name: 'snoozed' },
+  { id: 'pending', name: 'pending' },
+];
+
+const HARDCODED_MESSAGE_TYPES: AutomationFormDataOption[] = [
+  { id: 0, name: 'incoming' },
+  { id: 1, name: 'outgoing' },
+  { id: 2, name: 'activity' },
+  { id: 3, name: 'template' },
+];
+
+const toOption = (raw: { id: string | number; name?: string; title?: string }): AutomationFormDataOption => ({
+  id: raw.id,
+  name: raw.name ?? raw.title ?? String(raw.id),
+});
+
+export function useAutomationFormData(): {
+  data: AutomationFormData;
+  isLoading: boolean;
+  error: Error | null;
+} {
+  const [data, setData] = useState<AutomationFormData>({
+    inboxes: [],
+    agents: [],
+    teams: [],
+    labels: [],
+    pipelines: [],
+    pipelineStages: [],
+    priorities: HARDCODED_PRIORITIES,
+    statuses: HARDCODED_STATUSES,
+    messageTypes: HARDCODED_MESSAGE_TYPES,
+  });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const [formDataResult, pipelinesResult] = await Promise.allSettled([
+          automationService.getFormData(),
+          pipelinesService.getPipelines().catch(() => null),
+        ]);
+
+        if (cancelled) return;
+
+        const formData =
+          formDataResult.status === 'fulfilled'
+            ? formDataResult.value
+            : { inboxes: [], agents: [], teams: [], labels: [] };
+
+        const pipelinesPayload =
+          pipelinesResult.status === 'fulfilled' && pipelinesResult.value
+            ? pipelinesResult.value
+            : null;
+
+        const pipelinesArray =
+          (pipelinesPayload as { data?: { id: string; name: string }[] } | null)?.data ?? [];
+
+        let allStages: AutomationFormDataOption[] = [];
+        if (pipelinesArray.length > 0) {
+          const stagesResults = await Promise.allSettled(
+            pipelinesArray.map((p) => pipelinesService.getPipelineStages(p.id)),
+          );
+          allStages = stagesResults.flatMap((res) => {
+            if (res.status !== 'fulfilled' || !res.value) return [];
+            const stages =
+              (res.value as { data?: { id: string; name: string }[] }).data ?? [];
+            return stages.map(toOption);
+          });
+        }
+
+        if (cancelled) return;
+
+        setData({
+          inboxes: (formData.inboxes ?? []).map(toOption),
+          agents: (formData.agents ?? []).map(toOption),
+          teams: (formData.teams ?? []).map(toOption),
+          labels: (formData.labels ?? []).map(toOption),
+          pipelines: pipelinesArray.map(toOption),
+          pipelineStages: allStages,
+          priorities: HARDCODED_PRIORITIES,
+          statuses: HARDCODED_STATUSES,
+          messageTypes: HARDCODED_MESSAGE_TYPES,
+        });
+      } catch (e) {
+        if (!cancelled) setError(e as Error);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, isLoading, error };
+}

--- a/src/hooks/automation/useAutomationPermissions.ts
+++ b/src/hooks/automation/useAutomationPermissions.ts
@@ -1,0 +1,22 @@
+import { useUserPermissions } from '@/hooks/useUserPermissions';
+
+export interface AutomationPermissions {
+  canRead: boolean;
+  canCreate: boolean;
+  canUpdate: boolean;
+  canDelete: boolean;
+  canClone: boolean;
+  isReady: boolean;
+}
+
+export function useAutomationPermissions(): AutomationPermissions {
+  const { can, isReady } = useUserPermissions();
+  return {
+    canRead: can('automation_rules', 'read'),
+    canCreate: can('automation_rules', 'create'),
+    canUpdate: can('automation_rules', 'update'),
+    canDelete: can('automation_rules', 'delete'),
+    canClone: can('automation_rules', 'clone'),
+    isReady,
+  };
+}

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -27,6 +27,7 @@ import ptBRCannedResponses from './locales/pt-BR/cannedResponses.json';
 import ptBRCustomAttributes from './locales/pt-BR/customAttributes.json';
 import ptBRLabels from './locales/pt-BR/labels.json';
 import ptBRMacros from './locales/pt-BR/macros.json';
+import ptBRAutomation from './locales/pt-BR/automation.json';
 import ptBRTeams from './locales/pt-BR/teams.json';
 import ptBRUsers from './locales/pt-BR/users.json';
 import ptBRMarketplace from './locales/pt-BR/marketplace.json';
@@ -118,6 +119,7 @@ import enCannedResponses from './locales/en/cannedResponses.json';
 import enCustomAttributes from './locales/en/customAttributes.json';
 import enLabels from './locales/en/labels.json';
 import enMacros from './locales/en/macros.json';
+import enAutomation from './locales/en/automation.json';
 import enTeams from './locales/en/teams.json';
 import enUsers from './locales/en/users.json';
 import enMarketplace from './locales/en/marketplace.json';
@@ -341,6 +343,7 @@ const resources = {
     customAttributes: ptBRCustomAttributes,
     labels: ptBRLabels,
     macros: ptBRMacros,
+    automation: ptBRAutomation,
     teams: ptBRTeams,
     users: ptBRUsers,
     marketplace: ptBRMarketplace,
@@ -438,6 +441,7 @@ const resources = {
     customAttributes: enCustomAttributes,
     labels: enLabels,
     macros: enMacros,
+    automation: enAutomation,
     teams: enTeams,
     users: enUsers,
     marketplace: enMarketplace,

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -89,7 +89,8 @@
         "attribute": "Attribute",
         "operator": "Operator",
         "value": "Value",
-        "remove": "Remove condition"
+        "remove": "Remove condition",
+        "noValueNeeded": "No value needed"
       },
       "actionRow": {
         "action": "Action",
@@ -110,7 +111,13 @@
           "update_pipeline_stage": "Pick a pipeline stage",
           "send_email_to_team": "Email body",
           "create_pipeline_task": "Task title",
-          "send_attachment_pending": "Attachment selection coming soon"
+          "create_pipeline_task_description": "Description (optional)",
+          "create_pipeline_task_type": "Type (optional)",
+          "create_pipeline_task_priority": "Priority (optional)",
+          "create_pipeline_task_assignee": "Assignee user ID (optional)",
+          "create_pipeline_task_due_in": "Due in (e.g., 2d, 1w)",
+          "send_attachment_ids": "Attachment IDs (comma-separated)",
+          "send_attachment_inbox": "Inbox ID (optional)"
         }
       },
       "operators": {
@@ -178,6 +185,7 @@
   },
   "messages": {
     "loadError": "Failed to load automations",
+    "bulkDeletePartial": "{{success}} deleted, {{failed}} failed",
     "ruleNotFound": "Automation rule not found",
     "createSuccess": "Automation created",
     "createError": "Failed to create automation",

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -45,6 +45,7 @@
       "event": {
         "label": "Trigger event",
         "placeholder": "Select an event",
+        "hint": "Tip: To react to a status change, pick \"Conversation updated\" and add a Status condition.",
         "options": {
           "conversation_created": "Conversation created",
           "conversation_updated": "Conversation updated",
@@ -177,6 +178,7 @@
   },
   "messages": {
     "loadError": "Failed to load automations",
+    "ruleNotFound": "Automation rule not found",
     "createSuccess": "Automation created",
     "createError": "Failed to create automation",
     "updateSuccess": "Automation updated",

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -1,0 +1,198 @@
+{
+  "page": {
+    "title": "Automations",
+    "subtitle": "{{count}} automation rules",
+    "searchPlaceholder": "Search by name",
+    "newAutomation": "New automation",
+    "bulkDelete": "Delete selected",
+    "clearSelection": "Clear ({{count}})",
+    "loading": "Loading...",
+    "empty": {
+      "title": "No automations yet",
+      "description": "Create rules that fire on events like new conversations, contacts and pipeline stage changes.",
+      "action": "Create your first automation"
+    }
+  },
+  "table": {
+    "columns": {
+      "name": "Name",
+      "event": "Event",
+      "status": "Status",
+      "actionsCount": "Actions",
+      "createdAt": "Created"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "actions": {
+      "edit": "Edit",
+      "clone": "Clone",
+      "delete": "Delete"
+    }
+  },
+  "form": {
+    "title": {
+      "create": "New automation",
+      "edit": "Edit automation"
+    },
+    "fields": {
+      "name": "Name",
+      "namePlaceholder": "e.g. Notify sales when conversation enters Won",
+      "description": "Description",
+      "descriptionPlaceholder": "Optional context for your team",
+      "active": "Active",
+      "event": {
+        "label": "Trigger event",
+        "placeholder": "Select an event",
+        "options": {
+          "conversation_created": "Conversation created",
+          "conversation_updated": "Conversation updated",
+          "conversation_opened": "Conversation opened",
+          "message_created": "Message created",
+          "pipeline_stage_updated": "Pipeline stage updated",
+          "contact_created": "Contact created",
+          "contact_updated": "Contact updated",
+          "conversation_resolved": "Conversation resolved",
+          "conversation_status_changed": "Conversation status changed"
+        }
+      },
+      "conditions": {
+        "label": "Conditions",
+        "addRow": "Add condition",
+        "empty": "No conditions — this rule will fire on every event."
+      },
+      "actions": {
+        "label": "Actions",
+        "addRow": "Add action",
+        "empty": "Add at least one action.",
+        "send_message": "Send message",
+        "add_label": "Add label",
+        "remove_label": "Remove label",
+        "send_email_to_team": "Send email to team",
+        "assign_team": "Assign team",
+        "assign_agent": "Assign agent",
+        "send_webhook_event": "Send webhook event",
+        "mute_conversation": "Mute conversation",
+        "send_attachment": "Send attachment",
+        "change_status": "Change status",
+        "resolve_conversation": "Resolve conversation",
+        "snooze_conversation": "Snooze conversation",
+        "change_priority": "Change priority",
+        "send_email_transcript": "Send email transcript",
+        "assign_to_pipeline": "Assign to pipeline",
+        "update_pipeline_stage": "Update pipeline stage",
+        "create_pipeline_task": "Create pipeline task"
+      },
+      "conditionRow": {
+        "attribute": "Attribute",
+        "operator": "Operator",
+        "value": "Value",
+        "remove": "Remove condition"
+      },
+      "actionRow": {
+        "action": "Action",
+        "remove": "Remove action",
+        "selectActionFirst": "Select an action to configure",
+        "noParams": "No parameters required",
+        "params": {
+          "send_message": "Message content",
+          "send_webhook_event": "Webhook URL",
+          "send_email_transcript": "Recipient email",
+          "assign_team": "Pick a team",
+          "assign_agent": "Pick an agent",
+          "add_label": "Pick a label",
+          "remove_label": "Pick a label",
+          "change_priority": "Pick a priority",
+          "change_status": "Pick a status",
+          "assign_to_pipeline": "Pick a pipeline",
+          "update_pipeline_stage": "Pick a pipeline stage",
+          "send_email_to_team": "Email body",
+          "create_pipeline_task": "Task title",
+          "send_attachment_pending": "Attachment selection coming soon"
+        }
+      },
+      "operators": {
+        "equal_to": "Equals",
+        "not_equal_to": "Does not equal",
+        "contains": "Contains",
+        "does_not_contain": "Does not contain",
+        "is_present": "Is present",
+        "is_not_present": "Is not present",
+        "is_greater_than": "Greater than",
+        "is_less_than": "Less than",
+        "days_before": "Days before",
+        "starts_with": "Starts with",
+        "attribute_changed": "Attribute changed",
+        "is_in": "Is in",
+        "is_not_in": "Is not in"
+      },
+      "attributes": {
+        "status": "Status",
+        "assignee_id": "Assignee",
+        "inbox_id": "Inbox",
+        "team_id": "Team",
+        "priority": "Priority",
+        "labels": "Labels",
+        "browser_language": "Browser language",
+        "conversation_language": "Conversation language",
+        "country_code": "Country code",
+        "referer": "Referer",
+        "mail_subject": "Mail subject",
+        "content": "Message content",
+        "message_type": "Message type",
+        "name": "Name",
+        "email": "Email",
+        "phone_number": "Phone number",
+        "identifier": "Identifier",
+        "city": "City",
+        "company": "Company",
+        "blocked": "Blocked",
+        "pipeline_id": "Pipeline",
+        "pipeline_stage_id": "Pipeline stage"
+      }
+    },
+    "buttons": {
+      "create": "Create",
+      "update": "Save",
+      "saving": "Saving...",
+      "cancel": "Cancel"
+    }
+  },
+  "dialog": {
+    "delete": {
+      "title": "Delete automation",
+      "description": "Are you sure you want to delete \"{{name}}\"? This cannot be undone.",
+      "confirm": "Delete",
+      "cancel": "Cancel",
+      "deleting": "Deleting..."
+    },
+    "bulkDelete": {
+      "title": "Delete automations",
+      "description": "Are you sure you want to delete {{count}} automations? This cannot be undone.",
+      "confirm": "Delete all",
+      "cancel": "Cancel",
+      "deleting": "Deleting..."
+    }
+  },
+  "messages": {
+    "loadError": "Failed to load automations",
+    "createSuccess": "Automation created",
+    "createError": "Failed to create automation",
+    "updateSuccess": "Automation updated",
+    "updateError": "Failed to update automation",
+    "deleteSuccess": "Automation deleted",
+    "deleteError": "Failed to delete automation",
+    "bulkDeleteSuccess": "{{count}} automations deleted",
+    "bulkDeleteError": "Failed to delete automations",
+    "cloneSuccess": "Automation cloned",
+    "cloneError": "Failed to clone automation",
+    "permissionDenied": {
+      "read": "You don't have permission to view automations",
+      "create": "You don't have permission to create automations",
+      "update": "You don't have permission to edit automations",
+      "delete": "You don't have permission to delete automations",
+      "clone": "You don't have permission to clone automations"
+    }
+  }
+}

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -86,6 +86,7 @@
       "pipelines": "Pipelines",
       "agents": "AI Agents",
       "channels": "Channels",
+      "automation": "Automations",
       "tutorials": "Tutorials",
       "settings": "Settings"
     },

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -86,6 +86,7 @@
       "pipelines": "Pipelines",
       "agents": "Agentes",
       "channels": "Canales",
+      "automation": "Automatizaciones",
       "tutorials": "Tutoriales",
       "settings": "Configuraciones"
     },

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -86,6 +86,7 @@
       "pipelines": "Pipelines",
       "agents": "Agents",
       "channels": "Canaux",
+      "automation": "Automatisations",
       "tutorials": "Tutoriels",
       "settings": "Paramètres"
     },

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -86,6 +86,7 @@
       "pipelines": "Pipeline",
       "agents": "Agenti",
       "channels": "Canali",
+      "automation": "Automazioni",
       "tutorials": "Tutorial",
       "settings": "Impostazioni"
     },

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -89,7 +89,8 @@
         "attribute": "Atributo",
         "operator": "Operador",
         "value": "Valor",
-        "remove": "Remover condição"
+        "remove": "Remover condição",
+        "noValueNeeded": "Nenhum valor necessário"
       },
       "actionRow": {
         "action": "Ação",
@@ -110,7 +111,13 @@
           "update_pipeline_stage": "Escolha um estágio",
           "send_email_to_team": "Corpo do email",
           "create_pipeline_task": "Título da tarefa",
-          "send_attachment_pending": "Seleção de anexo em breve"
+          "create_pipeline_task_description": "Descrição (opcional)",
+          "create_pipeline_task_type": "Tipo (opcional)",
+          "create_pipeline_task_priority": "Prioridade (opcional)",
+          "create_pipeline_task_assignee": "ID do responsável (opcional)",
+          "create_pipeline_task_due_in": "Vencimento (ex.: 2d, 1w)",
+          "send_attachment_ids": "IDs dos anexos separados por vírgula",
+          "send_attachment_inbox": "ID da caixa (opcional)"
         }
       },
       "operators": {
@@ -178,6 +185,7 @@
   },
   "messages": {
     "loadError": "Falha ao carregar automações",
+    "bulkDeletePartial": "{{success}} excluídas, {{failed}} falharam",
     "ruleNotFound": "Automação não encontrada",
     "createSuccess": "Automação criada",
     "createError": "Falha ao criar automação",

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -45,6 +45,7 @@
       "event": {
         "label": "Evento gatilho",
         "placeholder": "Selecione um evento",
+        "hint": "Dica: Para reagir a uma mudança de status, escolha \"Conversa atualizada\" e adicione uma condição em Status.",
         "options": {
           "conversation_created": "Conversa criada",
           "conversation_updated": "Conversa atualizada",
@@ -177,6 +178,7 @@
   },
   "messages": {
     "loadError": "Falha ao carregar automações",
+    "ruleNotFound": "Automação não encontrada",
     "createSuccess": "Automação criada",
     "createError": "Falha ao criar automação",
     "updateSuccess": "Automação atualizada",

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -1,0 +1,198 @@
+{
+  "page": {
+    "title": "Automações",
+    "subtitle": "{{count}} regras de automação",
+    "searchPlaceholder": "Buscar por nome",
+    "newAutomation": "Nova automação",
+    "bulkDelete": "Excluir selecionadas",
+    "clearSelection": "Limpar ({{count}})",
+    "loading": "Carregando...",
+    "empty": {
+      "title": "Nenhuma automação ainda",
+      "description": "Crie regras que disparam em eventos como novas conversas, contatos e mudanças de estágio do pipeline.",
+      "action": "Criar primeira automação"
+    }
+  },
+  "table": {
+    "columns": {
+      "name": "Nome",
+      "event": "Evento",
+      "status": "Status",
+      "actionsCount": "Ações",
+      "createdAt": "Criada em"
+    },
+    "status": {
+      "active": "Ativa",
+      "inactive": "Inativa"
+    },
+    "actions": {
+      "edit": "Editar",
+      "clone": "Clonar",
+      "delete": "Excluir"
+    }
+  },
+  "form": {
+    "title": {
+      "create": "Nova automação",
+      "edit": "Editar automação"
+    },
+    "fields": {
+      "name": "Nome",
+      "namePlaceholder": "Ex: Notificar vendas quando conversa entrar em Ganho",
+      "description": "Descrição",
+      "descriptionPlaceholder": "Contexto opcional para o time",
+      "active": "Ativa",
+      "event": {
+        "label": "Evento gatilho",
+        "placeholder": "Selecione um evento",
+        "options": {
+          "conversation_created": "Conversa criada",
+          "conversation_updated": "Conversa atualizada",
+          "conversation_opened": "Conversa aberta",
+          "message_created": "Mensagem criada",
+          "pipeline_stage_updated": "Estágio do pipeline atualizado",
+          "contact_created": "Contato criado",
+          "contact_updated": "Contato atualizado",
+          "conversation_resolved": "Conversa resolvida",
+          "conversation_status_changed": "Status da conversa alterado"
+        }
+      },
+      "conditions": {
+        "label": "Condições",
+        "addRow": "Adicionar condição",
+        "empty": "Sem condições — esta regra dispara em todo evento."
+      },
+      "actions": {
+        "label": "Ações",
+        "addRow": "Adicionar ação",
+        "empty": "Adicione ao menos uma ação.",
+        "send_message": "Enviar mensagem",
+        "add_label": "Adicionar etiqueta",
+        "remove_label": "Remover etiqueta",
+        "send_email_to_team": "Enviar email ao time",
+        "assign_team": "Atribuir time",
+        "assign_agent": "Atribuir atendente",
+        "send_webhook_event": "Disparar webhook",
+        "mute_conversation": "Silenciar conversa",
+        "send_attachment": "Enviar anexo",
+        "change_status": "Alterar status",
+        "resolve_conversation": "Resolver conversa",
+        "snooze_conversation": "Adiar conversa",
+        "change_priority": "Alterar prioridade",
+        "send_email_transcript": "Enviar transcrição por email",
+        "assign_to_pipeline": "Atribuir ao pipeline",
+        "update_pipeline_stage": "Atualizar estágio do pipeline",
+        "create_pipeline_task": "Criar tarefa do pipeline"
+      },
+      "conditionRow": {
+        "attribute": "Atributo",
+        "operator": "Operador",
+        "value": "Valor",
+        "remove": "Remover condição"
+      },
+      "actionRow": {
+        "action": "Ação",
+        "remove": "Remover ação",
+        "selectActionFirst": "Selecione uma ação para configurar",
+        "noParams": "Sem parâmetros",
+        "params": {
+          "send_message": "Conteúdo da mensagem",
+          "send_webhook_event": "URL do webhook",
+          "send_email_transcript": "Email do destinatário",
+          "assign_team": "Escolha um time",
+          "assign_agent": "Escolha um atendente",
+          "add_label": "Escolha uma etiqueta",
+          "remove_label": "Escolha uma etiqueta",
+          "change_priority": "Escolha uma prioridade",
+          "change_status": "Escolha um status",
+          "assign_to_pipeline": "Escolha um pipeline",
+          "update_pipeline_stage": "Escolha um estágio",
+          "send_email_to_team": "Corpo do email",
+          "create_pipeline_task": "Título da tarefa",
+          "send_attachment_pending": "Seleção de anexo em breve"
+        }
+      },
+      "operators": {
+        "equal_to": "Igual a",
+        "not_equal_to": "Diferente de",
+        "contains": "Contém",
+        "does_not_contain": "Não contém",
+        "is_present": "Está preenchido",
+        "is_not_present": "Está vazio",
+        "is_greater_than": "Maior que",
+        "is_less_than": "Menor que",
+        "days_before": "Dias antes",
+        "starts_with": "Começa com",
+        "attribute_changed": "Atributo mudou",
+        "is_in": "Está em",
+        "is_not_in": "Não está em"
+      },
+      "attributes": {
+        "status": "Status",
+        "assignee_id": "Atendente",
+        "inbox_id": "Caixa",
+        "team_id": "Time",
+        "priority": "Prioridade",
+        "labels": "Etiquetas",
+        "browser_language": "Idioma do navegador",
+        "conversation_language": "Idioma da conversa",
+        "country_code": "Código do país",
+        "referer": "Referência",
+        "mail_subject": "Assunto do email",
+        "content": "Conteúdo da mensagem",
+        "message_type": "Tipo de mensagem",
+        "name": "Nome",
+        "email": "Email",
+        "phone_number": "Telefone",
+        "identifier": "Identificador",
+        "city": "Cidade",
+        "company": "Empresa",
+        "blocked": "Bloqueado",
+        "pipeline_id": "Pipeline",
+        "pipeline_stage_id": "Estágio do pipeline"
+      }
+    },
+    "buttons": {
+      "create": "Criar",
+      "update": "Salvar",
+      "saving": "Salvando...",
+      "cancel": "Cancelar"
+    }
+  },
+  "dialog": {
+    "delete": {
+      "title": "Excluir automação",
+      "description": "Tem certeza que deseja excluir \"{{name}}\"? Esta ação não pode ser desfeita.",
+      "confirm": "Excluir",
+      "cancel": "Cancelar",
+      "deleting": "Excluindo..."
+    },
+    "bulkDelete": {
+      "title": "Excluir automações",
+      "description": "Tem certeza que deseja excluir {{count}} automações? Esta ação não pode ser desfeita.",
+      "confirm": "Excluir todas",
+      "cancel": "Cancelar",
+      "deleting": "Excluindo..."
+    }
+  },
+  "messages": {
+    "loadError": "Falha ao carregar automações",
+    "createSuccess": "Automação criada",
+    "createError": "Falha ao criar automação",
+    "updateSuccess": "Automação atualizada",
+    "updateError": "Falha ao atualizar automação",
+    "deleteSuccess": "Automação excluída",
+    "deleteError": "Falha ao excluir automação",
+    "bulkDeleteSuccess": "{{count}} automações excluídas",
+    "bulkDeleteError": "Falha ao excluir automações",
+    "cloneSuccess": "Automação clonada",
+    "cloneError": "Falha ao clonar automação",
+    "permissionDenied": {
+      "read": "Você não tem permissão para ver automações",
+      "create": "Você não tem permissão para criar automações",
+      "update": "Você não tem permissão para editar automações",
+      "delete": "Você não tem permissão para excluir automações",
+      "clone": "Você não tem permissão para clonar automações"
+    }
+  }
+}

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -86,6 +86,7 @@
       "pipelines": "Pipelines",
       "agents": "Agentes de IA",
       "channels": "Canais",
+      "automation": "Automações",
       "tutorials": "Tutoriais",
       "settings": "Configurações"
     },

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -86,6 +86,7 @@
       "pipelines": "Pipelines",
       "agents": "Agentes de IA",
       "channels": "Canais",
+      "automation": "Automações",
       "tutorials": "Tutoriais",
       "settings": "Configurações"
     },

--- a/src/pages/Customer/Automation/AutomationForm.spec.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.spec.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AutomationForm from './AutomationForm';
+
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill as never);
+
+vi.mock('@/services/automation/automationService', () => ({
+  automationService: {
+    getFormData: vi.fn().mockResolvedValue({
+      inboxes: [],
+      agents: [],
+      teams: [],
+      labels: [],
+      campaigns: [],
+      customAttributes: [],
+    }),
+    getAutomation: vi.fn(),
+    createAutomation: vi.fn(),
+    updateAutomation: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/pipelines/pipelinesService', () => ({
+  pipelinesService: {
+    getPipelines: vi.fn().mockResolvedValue({ data: [] }),
+    getPipelineStages: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+function renderForm(mode: 'create' | 'edit', initialPath = '/automation/new') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/automation/new" element={<AutomationForm mode={mode} />} />
+        <Route path="/automation/:id/edit" element={<AutomationForm mode={mode} />} />
+        <Route path="/automation" element={<div>list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AutomationForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders create mode title and form fields after form-data loads', async () => {
+    renderForm('create');
+    await waitFor(() => {
+      expect(screen.getByText(/form\.title\.create/)).toBeTruthy();
+    });
+    expect(screen.getByText(/form\.fields\.name/)).toBeTruthy();
+    expect(screen.getByText(/form\.fields\.event\.label/)).toBeTruthy();
+  });
+
+  it('renders edit mode title when mode is edit', async () => {
+    const { automationService } = await import('@/services/automation/automationService');
+    vi.mocked(automationService.getAutomation).mockResolvedValue({
+      data: {
+        id: 'rule-1',
+        name: 'Existing rule',
+        description: '',
+        event_name: 'conversation_created',
+        active: true,
+        mode: 'simple',
+        conditions: [],
+        actions: [{ action_name: 'send_message', action_params: ['hi'] }],
+      },
+    } as never);
+
+    renderForm('edit', '/automation/rule-1/edit');
+    await waitFor(() => {
+      expect(screen.getByText(/form\.title\.edit/)).toBeTruthy();
+    });
+  });
+
+  it('navigates back to list and toasts on 404 in edit mode', async () => {
+    const { automationService } = await import('@/services/automation/automationService');
+    vi.mocked(automationService.getAutomation).mockRejectedValue({
+      response: { status: 404 },
+    });
+
+    renderForm('edit', '/automation/missing/edit');
+    await waitFor(() => {
+      expect(screen.getByText('list')).toBeTruthy();
+    });
+  });
+});

--- a/src/pages/Customer/Automation/AutomationForm.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useForm, Controller } from 'react-hook-form';
+import { useForm, Controller, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useLanguage } from '@/hooks/useLanguage';
 import { toast } from 'sonner';
@@ -46,15 +46,16 @@ export default function AutomationForm({ mode }: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [loadingExisting, setLoadingExisting] = useState(mode === 'edit');
 
+  const methods = useForm<AutomationRuleFormData>({
+    resolver: zodResolver(automationRuleSchema),
+    defaultValues: DEFAULTS,
+  });
   const {
     control,
     handleSubmit,
     reset,
     formState: { errors },
-  } = useForm<AutomationRuleFormData>({
-    resolver: zodResolver(automationRuleSchema),
-    defaultValues: DEFAULTS,
-  });
+  } = methods;
 
   useEffect(() => {
     if (mode !== 'edit' || !id) return;
@@ -120,6 +121,7 @@ export default function AutomationForm({ mode }: Props) {
   }
 
   return (
+    <FormProvider {...methods}>
     <div className="h-full flex flex-col p-4 max-w-4xl mx-auto w-full">
       <div className="flex items-center gap-2 mb-4">
         <Button variant="ghost" size="icon" onClick={() => navigate('/automation')}>
@@ -212,5 +214,6 @@ export default function AutomationForm({ mode }: Props) {
         </div>
       </form>
     </div>
+    </FormProvider>
   );
 }

--- a/src/pages/Customer/Automation/AutomationForm.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useLanguage } from '@/hooks/useLanguage';
+import { toast } from 'sonner';
+import {
+  Button,
+  Input,
+  Textarea,
+  Switch,
+} from '@evoapi/design-system';
+import { ArrowLeft } from 'lucide-react';
+import { automationService } from '@/services/automation/automationService';
+import {
+  automationRuleSchema,
+  type AutomationRuleFormData,
+} from '@/pages/Customer/Automation/registries';
+import {
+  EventSelector,
+  ConditionsBuilder,
+  ActionsBuilder,
+} from '@/components/automation';
+import { useAutomationFormData } from '@/hooks/automation/useAutomationFormData';
+
+const DEFAULTS: AutomationRuleFormData = {
+  name: '',
+  description: '',
+  event_name: 'conversation_created',
+  active: true,
+  mode: 'simple',
+  conditions: [],
+  actions: [{ action_name: 'send_message', action_params: [''] }],
+};
+
+interface Props {
+  mode: 'create' | 'edit';
+}
+
+export default function AutomationForm({ mode }: Props) {
+  const { t } = useLanguage('automation');
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const { data: formData, isLoading: formDataLoading } = useAutomationFormData();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [loadingExisting, setLoadingExisting] = useState(mode === 'edit');
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<AutomationRuleFormData>({
+    resolver: zodResolver(automationRuleSchema),
+    defaultValues: DEFAULTS,
+  });
+
+  useEffect(() => {
+    if (mode !== 'edit' || !id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await automationService.getAutomation(id);
+        const rule = (response as unknown as { data?: AutomationRuleFormData }).data;
+        if (!cancelled && rule) {
+          reset({
+            name: rule.name,
+            description: rule.description ?? '',
+            event_name: rule.event_name,
+            active: rule.active ?? true,
+            mode: 'simple',
+            conditions: rule.conditions ?? [],
+            actions: rule.actions ?? DEFAULTS.actions,
+          });
+        }
+      } catch (error) {
+        console.error('Error loading automation:', error);
+        toast.error(t('messages.loadError'));
+        navigate('/automation');
+      } finally {
+        if (!cancelled) setLoadingExisting(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, id, navigate, reset, t]);
+
+  const onSubmit = handleSubmit(async (data) => {
+    setSubmitting(true);
+    try {
+      const payload = data as unknown as Parameters<typeof automationService.createAutomation>[0];
+      if (mode === 'create') {
+        await automationService.createAutomation(payload);
+        toast.success(t('messages.createSuccess'));
+      } else if (id) {
+        await automationService.updateAutomation(id, { ...payload, id });
+        toast.success(t('messages.updateSuccess'));
+      }
+      navigate('/automation');
+    } catch (error) {
+      console.error('Error saving automation:', error);
+      toast.error(
+        mode === 'create' ? t('messages.createError') : t('messages.updateError'),
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  });
+
+  if (loadingExisting || formDataLoading) {
+    return <div className="p-4 text-muted-foreground">{t('page.loading')}</div>;
+  }
+
+  return (
+    <div className="h-full flex flex-col p-4 max-w-4xl mx-auto w-full">
+      <div className="flex items-center gap-2 mb-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/automation')}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-xl font-semibold">
+          {mode === 'create' ? t('form.title.create') : t('form.title.edit')}
+        </h1>
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-6 flex-1">
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="name">
+            {t('form.fields.name')} *
+          </label>
+          <Controller
+            control={control}
+            name="name"
+            render={({ field }) => (
+              <Input
+                id="name"
+                value={field.value ?? ''}
+                onChange={field.onChange}
+                placeholder={t('form.fields.namePlaceholder')}
+                disabled={submitting}
+              />
+            )}
+          />
+          {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm font-medium" htmlFor="description">
+            {t('form.fields.description')}
+          </label>
+          <Controller
+            control={control}
+            name="description"
+            render={({ field }) => (
+              <Textarea
+                id="description"
+                value={field.value ?? ''}
+                onChange={field.onChange}
+                placeholder={t('form.fields.descriptionPlaceholder')}
+                rows={2}
+                disabled={submitting}
+              />
+            )}
+          />
+        </div>
+
+        <Controller
+          control={control}
+          name="active"
+          render={({ field }) => (
+            <div className="flex items-center gap-3">
+              <Switch
+                checked={field.value}
+                onCheckedChange={field.onChange}
+                disabled={submitting}
+              />
+              <label className="text-sm font-medium">{t('form.fields.active')}</label>
+            </div>
+          )}
+        />
+
+        <EventSelector control={control} disabled={submitting} />
+
+        <ConditionsBuilder control={control} formData={formData} />
+
+        <ActionsBuilder control={control} formData={formData} />
+
+        {errors.actions && (
+          <p className="text-sm text-red-500">{t('form.fields.actions.empty')}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-4 border-t">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => navigate('/automation')}
+            disabled={submitting}
+          >
+            {t('form.buttons.cancel')}
+          </Button>
+          <Button type="submit" disabled={submitting}>
+            {submitting
+              ? t('form.buttons.saving')
+              : mode === 'create'
+                ? t('form.buttons.create')
+                : t('form.buttons.update')}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/Customer/Automation/AutomationForm.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.tsx
@@ -75,8 +75,10 @@ export default function AutomationForm({ mode }: Props) {
           });
         }
       } catch (error) {
+        const status = (error as { response?: { status?: number } })?.response?.status;
+        const i18nKey = status === 404 ? 'messages.ruleNotFound' : 'messages.loadError';
         console.error('Error loading automation:', error);
-        toast.error(t('messages.loadError'));
+        toast.error(t(i18nKey));
         navigate('/automation');
       } finally {
         if (!cancelled) setLoadingExisting(false);
@@ -88,8 +90,12 @@ export default function AutomationForm({ mode }: Props) {
   }, [mode, id, navigate, reset, t]);
 
   const onSubmit = handleSubmit(async (data) => {
+    if (submitting) return;
     setSubmitting(true);
     try {
+      // Cast: AutomationCondition.values is typed as string[] | number[] (homogeneous)
+      // but the Zod schema produces (string | number)[]. Backend accepts mixed; the
+      // type cleanup is deferred per Story 1 audit findings.
       const payload = data as unknown as Parameters<typeof automationService.createAutomation>[0];
       if (mode === 'create') {
         await automationService.createAutomation(payload);
@@ -181,14 +187,11 @@ export default function AutomationForm({ mode }: Props) {
         />
 
         <EventSelector control={control} disabled={submitting} />
+        <p className="text-xs text-muted-foreground">{t('form.fields.event.hint')}</p>
 
         <ConditionsBuilder control={control} formData={formData} />
 
         <ActionsBuilder control={control} formData={formData} />
-
-        {errors.actions && (
-          <p className="text-sm text-red-500">{t('form.fields.actions.empty')}</p>
-        )}
 
         <div className="flex justify-end gap-2 pt-4 border-t">
           <Button

--- a/src/pages/Customer/Automation/index.tsx
+++ b/src/pages/Customer/Automation/index.tsx
@@ -78,8 +78,9 @@ export default function AutomationsListPage() {
         automations: dataArray,
         meta: {
           pagination: {
-            page: meta?.pagination?.page ?? 1,
-            page_size: meta?.pagination?.page_size ?? DEFAULT_PAGE_SIZE,
+            // Preserve the user's current page across refetches — pagination is client-side.
+            page: prev.meta.pagination.page,
+            page_size: prev.meta.pagination.page_size,
             total: meta?.pagination?.total ?? dataArray.length,
             total_pages: meta?.pagination?.total_pages ?? 1,
           },
@@ -165,16 +166,25 @@ export default function AutomationsListPage() {
     if (state.selectedIds.length === 0) return;
     setState((prev) => ({ ...prev, loading: { ...prev.loading, delete: true } }));
     try {
-      for (const id of state.selectedIds) {
-        await automationService.deleteAutomation(id);
+      const results = await Promise.allSettled(
+        state.selectedIds.map((id) => automationService.deleteAutomation(id)),
+      );
+      const successCount = results.filter((r) => r.status === 'fulfilled').length;
+      const failedCount = results.length - successCount;
+
+      if (failedCount === 0) {
+        toast.success(t('messages.bulkDeleteSuccess', { count: successCount }));
+      } else if (successCount === 0) {
+        toast.error(t('messages.bulkDeleteError'));
+      } else {
+        toast.warning(
+          t('messages.bulkDeletePartial', { success: successCount, failed: failedCount }),
+        );
       }
-      toast.success(t('messages.bulkDeleteSuccess', { count: state.selectedIds.length }));
+
       setState((prev) => ({ ...prev, selectedIds: [] }));
       loadAutomations();
       setBulkDeleteOpen(false);
-    } catch (error) {
-      console.error('Error bulk deleting automations:', error);
-      toast.error(t('messages.bulkDeleteError'));
     } finally {
       setState((prev) => ({ ...prev, loading: { ...prev.loading, delete: false } }));
     }
@@ -186,15 +196,30 @@ export default function AutomationsListPage() {
       )
     : state.automations;
 
+  const { page, page_size } = state.meta.pagination;
+  const totalFiltered = filteredAutomations.length;
+  const totalPages = Math.max(1, Math.ceil(totalFiltered / page_size));
+  const safePage = Math.min(page, totalPages);
+  const paginatedAutomations = filteredAutomations.slice(
+    (safePage - 1) * page_size,
+    safePage * page_size,
+  );
+
   const selected = state.automations.filter((rule) => state.selectedIds.includes(rule.id));
 
   return (
     <div className="h-full flex flex-col p-4">
       <AutomationsHeader
-        totalCount={state.meta.pagination.total}
+        totalCount={totalFiltered}
         selectedCount={state.selectedIds.length}
         searchValue={state.searchQuery}
-        onSearchChange={(v) => setState((prev) => ({ ...prev, searchQuery: v }))}
+        onSearchChange={(v) =>
+          setState((prev) => ({
+            ...prev,
+            searchQuery: v,
+            meta: { pagination: { ...prev.meta.pagination, page: 1 } },
+          }))
+        }
         onNewAutomation={handleCreate}
         onBulkDelete={() => setBulkDeleteOpen(true)}
         onClearSelection={() => setState((prev) => ({ ...prev, selectedIds: [] }))}
@@ -204,7 +229,7 @@ export default function AutomationsListPage() {
 
       <div className="flex-1 overflow-auto mt-6">
         <AutomationsTable
-          automations={filteredAutomations}
+          automations={paginatedAutomations}
           selected={selected}
           loading={state.loading.list}
           onSelectionChange={(items) =>
@@ -220,13 +245,13 @@ export default function AutomationsListPage() {
         />
       </div>
 
-      {state.meta.pagination.total > 0 && (
+      {totalFiltered > 0 && (
         <div className="mt-auto pt-4 border-t">
           <AutomationsPagination
-            currentPage={state.meta.pagination.page}
-            totalPages={state.meta.pagination.total_pages}
-            totalCount={state.meta.pagination.total}
-            perPage={state.meta.pagination.page_size}
+            currentPage={safePage}
+            totalPages={totalPages}
+            totalCount={totalFiltered}
+            perPage={page_size}
             onPageChange={(page) =>
               setState((prev) => ({
                 ...prev,

--- a/src/pages/Customer/Automation/index.tsx
+++ b/src/pages/Customer/Automation/index.tsx
@@ -1,0 +1,304 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useLanguage } from '@/hooks/useLanguage';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Button,
+} from '@evoapi/design-system';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
+import { automationService } from '@/services/automation/automationService';
+import type { AutomationRule } from '@/types/automation';
+import { AutomationsHeader, AutomationsTable, AutomationsPagination } from '@/components/automation';
+import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+
+interface Pagination {
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+}
+
+interface State {
+  automations: AutomationRule[];
+  selectedIds: string[];
+  meta: { pagination: Pagination };
+  loading: { list: boolean; delete: boolean; clone: boolean };
+  searchQuery: string;
+  sortBy: string;
+  sortOrder: 'asc' | 'desc';
+}
+
+const INITIAL_STATE: State = {
+  automations: [],
+  selectedIds: [],
+  meta: {
+    pagination: { page: 1, page_size: DEFAULT_PAGE_SIZE, total: 0, total_pages: 0 },
+  },
+  loading: { list: false, delete: false, clone: false },
+  searchQuery: '',
+  sortBy: 'name',
+  sortOrder: 'asc',
+};
+
+export default function AutomationsListPage() {
+  const { t } = useLanguage('automation');
+  const navigate = useNavigate();
+  const { can, isReady: permissionsReady } = useUserPermissions();
+
+  const [state, setState] = useState<State>(INITIAL_STATE);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [ruleToDelete, setRuleToDelete] = useState<AutomationRule | null>(null);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const hasLoaded = useRef(false);
+
+  const canRead = can('automation_rules', 'read');
+  const canCreate = can('automation_rules', 'create');
+  const canUpdate = can('automation_rules', 'update');
+  const canDeleteCap = can('automation_rules', 'delete');
+  const canCloneCap = can('automation_rules', 'clone');
+
+  const loadAutomations = useCallback(async () => {
+    if (!canRead) {
+      toast.error(t('messages.permissionDenied.read'));
+      return;
+    }
+    setState((prev) => ({ ...prev, loading: { ...prev.loading, list: true } }));
+    try {
+      const response = await automationService.getAutomations();
+      const dataArray = (response as unknown as { data?: AutomationRule[] }).data ?? [];
+      const meta = (response as unknown as { meta?: { pagination?: Pagination } }).meta;
+      setState((prev) => ({
+        ...prev,
+        automations: dataArray,
+        meta: {
+          pagination: {
+            page: meta?.pagination?.page ?? 1,
+            page_size: meta?.pagination?.page_size ?? DEFAULT_PAGE_SIZE,
+            total: meta?.pagination?.total ?? dataArray.length,
+            total_pages: meta?.pagination?.total_pages ?? 1,
+          },
+        },
+        loading: { ...prev.loading, list: false },
+      }));
+    } catch (error) {
+      console.error('Error loading automations:', error);
+      toast.error(t('messages.loadError'));
+      setState((prev) => ({ ...prev, loading: { ...prev.loading, list: false } }));
+    }
+  }, [canRead, t]);
+
+  useEffect(() => {
+    if (!permissionsReady) return;
+    if (!hasLoaded.current) {
+      hasLoaded.current = true;
+      loadAutomations();
+    }
+  }, [permissionsReady, loadAutomations]);
+
+  const handleCreate = () => {
+    if (!canCreate) {
+      toast.error(t('messages.permissionDenied.create'));
+      return;
+    }
+    navigate('/automation/new');
+  };
+
+  const handleEdit = (rule: AutomationRule) => {
+    if (!canUpdate) {
+      toast.error(t('messages.permissionDenied.update'));
+      return;
+    }
+    navigate(`/automation/${rule.id}/edit`);
+  };
+
+  const handleDelete = (rule: AutomationRule) => {
+    if (!canDeleteCap) {
+      toast.error(t('messages.permissionDenied.delete'));
+      return;
+    }
+    setRuleToDelete(rule);
+    setDeleteOpen(true);
+  };
+
+  const handleClone = async (rule: AutomationRule) => {
+    if (!canCloneCap) {
+      toast.error(t('messages.permissionDenied.clone'));
+      return;
+    }
+    setState((prev) => ({ ...prev, loading: { ...prev.loading, clone: true } }));
+    try {
+      await automationService.cloneAutomation(rule.id);
+      toast.success(t('messages.cloneSuccess'));
+      loadAutomations();
+    } catch (error) {
+      console.error('Error cloning automation:', error);
+      toast.error(t('messages.cloneError'));
+    } finally {
+      setState((prev) => ({ ...prev, loading: { ...prev.loading, clone: false } }));
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!ruleToDelete) return;
+    setState((prev) => ({ ...prev, loading: { ...prev.loading, delete: true } }));
+    try {
+      await automationService.deleteAutomation(ruleToDelete.id);
+      toast.success(t('messages.deleteSuccess'));
+      loadAutomations();
+      setDeleteOpen(false);
+      setRuleToDelete(null);
+    } catch (error) {
+      console.error('Error deleting automation:', error);
+      toast.error(t('messages.deleteError'));
+    } finally {
+      setState((prev) => ({ ...prev, loading: { ...prev.loading, delete: false } }));
+    }
+  };
+
+  const confirmBulkDelete = async () => {
+    if (state.selectedIds.length === 0) return;
+    setState((prev) => ({ ...prev, loading: { ...prev.loading, delete: true } }));
+    try {
+      for (const id of state.selectedIds) {
+        await automationService.deleteAutomation(id);
+      }
+      toast.success(t('messages.bulkDeleteSuccess', { count: state.selectedIds.length }));
+      setState((prev) => ({ ...prev, selectedIds: [] }));
+      loadAutomations();
+      setBulkDeleteOpen(false);
+    } catch (error) {
+      console.error('Error bulk deleting automations:', error);
+      toast.error(t('messages.bulkDeleteError'));
+    } finally {
+      setState((prev) => ({ ...prev, loading: { ...prev.loading, delete: false } }));
+    }
+  };
+
+  const filteredAutomations = state.searchQuery.trim()
+    ? state.automations.filter((rule) =>
+        rule.name.toLowerCase().includes(state.searchQuery.toLowerCase()),
+      )
+    : state.automations;
+
+  const selected = state.automations.filter((rule) => state.selectedIds.includes(rule.id));
+
+  return (
+    <div className="h-full flex flex-col p-4">
+      <AutomationsHeader
+        totalCount={state.meta.pagination.total}
+        selectedCount={state.selectedIds.length}
+        searchValue={state.searchQuery}
+        onSearchChange={(v) => setState((prev) => ({ ...prev, searchQuery: v }))}
+        onNewAutomation={handleCreate}
+        onBulkDelete={() => setBulkDeleteOpen(true)}
+        onClearSelection={() => setState((prev) => ({ ...prev, selectedIds: [] }))}
+        canCreate={canCreate}
+        canDelete={canDeleteCap}
+      />
+
+      <div className="flex-1 overflow-auto mt-6">
+        <AutomationsTable
+          automations={filteredAutomations}
+          selected={selected}
+          loading={state.loading.list}
+          onSelectionChange={(items) =>
+            setState((prev) => ({ ...prev, selectedIds: items.map((r) => r.id) }))
+          }
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          onClone={handleClone}
+          onCreate={handleCreate}
+          canEdit={canUpdate}
+          canDelete={canDeleteCap}
+          canClone={canCloneCap}
+        />
+      </div>
+
+      {state.meta.pagination.total > 0 && (
+        <div className="mt-auto pt-4 border-t">
+          <AutomationsPagination
+            currentPage={state.meta.pagination.page}
+            totalPages={state.meta.pagination.total_pages}
+            totalCount={state.meta.pagination.total}
+            perPage={state.meta.pagination.page_size}
+            onPageChange={(page) =>
+              setState((prev) => ({
+                ...prev,
+                meta: { pagination: { ...prev.meta.pagination, page } },
+              }))
+            }
+            onPerPageChange={(perPage) =>
+              setState((prev) => ({
+                ...prev,
+                meta: { pagination: { ...prev.meta.pagination, page_size: perPage, page: 1 } },
+              }))
+            }
+            loading={state.loading.list}
+          />
+        </div>
+      )}
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('dialog.delete.title')}</DialogTitle>
+            <DialogDescription>
+              {t('dialog.delete.description', { name: ruleToDelete?.name })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteOpen(false)}
+              disabled={state.loading.delete}
+            >
+              {t('dialog.delete.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmDelete}
+              disabled={state.loading.delete}
+            >
+              {state.loading.delete ? t('dialog.delete.deleting') : t('dialog.delete.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('dialog.bulkDelete.title')}</DialogTitle>
+            <DialogDescription>
+              {t('dialog.bulkDelete.description', { count: state.selectedIds.length })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBulkDeleteOpen(false)}
+              disabled={state.loading.delete}
+            >
+              {t('dialog.bulkDelete.cancel')}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={confirmBulkDelete}
+              disabled={state.loading.delete}
+            >
+              {state.loading.delete
+                ? t('dialog.bulkDelete.deleting')
+                : t('dialog.bulkDelete.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
@@ -49,7 +49,8 @@ describe('actionRegistry', () => {
           (issue) =>
             issue.code === 'too_small' ||
             issue.code === 'invalid_string' ||
-            issue.code === 'invalid_type',
+            issue.code === 'invalid_type' ||
+            issue.code === 'invalid_union',
         );
         expect(allFailuresAreContent).toBe(true);
       }

--- a/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { actionRegistry, ALL_ACTION_NAMES } from './actionRegistry';
+
+const BACKEND_ACTION_NAMES = [
+  'send_message',
+  'add_label',
+  'remove_label',
+  'send_email_to_team',
+  'assign_team',
+  'assign_agent',
+  'send_webhook_event',
+  'mute_conversation',
+  'send_attachment',
+  'change_status',
+  'resolve_conversation',
+  'snooze_conversation',
+  'change_priority',
+  'send_email_transcript',
+  'assign_to_pipeline',
+  'update_pipeline_stage',
+  'create_pipeline_task',
+];
+
+describe('actionRegistry', () => {
+  it('exposes all 17 backend actions', () => {
+    expect(ALL_ACTION_NAMES.sort()).toEqual([...BACKEND_ACTION_NAMES].sort());
+  });
+
+  it('every descriptor has a defined schema, defaultParams and i18nKey', () => {
+    for (const actionName of ALL_ACTION_NAMES) {
+      const descriptor = actionRegistry[actionName];
+      expect(descriptor.actionName).toBe(actionName);
+      expect(descriptor.schema).toBeDefined();
+      expect(descriptor.defaultParams).toBeDefined();
+      expect(descriptor.i18nKey).toMatch(/^form\.fields\.actions\./);
+    }
+  });
+
+  it('every defaultParams passes its own schema', () => {
+    for (const actionName of ALL_ACTION_NAMES) {
+      const descriptor = actionRegistry[actionName];
+      const result = descriptor.schema.safeParse(descriptor.defaultParams);
+      // We allow the default to fail strict validation when it represents an
+      // empty placeholder the user MUST fill in (e.g., empty message string).
+      // This test only requires that the schema accepts the SHAPE; we check
+      // that by ensuring failure is due to content, never to a missing field.
+      if (!result.success) {
+        const allFailuresAreContent = result.error.issues.every(
+          (issue) =>
+            issue.code === 'too_small' ||
+            issue.code === 'invalid_string' ||
+            issue.code === 'invalid_type',
+        );
+        expect(allFailuresAreContent).toBe(true);
+      }
+    }
+  });
+
+  it('rejects unknown action params shapes for send_message', () => {
+    const result = actionRegistry.send_message.schema.safeParse([]);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a valid send_email_to_team payload', () => {
+    const valid = [{ team_ids: [1, 2], message: 'Heads up' }];
+    const result = actionRegistry.send_email_to_team.schema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid create_pipeline_task payload with only title', () => {
+    const valid = [{ title: 'Follow up call' }];
+    const result = actionRegistry.create_pipeline_task.schema.safeParse(valid);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/pages/Customer/Automation/registries/actionRegistry.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.ts
@@ -35,9 +35,14 @@ const changePrioritySchema = z.tuple([z.union([z.string(), z.null()])]);
 
 const sendEmailTranscriptSchema = z.tuple([z.string().email()]);
 
-const assignToPipelineSchema = z.tuple([idValueSchema]);
+const requiredIdSchema = z.union([
+  z.string().min(1),
+  z.number().refine((n) => Number.isFinite(n), { message: 'invalid_id' }),
+]);
 
-const updatePipelineStageSchema = z.tuple([idValueSchema]);
+const assignToPipelineSchema = z.tuple([requiredIdSchema]);
+
+const updatePipelineStageSchema = z.tuple([requiredIdSchema]);
 
 const createPipelineTaskSchema = z.tuple([
   z.object({
@@ -145,13 +150,13 @@ export const actionRegistry: Record<AutomationActionType, ActionDescriptor> = {
   assign_to_pipeline: {
     actionName: 'assign_to_pipeline',
     schema: assignToPipelineSchema,
-    defaultParams: [''],
+    defaultParams: [null],
     i18nKey: 'form.fields.actions.assign_to_pipeline',
   },
   update_pipeline_stage: {
     actionName: 'update_pipeline_stage',
     schema: updatePipelineStageSchema,
-    defaultParams: [''],
+    defaultParams: [null],
     i18nKey: 'form.fields.actions.update_pipeline_stage',
   },
   create_pipeline_task: {

--- a/src/pages/Customer/Automation/registries/actionRegistry.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+import type { AutomationActionType } from '@/types/automation';
+
+const idValueSchema = z.union([z.string(), z.number()]);
+
+const sendMessageSchema = z.tuple([z.string().min(1)]);
+
+const labelListSchema = z.array(idValueSchema).min(1);
+
+const sendEmailToTeamSchema = z.tuple([
+  z.object({
+    team_ids: z.array(z.number()).min(1),
+    message: z.string().min(1),
+  }),
+]);
+
+const assignTeamSchema = z.tuple([z.union([z.number(), z.null()])]);
+
+const assignAgentSchema = z.tuple([z.union([z.number(), z.null()])]);
+
+const sendWebhookEventSchema = z.tuple([z.string().url()]);
+
+const sendAttachmentSchema = z.tuple([
+  z.object({
+    attachment_ids: z.array(idValueSchema).min(1),
+    inbox_id: z.number().optional(),
+  }),
+]);
+
+const changeStatusSchema = z.tuple([z.string().min(1)]);
+
+const noParamsSchema = z.tuple([]);
+
+const changePrioritySchema = z.tuple([z.union([z.string(), z.null()])]);
+
+const sendEmailTranscriptSchema = z.tuple([z.string().email()]);
+
+const assignToPipelineSchema = z.tuple([idValueSchema]);
+
+const updatePipelineStageSchema = z.tuple([idValueSchema]);
+
+const createPipelineTaskSchema = z.tuple([
+  z.object({
+    title: z.string().min(1),
+    description: z.string().optional(),
+    task_type: z.string().optional(),
+    priority: z.string().optional(),
+    assigned_to_id: z.number().optional(),
+    due_in: z.string().optional(),
+  }),
+]);
+
+export interface ActionDescriptor {
+  actionName: AutomationActionType;
+  schema: z.ZodTypeAny;
+  defaultParams: unknown;
+  i18nKey: string;
+}
+
+export const actionRegistry: Record<AutomationActionType, ActionDescriptor> = {
+  send_message: {
+    actionName: 'send_message',
+    schema: sendMessageSchema,
+    defaultParams: [''],
+    i18nKey: 'form.fields.actions.send_message',
+  },
+  add_label: {
+    actionName: 'add_label',
+    schema: labelListSchema,
+    defaultParams: [],
+    i18nKey: 'form.fields.actions.add_label',
+  },
+  remove_label: {
+    actionName: 'remove_label',
+    schema: labelListSchema,
+    defaultParams: [],
+    i18nKey: 'form.fields.actions.remove_label',
+  },
+  send_email_to_team: {
+    actionName: 'send_email_to_team',
+    schema: sendEmailToTeamSchema,
+    defaultParams: [{ team_ids: [], message: '' }],
+    i18nKey: 'form.fields.actions.send_email_to_team',
+  },
+  assign_team: {
+    actionName: 'assign_team',
+    schema: assignTeamSchema,
+    defaultParams: [null],
+    i18nKey: 'form.fields.actions.assign_team',
+  },
+  assign_agent: {
+    actionName: 'assign_agent',
+    schema: assignAgentSchema,
+    defaultParams: [null],
+    i18nKey: 'form.fields.actions.assign_agent',
+  },
+  send_webhook_event: {
+    actionName: 'send_webhook_event',
+    schema: sendWebhookEventSchema,
+    defaultParams: [''],
+    i18nKey: 'form.fields.actions.send_webhook_event',
+  },
+  mute_conversation: {
+    actionName: 'mute_conversation',
+    schema: noParamsSchema,
+    defaultParams: [],
+    i18nKey: 'form.fields.actions.mute_conversation',
+  },
+  send_attachment: {
+    actionName: 'send_attachment',
+    schema: sendAttachmentSchema,
+    defaultParams: [{ attachment_ids: [] }],
+    i18nKey: 'form.fields.actions.send_attachment',
+  },
+  change_status: {
+    actionName: 'change_status',
+    schema: changeStatusSchema,
+    defaultParams: [''],
+    i18nKey: 'form.fields.actions.change_status',
+  },
+  resolve_conversation: {
+    actionName: 'resolve_conversation',
+    schema: noParamsSchema,
+    defaultParams: [],
+    i18nKey: 'form.fields.actions.resolve_conversation',
+  },
+  snooze_conversation: {
+    actionName: 'snooze_conversation',
+    schema: noParamsSchema,
+    defaultParams: [],
+    i18nKey: 'form.fields.actions.snooze_conversation',
+  },
+  change_priority: {
+    actionName: 'change_priority',
+    schema: changePrioritySchema,
+    defaultParams: [null],
+    i18nKey: 'form.fields.actions.change_priority',
+  },
+  send_email_transcript: {
+    actionName: 'send_email_transcript',
+    schema: sendEmailTranscriptSchema,
+    defaultParams: [''],
+    i18nKey: 'form.fields.actions.send_email_transcript',
+  },
+  assign_to_pipeline: {
+    actionName: 'assign_to_pipeline',
+    schema: assignToPipelineSchema,
+    defaultParams: [''],
+    i18nKey: 'form.fields.actions.assign_to_pipeline',
+  },
+  update_pipeline_stage: {
+    actionName: 'update_pipeline_stage',
+    schema: updatePipelineStageSchema,
+    defaultParams: [''],
+    i18nKey: 'form.fields.actions.update_pipeline_stage',
+  },
+  create_pipeline_task: {
+    actionName: 'create_pipeline_task',
+    schema: createPipelineTaskSchema,
+    defaultParams: [{ title: '' }],
+    i18nKey: 'form.fields.actions.create_pipeline_task',
+  },
+};
+
+export function getActionDescriptor(
+  actionName: AutomationActionType,
+): ActionDescriptor | undefined {
+  return actionRegistry[actionName];
+}
+
+export const ALL_ACTION_NAMES = Object.keys(actionRegistry) as AutomationActionType[];

--- a/src/pages/Customer/Automation/registries/conditionAttributeRegistry.spec.ts
+++ b/src/pages/Customer/Automation/registries/conditionAttributeRegistry.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { conditionAttributeRegistry, getAttributesForEvent } from './conditionAttributeRegistry';
+import { conditionTypeRegistry } from './conditionTypeRegistry';
+
+const BACKEND_CONDITION_KEYS = [
+  'content',
+  'email',
+  'country_code',
+  'status',
+  'message_type',
+  'browser_language',
+  'assignee_id',
+  'team_id',
+  'referer',
+  'city',
+  'company',
+  'inbox_id',
+  'mail_subject',
+  'phone_number',
+  'priority',
+  'conversation_language',
+  'pipeline_id',
+  'pipeline_stage_id',
+  'labels',
+  'name',
+  'identifier',
+  'blocked',
+];
+
+describe('conditionAttributeRegistry', () => {
+  it('exposes all 22 backend condition attributes', () => {
+    const registryKeys = Object.keys(conditionAttributeRegistry).sort();
+    expect(registryKeys).toEqual([...BACKEND_CONDITION_KEYS].sort());
+  });
+
+  it('every descriptor references a known data type', () => {
+    const knownTypes = Object.keys(conditionTypeRegistry);
+    for (const descriptor of Object.values(conditionAttributeRegistry)) {
+      expect(knownTypes).toContain(descriptor.dataType);
+    }
+  });
+
+  it('every descriptor declares at least one operator', () => {
+    for (const descriptor of Object.values(conditionAttributeRegistry)) {
+      expect(descriptor.operators.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every descriptor has a non-empty validFor list and an i18nKey', () => {
+    for (const descriptor of Object.values(conditionAttributeRegistry)) {
+      expect(descriptor.validFor.length).toBeGreaterThan(0);
+      expect(descriptor.i18nKey).toMatch(/^form\.fields\.attributes\./);
+    }
+  });
+
+  it('pipeline attributes restrict to the four allowed operators', () => {
+    const pipelineOps = ['equal_to', 'not_equal_to', 'is_present', 'is_not_present'];
+    expect(conditionAttributeRegistry.pipeline_id.operators.sort()).toEqual([...pipelineOps].sort());
+    expect(conditionAttributeRegistry.pipeline_stage_id.operators.sort()).toEqual([...pipelineOps].sort());
+  });
+
+  it('contact_created event surfaces only contact-context attributes', () => {
+    const attrs = getAttributesForEvent('contact_created');
+    const keys = attrs.map((a) => a.attributeKey);
+    expect(keys).toContain('email');
+    expect(keys).toContain('name');
+    expect(keys).toContain('blocked');
+    expect(keys).not.toContain('status');
+    expect(keys).not.toContain('content');
+  });
+
+  it('pipeline_stage_updated event surfaces pipeline and conversation attributes', () => {
+    const attrs = getAttributesForEvent('pipeline_stage_updated');
+    const keys = attrs.map((a) => a.attributeKey);
+    expect(keys).toContain('pipeline_id');
+    expect(keys).toContain('pipeline_stage_id');
+    expect(keys).toContain('status');
+  });
+
+  it('phone_number includes starts_with operator (case-insensitive YML override)', () => {
+    expect(conditionAttributeRegistry.phone_number.operators).toContain('starts_with');
+  });
+});

--- a/src/pages/Customer/Automation/registries/conditionAttributeRegistry.ts
+++ b/src/pages/Customer/Automation/registries/conditionAttributeRegistry.ts
@@ -1,0 +1,218 @@
+import type { AutomationFilterOperator, AutomationEventType } from '@/types/automation';
+import { conditionTypeRegistry, type ConditionDataType } from './conditionTypeRegistry';
+
+export type OptionLoaderKey =
+  | 'pipelines'
+  | 'pipeline_stages'
+  | 'agents'
+  | 'teams'
+  | 'inboxes'
+  | 'labels'
+  | 'priorities'
+  | 'statuses'
+  | 'message_types';
+
+export type EventContext = 'conversation' | 'contact' | 'pipeline' | 'message';
+
+export interface ConditionAttributeDescriptor {
+  attributeKey: string;
+  dataType: ConditionDataType;
+  operators: AutomationFilterOperator[];
+  optionLoaderKey?: OptionLoaderKey;
+  validFor: EventContext[];
+  i18nKey: string;
+}
+
+const fromType = (
+  dataType: ConditionDataType,
+  override?: AutomationFilterOperator[],
+): AutomationFilterOperator[] => override ?? conditionTypeRegistry[dataType].defaultOperators;
+
+export const conditionAttributeRegistry: Record<string, ConditionAttributeDescriptor> = {
+  status: {
+    attributeKey: 'status',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    optionLoaderKey: 'statuses',
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.status',
+  },
+  assignee_id: {
+    attributeKey: 'assignee_id',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present']),
+    optionLoaderKey: 'agents',
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.assignee_id',
+  },
+  inbox_id: {
+    attributeKey: 'inbox_id',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present']),
+    optionLoaderKey: 'inboxes',
+    validFor: ['conversation', 'pipeline', 'message'],
+    i18nKey: 'form.fields.attributes.inbox_id',
+  },
+  team_id: {
+    attributeKey: 'team_id',
+    dataType: 'number',
+    operators: fromType('number', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present']),
+    optionLoaderKey: 'teams',
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.team_id',
+  },
+  priority: {
+    attributeKey: 'priority',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    optionLoaderKey: 'priorities',
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.priority',
+  },
+  labels: {
+    attributeKey: 'labels',
+    dataType: 'labels',
+    operators: fromType('labels'),
+    optionLoaderKey: 'labels',
+    validFor: ['conversation', 'contact', 'pipeline'],
+    i18nKey: 'form.fields.attributes.labels',
+  },
+  browser_language: {
+    attributeKey: 'browser_language',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.browser_language',
+  },
+  conversation_language: {
+    attributeKey: 'conversation_language',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.conversation_language',
+  },
+  country_code: {
+    attributeKey: 'country_code',
+    dataType: 'text',
+    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    validFor: ['conversation', 'contact', 'pipeline'],
+    i18nKey: 'form.fields.attributes.country_code',
+  },
+  referer: {
+    attributeKey: 'referer',
+    dataType: 'link',
+    operators: fromType('link'),
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.referer',
+  },
+  mail_subject: {
+    attributeKey: 'mail_subject',
+    dataType: 'text',
+    operators: fromType('text'),
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.mail_subject',
+  },
+  content: {
+    attributeKey: 'content',
+    dataType: 'text',
+    operators: fromType('text'),
+    validFor: ['message'],
+    i18nKey: 'form.fields.attributes.content',
+  },
+  message_type: {
+    attributeKey: 'message_type',
+    dataType: 'numeric',
+    operators: fromType('numeric'),
+    optionLoaderKey: 'message_types',
+    validFor: ['message'],
+    i18nKey: 'form.fields.attributes.message_type',
+  },
+  name: {
+    attributeKey: 'name',
+    dataType: 'text_case_insensitive',
+    operators: fromType('text_case_insensitive'),
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.name',
+  },
+  email: {
+    attributeKey: 'email',
+    dataType: 'text_case_insensitive',
+    operators: fromType('text_case_insensitive'),
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.email',
+  },
+  phone_number: {
+    attributeKey: 'phone_number',
+    dataType: 'text_case_insensitive',
+    operators: [...fromType('text_case_insensitive'), 'starts_with'],
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.phone_number',
+  },
+  identifier: {
+    attributeKey: 'identifier',
+    dataType: 'text_case_insensitive',
+    operators: fromType('text_case_insensitive', ['equal_to', 'not_equal_to']),
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.identifier',
+  },
+  city: {
+    attributeKey: 'city',
+    dataType: 'text_case_insensitive',
+    operators: fromType('text_case_insensitive'),
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.city',
+  },
+  company: {
+    attributeKey: 'company',
+    dataType: 'text_case_insensitive',
+    operators: fromType('text_case_insensitive'),
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.company',
+  },
+  blocked: {
+    attributeKey: 'blocked',
+    dataType: 'boolean',
+    operators: fromType('boolean'),
+    validFor: ['contact'],
+    i18nKey: 'form.fields.attributes.blocked',
+  },
+  pipeline_id: {
+    attributeKey: 'pipeline_id',
+    dataType: 'pipeline',
+    operators: fromType('pipeline'),
+    optionLoaderKey: 'pipelines',
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.pipeline_id',
+  },
+  pipeline_stage_id: {
+    attributeKey: 'pipeline_stage_id',
+    dataType: 'pipeline',
+    operators: fromType('pipeline'),
+    optionLoaderKey: 'pipeline_stages',
+    validFor: ['conversation', 'pipeline'],
+    i18nKey: 'form.fields.attributes.pipeline_stage_id',
+  },
+};
+
+const eventContextMap: Record<AutomationEventType, EventContext[]> = {
+  conversation_created: ['conversation', 'message'],
+  conversation_updated: ['conversation', 'message'],
+  conversation_opened: ['conversation', 'message'],
+  message_created: ['conversation', 'message'],
+  pipeline_stage_updated: ['pipeline', 'conversation'],
+  contact_created: ['contact'],
+  contact_updated: ['contact'],
+  conversation_resolved: ['conversation', 'message'],
+  conversation_status_changed: ['conversation', 'message'],
+};
+
+export function getAttributesForEvent(eventName: AutomationEventType): ConditionAttributeDescriptor[] {
+  const allowedContexts = eventContextMap[eventName] ?? [];
+  return Object.values(conditionAttributeRegistry).filter((descriptor) =>
+    descriptor.validFor.some((context) => allowedContexts.includes(context)),
+  );
+}
+
+export function getAttributeDescriptor(attributeKey: string): ConditionAttributeDescriptor | undefined {
+  return conditionAttributeRegistry[attributeKey];
+}

--- a/src/pages/Customer/Automation/registries/conditionTypeRegistry.ts
+++ b/src/pages/Customer/Automation/registries/conditionTypeRegistry.ts
@@ -1,0 +1,54 @@
+import type { AutomationFilterOperator } from '@/types/automation';
+
+export type ConditionDataType =
+  | 'text'
+  | 'text_case_insensitive'
+  | 'number'
+  | 'numeric'
+  | 'boolean'
+  | 'labels'
+  | 'date'
+  | 'link'
+  | 'pipeline'
+  | 'custom_attribute';
+
+export interface ConditionTypeDescriptor {
+  defaultOperators: AutomationFilterOperator[];
+}
+
+export const conditionTypeRegistry: Record<ConditionDataType, ConditionTypeDescriptor> = {
+  text: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'contains', 'does_not_contain'],
+  },
+  text_case_insensitive: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'contains', 'does_not_contain'],
+  },
+  number: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'is_greater_than', 'is_less_than'],
+  },
+  numeric: {
+    defaultOperators: ['equal_to', 'not_equal_to'],
+  },
+  boolean: {
+    defaultOperators: ['equal_to', 'not_equal_to'],
+  },
+  labels: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'is_present', 'is_not_present'],
+  },
+  date: {
+    defaultOperators: ['is_greater_than', 'is_less_than', 'days_before'],
+  },
+  link: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'contains', 'does_not_contain'],
+  },
+  pipeline: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'is_present', 'is_not_present'],
+  },
+  custom_attribute: {
+    defaultOperators: ['equal_to', 'not_equal_to', 'is_present', 'is_not_present'],
+  },
+};
+
+export function getOperatorsForType(dataType: ConditionDataType): AutomationFilterOperator[] {
+  return conditionTypeRegistry[dataType].defaultOperators;
+}

--- a/src/pages/Customer/Automation/registries/index.ts
+++ b/src/pages/Customer/Automation/registries/index.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import type { AutomationEventType, AutomationActionType } from '@/types/automation';
+import { actionRegistry } from './actionRegistry';
+
+export * from './conditionTypeRegistry';
+export * from './conditionAttributeRegistry';
+export * from './actionRegistry';
+
+const automationEventNames = [
+  'conversation_created',
+  'conversation_updated',
+  'conversation_opened',
+  'message_created',
+  'pipeline_stage_updated',
+  'contact_created',
+  'contact_updated',
+] as const satisfies readonly AutomationEventType[];
+
+const conditionSchema = z.object({
+  attribute_key: z.string().min(1),
+  filter_operator: z.string().min(1),
+  query_operator: z.enum(['AND', 'OR', 'and', 'or']).optional(),
+  values: z.array(z.union([z.string(), z.number()])),
+  custom_attribute_type: z.string().optional(),
+});
+
+const actionUnionSchema = z.discriminatedUnion('action_name', [
+  z.object({ action_name: z.literal('send_message'), action_params: actionRegistry.send_message.schema }),
+  z.object({ action_name: z.literal('add_label'), action_params: actionRegistry.add_label.schema }),
+  z.object({ action_name: z.literal('remove_label'), action_params: actionRegistry.remove_label.schema }),
+  z.object({ action_name: z.literal('send_email_to_team'), action_params: actionRegistry.send_email_to_team.schema }),
+  z.object({ action_name: z.literal('assign_team'), action_params: actionRegistry.assign_team.schema }),
+  z.object({ action_name: z.literal('assign_agent'), action_params: actionRegistry.assign_agent.schema }),
+  z.object({ action_name: z.literal('send_webhook_event'), action_params: actionRegistry.send_webhook_event.schema }),
+  z.object({ action_name: z.literal('mute_conversation'), action_params: actionRegistry.mute_conversation.schema }),
+  z.object({ action_name: z.literal('send_attachment'), action_params: actionRegistry.send_attachment.schema }),
+  z.object({ action_name: z.literal('change_status'), action_params: actionRegistry.change_status.schema }),
+  z.object({ action_name: z.literal('resolve_conversation'), action_params: actionRegistry.resolve_conversation.schema }),
+  z.object({ action_name: z.literal('snooze_conversation'), action_params: actionRegistry.snooze_conversation.schema }),
+  z.object({ action_name: z.literal('change_priority'), action_params: actionRegistry.change_priority.schema }),
+  z.object({ action_name: z.literal('send_email_transcript'), action_params: actionRegistry.send_email_transcript.schema }),
+  z.object({ action_name: z.literal('assign_to_pipeline'), action_params: actionRegistry.assign_to_pipeline.schema }),
+  z.object({ action_name: z.literal('update_pipeline_stage'), action_params: actionRegistry.update_pipeline_stage.schema }),
+  z.object({ action_name: z.literal('create_pipeline_task'), action_params: actionRegistry.create_pipeline_task.schema }),
+]);
+
+export const automationRuleSchema = z.object({
+  name: z.string().min(1, 'name_required'),
+  description: z.string().optional(),
+  event_name: z.enum(automationEventNames),
+  active: z.boolean(),
+  mode: z.literal('simple'),
+  conditions: z.array(conditionSchema),
+  actions: z.array(actionUnionSchema).min(1, 'actions_required'),
+});
+
+export type AutomationRuleFormData = z.infer<typeof automationRuleSchema>;
+
+export const ALL_PHASE_1_EVENTS = automationEventNames;
+
+export function getDefaultActionForName(actionName: AutomationActionType) {
+  const descriptor = actionRegistry[actionName];
+  return { action_name: actionName, action_params: descriptor.defaultParams };
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -39,7 +39,8 @@ import ScheduledActions from '@/pages/Customer/Contacts/ScheduledActions';
 import { Channels, ChannelSettings, NewChannel } from '@/pages/Customer/Channels';
 const ChatPage = React.lazy(() => import('@/pages/Customer/Chat/ChatPage'));
 
-// import Automation from '../pages/Customer/Automation';
+import Automation from '../pages/Customer/Automation';
+import AutomationForm from '../pages/Customer/Automation/AutomationForm';
 // import AutomationFlowEditor from '../pages/Customer/Automation/AutomationFlowEditor';
 import Pipelines from '@/pages/Customer/Pipelines/Pipelines';
 import PipelineKanban from '@/pages/Customer/Pipelines/PipelineKanban';
@@ -440,13 +441,13 @@ const AppRouter = () => {
             }
           />
 
-          {/* <Route
+          <Route
             path="/automation"
             element={
               <PrivateRoute>
                 <CustomerRoute>
                   <MainLayout>
-                    <PermissionRoute resource="automations" action="read">
+                    <PermissionRoute resource="automation_rules" action="read">
                       <Automation />
                     </PermissionRoute>
                   </MainLayout>
@@ -456,11 +457,41 @@ const AppRouter = () => {
           />
 
           <Route
+            path="/automation/new"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="automation_rules" action="create">
+                      <AutomationForm mode="create" />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/automation/:id/edit"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="automation_rules" action="update">
+                      <AutomationForm mode="edit" />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          {/* <Route
             path="/automation/:id/flow"
             element={
               <PrivateRoute>
                 <CustomerRoute>
-                  <PermissionRoute resource="automations" action="update">
+                  <PermissionRoute resource="automation_rules" action="update">
                     <AutomationFlowEditor />
                   </PermissionRoute>
                 </CustomerRoute>

--- a/src/types/automation/automation.ts
+++ b/src/types/automation/automation.ts
@@ -122,8 +122,11 @@ export interface AutomationFlowContext {
 export type AutomationEventType =
   | 'conversation_created'
   | 'conversation_updated'
-  | 'message_created'
   | 'conversation_opened'
+  | 'message_created'
+  | 'pipeline_stage_updated'
+  | 'contact_created'
+  | 'contact_updated'
   | 'conversation_resolved'
   | 'conversation_status_changed';
 
@@ -138,6 +141,8 @@ export type AutomationFilterOperator =
   | 'is_greater_than'
   | 'is_less_than'
   | 'days_before'
+  | 'starts_with'
+  | 'attribute_changed'
   | 'is_in'
   | 'is_not_in';
 
@@ -158,7 +163,8 @@ export type AutomationActionType =
   | 'change_priority'
   | 'send_email_transcript'
   | 'assign_to_pipeline'
-  | 'update_pipeline_stage';
+  | 'update_pipeline_stage'
+  | 'create_pipeline_task';
 
 // Flow builder state interface
 export interface AutomationFlowBuilderState {


### PR DESCRIPTION
## Summary

Builds the missing UI for the Rails AutomationRule engine in `evo-ai-frontend-community`. The backend has been production-ready for some time but had no front door — routes were commented out and `src/pages/Customer/Automation/` did not exist. This PR ships Phase 1 (simple-mode CRUD).

What's new:

- `/automation` route active (sidebar entry between Channels and Tutorials, guarded by `automation_rules.read`).
- List page with name, event, status, actions count, plus per-row edit / clone / delete and bulk delete.
- Full-page create / edit form composing three registry-driven builders: event selector (7 events), conditions builder (22 attributes with type-aware operators and async option lookups for pipelines, stages, agents, teams, inboxes, labels), actions builder (all 17 backend actions with per-action Zod schemas).
- React Hook Form + Zod via `zodResolver`, schemas sourced from registries.
- Pessimistic mutations with sonner toasts and refetch (matches Macros pattern).
- pt-BR + en translations; pt / es / fr / it fall back to en automatically via existing `fallbackLng`.
- Capability hook `useAutomationPermissions` (read / create / update / delete / clone) for button-level affordance, plus `<PermissionRoute>` at the route layer.
- Helper text under the event selector pointing users at the canonical `conversation_updated` + `status` condition pattern (parent of the `attribute_changed` follow-up).

What's not in this PR (deferred):

- Phase 2 flow editor — `@xyflow/react` is already installed, types in `src/types/automation/flows.ts` are pre-modeled. Tracked separately.
- `attribute_changed` operator UI — see EVO-1058.
- `AutomationCondition.values` type cleanup — see EVO-1059.

## Security

- Authorization: every mutation handler checks `useUserPermissions().can('automation_rules', '<action>')` before invoking the service. Routes additionally wrapped by `<PermissionRoute>`.
- RBAC resource is `automation_rules` (not `automations`) to match the backend `require_permissions` DSL.
- Validation: dual-layer. RHF + Zod gate the form client-side; backend strong params + model validations are the source of truth. Form schema requires `actions.length >= 1` (UX) while accepting empty `conditions` (matches backend behavior).
- XSS: no `dangerouslySetInnerHTML`. All user-authored strings render via React text nodes or `t()`.
- Tenant isolation: backend handles via `accounts/:account_id` scoping; frontend goes through the existing `services/core/api` axios instance which prepends the account scope.
- No new secrets, env vars, or hardcoded URLs.

## Test plan

Automated:

- `pnpm exec tsc -b --noEmit` — clean.
- `pnpm lint` against new files — clean.
- `pnpm test src/pages/Customer/Automation src/components/automation` — 20/20 passing (registries, ConditionRow, ActionRow, AutomationForm).

Manual smoke (user-validated):

- Create rule with event `pipeline_stage_updated`, condition `pipeline_stage_id equal_to <stage>`, action `add_label`.
- Move a conversation into the target stage.
- Confirmed the label is applied automatically.
- List, edit, clone, delete flows exercised.
- Toggle pt-BR ↔ en — all strings translated, including the sidebar entry.

## Changed Files

New (~25):

- `src/pages/Customer/Automation/{index.tsx, AutomationForm.tsx, AutomationForm.spec.tsx}`
- `src/pages/Customer/Automation/registries/{conditionTypeRegistry, conditionAttributeRegistry, actionRegistry, index}.ts`
- `src/pages/Customer/Automation/registries/{actionRegistry, conditionAttributeRegistry}.spec.ts`
- `src/components/automation/{EventSelector, ConditionRow, ConditionsBuilder, ActionRow, ActionsBuilder, AutomationsHeader, AutomationsTable, AutomationsPagination}.tsx`
- `src/components/automation/{ConditionRow, ActionRow}.spec.tsx`
- `src/components/automation/index.ts`
- `src/hooks/automation/{useAutomationFormData, useAutomationPermissions, index}.ts`
- `src/i18n/locales/{en, pt-BR}/automation.json`

Modified:

- `src/types/automation/automation.ts` — additive type fixes (3 missing events, 1 missing action, 2 missing operators).
- `src/routes/index.tsx` — uncomment the existing `/automation` block, add `/automation/new` and `/automation/:id/edit` routes, fix RBAC resource string from `automations` to `automation_rules`.
- `src/i18n/config.ts` — register the `automation` namespace on en + pt-BR.
- `src/i18n/locales/{en, pt-BR, pt, es, fr, it}/layout.json` — add `menu.customer.automation` key.
- `src/components/layout/config/menuItems.ts` — add the top-level sidebar entry.

## Linked Issue

- EVO-1057 — parent feature card: https://linear.app/evoai/issue/EVO-1057

Follow-up cards filed during the QA review:

- EVO-1058 — `attribute_changed` operator UI: https://linear.app/evoai/issue/EVO-1058
- EVO-1059 — `AutomationCondition.values` type cleanup: https://linear.app/evoai/issue/EVO-1059

## Summary by Sourcery

Introduce a frontend UI for managing automation rules, including list and CRUD pages wired to the existing backend with permissions and localization support.

New Features:
- Add /automation, /automation/new, and /automation/:id/edit routes with corresponding list and form pages for automation rules.
- Provide registry-driven builders for events, conditions, and actions, including option loading hooks and per-action validation schemas.
- Expose reusable automation UI components and hooks (table, header, pagination, form data loader, permissions) for use across the customer area.

Enhancements:
- Extend automation types with additional events, operators, and actions to align the frontend model with backend capabilities.
- Add an Automation entry to the customer sidebar menu and register the automation i18n namespace for supported locales.

Documentation:
- Add automation-specific translation resources and layout labels for multiple locales.

Tests:
- Add unit tests for the automation form, condition/action registries, and condition/action row components to validate configuration and rendering.