### PR TITLE
fix(frontend): ContactHeader presence reflects availability_status and channel (EVO-1083)

### DIFF
--- a/src/components/chat/contact-sidebar/ContactHeader.tsx
+++ b/src/components/chat/contact-sidebar/ContactHeader.tsx
@@ -3,14 +3,28 @@ import { Phone, Mail, MapPin, Hash } from 'lucide-react';
 import { Contact } from '@/types/chat/api';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
 import { formatContactPhone } from '@/utils/contact/formatContactPhone';
+import { isPresenceCapableChannel } from '@/utils/channelUtils';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface ContactHeaderProps {
   contact: Contact | null;
+  channelType?: string | null;
 }
 
-const ContactHeader: React.FC<ContactHeaderProps> = ({ contact }) => {
+type AvailabilityStatus = NonNullable<Contact['availability_status']>;
+
+const AVAILABILITY_DOT_CLASS: Record<AvailabilityStatus, string> = {
+  online: 'bg-green-500',
+  away: 'bg-yellow-500',
+  busy: 'bg-orange-500',
+  offline: 'bg-gray-400',
+};
+
+const ContactHeader: React.FC<ContactHeaderProps> = ({ contact, channelType }) => {
   const { t } = useLanguage('chat');
+
+  const availability = contact?.availability_status;
+  const showPresence = isPresenceCapableChannel(channelType) && !!availability;
 
   return (
     <div className="p-6 flex-shrink-0">
@@ -24,11 +38,16 @@ const ContactHeader: React.FC<ContactHeaderProps> = ({ contact }) => {
             {contact?.name || t('contactSidebar.contactHeader.contactNoName')}
           </h2>
 
-          {/* Status Online/Offline */}
-          <div className="flex items-center gap-2 mt-1">
-            <div className="w-2 h-2 bg-green-500 rounded-full flex-shrink-0"></div>
-            <span className="text-sm text-muted-foreground">{t('contactSidebar.contactHeader.online')}</span>
-          </div>
+          {showPresence && availability && (
+            <div className="flex items-center gap-2 mt-1">
+              <div
+                className={`w-2 h-2 ${AVAILABILITY_DOT_CLASS[availability]} rounded-full flex-shrink-0`}
+              ></div>
+              <span className="text-sm text-muted-foreground">
+                {t(`contactSidebar.contactHeader.${availability}`)}
+              </span>
+            </div>
+          )}
 
           {/* Info Secundária */}
           <div className="mt-3 space-y-1">

--- a/src/components/chat/contact-sidebar/ContactSidebar.tsx
+++ b/src/components/chat/contact-sidebar/ContactSidebar.tsx
@@ -182,7 +182,7 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
       >
         {/* Header com Avatar e Info Básica + Close Button */}
         <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 relative">
-          <ContactHeader contact={contact} />
+          <ContactHeader contact={contact} channelType={conversation?.inbox?.channel_type} />
 
           {/* Close Button */}
           <Button

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -382,7 +382,10 @@
     },
     "contactHeader": {
       "contactNoName": "Contact without name",
-      "online": "Online"
+      "online": "Online",
+      "away": "Away",
+      "busy": "Busy",
+      "offline": "Offline"
     },
     "contactDetails": {
       "actions": {

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -369,7 +369,10 @@
     },
     "contactHeader": {
       "contactNoName": "Contacto sin nombre",
-      "online": "En línea"
+      "online": "En línea",
+      "away": "Ausente",
+      "busy": "Ocupado",
+      "offline": "Desconectado"
     },
     "contactDetails": {
       "actions": {

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -369,7 +369,10 @@
     },
     "contactHeader": {
       "contactNoName": "Contact sans nom",
-      "online": "En ligne"
+      "online": "En ligne",
+      "away": "Absent",
+      "busy": "Occupé",
+      "offline": "Hors ligne"
     },
     "contactDetails": {
       "actions": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -369,7 +369,10 @@
     },
     "contactHeader": {
       "contactNoName": "Contatto senza nome",
-      "online": "Online"
+      "online": "Online",
+      "away": "Assente",
+      "busy": "Occupato",
+      "offline": "Offline"
     },
     "contactDetails": {
       "actions": {

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -382,7 +382,10 @@
     },
     "contactHeader": {
       "contactNoName": "Contato sem nome",
-      "online": "Online"
+      "online": "Online",
+      "away": "Ausente",
+      "busy": "Ocupado",
+      "offline": "Offline"
     },
     "contactDetails": {
       "actions": {

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -369,7 +369,10 @@
     },
     "contactHeader": {
       "contactNoName": "Contato sem nome",
-      "online": "Online"
+      "online": "Online",
+      "away": "Ausente",
+      "busy": "Ocupado",
+      "offline": "Offline"
     },
     "contactDetails": {
       "actions": {

--- a/src/utils/channelUtils.ts
+++ b/src/utils/channelUtils.ts
@@ -58,6 +58,21 @@ export function isPhoneBearingChannel(channelType?: string | null): boolean {
   return PHONE_BEARING_CHANNEL_TYPES.has(channelType);
 }
 
+// Channel types where the contact's `availability_status` carries real
+// presence semantics. Today this is limited to the Website widget; other
+// channels (WhatsApp, SMS, Email, social, API) do not expose live presence,
+// so the UI must hide the indicator instead of showing a misleading state.
+const PRESENCE_CAPABLE_CHANNEL_TYPES = new Set<string>([
+  'Channel::WebWidget',
+  'webwidget',
+  'web_widget',
+]);
+
+export function isPresenceCapableChannel(channelType?: string | null): boolean {
+  if (!channelType) return false;
+  return PRESENCE_CAPABLE_CHANNEL_TYPES.has(channelType);
+}
+
 // Provider-specific translations for detailed display
 const PROVIDER_TRANSLATIONS: Record<string, string> = {
   'whatsapp_cloud': 'WhatsApp Cloud',


### PR DESCRIPTION
## Summary

- Replace the hardcoded green dot + `Online` label in the contact sidebar with a presence indicator that reflects `Contact.availability_status`.
- Hide the indicator on channels without presence semantics (WhatsApp, SMS, Email, API, Facebook, Instagram, Twitter, Telegram, Line); only `Channel::WebWidget` keeps presence.
- Hide the indicator when `availability_status` is null/undefined on a presence-capable channel (no fallback to a fake `Online`).
- Map status → color + i18n label: `online` (green), `away` (yellow), `busy` (orange), `offline` (gray).
- Add `away`, `busy`, `offline` keys under `contactSidebar.contactHeader` in all 6 locales (`en`, `pt-BR`, `pt`, `es`, `fr`, `it`).

## Changed Files

- `src/utils/channelUtils.ts` — new `isPresenceCapableChannel` helper.
- `src/components/chat/contact-sidebar/ContactHeader.tsx` — gating + state→color/label mapping.
- `src/components/chat/contact-sidebar/ContactSidebar.tsx` — passes `conversation.inbox.channel_type` to the header.
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/chat.json` — new i18n keys.

## Validation

- `pnpm exec tsc -b --noEmit` — clean.
- `pnpm lint` — no new errors on changed files (pre-existing repo-wide lint debt is out of scope).
- `pnpm test` — **not run**: the full vitest suite hangs locally (>10min, one worker pegged at ~99% CPU). Tracked separately as a draft card; the patch touches only `.ts`/`.tsx`/`.json` files with no timers or async code, so it does not introduce the hang.
- Manual test plan executed against the acceptance criteria:
  - [x] Indicator hidden on non-presence channels (WhatsApp/SMS/Email/social).
  - [x] Indicator hidden on Web widget when `availability_status` is null.
  - [x] Indicator shows correct color + label per status on Web widget.
  - [x] No literal i18n key visible in any locale.
  - [x] No regression in EVO-988 phone display.

## Linked Issue

- [EVO-1083](https://linear.app/evoai/issue/EVO-1083/contactheader-hardcoded-online-indicator-misleads-agents-on-non)

## Summary by Sourcery

Update the contact sidebar header to display a presence indicator only for presence-capable web widget channels and to reflect the contact’s actual availability status with localized labels.

New Features:
- Add a presence-aware status indicator in the contact header that maps contact availability states to colored dots and localized labels.

Enhancements:
- Introduce a channel utility helper to detect presence-capable channels and wire channel type through the contact sidebar to the header.
- Extend chat locale files with new availability status translations across all supported languages.