### PR TITLE
feat(chat): show contact phone number in conversation list and header (EVO-988)

### DIFF
--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -88,6 +88,12 @@ const ChatHeader = ({
   const isArchived = Boolean(conversation.custom_attributes?.archived);
 
   const inboxName = conversation.inbox?.name || '';
+  const rawPhone = conversation.contact?.phone_number;
+  const phoneDisplay = rawPhone
+    ? rawPhone.startsWith('+')
+      ? rawPhone
+      : `+${rawPhone}`
+    : null;
 
   const renderConversationStatusDropdown = () => {
     return (
@@ -288,9 +294,19 @@ const ChatHeader = ({
             <ContactAvatar contact={conversation.contact} />
           </div>
           <div>
-            <h3 className="font-semibold">
-              {conversation.contact?.name || t('chatHeader.contactNoName')}
-            </h3>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="font-semibold">
+                {conversation.contact?.name || t('chatHeader.contactNoName')}
+              </h3>
+              {phoneDisplay && (
+                <span
+                  className="text-sm text-muted-foreground"
+                  title={t('chatHeader.whatsappNumber')}
+                >
+                  {phoneDisplay}
+                </span>
+              )}
+            </div>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               {inboxName && (
                 <>

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -31,6 +31,8 @@ import {
 import { Conversation } from '@/types/chat/api';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
 import { getStatusLabel, isPendingStatus } from '@/utils/chat/conversationStatus';
+import { isPhoneBearingChannel } from '@/utils/channelUtils';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface ChatHeaderProps {
@@ -88,11 +90,8 @@ const ChatHeader = ({
   const isArchived = Boolean(conversation.custom_attributes?.archived);
 
   const inboxName = conversation.inbox?.name || '';
-  const rawPhone = conversation.contact?.phone_number;
-  const phoneDisplay = rawPhone
-    ? rawPhone.startsWith('+')
-      ? rawPhone
-      : `+${rawPhone}`
+  const phoneDisplay = isPhoneBearingChannel(conversation.inbox?.channel_type)
+    ? formatContactPhone(conversation.contact?.phone_number)
     : null;
 
   const renderConversationStatusDropdown = () => {
@@ -301,7 +300,8 @@ const ChatHeader = ({
               {phoneDisplay && (
                 <span
                   className="text-sm text-muted-foreground"
-                  title={t('chatHeader.whatsappNumber')}
+                  title={t('chatHeader.phoneNumber')}
+                  aria-label={`${t('chatHeader.phoneNumber')}: ${phoneDisplay}`}
                 >
                   {phoneDisplay}
                 </span>

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -725,6 +725,12 @@ const ChatSidebar = ({
               const channelType =
                 conversation.inbox?.channel_type || conversation.inbox?.channel_type;
               const channelProvider = conversation.inbox?.provider;
+              const rawPhone = conversation.contact?.phone_number;
+              const phoneDisplay = rawPhone
+                ? rawPhone.startsWith('+')
+                  ? rawPhone
+                  : `+${rawPhone}`
+                : null;
 
               return renderConversationContextMenu(
                 conversation,
@@ -775,6 +781,15 @@ const ChatSidebar = ({
                             </span>
                           </div>
                         </div>
+
+                        {phoneDisplay && (
+                          <p
+                            className="text-xs text-muted-foreground truncate"
+                            title={t('chatSidebar.whatsappNumber')}
+                          >
+                            {phoneDisplay}
+                          </p>
+                        )}
 
                         <p className="text-sm text-muted-foreground truncate">
                           {getLastMessage(conversation)}

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -40,6 +40,8 @@ import {
   senderNameFromAttributes,
 } from '@/utils/chat/mediaLabels';
 import { formatConversationTime, formatDetailedTime } from '@/utils/time/timeHelpers';
+import { isPhoneBearingChannel } from '@/utils/channelUtils';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { ConversationSkeleton } from '../loading-states';
 import { NoConversations } from '../empty-states';
 import ContactAvatar from '../contact/ContactAvatar';
@@ -725,11 +727,8 @@ const ChatSidebar = ({
               const channelType =
                 conversation.inbox?.channel_type || conversation.inbox?.channel_type;
               const channelProvider = conversation.inbox?.provider;
-              const rawPhone = conversation.contact?.phone_number;
-              const phoneDisplay = rawPhone
-                ? rawPhone.startsWith('+')
-                  ? rawPhone
-                  : `+${rawPhone}`
+              const phoneDisplay = isPhoneBearingChannel(channelType)
+                ? formatContactPhone(conversation.contact?.phone_number)
                 : null;
 
               return renderConversationContextMenu(
@@ -785,7 +784,8 @@ const ChatSidebar = ({
                         {phoneDisplay && (
                           <p
                             className="text-xs text-muted-foreground truncate"
-                            title={t('chatSidebar.whatsappNumber')}
+                            title={t('chatSidebar.phoneNumber')}
+                            aria-label={`${t('chatSidebar.phoneNumber')}: ${phoneDisplay}`}
                           >
                             {phoneDisplay}
                           </p>

--- a/src/components/chat/contact-sidebar/ContactDetails.tsx
+++ b/src/components/chat/contact-sidebar/ContactDetails.tsx
@@ -137,7 +137,8 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ contact }) => {
           {contact?.phone_number && (
             <InfoField
               label={t('contactSidebar.contactDetails.fields.phone')}
-              value={formatContactPhone(contact.phone_number) ?? contact.phone_number}
+              value={formatContactPhone(contact.phone_number)}
+              copyValue={contact.phone_number}
               icon={<Phone className="h-4 w-4" />}
               copyable
             />
@@ -300,14 +301,26 @@ interface InfoFieldProps {
   value?: string | null;
   icon?: React.ReactNode;
   copyable?: boolean;
+  // Optional override for what `handleCopy` writes to the clipboard. Use this
+  // when `value` is a presentation-only string (e.g. a formatted phone) and
+  // the unformatted raw should be copied so integrations like `wa.me/<digits>`
+  // keep working.
+  copyValue?: string | null;
 }
 
-const InfoField: React.FC<InfoFieldProps> = ({ label, value, icon, copyable = false }) => {
+const InfoField: React.FC<InfoFieldProps> = ({
+  label,
+  value,
+  icon,
+  copyable = false,
+  copyValue,
+}) => {
   const { t } = useLanguage('chat');
 
   const handleCopy = () => {
-    if (value) {
-      navigator.clipboard.writeText(value);
+    const target = copyValue ?? value;
+    if (target) {
+      navigator.clipboard.writeText(target);
       toast.success(t('contactSidebar.contactDetails.copiedToClipboard'));
     }
   };

--- a/src/components/chat/contact-sidebar/ContactDetails.tsx
+++ b/src/components/chat/contact-sidebar/ContactDetails.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { useConversations } from '@/hooks/chat/useConversations';
 
 import { contactsService } from '@/services/contacts/contactsService';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 
 import { Button } from '@evoapi/design-system/button';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@evoapi/design-system/card';
@@ -136,7 +137,7 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ contact }) => {
           {contact?.phone_number && (
             <InfoField
               label={t('contactSidebar.contactDetails.fields.phone')}
-              value={contact.phone_number}
+              value={formatContactPhone(contact.phone_number) ?? contact.phone_number}
               icon={<Phone className="h-4 w-4" />}
               copyable
             />

--- a/src/components/chat/contact-sidebar/ContactHeader.tsx
+++ b/src/components/chat/contact-sidebar/ContactHeader.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Phone, Mail, MapPin, Hash } from 'lucide-react';
 import { Contact } from '@/types/chat/api';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface ContactHeaderProps {
@@ -34,7 +35,7 @@ const ContactHeader: React.FC<ContactHeaderProps> = ({ contact }) => {
             {contact?.phone_number && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Phone className="h-3 w-3 flex-shrink-0" />
-                <span className="truncate">{contact.phone_number}</span>
+                <span className="truncate">{formatContactPhone(contact.phone_number)}</span>
               </div>
             )}
             {contact?.identifier && (

--- a/src/components/contacts/ContactCard.tsx
+++ b/src/components/contacts/ContactCard.tsx
@@ -3,6 +3,7 @@ import { Button, Card, CardContent } from '@evoapi/design-system';
 import { Edit, MessageSquare, Activity, Eye } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import ContactStatusBadge from './ContactStatusBadge';
 import ContactTagsList from './ContactTagsList';
 import ContactTypeBadge from './ContactTypeBadge';
@@ -54,7 +55,7 @@ export default function ContactCard({
           </div>
           <div className="flex items-center justify-between">
             <span>{t('card.phone')}</span>
-            <span className="font-mono">{contact.phone_number}</span>
+            <span className="font-mono">{formatContactPhone(contact.phone_number)}</span>
           </div>
           {contact.labels && contact.labels.length > 0 && (
             <div className="pt-2">

--- a/src/components/contacts/ContactDetails.tsx
+++ b/src/components/contacts/ContactDetails.tsx
@@ -41,6 +41,7 @@ import {
 // import { ScheduledActionsList } from '@/components/scheduledActions';
 import { Contact } from '@/types/contacts';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import ContactPipelineItem from '@/components/pipelines/ContactPipelineItem';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
@@ -248,7 +249,7 @@ export default function ContactDetails({
               {contact.phone_number && (
                 <div className="flex items-center flex-wrap gap-2 mb-2">
                   <Phone className="h-4 w-4" />
-                  <span>{contact.phone_number}</span>
+                  <span>{formatContactPhone(contact.phone_number)}</span>
                 </div>
               )}
             </div>
@@ -348,7 +349,7 @@ export default function ContactDetails({
                                 </div>
                                 <div className="text-sm text-muted-foreground space-y-1">
                                   {company.email && <div className="truncate">{company.email}</div>}
-                                  {company.phone_number && <div>{company.phone_number}</div>}
+                                  {company.phone_number && <div>{formatContactPhone(company.phone_number)}</div>}
                                 </div>
                               </div>
                               <ContactTypeBadge type="company" />
@@ -407,7 +408,7 @@ export default function ContactDetails({
                                 </div>
                                 <div className="text-sm text-muted-foreground space-y-1">
                                   {person.email && <div className="truncate">{person.email}</div>}
-                                  {person.phone_number && <div>{person.phone_number}</div>}
+                                  {person.phone_number && <div>{formatContactPhone(person.phone_number)}</div>}
                                 </div>
                               </div>
                               <ContactTypeBadge type="person" />

--- a/src/components/contacts/ContactMergeModal.tsx
+++ b/src/components/contacts/ContactMergeModal.tsx
@@ -18,6 +18,7 @@ import {
 } from '@evoapi/design-system';
 import { Contact } from '@/types/contacts';
 import { Mail, Phone, Building2, User, Calendar } from 'lucide-react';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 
 interface ContactMergeModalProps {
   open: boolean;
@@ -121,7 +122,7 @@ export default function ContactMergeModal({
                           {contact.phone_number && (
                             <div className="flex items-center gap-2">
                               <Phone className="h-3 w-3" />
-                              <span>{contact.phone_number}</span>
+                              <span>{formatContactPhone(contact.phone_number)}</span>
                             </div>
                           )}
 

--- a/src/components/contacts/ContactMergeSelectorModal.tsx
+++ b/src/components/contacts/ContactMergeSelectorModal.tsx
@@ -17,6 +17,7 @@ import {
 import { Contact } from '@/types/contacts';
 import { contactsService } from '@/services/contacts/contactsService';
 import { Search, Mail, Phone, Building2, User, Loader2 } from 'lucide-react';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { toast } from 'sonner';
 
 interface ContactMergeSelectorModalProps {
@@ -158,7 +159,7 @@ export default function ContactMergeSelectorModal({
                       {contact.phone_number && (
                         <div className="flex items-center gap-2">
                           <Phone className="h-3 w-3 shrink-0" />
-                          <span>{contact.phone_number}</span>
+                          <span>{formatContactPhone(contact.phone_number)}</span>
                         </div>
                       )}
                     </div>

--- a/src/components/contacts/ContactsTable.tsx
+++ b/src/components/contacts/ContactsTable.tsx
@@ -3,6 +3,7 @@ import { MessageSquare, Edit, Users, Activity } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import { BaseTable, TableColumn, TableAction } from '@/components/base';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import ContactStatusBadge from './ContactStatusBadge';
 import ContactTagsList from './ContactTagsList';
 import ContactTypeBadge from './ContactTypeBadge';
@@ -73,7 +74,7 @@ export default function ContactsTable({
                 <span className="text-muted-foreground/50">|</span>
               )}
               {contact.phone_number && (
-                <span className="whitespace-nowrap">{contact.phone_number}</span>
+                <span className="whitespace-nowrap">{formatContactPhone(contact.phone_number)}</span>
               )}
             </div>
           </div>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -288,7 +288,8 @@
     "contactNoName": "Contact without name",
     "status": "Status:",
     "openConversation": "Open Conversation",
-    "closeConversation": "Close conversation"
+    "closeConversation": "Close conversation",
+    "whatsappNumber": "WhatsApp number"
   },
   "chatSidebar": {
     "searchPlaceholder": "Search conversations...",
@@ -318,7 +319,8 @@
       "noMessages": "No messages",
       "noContent": "Message without content"
     },
-    "contactNoName": "Contact without name"
+    "contactNoName": "Contact without name",
+    "whatsappNumber": "WhatsApp number"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -289,7 +289,7 @@
     "status": "Status:",
     "openConversation": "Open Conversation",
     "closeConversation": "Close conversation",
-    "whatsappNumber": "WhatsApp number"
+    "phoneNumber": "Phone number"
   },
   "chatSidebar": {
     "searchPlaceholder": "Search conversations...",
@@ -320,7 +320,7 @@
       "noContent": "Message without content"
     },
     "contactNoName": "Contact without name",
-    "whatsappNumber": "WhatsApp number"
+    "phoneNumber": "Phone number"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -283,7 +283,8 @@
     "contactNoName": "Contacto sin nombre",
     "status": "Estado:",
     "openConversation": "Abrir Conversación",
-    "closeConversation": "Cerrar conversación"
+    "closeConversation": "Cerrar conversación",
+    "phoneNumber": "Número de teléfono"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversaciones...",
@@ -313,7 +314,8 @@
       "noMessages": "Sin mensajes",
       "noContent": "Mensaje sin contenido"
     },
-    "contactNoName": "Contacto sin nombre"
+    "contactNoName": "Contacto sin nombre",
+    "phoneNumber": "Número de teléfono"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -283,7 +283,8 @@
     "contactNoName": "Contact sans nom",
     "status": "Statut :",
     "openConversation": "Ouvrir la Conversation",
-    "closeConversation": "Fermer la conversation"
+    "closeConversation": "Fermer la conversation",
+    "phoneNumber": "Numéro de téléphone"
   },
   "chatSidebar": {
     "searchPlaceholder": "Rechercher des conversations...",
@@ -313,7 +314,8 @@
       "noMessages": "Aucun message",
       "noContent": "Message sans contenu"
     },
-    "contactNoName": "Contact sans nom"
+    "contactNoName": "Contact sans nom",
+    "phoneNumber": "Numéro de téléphone"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -283,7 +283,8 @@
     "contactNoName": "Contatto senza nome",
     "status": "Stato:",
     "openConversation": "Apri Conversazione",
-    "closeConversation": "Chiudi conversazione"
+    "closeConversation": "Chiudi conversazione",
+    "phoneNumber": "Numero di telefono"
   },
   "chatSidebar": {
     "searchPlaceholder": "Cerca conversazioni...",
@@ -313,7 +314,8 @@
       "noMessages": "Nessun messaggio",
       "noContent": "Messaggio senza contenuto"
     },
-    "contactNoName": "Contatto senza nome"
+    "contactNoName": "Contatto senza nome",
+    "phoneNumber": "Numero di telefono"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -288,7 +288,8 @@
     "contactNoName": "Contato sem nome",
     "status": "Status:",
     "openConversation": "Abrir Conversa",
-    "closeConversation": "Fechar conversa"
+    "closeConversation": "Fechar conversa",
+    "whatsappNumber": "Número de WhatsApp"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversas...",
@@ -318,7 +319,8 @@
       "noMessages": "Sem mensagens",
       "noContent": "Mensagem sem conteúdo"
     },
-    "contactNoName": "Contato sem nome"
+    "contactNoName": "Contato sem nome",
+    "whatsappNumber": "Número de WhatsApp"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -289,7 +289,7 @@
     "status": "Status:",
     "openConversation": "Abrir Conversa",
     "closeConversation": "Fechar conversa",
-    "whatsappNumber": "Número de WhatsApp"
+    "phoneNumber": "Número de telefone"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversas...",
@@ -320,7 +320,7 @@
       "noContent": "Mensagem sem conteúdo"
     },
     "contactNoName": "Contato sem nome",
-    "whatsappNumber": "Número de WhatsApp"
+    "phoneNumber": "Número de telefone"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -283,7 +283,8 @@
     "contactNoName": "Contato sem nome",
     "status": "Status:",
     "openConversation": "Abrir Conversa",
-    "closeConversation": "Fechar conversa"
+    "closeConversation": "Fechar conversa",
+    "phoneNumber": "Número de telefone"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversas...",
@@ -313,7 +314,8 @@
       "noMessages": "Sem mensagens",
       "noContent": "Mensagem sem conteúdo"
     },
-    "contactNoName": "Contato sem nome"
+    "contactNoName": "Contato sem nome",
+    "phoneNumber": "Número de telefone"
   },
   "chatTabs": {
     "chat": "Chat"

--- a/src/utils/channelUtils.spec.ts
+++ b/src/utils/channelUtils.spec.ts
@@ -9,6 +9,15 @@ describe('isPhoneBearingChannel', () => {
     expect(isPhoneBearingChannel('Channel::Telegram')).toBe(true);
   });
 
+  it('returns true for all WhatsApp variants (legacy, Cloud, 360Dialog)', () => {
+    expect(isPhoneBearingChannel('Channel::WhatsappCloud')).toBe(true);
+    expect(isPhoneBearingChannel('Channel::Whatsapp360Dialog')).toBe(true);
+    expect(isPhoneBearingChannel('whatsapp_cloud')).toBe(true);
+    expect(isPhoneBearingChannel('whatsappcloud')).toBe(true);
+    expect(isPhoneBearingChannel('whatsapp_360dialog')).toBe(true);
+    expect(isPhoneBearingChannel('whatsapp360dialog')).toBe(true);
+  });
+
   it('returns true for lowercase channel type aliases the API can return', () => {
     expect(isPhoneBearingChannel('whatsapp')).toBe(true);
     expect(isPhoneBearingChannel('twiliosms')).toBe(true);

--- a/src/utils/channelUtils.spec.ts
+++ b/src/utils/channelUtils.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { isPhoneBearingChannel } from './channelUtils';
+
+describe('isPhoneBearingChannel', () => {
+  it('returns true for canonical Channel:: phone channel types', () => {
+    expect(isPhoneBearingChannel('Channel::Whatsapp')).toBe(true);
+    expect(isPhoneBearingChannel('Channel::TwilioSms')).toBe(true);
+    expect(isPhoneBearingChannel('Channel::Sms')).toBe(true);
+    expect(isPhoneBearingChannel('Channel::Telegram')).toBe(true);
+  });
+
+  it('returns true for lowercase channel type aliases the API can return', () => {
+    expect(isPhoneBearingChannel('whatsapp')).toBe(true);
+    expect(isPhoneBearingChannel('twiliosms')).toBe(true);
+    expect(isPhoneBearingChannel('twilio_sms')).toBe(true);
+    expect(isPhoneBearingChannel('sms')).toBe(true);
+    expect(isPhoneBearingChannel('telegram')).toBe(true);
+  });
+
+  it('returns false for non-phone channels', () => {
+    expect(isPhoneBearingChannel('Channel::WebWidget')).toBe(false);
+    expect(isPhoneBearingChannel('Channel::Email')).toBe(false);
+    expect(isPhoneBearingChannel('Channel::Api')).toBe(false);
+    expect(isPhoneBearingChannel('Channel::FacebookPage')).toBe(false);
+    expect(isPhoneBearingChannel('Channel::Instagram')).toBe(false);
+    expect(isPhoneBearingChannel('Channel::Line')).toBe(false);
+    expect(isPhoneBearingChannel('Channel::TwitterProfile')).toBe(false);
+    expect(isPhoneBearingChannel('email')).toBe(false);
+    expect(isPhoneBearingChannel('webwidget')).toBe(false);
+  });
+
+  it('returns false for empty or nullish input', () => {
+    expect(isPhoneBearingChannel('')).toBe(false);
+    expect(isPhoneBearingChannel(null)).toBe(false);
+    expect(isPhoneBearingChannel(undefined)).toBe(false);
+  });
+
+  it('returns false for unknown channel types (defaults closed)', () => {
+    expect(isPhoneBearingChannel('Channel::MysteryChannel')).toBe(false);
+    expect(isPhoneBearingChannel('random_string')).toBe(false);
+  });
+});

--- a/src/utils/channelUtils.ts
+++ b/src/utils/channelUtils.ts
@@ -37,10 +37,16 @@ const CHANNEL_TYPE_TRANSLATIONS: Record<string, string> = {
 // so we never render a phone field for website/email/API contacts.
 const PHONE_BEARING_CHANNEL_TYPES = new Set<string>([
   'Channel::Whatsapp',
+  'Channel::WhatsappCloud',
+  'Channel::Whatsapp360Dialog',
   'Channel::TwilioSms',
   'Channel::Sms',
   'Channel::Telegram',
   'whatsapp',
+  'whatsappcloud',
+  'whatsapp_cloud',
+  'whatsapp360dialog',
+  'whatsapp_360dialog',
   'twiliosms',
   'twilio_sms',
   'sms',

--- a/src/utils/channelUtils.ts
+++ b/src/utils/channelUtils.ts
@@ -32,6 +32,26 @@ const CHANNEL_TYPE_TRANSLATIONS: Record<string, string> = {
   'twilio_sms': 'SMS - Twilio',
 };
 
+// Channel types where a phone number is the contact's primary identifier.
+// Used to gate UI affordances (e.g. showing the phone in conversation lists)
+// so we never render a phone field for website/email/API contacts.
+const PHONE_BEARING_CHANNEL_TYPES = new Set<string>([
+  'Channel::Whatsapp',
+  'Channel::TwilioSms',
+  'Channel::Sms',
+  'Channel::Telegram',
+  'whatsapp',
+  'twiliosms',
+  'twilio_sms',
+  'sms',
+  'telegram',
+]);
+
+export function isPhoneBearingChannel(channelType?: string | null): boolean {
+  if (!channelType) return false;
+  return PHONE_BEARING_CHANNEL_TYPES.has(channelType);
+}
+
 // Provider-specific translations for detailed display
 const PROVIDER_TRANSLATIONS: Record<string, string> = {
   'whatsapp_cloud': 'WhatsApp Cloud',

--- a/src/utils/contact/formatContactPhone.spec.ts
+++ b/src/utils/contact/formatContactPhone.spec.ts
@@ -23,24 +23,26 @@ describe('formatContactPhone', () => {
     expect(formatContactPhone('+551133334444')).toBe('+55 11 3333-4444');
   });
 
-  it('strips non-digit punctuation before formatting', () => {
-    // Without country code the 11 digits fall through to the generic +digits
-    // branch since we cannot safely infer BR vs. US from length alone.
-    expect(formatContactPhone('(11) 99999-9999')).toBe('+11999999999');
+  it('strips non-digit punctuation only when the resulting digits match a BR E.164 pattern', () => {
+    // Already in E.164 with BR DDI → formatted.
     expect(formatContactPhone('+55 (11) 99999-9999')).toBe('+55 11 99999-9999');
+    // Local number without DDI → returned as-is. Guessing the country from
+    // length produced misleading displays (e.g. `+11999999999` suggests US),
+    // so we leave the original string untouched.
+    expect(formatContactPhone('(11) 99999-9999')).toBe('(11) 99999-9999');
   });
 
-  it('falls back to a plain +digits string for non-BR numbers', () => {
-    expect(formatContactPhone('12155551234')).toBe('+12155551234');
+  it('returns the original string for non-BR numbers (no automatic + prefix)', () => {
+    expect(formatContactPhone('12155551234')).toBe('12155551234');
     expect(formatContactPhone('+12155551234')).toBe('+12155551234');
   });
 
-  it('preserves the leading + when input is already prefixed', () => {
+  it('preserves the leading + when input is already prefixed and BR-formatted', () => {
     expect(formatContactPhone('+5511999999999')).toBe('+55 11 99999-9999');
   });
 
-  it('prepends + when missing', () => {
+  it('leaves short or unrecognised digit strings untouched', () => {
+    expect(formatContactPhone('12345')).toBe('12345');
     expect(formatContactPhone('5511999999999')).toBe('+55 11 99999-9999');
-    expect(formatContactPhone('12345')).toBe('+12345');
   });
 });

--- a/src/utils/contact/formatContactPhone.spec.ts
+++ b/src/utils/contact/formatContactPhone.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { formatContactPhone } from './formatContactPhone';
+
+describe('formatContactPhone', () => {
+  it('returns null for empty input', () => {
+    expect(formatContactPhone('')).toBeNull();
+    expect(formatContactPhone(null)).toBeNull();
+    expect(formatContactPhone(undefined)).toBeNull();
+  });
+
+  it('returns null when input has no digits', () => {
+    expect(formatContactPhone('abc')).toBeNull();
+    expect(formatContactPhone('---')).toBeNull();
+  });
+
+  it('formats a Brazilian mobile in E.164 with grouping (13 digits)', () => {
+    expect(formatContactPhone('5511999999999')).toBe('+55 11 99999-9999');
+    expect(formatContactPhone('+5511999999999')).toBe('+55 11 99999-9999');
+  });
+
+  it('formats a Brazilian landline in E.164 (12 digits)', () => {
+    expect(formatContactPhone('551133334444')).toBe('+55 11 3333-4444');
+    expect(formatContactPhone('+551133334444')).toBe('+55 11 3333-4444');
+  });
+
+  it('strips non-digit punctuation before formatting', () => {
+    // Without country code the 11 digits fall through to the generic +digits
+    // branch since we cannot safely infer BR vs. US from length alone.
+    expect(formatContactPhone('(11) 99999-9999')).toBe('+11999999999');
+    expect(formatContactPhone('+55 (11) 99999-9999')).toBe('+55 11 99999-9999');
+  });
+
+  it('falls back to a plain +digits string for non-BR numbers', () => {
+    expect(formatContactPhone('12155551234')).toBe('+12155551234');
+    expect(formatContactPhone('+12155551234')).toBe('+12155551234');
+  });
+
+  it('preserves the leading + when input is already prefixed', () => {
+    expect(formatContactPhone('+5511999999999')).toBe('+55 11 99999-9999');
+  });
+
+  it('prepends + when missing', () => {
+    expect(formatContactPhone('5511999999999')).toBe('+55 11 99999-9999');
+    expect(formatContactPhone('12345')).toBe('+12345');
+  });
+});

--- a/src/utils/contact/formatContactPhone.ts
+++ b/src/utils/contact/formatContactPhone.ts
@@ -3,8 +3,10 @@
  *
  * Returns null for empty input so callers can use `phone && ...` to hide the
  * element entirely. The formatter targets Brazilian E.164 numbers (the common
- * case in Evolution) but falls back to `+digits` for anything it does not
- * recognise, so an unexpected shape never blanks the UI silently.
+ * case in Evolution). For anything else the original string is returned
+ * untouched — guessing country code from digit count produced misleading
+ * displays for legacy contacts saved without a DDI (e.g. `(11) 99999-9999`
+ * was being shown as `+11999999999`, which suggests US dialing).
  */
 export function formatContactPhone(raw: string | null | undefined): string | null {
   if (!raw) return null;
@@ -22,5 +24,5 @@ export function formatContactPhone(raw: string | null | undefined): string | nul
     return `+55 ${digits.slice(2, 4)} ${digits.slice(4, 8)}-${digits.slice(8)}`;
   }
 
-  return `+${digits}`;
+  return raw;
 }

--- a/src/utils/contact/formatContactPhone.ts
+++ b/src/utils/contact/formatContactPhone.ts
@@ -1,0 +1,26 @@
+/**
+ * Format a contact phone number for display.
+ *
+ * Returns null for empty input so callers can use `phone && ...` to hide the
+ * element entirely. The formatter targets Brazilian E.164 numbers (the common
+ * case in Evolution) but falls back to `+digits` for anything it does not
+ * recognise, so an unexpected shape never blanks the UI silently.
+ */
+export function formatContactPhone(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  const digits = raw.replace(/\D/g, '');
+  if (!digits) return null;
+
+  // Brazil mobile in E.164: 55 + DDD (2) + 9 + 8 digits = 13 digits.
+  if (digits.length === 13 && digits.startsWith('55')) {
+    return `+55 ${digits.slice(2, 4)} ${digits.slice(4, 9)}-${digits.slice(9)}`;
+  }
+
+  // Brazil landline in E.164: 55 + DDD (2) + 8 digits = 12 digits.
+  if (digits.length === 12 && digits.startsWith('55')) {
+    return `+55 ${digits.slice(2, 4)} ${digits.slice(4, 8)}-${digits.slice(8)}`;
+  }
+
+  return `+${digits}`;
+}


### PR DESCRIPTION
## Summary

Surfaces the contact's phone number in two places so agents can tell at a glance whether they're talking to a domestic or international contact, without opening the details drawer.

- **Conversation list row** (`ChatSidebar.tsx`): small line with the contact phone, rendered between the name row and the last-message preview.
- **Conversation header** (`ChatHeader.tsx`): phone shown inline next to the contact name.
- **Visibility**: rendered only when `conversation.contact.phone_number` is present. Email/website/API conversations don't populate that field, so they remain unchanged.
- **Formatting**: prepend `+` when the stored value doesn't already start with one. No further reformatting (kept minimal on purpose).
- **i18n**: new `whatsappNumber` key under both `chatHeader` and `chatSidebar` namespaces in `pt-BR` and `en` (used as the tooltip on hover).

No backend changes — `phone_number` was already in the conversation payload.

## Validation

- `pnpm exec tsc -b --noEmit` → clean
- `pnpm lint` → no new errors in changed files (existing baseline noise unchanged)
- `pnpm exec vitest run src/components/chat` → 51/51 passed (6 spec files)

## Changed Files

- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/chat/chat-header/ChatHeader.tsx`
- `src/i18n/locales/pt-BR/chat.json`
- `src/i18n/locales/en/chat.json`

## Linked Issue

- [EVO-988](https://linear.app/evoai/issue/EVO-988/conversation-list-show-contacts-whatsapp-number-in-list-and-header)

## Summary by Sourcery

Display WhatsApp contact phone numbers in the chat conversation list and header when available.

New Features:
- Show the contact phone number inline next to the contact name in the chat header when a phone number is present.
- Show the contact phone number in each conversation row in the chat sidebar between the contact name and last message preview.

Enhancements:
- Normalize displayed phone numbers by ensuring they are prefixed with '+' without additional formatting.
- Add localized tooltip labels for the displayed WhatsApp phone number in both English and Brazilian Portuguese chat translations.