### PR TITLE
fix(frontend): send correct notificame verify payload (EVO-986)

### DIFF
--- a/src/hooks/channels/useChannelSubmission.ts
+++ b/src/hooks/channels/useChannelSubmission.ts
@@ -221,9 +221,8 @@ export const useChannelSubmission = (form?: FormData) => {
       } else if (selectedProvider.id === 'notificame') {
         try {
           result = await NotificameService.verifyConnection({
-            api_url: getStr(form, 'api_url'),
-            admin_token: getStr(form, 'admin_token'),
-            instance_id: getStr(form, 'instance_id'),
+            api_token: getStr(form, 'api_token'),
+            channel_id: getStr(form, 'channel_id'),
             phone_number: getStr(form, 'phone_number'),
           });
         } catch (error) {
@@ -458,9 +457,8 @@ export const useChannelSubmission = (form?: FormData) => {
             // verify connection first
             try {
               await NotificameService.verifyConnection({
-                api_url: getStr(form, 'api_url'),
-                admin_token: getStr(form, 'admin_token'),
-                instance_id: getStr(form, 'instance_id'),
+                api_token: getStr(form, 'api_token'),
+                channel_id: getStr(form, 'channel_id'),
                 phone_number: getStr(form, 'phone_number'),
               });
             } catch (error) {

--- a/src/services/channels/notificameService.ts
+++ b/src/services/channels/notificameService.ts
@@ -19,9 +19,8 @@ class NotificameService {
    */
   async verifyConnection(payload: NotificameVerifyPayload): Promise<NotificameVerifyResponse> {
     const response = await api.post(`/channels/notificame/verify`, {
-      api_url: payload.api_url,
-      admin_token: payload.admin_token,
-      instance_id: payload.instance_id,
+      api_token: payload.api_token,
+      channel_id: payload.channel_id,
       phone_number: payload.phone_number,
     });
 

--- a/src/services/channels/notificameService.ts
+++ b/src/services/channels/notificameService.ts
@@ -24,11 +24,16 @@ class NotificameService {
       phone_number: payload.phone_number,
     });
 
+    // Backend envelope is `{ success, data: { channels: [...] }, message }`.
+    // The previous version read `response.data?.channels` (wrong nesting) and
+    // also spread `...response.data` at the end, which clobbered the literal
+    // `success` and `message` with values from a higher level of the response.
+    const body = response.data ?? {};
+    const inner = body.data ?? {};
     return {
-      success: true,
-      message: response.data?.message || 'Conexão verificada com sucesso',
-      channels: response.data?.channels || [],
-      ...response.data,
+      success: body.success ?? true,
+      message: body.message || 'Conexão verificada com sucesso',
+      channels: inner.channels ?? [],
     };
   }
 

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -671,9 +671,8 @@ export interface EmailChannel {
 // ============================================
 
 export interface NotificameVerifyPayload {
-  api_url: string;
-  admin_token: string;
-  instance_id: string;
+  api_token: string;
+  channel_id: string;
   phone_number: string;
 }
 

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -689,6 +689,7 @@ export interface NotificameVerifyResponse {
   success: boolean;
   message?: string;
   error?: string;
+  channels: NotificameChannel[];
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- The Notificame verify call was sending Evolution-style fields (`api_url`, `admin_token`, `instance_id`) that the Notificame form never collects, so the body was always empty strings.
- Switched the verify payload, the service signature and the `NotificameVerifyPayload` type to the real fields the form already collects: `api_token`, `channel_id`, `phone_number`.

## Validation
- `pnpm exec tsc -b --noEmit`
- `pnpm lint` (no new offenses in the touched files; pre-existing `any`/exhaustive-deps warnings unchanged)

## Linked Issue
- https://linear.app/evoai/issue/EVO-986

## Related PRs
- Backend route + controller: see companion PR on `evo-ai-crm-community` `fix/EVO-986`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Send the correct Notificame verification payload fields (`api_token`, `channel_id`, `phone_number`) instead of unused Evolution-style fields.