### PR TITLE
fix(media): force file download via fetch+blob instead of window.open (EVO-999)

### DIFF
--- a/src/components/chat/messages/MessageFile.tsx
+++ b/src/components/chat/messages/MessageFile.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from '@evoapi/design-system/button';
 import { Download, FileText, File, Image, Music, Video } from 'lucide-react';
+import { toast } from 'sonner';
 import { Attachment } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
 import { openAttachmentInNewTab } from '@/components/chat/messages/utils/openAttachmentInNewTab';
@@ -22,6 +23,9 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
       const response = await fetch(url, { mode: 'cors' });
       if (!response.ok) {
         console.warn('[MessageFile] non-ok response:', response.status, url);
+        toast.warning(t('messages.messageFile.downloadFallbackOpenedInNewTab'), {
+          description: t('messages.messageFile.downloadFallbackReason.serverError', { status: response.status }),
+        });
         openAttachmentInNewTab({ url, filename });
         return;
       }
@@ -34,6 +38,9 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
       setTimeout(() => URL.revokeObjectURL(blobUrl), 0);
     } catch (err) {
       console.warn('[MessageFile] download fallback after fetch error:', err);
+      toast.warning(t('messages.messageFile.downloadFallbackOpenedInNewTab'), {
+        description: t('messages.messageFile.downloadFallbackReason.network'),
+      });
       openAttachmentInNewTab({ url, filename });
     }
   };

--- a/src/components/chat/messages/MessageFile.tsx
+++ b/src/components/chat/messages/MessageFile.tsx
@@ -20,14 +20,20 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
 
     try {
       const response = await fetch(url, { mode: 'cors' });
+      if (!response.ok) {
+        console.warn('[MessageFile] non-ok response:', response.status, url);
+        openAttachmentInNewTab({ url, filename });
+        return;
+      }
       const blob = await response.blob();
       const blobUrl = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = blobUrl;
       link.download = filename;
       link.click();
-      URL.revokeObjectURL(blobUrl);
-    } catch {
+      setTimeout(() => URL.revokeObjectURL(blobUrl), 0);
+    } catch (err) {
+      console.warn('[MessageFile] download fallback after fetch error:', err);
       openAttachmentInNewTab({ url, filename });
     }
   };

--- a/src/components/chat/messages/MessageFile.tsx
+++ b/src/components/chat/messages/MessageFile.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Button } from '@evoapi/design-system/button';
 import { Download, FileText, File, Image, Music, Video } from 'lucide-react';
-import { toast } from 'sonner';
 import { Attachment } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
 import { openAttachmentInNewTab } from '@/components/chat/messages/utils/openAttachmentInNewTab';
@@ -13,16 +12,23 @@ interface MessageFileProps {
 const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
   const { t } = useLanguage('chat');
 
-  const downloadFile = (attachment: Attachment) => {
-    const result = openAttachmentInNewTab({
-      url: attachment.data_url,
-      filename: attachment.fallback_title || t('messages.messageFile.fileFallback'),
-    });
+  const downloadFile = async (attachment: Attachment) => {
+    const url = attachment.data_url?.trim();
+    if (!url) return;
 
-    if (result === 'download-fallback') {
-      toast.info(t('messages.messageImage.downloadStarted'), {
-        description: attachment.fallback_title || t('messages.messageFile.fileFallbackTitle'),
-      });
+    const filename = attachment.fallback_title || t('messages.messageFile.fileFallback');
+
+    try {
+      const response = await fetch(url, { mode: 'cors' });
+      const blob = await response.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = blobUrl;
+      link.download = filename;
+      link.click();
+      URL.revokeObjectURL(blobUrl);
+    } catch {
+      openAttachmentInNewTab({ url, filename });
     }
   };
 

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -61,7 +61,12 @@
     "messageFile": {
       "fileFallback": "file",
       "unknownSize": "Unknown size",
-      "fileFallbackTitle": "File"
+      "fileFallbackTitle": "File",
+      "downloadFallbackOpenedInNewTab": "File opened in new tab",
+      "downloadFallbackReason": {
+        "serverError": "Server returned {{status}} — could not download directly.",
+        "network": "Network error or CORS block — could not download directly."
+      }
     },
     "messageImage": {
       "downloadStarted": "Download started",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -60,7 +60,12 @@
     "messageFile": {
       "fileFallback": "archivo",
       "unknownSize": "Tamaño desconocido",
-      "fileFallbackTitle": "Archivo"
+      "fileFallbackTitle": "Archivo",
+      "downloadFallbackOpenedInNewTab": "Archivo abierto en nueva pestaña",
+      "downloadFallbackReason": {
+        "serverError": "El servidor devolvió {{status}} — no se pudo descargar directamente.",
+        "network": "Error de red o bloqueo de CORS — no se pudo descargar directamente."
+      }
     },
     "messageImage": {
       "downloadStarted": "Descarga iniciada",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -60,7 +60,12 @@
     "messageFile": {
       "fileFallback": "fichier",
       "unknownSize": "Taille inconnue",
-      "fileFallbackTitle": "Fichier"
+      "fileFallbackTitle": "Fichier",
+      "downloadFallbackOpenedInNewTab": "Fichier ouvert dans un nouvel onglet",
+      "downloadFallbackReason": {
+        "serverError": "Le serveur a renvoyé {{status}} — impossible de télécharger directement.",
+        "network": "Erreur réseau ou blocage CORS — impossible de télécharger directement."
+      }
     },
     "messageImage": {
       "downloadStarted": "Téléchargement démarré",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -60,7 +60,12 @@
     "messageFile": {
       "fileFallback": "file",
       "unknownSize": "Dimensione sconosciuta",
-      "fileFallbackTitle": "File"
+      "fileFallbackTitle": "File",
+      "downloadFallbackOpenedInNewTab": "File aperto in una nuova scheda",
+      "downloadFallbackReason": {
+        "serverError": "Il server ha restituito {{status}} — impossibile scaricare direttamente.",
+        "network": "Errore di rete o blocco CORS — impossibile scaricare direttamente."
+      }
     },
     "messageImage": {
       "downloadStarted": "Download avviato",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -61,7 +61,12 @@
     "messageFile": {
       "fileFallback": "arquivo",
       "unknownSize": "Tamanho desconhecido",
-      "fileFallbackTitle": "Arquivo"
+      "fileFallbackTitle": "Arquivo",
+      "downloadFallbackOpenedInNewTab": "Arquivo aberto em nova aba",
+      "downloadFallbackReason": {
+        "serverError": "Servidor retornou {{status}} — não foi possível baixar diretamente.",
+        "network": "Falha de rede ou bloqueio de CORS — não foi possível baixar diretamente."
+      }
     },
     "messageImage": {
       "downloadStarted": "Download iniciado",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -60,7 +60,12 @@
     "messageFile": {
       "fileFallback": "arquivo",
       "unknownSize": "Tamanho desconhecido",
-      "fileFallbackTitle": "Arquivo"
+      "fileFallbackTitle": "Arquivo",
+      "downloadFallbackOpenedInNewTab": "Ficheiro aberto em nova aba",
+      "downloadFallbackReason": {
+        "serverError": "O servidor retornou {{status}} — não foi possível descarregar diretamente.",
+        "network": "Falha de rede ou bloqueio de CORS — não foi possível descarregar diretamente."
+      }
     },
     "messageImage": {
       "downloadStarted": "Download iniciado",


### PR DESCRIPTION
## Summary

- `MessageFile.tsx`: replaced `window.open` with fetch+blob download — forces real download instead of opening file in new browser tab
- `MessageFile.tsx`: added `toast.warning` on both fallback paths (`!response.ok` and CORS/network catch) so the user knows the file is being opened in a new tab and why
- i18n keys added for all 6 locales (`downloadFallbackOpenedInNewTab`, `downloadFallbackReason.serverError`, `downloadFallbackReason.network`)

> **Infrastructure prerequisite:** this fix depends on CORS being configured on the storage backend (`Access-Control-Allow-Origin` allowing the front-end domain). Without it, the download falls back to opening the file in a new tab — but now with an informative toast. Validate in staging that direct download works before merging.

## Validation

- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` → no errors
- `evo-ai-frontend-community: pnpm exec eslint src/components/chat/messages/MessageFile.tsx` → no errors

## Changed Files

- `src/components/chat/messages/MessageFile.tsx`
- `src/i18n/locales/en/chat.json`
- `src/i18n/locales/es/chat.json`
- `src/i18n/locales/fr/chat.json`
- `src/i18n/locales/it/chat.json`
- `src/i18n/locales/pt/chat.json`
- `src/i18n/locales/pt-BR/chat.json`

## Related PRs

- evo-ai-crm-community#47 (`fix/EVO-999` — backend changes)

## Linked Issue

- EVO-999