### PR TITLE
feat(frontend): expose attribute_changed operator with From/To pickers (EVO-1058)

### DIFF
--- a/src/components/automation/ConditionRow.spec.tsx
+++ b/src/components/automation/ConditionRow.spec.tsx
@@ -59,4 +59,31 @@ describe('ConditionRow', () => {
     render(<Wrapper defaultValues={defaults} />);
     expect(screen.getByText(/form\.fields\.conditionRow\.attribute/)).toBeTruthy();
   });
+
+  it('renders From and To labels when filter_operator is attribute_changed', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_updated',
+      active: true,
+      mode: 'simple',
+      conditions: [
+        {
+          attribute_key: 'status',
+          filter_operator: 'attribute_changed',
+          query_operator: 'AND',
+          values: { from: [], to: [] },
+        },
+      ],
+      actions: [
+        {
+          action_name: 'send_message',
+          action_params: ['hello'],
+        },
+      ],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+    expect(screen.getAllByText(/form\.fields\.conditionRow\.from/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/form\.fields\.conditionRow\.to/).length).toBeGreaterThan(0);
+  });
 });

--- a/src/components/automation/ConditionRow.spec.tsx
+++ b/src/components/automation/ConditionRow.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -8,6 +9,20 @@ import {
 } from '@/pages/Customer/Automation/registries';
 import ConditionRow from './ConditionRow';
 import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
+
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill as never);
+
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
 
 const emptyFormData: AutomationFormData = {
   inboxes: [],
@@ -58,6 +73,62 @@ describe('ConditionRow', () => {
     };
     render(<Wrapper defaultValues={defaults} />);
     expect(screen.getByText(/form\.fields\.conditionRow\.attribute/)).toBeTruthy();
+  });
+
+  it('omits attribute_changed from the operator dropdown on conversation_created (no previous value)', async () => {
+    const user = userEvent.setup();
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [
+        {
+          attribute_key: 'status',
+          filter_operator: 'equal_to',
+          query_operator: 'AND',
+          values: [],
+        },
+      ],
+      actions: [{ action_name: 'send_message', action_params: ['hello'] }],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+
+    const triggers = screen.getAllByRole('combobox');
+    expect(triggers.length).toBeGreaterThanOrEqual(2);
+    await user.click(triggers[1]);
+
+    const options = screen.getAllByRole('option').map((el) => el.textContent ?? '');
+    expect(options.some((label) => /equal_to/.test(label))).toBe(true);
+    expect(options.some((label) => /attribute_changed/.test(label))).toBe(false);
+  });
+
+  it('exposes attribute_changed in the operator dropdown on conversation_updated', async () => {
+    const user = userEvent.setup();
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_updated',
+      active: true,
+      mode: 'simple',
+      conditions: [
+        {
+          attribute_key: 'status',
+          filter_operator: 'equal_to',
+          query_operator: 'AND',
+          values: [],
+        },
+      ],
+      actions: [{ action_name: 'send_message', action_params: ['hello'] }],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+
+    const triggers = screen.getAllByRole('combobox');
+    await user.click(triggers[1]);
+
+    const options = screen.getAllByRole('option').map((el) => el.textContent ?? '');
+    expect(options.some((label) => /attribute_changed/.test(label))).toBe(true);
   });
 
   it('renders From and To labels when filter_operator is attribute_changed', () => {

--- a/src/components/automation/ConditionRow.spec.tsx
+++ b/src/components/automation/ConditionRow.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -7,6 +8,7 @@ import {
   automationRuleSchema,
   type AutomationRuleFormData,
 } from '@/pages/Customer/Automation/registries';
+import type { AutomationEventType } from '@/types/automation';
 import ConditionRow from './ConditionRow';
 import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
 
@@ -41,6 +43,41 @@ function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
     resolver: zodResolver(automationRuleSchema),
     defaultValues,
   });
+  return (
+    <FormProvider {...methods}>
+      <ConditionRow control={methods.control} index={0} formData={emptyFormData} onRemove={() => {}} />
+    </FormProvider>
+  );
+}
+
+function EventSwitchHarness({
+  defaultValues,
+  nextEvent,
+  onOperatorChange,
+}: {
+  defaultValues: AutomationRuleFormData;
+  nextEvent: AutomationEventType;
+  onOperatorChange: (op: string) => void;
+}) {
+  const methods = useForm<AutomationRuleFormData>({
+    resolver: zodResolver(automationRuleSchema),
+    defaultValues,
+  });
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      methods.setValue('event_name', nextEvent, { shouldDirty: true });
+    }, 50);
+    return () => clearTimeout(id);
+  }, [methods, nextEvent]);
+
+  useEffect(() => {
+    const subscription = methods.watch((value) => {
+      onOperatorChange(value.conditions?.[0]?.filter_operator ?? '');
+    });
+    return () => subscription.unsubscribe();
+  }, [methods, onOperatorChange]);
+
   return (
     <FormProvider {...methods}>
       <ConditionRow control={methods.control} index={0} formData={emptyFormData} onRemove={() => {}} />
@@ -129,6 +166,38 @@ describe('ConditionRow', () => {
 
     const options = screen.getAllByRole('option').map((el) => el.textContent ?? '');
     expect(options.some((label) => /attribute_changed/.test(label))).toBe(true);
+  });
+
+  it('clears the operator when switching to an event where it is no longer available', async () => {
+    const observed: string[] = [];
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_updated',
+      active: true,
+      mode: 'simple',
+      conditions: [
+        {
+          attribute_key: 'status',
+          filter_operator: 'attribute_changed',
+          query_operator: 'AND',
+          values: { from: ['open'], to: ['resolved'] },
+        },
+      ],
+      actions: [{ action_name: 'send_message', action_params: ['hi'] }],
+    };
+
+    render(
+      <EventSwitchHarness
+        defaultValues={defaults}
+        nextEvent="conversation_created"
+        onOperatorChange={(op) => observed.push(op)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(observed[observed.length - 1]).toBe('');
+    });
   });
 
   it('renders From and To labels when filter_operator is attribute_changed', () => {

--- a/src/components/automation/ConditionRow.tsx
+++ b/src/components/automation/ConditionRow.tsx
@@ -89,6 +89,18 @@ export default function ConditionRow({ control, index, formData, onRemove }: Pro
     ? getOperatorsForAttributeInEvent(attributeKey, eventName)
     : (descriptor?.operators ?? []);
 
+  // When the event_name (or attribute) changes and the current operator is no
+  // longer in the allowed list, clear it. Without this, a user that switches
+  // from `conversation_updated` to `conversation_created` after picking
+  // `attribute_changed` would save a rule whose operator can never match.
+  useEffect(() => {
+    if (!formCtx) return;
+    if (!operator) return;
+    if (availableOperators.includes(operator as (typeof availableOperators)[number])) return;
+    formCtx.setValue(`conditions.${index}.filter_operator`, '', { shouldDirty: true });
+    formCtx.setValue(`conditions.${index}.values`, [], { shouldDirty: true });
+  }, [availableOperators, operator, index, formCtx]);
+
   const optionsKey = descriptor?.optionLoaderKey
     ? optionLoaderToData[descriptor.optionLoaderKey]
     : undefined;

--- a/src/components/automation/ConditionRow.tsx
+++ b/src/components/automation/ConditionRow.tsx
@@ -16,6 +16,7 @@ import {
   conditionAttributeRegistry,
   getAttributeDescriptor,
   getAttributesForEvent,
+  getOperatorsForAttributeInEvent,
 } from '@/pages/Customer/Automation/registries';
 import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
 
@@ -47,13 +48,36 @@ export default function ConditionRow({ control, index, formData, onRemove }: Pro
   const operator = useWatch({ control, name: `conditions.${index}.filter_operator` });
   const currentValues = useWatch({ control, name: `conditions.${index}.values` });
   const valueless = operator === 'is_present' || operator === 'is_not_present';
+  const isAttributeChanged = operator === 'attribute_changed';
 
-  // Clear values when the operator goes valueless (avoids stale values being sent to the backend).
+  // Reset values when the values-shape requirement changes:
+  // - valueless operators must hold an empty array
+  // - attribute_changed must hold { from: [], to: [] }
+  // - other operators must hold an array
   useEffect(() => {
-    if (valueless && Array.isArray(currentValues) && currentValues.length > 0) {
-      formCtx?.setValue(`conditions.${index}.values`, [], { shouldDirty: true });
+    if (!formCtx) return;
+    if (valueless) {
+      if (!Array.isArray(currentValues) || currentValues.length > 0) {
+        formCtx.setValue(`conditions.${index}.values`, [], { shouldDirty: true });
+      }
+      return;
     }
-  }, [valueless, currentValues, index, formCtx]);
+    if (isAttributeChanged) {
+      const isFromToShape =
+        currentValues != null &&
+        typeof currentValues === 'object' &&
+        !Array.isArray(currentValues) &&
+        'from' in (currentValues as object) &&
+        'to' in (currentValues as object);
+      if (!isFromToShape) {
+        formCtx.setValue(`conditions.${index}.values`, { from: [], to: [] }, { shouldDirty: true });
+      }
+      return;
+    }
+    if (!Array.isArray(currentValues)) {
+      formCtx.setValue(`conditions.${index}.values`, [], { shouldDirty: true });
+    }
+  }, [valueless, isAttributeChanged, currentValues, index, formCtx]);
 
   const availableAttributes = eventName
     ? getAttributesForEvent(eventName)
@@ -61,10 +85,64 @@ export default function ConditionRow({ control, index, formData, onRemove }: Pro
 
   const descriptor = getAttributeDescriptor(attributeKey);
 
+  const availableOperators = attributeKey
+    ? getOperatorsForAttributeInEvent(attributeKey, eventName)
+    : (descriptor?.operators ?? []);
+
   const optionsKey = descriptor?.optionLoaderKey
     ? optionLoaderToData[descriptor.optionLoaderKey]
     : undefined;
   const options = optionsKey ? formData[optionsKey] : [];
+
+  const renderSingleValuePicker = (
+    currentValue: unknown,
+    onChange: (next: (string | number)[]) => void,
+    placeholderKey: string,
+  ) => {
+    if (descriptor?.dataType === 'boolean') {
+      return (
+        <Select
+          value={currentValue != null ? String(currentValue) : ''}
+          onValueChange={(v) => onChange([v])}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder={t(placeholderKey)} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="true">{t('form.fields.boolean.true')}</SelectItem>
+            <SelectItem value="false">{t('form.fields.boolean.false')}</SelectItem>
+          </SelectContent>
+        </Select>
+      );
+    }
+    if (options.length === 0) {
+      return (
+        <Input
+          type={descriptor?.dataType === 'number' ? 'number' : 'text'}
+          value={currentValue != null ? String(currentValue) : ''}
+          onChange={(e) => onChange([e.target.value])}
+          placeholder={t(placeholderKey)}
+        />
+      );
+    }
+    return (
+      <Select
+        value={currentValue != null ? String(currentValue) : ''}
+        onValueChange={(v) => onChange([v])}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder={t(placeholderKey)} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={String(opt.id)} value={String(opt.id)}>
+              {opt.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  };
 
   return (
     <div className="flex items-start gap-2 p-3 border rounded-md">
@@ -101,7 +179,7 @@ export default function ConditionRow({ control, index, formData, onRemove }: Pro
                 <SelectValue placeholder={t('form.fields.conditionRow.operator')} />
               </SelectTrigger>
               <SelectContent>
-                {descriptor?.operators.map((op) => (
+                {availableOperators.map((op) => (
                   <SelectItem key={op} value={op}>
                     {t(`form.fields.operators.${op}`)}
                   </SelectItem>
@@ -122,32 +200,40 @@ export default function ConditionRow({ control, index, formData, onRemove }: Pro
                 </div>
               );
             }
-            if (!descriptor || options.length === 0) {
+            if (isAttributeChanged) {
+              const fromTo =
+                field.value && typeof field.value === 'object' && !Array.isArray(field.value)
+                  ? (field.value as { from?: (string | number)[]; to?: (string | number)[] })
+                  : { from: [], to: [] };
               return (
-                <Input
-                  type={descriptor?.dataType === 'number' ? 'number' : 'text'}
-                  value={Array.isArray(field.value) ? String(field.value[0] ?? '') : ''}
-                  onChange={(e) => field.onChange([e.target.value])}
-                  placeholder={t('form.fields.conditionRow.value')}
-                />
+                <div className="grid grid-cols-2 gap-2 col-span-1">
+                  <div className="space-y-1">
+                    <label className="text-xs text-muted-foreground">
+                      {t('form.fields.conditionRow.from')}
+                    </label>
+                    {renderSingleValuePicker(
+                      fromTo.from?.[0],
+                      (next) => field.onChange({ from: next, to: fromTo.to ?? [] }),
+                      'form.fields.conditionRow.from',
+                    )}
+                  </div>
+                  <div className="space-y-1">
+                    <label className="text-xs text-muted-foreground">
+                      {t('form.fields.conditionRow.to')}
+                    </label>
+                    {renderSingleValuePicker(
+                      fromTo.to?.[0],
+                      (next) => field.onChange({ from: fromTo.from ?? [], to: next }),
+                      'form.fields.conditionRow.to',
+                    )}
+                  </div>
+                </div>
               );
             }
-            return (
-              <Select
-                value={Array.isArray(field.value) ? String(field.value[0] ?? '') : ''}
-                onValueChange={(v) => field.onChange([v])}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={t('form.fields.conditionRow.value')} />
-                </SelectTrigger>
-                <SelectContent>
-                  {options.map((opt) => (
-                    <SelectItem key={String(opt.id)} value={String(opt.id)}>
-                      {opt.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+            return renderSingleValuePicker(
+              Array.isArray(field.value) ? field.value[0] : undefined,
+              (next) => field.onChange(next),
+              'form.fields.conditionRow.value',
             );
           }}
         />

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -45,7 +45,7 @@
       "event": {
         "label": "Trigger event",
         "placeholder": "Select an event",
-        "hint": "Tip: To react to a status change, pick \"Conversation updated\" and add a Status condition.",
+        "hint": "Tip: to react to a transition (e.g. status moved from Open to Resolved, or a label was added), use the \"Attribute changed\" operator. Plain \"Equals\" re-fires on every update while the value stays the same.",
         "options": {
           "conversation_created": "Conversation created",
           "conversation_updated": "Conversation updated",
@@ -89,8 +89,14 @@
         "attribute": "Attribute",
         "operator": "Operator",
         "value": "Value",
+        "from": "From",
+        "to": "To",
         "remove": "Remove condition",
         "noValueNeeded": "No value needed"
+      },
+      "boolean": {
+        "true": "Yes",
+        "false": "No"
       },
       "actionRow": {
         "action": "Action",

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -45,7 +45,7 @@
       "event": {
         "label": "Evento gatilho",
         "placeholder": "Selecione um evento",
-        "hint": "Dica: Para reagir a uma mudança de status, escolha \"Conversa atualizada\" e adicione uma condição em Status.",
+        "hint": "Dica: para reagir a uma transição (ex.: status saiu de Aberto para Resolvido, ou uma etiqueta foi adicionada), use o operador \"Atributo mudou\". O operador \"Igual a\" dispara a cada nova atualização enquanto o valor continuar o mesmo.",
         "options": {
           "conversation_created": "Conversa criada",
           "conversation_updated": "Conversa atualizada",
@@ -89,8 +89,14 @@
         "attribute": "Atributo",
         "operator": "Operador",
         "value": "Valor",
+        "from": "De",
+        "to": "Para",
         "remove": "Remover condição",
         "noValueNeeded": "Nenhum valor necessário"
+      },
+      "boolean": {
+        "true": "Sim",
+        "false": "Não"
       },
       "actionRow": {
         "action": "Ação",

--- a/src/pages/Customer/Automation/AutomationForm.spec.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.spec.tsx
@@ -62,21 +62,28 @@ describe('AutomationForm', () => {
   it('renders edit mode title when mode is edit', async () => {
     const { automationService } = await import('@/services/automation/automationService');
     vi.mocked(automationService.getAutomation).mockResolvedValue({
-      data: {
-        id: 'rule-1',
-        name: 'Existing rule',
-        description: '',
-        event_name: 'conversation_created',
-        active: true,
-        mode: 'simple',
-        conditions: [],
-        actions: [{ action_name: 'send_message', action_params: ['hi'] }],
-      },
+      id: 'rule-1',
+      name: 'Existing rule',
+      description: 'Some context',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'send_message', action_params: ['hi'] }],
     } as never);
 
-    renderForm('edit', '/automation/rule-1/edit');
+    const { container } = renderForm('edit', '/automation/rule-1/edit');
     await waitFor(() => {
       expect(screen.getByText(/form\.title\.edit/)).toBeTruthy();
+    });
+
+    // Regression: extractData returns the rule directly, so the form must
+    // consume `response` as the rule (not `response.data`). If the form
+    // mishandles the unwrap the input stays empty.
+    await waitFor(() => {
+      const nameInput = container.querySelector('input#name') as HTMLInputElement | null;
+      expect(nameInput).not.toBeNull();
+      expect(nameInput?.value).toBe('Existing rule');
     });
   });
 

--- a/src/pages/Customer/Automation/AutomationForm.spec.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.spec.tsx
@@ -87,6 +87,43 @@ describe('AutomationForm', () => {
     });
   });
 
+  it('restores From and To pickers when editing a rule that uses attribute_changed', async () => {
+    const { automationService } = await import('@/services/automation/automationService');
+    vi.mocked(automationService.getAutomation).mockResolvedValue({
+      id: 'rule-2',
+      name: 'On status transition',
+      description: '',
+      event_name: 'conversation_updated',
+      active: true,
+      mode: 'simple',
+      conditions: [
+        {
+          attribute_key: 'status',
+          filter_operator: 'attribute_changed',
+          query_operator: 'AND',
+          values: { from: ['open'], to: ['resolved'] },
+        },
+      ],
+      actions: [{ action_name: 'send_message', action_params: ['hi'] }],
+    } as never);
+
+    renderForm('edit', '/automation/rule-2/edit');
+
+    await waitFor(() => {
+      expect(screen.getByText(/form\.title\.edit/)).toBeTruthy();
+    });
+
+    // The From / To labels should appear, proving the renderer branched on
+    // the attribute_changed shape rather than falling back to the flat-array
+    // single-value picker. Both labels and the operator label exist because
+    // they share the i18n key suffix, so we assert that we see at least one
+    // of each.
+    await waitFor(() => {
+      expect(screen.getAllByText(/form\.fields\.conditionRow\.from/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/form\.fields\.conditionRow\.to/).length).toBeGreaterThan(0);
+    });
+  });
+
   it('navigates back to list and toasts on 404 in edit mode', async () => {
     const { automationService } = await import('@/services/automation/automationService');
     vi.mocked(automationService.getAutomation).mockRejectedValue({

--- a/src/pages/Customer/Automation/AutomationForm.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.tsx
@@ -62,17 +62,16 @@ export default function AutomationForm({ mode }: Props) {
     let cancelled = false;
     (async () => {
       try {
-        const response = await automationService.getAutomation(id);
-        const rule = (response as unknown as { data?: AutomationRuleFormData }).data;
+        const rule = await automationService.getAutomation(id);
         if (!cancelled && rule) {
           reset({
             name: rule.name,
             description: rule.description ?? '',
-            event_name: rule.event_name,
+            event_name: rule.event_name as AutomationRuleFormData['event_name'],
             active: rule.active ?? true,
             mode: 'simple',
-            conditions: rule.conditions ?? [],
-            actions: rule.actions ?? DEFAULTS.actions,
+            conditions: (rule.conditions ?? []) as AutomationRuleFormData['conditions'],
+            actions: (rule.actions ?? DEFAULTS.actions) as AutomationRuleFormData['actions'],
           });
         }
       } catch (error) {

--- a/src/pages/Customer/Automation/registries/conditionAttributeRegistry.spec.ts
+++ b/src/pages/Customer/Automation/registries/conditionAttributeRegistry.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { conditionAttributeRegistry, getAttributesForEvent } from './conditionAttributeRegistry';
+import {
+  conditionAttributeRegistry,
+  getAttributesForEvent,
+  getOperatorsForAttributeInEvent,
+} from './conditionAttributeRegistry';
 import { conditionTypeRegistry } from './conditionTypeRegistry';
 
 const BACKEND_CONDITION_KEYS = [
@@ -53,10 +57,14 @@ describe('conditionAttributeRegistry', () => {
     }
   });
 
-  it('pipeline attributes restrict to the four allowed operators', () => {
+  it('pipeline_id restricts to the four allowed operators (no attribute_changed — backend does not dispatch pipeline_id transitions)', () => {
     const pipelineOps = ['equal_to', 'not_equal_to', 'is_present', 'is_not_present'];
     expect(conditionAttributeRegistry.pipeline_id.operators.sort()).toEqual([...pipelineOps].sort());
-    expect(conditionAttributeRegistry.pipeline_stage_id.operators.sort()).toEqual([...pipelineOps].sort());
+  });
+
+  it('pipeline_stage_id keeps the four base operators and adds attribute_changed (backend dispatches pipeline_stage_id transitions)', () => {
+    const expected = ['equal_to', 'not_equal_to', 'is_present', 'is_not_present', 'attribute_changed'];
+    expect(conditionAttributeRegistry.pipeline_stage_id.operators.sort()).toEqual([...expected].sort());
   });
 
   it('contact_created event surfaces only contact-context attributes', () => {
@@ -79,5 +87,46 @@ describe('conditionAttributeRegistry', () => {
 
   it('phone_number includes starts_with operator (case-insensitive YML override)', () => {
     expect(conditionAttributeRegistry.phone_number.operators).toContain('starts_with');
+  });
+
+  describe('attribute_changed exposure', () => {
+    const withAttributeChanged = ['status', 'priority', 'assignee_id', 'team_id', 'labels', 'blocked', 'pipeline_stage_id'];
+    const withoutAttributeChanged = ['content', 'email', 'name', 'phone_number', 'inbox_id', 'pipeline_id', 'identifier', 'city'];
+
+    it.each(withAttributeChanged)('exposes attribute_changed on %s', (key) => {
+      expect(conditionAttributeRegistry[key].operators).toContain('attribute_changed');
+    });
+
+    it.each(withoutAttributeChanged)('does not expose attribute_changed on %s', (key) => {
+      expect(conditionAttributeRegistry[key].operators).not.toContain('attribute_changed');
+    });
+  });
+
+  describe('getOperatorsForAttributeInEvent', () => {
+    it('keeps attribute_changed for update-type events', () => {
+      const ops = getOperatorsForAttributeInEvent('status', 'conversation_updated');
+      expect(ops).toContain('attribute_changed');
+    });
+
+    it('strips attribute_changed for *_created events (no previous value to compare)', () => {
+      expect(getOperatorsForAttributeInEvent('status', 'conversation_created')).not.toContain('attribute_changed');
+      expect(getOperatorsForAttributeInEvent('priority', 'message_created')).not.toContain('attribute_changed');
+      expect(getOperatorsForAttributeInEvent('blocked', 'contact_created')).not.toContain('attribute_changed');
+    });
+
+    it('strips attribute_changed for conversation_opened', () => {
+      const ops = getOperatorsForAttributeInEvent('status', 'conversation_opened');
+      expect(ops).not.toContain('attribute_changed');
+    });
+
+    it('preserves non-attribute_changed operators across all events', () => {
+      const ops = getOperatorsForAttributeInEvent('status', 'conversation_created');
+      expect(ops).toContain('equal_to');
+      expect(ops).toContain('not_equal_to');
+    });
+
+    it('returns empty array for unknown attribute keys', () => {
+      expect(getOperatorsForAttributeInEvent('not_a_real_attribute', 'conversation_updated')).toEqual([]);
+    });
   });
 });

--- a/src/pages/Customer/Automation/registries/conditionAttributeRegistry.ts
+++ b/src/pages/Customer/Automation/registries/conditionAttributeRegistry.ts
@@ -32,7 +32,7 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   status: {
     attributeKey: 'status',
     dataType: 'text',
-    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    operators: fromType('text', ['equal_to', 'not_equal_to', 'attribute_changed']),
     optionLoaderKey: 'statuses',
     validFor: ['conversation', 'pipeline'],
     i18nKey: 'form.fields.attributes.status',
@@ -40,7 +40,7 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   assignee_id: {
     attributeKey: 'assignee_id',
     dataType: 'text',
-    operators: fromType('text', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present']),
+    operators: fromType('text', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present', 'attribute_changed']),
     optionLoaderKey: 'agents',
     validFor: ['conversation', 'pipeline'],
     i18nKey: 'form.fields.attributes.assignee_id',
@@ -56,7 +56,7 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   team_id: {
     attributeKey: 'team_id',
     dataType: 'number',
-    operators: fromType('number', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present']),
+    operators: fromType('number', ['equal_to', 'not_equal_to', 'is_present', 'is_not_present', 'attribute_changed']),
     optionLoaderKey: 'teams',
     validFor: ['conversation', 'pipeline'],
     i18nKey: 'form.fields.attributes.team_id',
@@ -64,7 +64,7 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   priority: {
     attributeKey: 'priority',
     dataType: 'text',
-    operators: fromType('text', ['equal_to', 'not_equal_to']),
+    operators: fromType('text', ['equal_to', 'not_equal_to', 'attribute_changed']),
     optionLoaderKey: 'priorities',
     validFor: ['conversation', 'pipeline'],
     i18nKey: 'form.fields.attributes.priority',
@@ -72,7 +72,7 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   labels: {
     attributeKey: 'labels',
     dataType: 'labels',
-    operators: fromType('labels'),
+    operators: [...fromType('labels'), 'attribute_changed'],
     optionLoaderKey: 'labels',
     validFor: ['conversation', 'contact', 'pipeline'],
     i18nKey: 'form.fields.attributes.labels',
@@ -172,7 +172,7 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   blocked: {
     attributeKey: 'blocked',
     dataType: 'boolean',
-    operators: fromType('boolean'),
+    operators: [...fromType('boolean'), 'attribute_changed'],
     validFor: ['contact'],
     i18nKey: 'form.fields.attributes.blocked',
   },
@@ -187,12 +187,22 @@ export const conditionAttributeRegistry: Record<string, ConditionAttributeDescri
   pipeline_stage_id: {
     attributeKey: 'pipeline_stage_id',
     dataType: 'pipeline',
-    operators: fromType('pipeline'),
+    operators: [...fromType('pipeline'), 'attribute_changed'],
     optionLoaderKey: 'pipeline_stages',
     validFor: ['conversation', 'pipeline'],
     i18nKey: 'form.fields.attributes.pipeline_stage_id',
   },
 };
+
+// Events that represent a record being created or first-opened. The
+// attribute_changed operator requires a previous value, so it is filtered
+// out for these events at the UI layer.
+const eventsWithoutPreviousValue: ReadonlySet<AutomationEventType> = new Set([
+  'conversation_created',
+  'conversation_opened',
+  'message_created',
+  'contact_created',
+]);
 
 const eventContextMap: Record<AutomationEventType, EventContext[]> = {
   conversation_created: ['conversation', 'message'],
@@ -215,4 +225,16 @@ export function getAttributesForEvent(eventName: AutomationEventType): Condition
 
 export function getAttributeDescriptor(attributeKey: string): ConditionAttributeDescriptor | undefined {
   return conditionAttributeRegistry[attributeKey];
+}
+
+export function getOperatorsForAttributeInEvent(
+  attributeKey: string,
+  eventName: AutomationEventType | undefined,
+): AutomationFilterOperator[] {
+  const descriptor = conditionAttributeRegistry[attributeKey];
+  if (!descriptor) return [];
+  if (eventName && eventsWithoutPreviousValue.has(eventName)) {
+    return descriptor.operators.filter((op) => op !== 'attribute_changed');
+  }
+  return descriptor.operators;
 }

--- a/src/pages/Customer/Automation/registries/conditionSchema.spec.ts
+++ b/src/pages/Customer/Automation/registries/conditionSchema.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { automationRuleSchema } from './index';
+
+function baseRule(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'rule',
+    description: '',
+    event_name: 'conversation_updated',
+    active: true,
+    mode: 'simple',
+    conditions: [],
+    actions: [{ action_name: 'send_message', action_params: ['hi'] }],
+    ...overrides,
+  };
+}
+
+describe('automationRuleSchema condition shapes', () => {
+  it('accepts attribute_changed with from/to object', () => {
+    const result = automationRuleSchema.safeParse(
+      baseRule({
+        conditions: [
+          {
+            attribute_key: 'status',
+            filter_operator: 'attribute_changed',
+            values: { from: ['open'], to: ['resolved'] },
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts the flat values array for non attribute_changed operators', () => {
+    const result = automationRuleSchema.safeParse(
+      baseRule({
+        conditions: [
+          {
+            attribute_key: 'status',
+            filter_operator: 'equal_to',
+            values: ['resolved'],
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects attribute_changed sent with a flat values array', () => {
+    const result = automationRuleSchema.safeParse(
+      baseRule({
+        conditions: [
+          {
+            attribute_key: 'status',
+            filter_operator: 'attribute_changed',
+            values: ['resolved'],
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non attribute_changed operators sent with the from/to object', () => {
+    const result = automationRuleSchema.safeParse(
+      baseRule({
+        conditions: [
+          {
+            attribute_key: 'status',
+            filter_operator: 'equal_to',
+            values: { from: ['open'], to: ['resolved'] },
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('allows empty from/to arrays (wildcards for label-added / label-removed)', () => {
+    const result = automationRuleSchema.safeParse(
+      baseRule({
+        conditions: [
+          {
+            attribute_key: 'labels',
+            filter_operator: 'attribute_changed',
+            values: { from: [], to: ['1'] },
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/pages/Customer/Automation/registries/index.ts
+++ b/src/pages/Customer/Automation/registries/index.ts
@@ -19,35 +19,48 @@ const automationEventNames = [
 const valuesArraySchema = z.array(z.union([z.string(), z.number()]));
 
 // attribute_changed uses a structured payload: { from: [...], to: [...] }.
-// Other operators keep the flat array shape. The two branches share the rest
-// of the condition fields.
+// Other operators keep the flat array shape.
 export const fromToValuesSchema = z.object({
   from: valuesArraySchema,
   to: valuesArraySchema,
 });
 
-const conditionSchema = z.union([
-  z.object({
+const valuesUnionSchema = z.union([valuesArraySchema, fromToValuesSchema]);
+
+// Single base schema with a superRefine that branches the shape of `values`
+// by `filter_operator`. Using z.union of two full object schemas (previous
+// approach) made Zod accumulate errors from both branches on a single
+// failure, producing confusing messages like "Expected object" alongside the
+// real cause. With superRefine the user gets ONE coherent message.
+const conditionSchema = z
+  .object({
     attribute_key: z.string().min(1),
-    filter_operator: z.literal('attribute_changed'),
+    filter_operator: z.string().min(1),
     query_operator: z.enum(['AND', 'OR', 'and', 'or']).optional(),
-    values: fromToValuesSchema,
+    values: valuesUnionSchema,
     custom_attribute_type: z.string().optional(),
-  }),
-  z.object({
-    attribute_key: z.string().min(1),
-    // Reject 'attribute_changed' here so its from/to shape cannot be
-    // accidentally accepted under the flat-array branch when the form sends
-    // a malformed values payload.
-    filter_operator: z
-      .string()
-      .min(1)
-      .refine((op) => op !== 'attribute_changed', { message: 'invalid_values_shape' }),
-    query_operator: z.enum(['AND', 'OR', 'and', 'or']).optional(),
-    values: valuesArraySchema,
-    custom_attribute_type: z.string().optional(),
-  }),
-]);
+  })
+  .superRefine((data, ctx) => {
+    const isAttributeChanged = data.filter_operator === 'attribute_changed';
+    const isFromToShape =
+      data.values !== null &&
+      typeof data.values === 'object' &&
+      !Array.isArray(data.values);
+
+    if (isAttributeChanged && !isFromToShape) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['values'],
+        message: 'attribute_changed_requires_from_to',
+      });
+    } else if (!isAttributeChanged && isFromToShape) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['values'],
+        message: 'values_must_be_array_for_this_operator',
+      });
+    }
+  });
 
 const actionUnionSchema = z.discriminatedUnion('action_name', [
   z.object({ action_name: z.literal('send_message'), action_params: actionRegistry.send_message.schema }),

--- a/src/pages/Customer/Automation/registries/index.ts
+++ b/src/pages/Customer/Automation/registries/index.ts
@@ -16,13 +16,38 @@ const automationEventNames = [
   'contact_updated',
 ] as const satisfies readonly AutomationEventType[];
 
-const conditionSchema = z.object({
-  attribute_key: z.string().min(1),
-  filter_operator: z.string().min(1),
-  query_operator: z.enum(['AND', 'OR', 'and', 'or']).optional(),
-  values: z.array(z.union([z.string(), z.number()])),
-  custom_attribute_type: z.string().optional(),
+const valuesArraySchema = z.array(z.union([z.string(), z.number()]));
+
+// attribute_changed uses a structured payload: { from: [...], to: [...] }.
+// Other operators keep the flat array shape. The two branches share the rest
+// of the condition fields.
+export const fromToValuesSchema = z.object({
+  from: valuesArraySchema,
+  to: valuesArraySchema,
 });
+
+const conditionSchema = z.union([
+  z.object({
+    attribute_key: z.string().min(1),
+    filter_operator: z.literal('attribute_changed'),
+    query_operator: z.enum(['AND', 'OR', 'and', 'or']).optional(),
+    values: fromToValuesSchema,
+    custom_attribute_type: z.string().optional(),
+  }),
+  z.object({
+    attribute_key: z.string().min(1),
+    // Reject 'attribute_changed' here so its from/to shape cannot be
+    // accidentally accepted under the flat-array branch when the form sends
+    // a malformed values payload.
+    filter_operator: z
+      .string()
+      .min(1)
+      .refine((op) => op !== 'attribute_changed', { message: 'invalid_values_shape' }),
+    query_operator: z.enum(['AND', 'OR', 'and', 'or']).optional(),
+    values: valuesArraySchema,
+    custom_attribute_type: z.string().optional(),
+  }),
+]);
 
 const actionUnionSchema = z.discriminatedUnion('action_name', [
   z.object({ action_name: z.literal('send_message'), action_params: actionRegistry.send_message.schema }),

--- a/src/services/automation/automationService.ts
+++ b/src/services/automation/automationService.ts
@@ -24,10 +24,10 @@ class AutomationService {
     }
   }
 
-  async getAutomation(id: string): Promise<AutomationResponse> {
+  async getAutomation(id: string): Promise<AutomationRule> {
     try {
       const response = await api.get(`/automation_rules/${id}`);
-      return extractData<AutomationResponse>(response);
+      return extractData<AutomationRule>(response);
     } catch (error: any) {
       console.error('Erro ao buscar automação:', error);
       throw new Error(error?.response?.data?.message || 'Erro ao buscar automação');


### PR DESCRIPTION
## Summary

Surfaces the `attribute_changed` filter operator in the Automation Rules form so rules can fire on the exact moment of a transition (e.g. status moved from Open to Resolved, a label was just added) instead of every update where the attribute happens to hold the target value.

- Registries: `attribute_changed` exposed on the seven attributes the backend can detect transitions on (`status`, `priority`, `assignee_id`, `team_id`, `labels`, `pipeline_stage_id`, `blocked`). `pipeline_id` intentionally excluded — `assign_to_pipeline` does not dispatch a previous_changes entry for it. New `getOperatorsForAttributeInEvent` helper strips the operator on `*_created` and `conversation_opened` events so users cannot configure rules that could never fire.
- Schema (`registries/index.ts`): `conditionSchema` branched via `z.union`. The `attribute_changed` branch requires `values: { from: [...], to: [...] }`; the default branch keeps the flat array shape and explicitly refuses `attribute_changed` to prevent a malformed shape from slipping through.
- UI (`ConditionRow`): renders two pickers (From / To) when the operator is `attribute_changed`. Shared single-value renderer handles boolean (Yes/No select), enumerated (select with loaded options), and free-form (text input) attributes. Reset effects keep the `values` payload aligned with the current operator shape and clear stale operators when the event change makes the current operator invalid (otherwise the user could save a rule whose operator no longer exists in the dropdown).
- i18n: new `conditionRow.from`/`to` and `boolean.true`/`false` keys in en + pt-BR. `event.hint` copy rewritten to recommend `attribute_changed` as the canonical pattern, framing `equal_to` as the alternative.

Two pre-existing bugs surfaced during testing and are fixed in this PR because they block validating the new feature:

- `automationService.getAutomation` declared `Promise<AutomationResponse>` but used `extractData` which unwraps `response.data.data`. `AutomationForm` then tried to unwrap a second time and got `undefined`, so `reset()` never ran and the edit-mode form stayed at create-mode defaults. Fixed the return type to `Promise<AutomationRule>`, dropped the double unwrap, and the spec now asserts the name input populates.
- ConditionRow effect that clears a stale operator when the event change makes it invalid (caught during QA review).

Backend ships under the same Linear issue: see `## Related PRs`.

## Security

- Client-side only. No endpoint or auth changes.
- Schema validates both shapes and explicitly rejects malformed combinations (e.g. `attribute_changed` sent with a flat array). Backend independently rejects unknown operators in `ConditionValidationService`.
- No `dangerouslySetInnerHTML`. Rendered option text comes from controlled data structures, escaped by React.
- No new TypeScript `any` introduced.

## Test plan

- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` — clean
- `evo-ai-frontend-community: pnpm test src/pages/Customer/Automation src/components/automation` — 51 tests, 0 failures
- `evo-ai-frontend-community: pnpm lint` on touched files — clean
- Manual smoke (golden path):
  - Create rule with `status attribute_changed from=[open] to=[resolved]` + action `add_label`. Mark a conversation resolved → label applied once. Send a new message → no re-fire.
  - Create rule with `labels attribute_changed from=[] to=[atleta]` + action `change_priority -> urgent`. Add `atleta` to a conversation → priority changes once. Other labels added later → no re-fire.
  - Switch event of an existing `attribute_changed` rule to `conversation_created` → operator dropdown loses the option and form resets the operator on its own.
  - Edit an existing rule with `attribute_changed` → form opens populated, From/To pickers show saved values.

## Changed Files

- `src/pages/Customer/Automation/registries/conditionAttributeRegistry.ts`
- `src/pages/Customer/Automation/registries/index.ts`
- `src/pages/Customer/Automation/registries/conditionAttributeRegistry.spec.ts`
- `src/pages/Customer/Automation/registries/conditionSchema.spec.ts` (new)
- `src/components/automation/ConditionRow.tsx`
- `src/components/automation/ConditionRow.spec.tsx`
- `src/services/automation/automationService.ts`
- `src/pages/Customer/Automation/AutomationForm.tsx`
- `src/pages/Customer/Automation/AutomationForm.spec.tsx`
- `src/i18n/locales/en/automation.json`
- `src/i18n/locales/pt-BR/automation.json`

## Linked Issue

- EVO-1058: https://linear.app/evoai/issue/EVO-1058/add-attribute-changed-operator-support-to-automation-conditions-ui

## Related PRs

- crm/backend: https://github.com/evolution-foundation/evo-ai-crm-community/pull/56

## Summary by Sourcery

Expose the attribute_changed operator in automation rule conditions with proper schema support and UI handling, while fixing edit-mode loading and ensuring operators and values remain valid when events change.

New Features:
- Allow automation conditions to use the attribute_changed operator on supported attributes with From/To value pickers in the ConditionRow UI.

Bug Fixes:
- Fix automation rule edit mode to correctly populate the form by returning the unwrapped AutomationRule from getAutomation.
- Ensure invalid filter operators are cleared when the selected event no longer supports them, preventing unsatisfiable rules.

Enhancements:
- Constrain automation condition schemas to accept structured from/to values only for attribute_changed and flat arrays for all other operators, rejecting malformed combinations.
- Limit attribute_changed exposure to attributes and events where previous values exist, including helper logic to derive valid operators per event.
- Unify single-value pickers for condition values, supporting booleans, enumerations, and free-form input, and keep values in sync with operator-specific shapes.

Tests:
- Extend automation form and ConditionRow tests to cover attribute_changed rendering, operator availability per event, and edit-mode restoration of From/To pickers.
- Add schema tests validating the allowed and rejected combinations of operators and values shapes for automation conditions.