### PR TITLE
fix: EVO-1059, EVO-1107 review, duplicate messages, delete button color

### DIFF
--- a/src/components/users/UserFormModal.tsx
+++ b/src/components/users/UserFormModal.tsx
@@ -180,8 +180,25 @@ export default function UserFormModal({ isOpen, onClose, user, onSuccess }: User
 
       onSuccess();
       onClose();
-    } catch (error) {
+    } catch (error: any) {
       console.error('Erro ao salvar usuário:', error);
+
+      // Parse structured validation errors from the API (EVO-1063)
+      const details = error?.response?.data?.error?.details;
+      if (Array.isArray(details)) {
+        const fieldErrors: Record<string, string> = {};
+        details.forEach((d: { field: string; full_messages?: string[] }) => {
+          if (d.field && d.full_messages?.length) {
+            fieldErrors[d.field] = d.full_messages.join('. ');
+          }
+        });
+
+        if (Object.keys(fieldErrors).length > 0) {
+          setErrors(prev => ({ ...prev, ...fieldErrors }));
+          return;
+        }
+      }
+
       toast.error(t('form.messages.saveError'));
     } finally {
       setLoading(false);

--- a/src/types/automation/automation.ts
+++ b/src/types/automation/automation.ts
@@ -20,7 +20,7 @@ export interface AutomationCondition {
   attribute_key: string;
   filter_operator: string;
   query_operator?: string;
-  values: string[] | number[];
+  values: (string | number)[];
   custom_attribute_type?: string;
 }
 
@@ -80,7 +80,7 @@ export interface AutomationConditionNodeData extends Record<string, unknown> {
   type: 'condition';
   attribute_key: string;
   filter_operator: string;
-  values: string[] | number[];
+  values: (string | number)[];
   custom_attribute_type?: string;
   label: string;
 }


### PR DESCRIPTION
## Summary

Continuation of fixes after PR #58 was merged. Contains 3 commits addressing code review feedback, bugs found during testing, and a type alignment fix.

---

### EVO-1059: Widen AutomationCondition.values type to mixed array

**Problem:** `AutomationCondition.values` was typed as `string[] | number[]` (homogeneous union) but the backend accepts mixed arrays like `[1, "open"]`. This forced `as unknown as` casts at service call sites.

**Fix:** Changed to `(string | number)[]` in both `AutomationCondition` and `AutomationConditionNodeData` interfaces in `src/types/automation/automation.ts`. Zero cascading TS errors.

---

### EVO-1107: Code review fixes (Daniel's ALTO items)

Addresses all high-priority items from Daniel's code review:

1. **getIdentifier() null** — now shows explicit error card with descriptive message instead of silently rendering empty defaults
2. **Settings/profile useEffect** — unified into single effect with cancelled flag preventing stale setState on unmount
3. **Failed fetch** — loadError state drives explicit error UI instead of hiding skeleton and showing blank form
4. **Deps instability** — removed inbox.provider_config from deps array (object reference changes on every parent render); uses stable inbox.provider + inbox.name
5. **Accessibility** — added aria-busy on skeleton container and sr-only text for screen readers

**File:** `src/components/channels/settings/ConfigurationForm.tsx`

---

### Duplicate messages fix + delete button color

**Duplicate messages:** UPDATE_CONVERSATION reducer only did .map() over existing list. If a conversation matched filters but wasn't in the list, the update was silently dropped. Changed to upsert: prepends conversation if not found, updates in place if found.

**Delete button:** text-destructive-foreground resolved to red text on red bg-destructive background (unreadable). Changed to text-white on both AlertDialogAction instances.

**Files:** `src/contexts/chat/ConversationsContextReducer.ts`, `src/contexts/chat/ChatContext.tsx`, `src/components/chat/messages/MessageBubble.tsx`

---

## Test plan

- [x] `pnpm exec tsc --noEmit` — zero errors
- [x] Frontend serves correctly on localhost:5173
- [x] Delete message confirmation button has white text on red background (legible)
- [x] Messages do not duplicate in chat view (tested with live WhatsApp messages)
- [x] Configuration tab loads correctly (skeleton brief, then content)
- [x] EVO-1059 type change causes no cascading TS errors

## Summary by Sourcery

Enhancements:
- Allow AutomationCondition and AutomationConditionNodeData values to be mixed string/number arrays instead of homogeneous string[] or number[].