### PR TITLE
fix(frontend): default setupRequired=false when /setup/status errors (EVO-1046)

### DIFF
--- a/src/contexts/GlobalConfigContext.spec.tsx
+++ b/src/contexts/GlobalConfigContext.spec.tsx
@@ -103,11 +103,13 @@ describe('GlobalConfigContext', () => {
     });
   });
 
-  // EVO-971: when the /setup/status call fails (e.g. auth-service still warming
-  // up on first `docker compose up`), the frontend must default to showing the
-  // setup wizard rather than stranding the user on /login with no way to
-  // bootstrap. Bootstrap itself rejects double-init, so this is safe.
-  it('defaults setupRequired=true when /setup/status fails', async () => {
+  // EVO-1046: a transient /setup/status failure (network hiccup, auth-service
+  // restart) must NOT push a logged-in user to the bootstrap wizard. Fresh
+  // installs are already handled by the auth-service /setup/status reporting
+  // `inactive` when User.exists? is false (commit 2c7e6b8, EVO-971), so the
+  // fail-open path is no longer needed and was actively harmful (operators
+  // could re-run bootstrap by accident on a healthy install).
+  it('defaults setupRequired=false when /setup/status fails (no fail-open to wizard)', async () => {
     vi.mocked(setupService.getStatus).mockRejectedValueOnce(new Error('ECONNREFUSED'));
     mockApi.get.mockResolvedValueOnce({ data: {} });
 
@@ -120,7 +122,7 @@ describe('GlobalConfigContext', () => {
     await waitFor(() => {
       const configEl = screen.getByTestId('config');
       const parsed = JSON.parse(configEl.textContent || '{}');
-      expect(parsed.setupRequired).toBe(true);
+      expect(parsed.setupRequired).toBe(false);
       expect(parsed.setupLoading).toBe(false);
     });
   });

--- a/src/contexts/GlobalConfigContext.tsx
+++ b/src/contexts/GlobalConfigContext.tsx
@@ -82,14 +82,18 @@ export const fetchSetupStatus = async (): Promise<boolean> => {
     setupRequiredCache = status.status === 'inactive';
     return setupRequiredCache;
   } catch (e) {
-    // Fail open to the setup wizard so a transient backend outage during
-    // first boot (auth-service still warming up, migrations running, etc.)
-    // doesn't strand the user on /login with no way to bootstrap.
-    // The bootstrap endpoint itself rejects with AlreadyBootstrappedError
-    // if setup was already completed, so this is safe for healthy installs.
+    // Fail closed: when /setup/status errors transiently (network hiccup,
+    // auth-service restart) we do NOT push the user to the bootstrap wizard.
+    // Fresh installs are already handled correctly by the auth-service
+    // (commit 2c7e6b8, EVO-971): /setup/status now reports `inactive`
+    // whenever User.exists? is false, so a wiped install reaches /setup
+    // through the success path, not through this fallback. The previous
+    // fail-open default sent every logged-in user to the wizard on any
+    // transient outage, where an operator could re-run bootstrap by
+    // mistake.
     // Do not cache the failure — the next render retries.
-    console.warn('[GlobalConfig] /setup/status failed, defaulting setupRequired=true', e);
-    return true;
+    console.warn('[GlobalConfig] /setup/status failed, defaulting setupRequired=false', e);
+    return false;
   }
 };
 


### PR DESCRIPTION
## Summary

When `/setup/status` errors transiently (network hiccup, auth-service restart), `fetchSetupStatus` in `GlobalConfigContext` used to default `setupRequired = true`, redirecting every logged-in user to the bootstrap wizard. On an already-bootstrapped install, an operator could re-run bootstrap by mistake.

The fail-open default no longer protects fresh installs. The auth-service fix in commit `2c7e6b8` (EVO-971) made `/setup/status` report `inactive` whenever `User.exists?` is false — fresh installs reach `/setup` through the success path now, not the error fallback. The only remaining error case is a healthy install hit by a transient outage, where the safe default is to NOT push the user into the bootstrap flow.

- `src/contexts/GlobalConfigContext.tsx` — catch-block default flipped from `true` to `false`. Inline comment rewritten to record the rationale (EVO-1046 + 2c7e6b8).
- `src/contexts/GlobalConfigContext.spec.tsx` — existing spec inverted to pin the new contract.

## Security

- No endpoint or auth changes.
- Reduces a UX foot-gun: operators no longer face a fresh-install wizard on a transient hiccup.

## Test plan

Manual reproduction (recommended via DevTools):

1. Sign in to a bootstrapped install.
2. DevTools → Network tab → reload once to capture `GET /api/v1/setup/status`.
3. Right-click the request → **Block request URL**.
4. Hard refresh (Ctrl+Shift+R / Cmd+Shift+R).
5. Expected with this PR: user stays on the current page, no redirect to `/setup`.
6. Expected before this PR: user is redirected to `/setup` (bug).

Also valid via `docker compose stop evo-auth-service` followed by a frontend refresh, or via DevTools Network → Offline (less isolated since it knocks out every request).

Automated:

- `pnpm test src/contexts/GlobalConfigContext.spec.tsx` — 3 examples, 0 failures (the existing fail-open spec was inverted to assert `setupRequired === false`).
- `pnpm exec tsc -b --noEmit` — clean.

## Changed Files

- `src/contexts/GlobalConfigContext.tsx`
- `src/contexts/GlobalConfigContext.spec.tsx`

## Linked Issue

- EVO-1046: https://linear.app/evoai/issue/EVO-1046

## Related

- Auth-service commit `2c7e6b8` (EVO-971) — fixed `/setup/status` to report `inactive` when `User.exists?` is false, which is what made this fail-open default obsolete.

## Summary by Sourcery

Adjust setup status handling to avoid redirecting users to the bootstrap wizard on transient /setup/status failures.

Bug Fixes:
- Change the default setupRequired flag to false when /setup/status fails to prevent unnecessary redirects to the bootstrap wizard on healthy installs.

Tests:
- Update GlobalConfigContext tests to assert the new fail-closed behavior when /setup/status requests fail.