### PR TITLE
fix(EVO-1106) + test(EVO-1132): preserve scroll on pagination + MessageFile download tests

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -555,16 +555,34 @@ const ChatSidebar = ({
 
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
+
+    // Save scroll position before loading — the re-sort in visibleConversations
+    // causes a DOM restructure that resets scrollTop to 0.
+    const scrollTop = container.scrollTop;
+    const scrollHeight = container.scrollHeight;
+
     try {
       await conversations.loadMoreConversations();
     } finally {
       setIsLoadingMoreConversations(false);
       loadingMoreRef.current = false;
+
+      // Restore scroll position after React re-renders the appended list
+      requestAnimationFrame(() => {
+        if (sidebarScrollRef.current) {
+          const newScrollHeight = sidebarScrollRef.current.scrollHeight;
+          sidebarScrollRef.current.scrollTop = scrollTop + (newScrollHeight - scrollHeight);
+        }
+      });
     }
   }, [conversations]);
 
   const handleLoadMoreClick = useCallback(async () => {
     if (loadingMoreRef.current || isLoadingMoreConversations || !hasNextPage) return;
+
+    const container = sidebarScrollRef.current;
+    const savedScrollTop = container?.scrollTop ?? 0;
+    const savedScrollHeight = container?.scrollHeight ?? 0;
 
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
@@ -573,6 +591,13 @@ const ChatSidebar = ({
     } finally {
       setIsLoadingMoreConversations(false);
       loadingMoreRef.current = false;
+
+      requestAnimationFrame(() => {
+        if (sidebarScrollRef.current) {
+          const newScrollHeight = sidebarScrollRef.current.scrollHeight;
+          sidebarScrollRef.current.scrollTop = savedScrollTop + (newScrollHeight - savedScrollHeight);
+        }
+      });
     }
   }, [conversations, hasNextPage, isLoadingMoreConversations]);
 

--- a/src/components/chat/messages/MessageFile.spec.tsx
+++ b/src/components/chat/messages/MessageFile.spec.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// Mock dependencies before importing component
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string, fallback?: Record<string, unknown>) => {
+      const map: Record<string, string> = {
+        'messages.messageFile.fileFallback': 'file',
+        'messages.messageFile.downloadFallbackOpenedInNewTab': 'Opened in new tab',
+        'messages.messageFile.downloadFallbackReason.serverError': `Server error: ${fallback?.status ?? ''}`,
+        'messages.messageFile.downloadFallbackReason.network': 'Network error',
+        'messages.messageFile.unknownSize': 'Unknown size',
+        'messages.messageFile.download': 'Download',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/components/chat/messages/utils/openAttachmentInNewTab', () => ({
+  openAttachmentInNewTab: vi.fn(),
+}));
+
+import MessageFile from './MessageFile';
+import { openAttachmentInNewTab } from '@/components/chat/messages/utils/openAttachmentInNewTab';
+import { toast } from 'sonner';
+
+const mockAttachment = (overrides = {}) => ({
+  id: '1',
+  message_id: '1',
+  file_type: 'file',
+  data_url: 'https://example.com/file.pdf',
+  fallback_title: 'test-file.pdf',
+  extension: 'pdf',
+  file_size: 1024,
+  ...overrides,
+});
+
+describe('MessageFile', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let createObjectURLSpy: ReturnType<typeof vi.fn>;
+  let revokeObjectURLSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    createObjectURLSpy = vi.fn().mockReturnValue('blob:mock-url');
+    revokeObjectURLSpy = vi.fn();
+    URL.createObjectURL = createObjectURLSpy;
+    URL.revokeObjectURL = revokeObjectURLSpy;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('renders attachment with filename and download button', () => {
+    render(<MessageFile attachments={[mockAttachment()]} />);
+    expect(screen.getByText('test-file.pdf')).toBeTruthy();
+  });
+
+  it('happy path: fetch 200 triggers blob download and revokes URL', async () => {
+    const mockBlob = new Blob(['test'], { type: 'application/pdf' });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(mockBlob),
+    });
+
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'a') {
+        return { href: '', download: '', click: clickSpy } as unknown as HTMLElement;
+      }
+      return originalCreateElement(tag);
+    });
+
+    render(<MessageFile attachments={[mockAttachment()]} />);
+    const downloadBtn = screen.getAllByRole('button')[0];
+    fireEvent.click(downloadBtn);
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith('https://example.com/file.pdf', { mode: 'cors' });
+      expect(createObjectURLSpy).toHaveBeenCalledWith(mockBlob);
+      expect(clickSpy).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+    });
+
+    vi.restoreAllMocks();
+  });
+
+  it('non-ok response: falls back to openAttachmentInNewTab with toast warning', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      blob: () => Promise.resolve(new Blob()),
+    });
+
+    render(<MessageFile attachments={[mockAttachment()]} />);
+    const downloadBtn = screen.getAllByRole('button')[0];
+    fireEvent.click(downloadBtn);
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled();
+      expect(openAttachmentInNewTab).toHaveBeenCalledWith({
+        url: 'https://example.com/file.pdf',
+        filename: 'test-file.pdf',
+      });
+    });
+  });
+
+  it('fetch rejects (CORS/network): falls back to openAttachmentInNewTab', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('CORS blocked'));
+
+    render(<MessageFile attachments={[mockAttachment()]} />);
+    const downloadBtn = screen.getAllByRole('button')[0];
+    fireEvent.click(downloadBtn);
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalled();
+      expect(openAttachmentInNewTab).toHaveBeenCalledWith({
+        url: 'https://example.com/file.pdf',
+        filename: 'test-file.pdf',
+      });
+    });
+  });
+
+  it('empty data_url: download does not trigger fetch', async () => {
+    globalThis.fetch = vi.fn();
+
+    render(<MessageFile attachments={[mockAttachment({ data_url: '   ' })]} />);
+    const buttons = screen.queryAllByRole('button');
+
+    if (buttons.length > 0) {
+      fireEvent.click(buttons[0]);
+    }
+
+    // Whether button exists or not, fetch should never be called for blank URL
+    await waitFor(() => {
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+      expect(openAttachmentInNewTab).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two fixes: conversation list scroll reset during pagination and missing test coverage for MessageFile download flow.

---

### EVO-1106 — Conversation list scroll resets to top on page load

**Problem:** When scrolling down the conversation sidebar, each new page of ~20 items caused the scroll to jump back to the top. Users had to re-scroll after every page load, making it impossible to reach older conversations.

**Root cause:** `visibleConversations` useMemo re-sorts the entire list by timestamp when new items are appended via `APPEND_CONVERSATIONS`. The DOM restructure resets `scrollTop` to 0.

**Fix:** Save `scrollTop` and `scrollHeight` before `loadMoreConversations()`. After React re-renders, restore position via `requestAnimationFrame` adjusting for the new `scrollHeight`. Applied to both `handleSidebarScroll` (auto-load) and `handleLoadMoreClick` (manual button).

**File:** `src/components/chat/chat-sidebar/ChatSidebar.tsx` (+25 lines)

---

### EVO-1132 — MessageFile.tsx download flow tests

**Problem:** `MessageFile.tsx` had zero test coverage. The download flow was rewritten twice in one week without regression protection.

**Fix:** Created `MessageFile.spec.tsx` covering all 4 code paths from the acceptance criteria:

| # | Scenario | What is tested |
|---|----------|----------------|
| 1 | Component render | Filename and download button appear |
| 2 | Happy path (200) | fetch → blob → createElement('a') → click → revokeObjectURL |
| 3 | Non-ok response (4xx/5xx) | Falls back to openAttachmentInNewTab + toast.warning |
| 4 | Fetch rejects (CORS/network) | Falls back to openAttachmentInNewTab + toast.warning |
| 5 | Empty/whitespace data_url | Does not trigger fetch or fallback |

**Mocks:** `fetch`, `URL.createObjectURL`, `URL.revokeObjectURL`, `document.createElement('a')`, `toast`, `openAttachmentInNewTab`

**File:** `src/components/chat/messages/MessageFile.spec.tsx` (153 lines, new)

---

## Test plan

- [x] `pnpm exec tsc --noEmit` — zero errors
- [x] `vitest run MessageFile.spec.tsx` — 5/5 passed
- [x] EVO-1106: manually confirmed scroll stays in place during pagination (user tested)
- [x] Branch based on latest develop
- [x] 2 files changed, clean scope