### PR TITLE
fix(frontend): remove EVO-1049 workaround banner from email config (EVO-1049)

### DIFF
--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -61,11 +61,7 @@
     "testConnection": "Test Connection",
     "testing": "Testing...",
     "testFailed": "Connection test failed",
-    "testError": "Failed to run connection test",
-    "envWarning": {
-      "title": "Heads up:",
-      "body": "Saving here persists the values, but the email service still reads SMTP credentials from environment variables at boot time. Until EVO-1049 ships, configure SMTP via env vars to take effect."
-    }
+    "testError": "Failed to run connection test"
   },
   "storage": {
     "title": "Storage Configuration",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -61,11 +61,7 @@
     "testConnection": "Probar Conexion",
     "testing": "Probando...",
     "testFailed": "La prueba de conexion fallo",
-    "testError": "Error al ejecutar la prueba de conexion",
-    "envWarning": {
-      "title": "Atención:",
-      "body": "Guardar aquí persiste los valores, pero el servicio de email aún lee las credenciales SMTP de las variables de entorno al arrancar. Hasta que EVO-1049 se entregue, configure SMTP vía env vars para que surta efecto."
-    }
+    "testError": "Error al ejecutar la prueba de conexion"
   },
   "storage": {
     "title": "Configuracion de Almacenamiento",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -61,11 +61,7 @@
     "testConnection": "Tester la Connexion",
     "testing": "Test en cours...",
     "testFailed": "Le test de connexion a echoue",
-    "testError": "Impossible d'executer le test de connexion",
-    "envWarning": {
-      "title": "Avertissement :",
-      "body": "Enregistrer ici conserve les valeurs, mais le service email lit toujours les identifiants SMTP des variables d'environnement au démarrage. Jusqu'à ce que EVO-1049 soit livré, configurez SMTP via env vars pour prendre effet."
-    }
+    "testError": "Impossible d'executer le test de connexion"
   },
   "storage": {
     "title": "Configuration du Stockage",

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -61,11 +61,7 @@
     "testConnection": "Testa Connessione",
     "testing": "Test in corso...",
     "testFailed": "Test di connessione fallito",
-    "testError": "Impossibile eseguire il test di connessione",
-    "envWarning": {
-      "title": "Attenzione:",
-      "body": "Salvare qui persiste i valori, ma il servizio email legge ancora le credenziali SMTP dalle variabili d'ambiente all'avvio. Fino al rilascio di EVO-1049, configurare SMTP tramite env var per avere effetto."
-    }
+    "testError": "Impossibile eseguire il test di connessione"
   },
   "storage": {
     "title": "Configurazione Archiviazione",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -61,11 +61,7 @@
     "testConnection": "Testar Conexao",
     "testing": "Testando...",
     "testFailed": "Teste de conexao falhou",
-    "testError": "Falha ao executar teste de conexao",
-    "envWarning": {
-      "title": "Atenção:",
-      "body": "Salvar aqui persiste os valores, mas o serviço de email ainda lê as credenciais SMTP das variáveis de ambiente no boot. Até a EVO-1049 ser entregue, configure SMTP via env vars para fazer efeito."
-    }
+    "testError": "Falha ao executar teste de conexao"
   },
   "storage": {
     "title": "Configuracao de Armazenamento",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -61,11 +61,7 @@
     "testConnection": "Testar Ligacao",
     "testing": "A testar...",
     "testFailed": "Teste de ligacao falhou",
-    "testError": "Falha ao executar teste de ligacao",
-    "envWarning": {
-      "title": "Atenção:",
-      "body": "Guardar aqui persiste os valores, mas o serviço de email ainda lê as credenciais SMTP das variáveis de ambiente no arranque. Até a EVO-1049 ser concluída, configure SMTP via env vars para fazer efeito."
-    }
+    "testError": "Falha ao executar teste de ligacao"
   },
   "storage": {
     "title": "Configuracao de Armazenamento",

--- a/src/pages/Admin/Settings/SmtpConfig.tsx
+++ b/src/pages/Admin/Settings/SmtpConfig.tsx
@@ -171,7 +171,7 @@ export default function SmtpConfig() {
       const type = (data.MAILER_TYPE as MailerType) || 'smtp';
       updateSecretStatus(data);
       reset(buildFormValues(data, type));
-    } catch (error) {
+    } catch {
       toast.error(t('email.messages.loadError'));
     } finally {
       setLoading(false);
@@ -226,7 +226,7 @@ export default function SmtpConfig() {
       } else {
         toast.error(t('email.testFailed'), { description: result.message });
       }
-    } catch (error) {
+    } catch {
       toast.error(t('email.testError'));
     } finally {
       setTesting(false);
@@ -296,14 +296,6 @@ export default function SmtpConfig() {
       <div className="mb-6">
         <h2 className="text-xl font-semibold text-sidebar-foreground">{t('email.title')}</h2>
         <p className="text-sm text-sidebar-foreground/70 mt-1">{t('email.description')}</p>
-      </div>
-
-      {/* Runtime-not-applied warning — see Linear EVO-1049. Until that ships,
-          values saved here are persisted but the Rails apps continue reading
-          SMTP_* from ENV at boot time. */}
-      <div className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
-        <strong className="font-semibold">{t('email.envWarning.title')}</strong>{' '}
-        {t('email.envWarning.body')}
       </div>
 
       <Card>


### PR DESCRIPTION
## Summary
- Remove amber warning banner from `SmtpConfig.tsx` that advised users to configure SMTP via env vars — the fix is now live in the Rails services
- Remove `envWarning` i18n keys from all 6 locales (en, pt-BR, pt, es, fr, it); storage `envWarning` (EVO-1050) is preserved
- Fix pre-existing unused `error` variable in two catch blocks (lint)

## Validation
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` → 0 errors
- `evo-ai-frontend-community: pnpm lint` → no errors in changed files

## Changed Files
- `src/pages/Admin/Settings/SmtpConfig.tsx`
- `src/i18n/locales/en/adminSettings.json`
- `src/i18n/locales/pt-BR/adminSettings.json`
- `src/i18n/locales/pt/adminSettings.json`
- `src/i18n/locales/es/adminSettings.json`
- `src/i18n/locales/fr/adminSettings.json`
- `src/i18n/locales/it/adminSettings.json`

## Related PRs
- evo-auth-service-community: https://github.com/evolution-foundation/evo-auth-service-community/pull/24
- evo-ai-crm-community: https://github.com/evolution-foundation/evo-ai-crm-community/pull/66

## Linked Issue
- EVO-1049

## Summary by Sourcery

Remove the deprecated SMTP environment warning banner from the admin email settings and clean up related translations and lint issues.

Bug Fixes:
- Resolve lint warnings by removing unused error variables in SMTP configuration error handlers.

Enhancements:
- Remove the obsolete SMTP environment warning banner from the admin email settings page.
- Delete unused envWarning i18n entries for the email settings in all supported locales.