### PR TITLE
fix(EVO-1059): widen AutomationCondition.values to mixed array, remove cast

### DIFF
--- a/src/pages/Customer/Automation/AutomationForm.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.tsx
@@ -98,10 +98,7 @@ export default function AutomationForm({ mode }: Props) {
     if (submitting) return;
     setSubmitting(true);
     try {
-      // Cast: AutomationCondition.values is typed as string[] | number[] (homogeneous)
-      // but the Zod schema produces (string | number)[]. Backend accepts mixed; the
-      // type cleanup is deferred per Story 1 audit findings.
-      const payload = data as unknown as Parameters<typeof automationService.createAutomation>[0];
+      const payload = data as Parameters<typeof automationService.createAutomation>[0];
       if (mode === 'create') {
         await automationService.createAutomation(payload);
         toast.success(t('messages.createSuccess'));

--- a/src/types/automation/automation.ts
+++ b/src/types/automation/automation.ts
@@ -20,7 +20,7 @@ export interface AutomationCondition {
   attribute_key: string;
   filter_operator: string;
   query_operator?: string;
-  values: string[] | number[];
+  values: (string | number)[];
   custom_attribute_type?: string;
 }
 
@@ -103,7 +103,7 @@ export interface AutomationConditionNodeData extends Record<string, unknown> {
   type: 'condition';
   attribute_key: string;
   filter_operator: string;
-  values: string[] | number[];
+  values: (string | number)[];
   custom_attribute_type?: string;
   label: string;
 }


### PR DESCRIPTION
## Summary

Aligns `AutomationCondition.values` type with backend reality. The backend (`AutomationRule#json_conditions_format` and `ConditionsFilterService`) accepts mixed arrays without enforcing homogeneity — a single condition can have values like `[1, "open"]`.

## Changes

### 1. `src/types/automation/automation.ts` (2 lines)
- `AutomationCondition.values`: `string[] | number[]` → `(string | number)[]`
- `AutomationConditionNodeData.values`: same change

### 2. `src/pages/Customer/Automation/AutomationForm.tsx` (4 lines removed)
- Removed `as unknown as` cast at line 104 — no longer needed with widened type
- Removed fossil comment (lines 101-103) referencing "type cleanup deferred per Story 1 audit" — this commit IS that cleanup

## Why the cast existed

The Zod form schema in EVO-1057 correctly produces `(string | number)[]` (heterogeneous), but the TypeScript interface only accepted `string[] | number[]` (homogeneous). These are incompatible — `[1, "open"]` satisfies `(string | number)[]` but NOT `string[] | number[]`. The cast worked around this at the service call site.

## Validation

- [x] `pnpm exec tsc --noEmit` — zero errors
- [x] `pnpm exec tsc -b --noEmit` — zero errors
- [x] `vitest run src/pages/Customer/Automation/` — 44 tests passed, 0 failed
- [x] Existing consumers (`automationService.ts`, `ConditionRow.tsx`) already handle mixed values via `String()` coercion — no changes needed
- [x] Branch based on latest `develop` (33be652)
- [x] 2 files changed, clean scope