### PR TITLE
fix(frontend): match conversations by id||uuid in selection and lifecycle reducers (EVO-1145)

### DIFF
--- a/src/contexts/chat/ConversationsContext.spec.tsx
+++ b/src/contexts/chat/ConversationsContext.spec.tsx
@@ -1,15 +1,29 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { conversationsReducer } from './ConversationsContextReducer';
 import { initialState } from '@/types/chat/conversations';
+import type { Conversation } from '@/types/chat/api';
+import { matchesConversationId } from '@/utils/chat/conversationMatcher';
 
-const makeConversation = (overrides: Record<string, unknown> = {}) =>
-  ({
+// Test fixtures admit numeric ids because the backend / WebSocket can deliver
+// either form despite the strict `Conversation.id: string` typing. Cast back
+// to `Conversation` at the boundary so the reducer sees its expected shape.
+type ConversationFixture = Omit<Partial<Conversation>, 'id' | 'uuid'> & {
+  id: string | number;
+  uuid?: string | null;
+};
+
+const makeConversation = (
+  overrides: Partial<ConversationFixture> = {},
+): Conversation => {
+  const base: ConversationFixture = {
     id: 'conversation-1',
     uuid: 'conversation-1',
     unread_count: 5,
     status: 'open',
     ...overrides,
-  }) as any;
+  };
+  return base as unknown as Conversation;
+};
 
 describe('ConversationsContext reducer', () => {
   beforeEach(() => {
@@ -66,5 +80,320 @@ describe('ConversationsContext reducer', () => {
     });
 
     expect(nextState.conversations[0].unread_count).toBe(0);
+  });
+
+  describe('UPDATE_CONVERSATION id/uuid matching (EVO-1145)', () => {
+    it('merges in place when payload.id matches existing conv.id', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', status: 'open' }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({ id: 42, uuid: 'conv-uuid-42', status: 'resolved' }),
+      });
+
+      expect(nextState.conversations).toHaveLength(1);
+      expect(nextState.conversations[0].id).toBe(42);
+      expect(nextState.conversations[0].status).toBe('resolved');
+    });
+
+    it('merges in place when payload.id matches existing conv.uuid (regression for C3)', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', status: 'open' }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({ id: 'conv-uuid-42', uuid: 'conv-uuid-42', status: 'pending' }),
+      });
+
+      expect(nextState.conversations).toHaveLength(1);
+      expect(nextState.conversations[0].uuid).toBe('conv-uuid-42');
+      expect(nextState.conversations[0].status).toBe('pending');
+    });
+
+    it('prepends when conversation is not in the list', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 1, uuid: 'conv-uuid-1' }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({ id: 99, uuid: 'conv-uuid-99', status: 'open' }),
+      });
+
+      expect(nextState.conversations).toHaveLength(2);
+      expect(nextState.conversations[0].id).toBe(99);
+      expect(nextState.conversations[1].id).toBe(1);
+    });
+  });
+
+  describe('ADD_CONVERSATION id/uuid dedupe (EVO-1145)', () => {
+    it('merges in place when payload.id matches existing conv.uuid', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 7, uuid: 'conv-uuid-7', status: 'open' }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'ADD_CONVERSATION',
+        payload: makeConversation({ id: 'conv-uuid-7', uuid: 'conv-uuid-7', status: 'snoozed' }),
+      });
+
+      expect(nextState.conversations).toHaveLength(1);
+      expect(nextState.conversations[0].uuid).toBe('conv-uuid-7');
+      expect(nextState.conversations[0].status).toBe('snoozed');
+    });
+
+    it('prepends a brand-new conversation when no match by id or uuid', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 7, uuid: 'conv-uuid-7' }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'ADD_CONVERSATION',
+        payload: makeConversation({ id: 8, uuid: 'conv-uuid-8' }),
+      });
+
+      expect(nextState.conversations).toHaveLength(2);
+      expect(nextState.conversations[0].id).toBe(8);
+    });
+  });
+
+  describe('UPDATE_CONVERSATION selected-data alignment (EVO-1145 H1)', () => {
+    it('updates selectedConversationData when selection is by id and payload is keyed by uuid', () => {
+      // Selected by numeric id; WebSocket frame arrives keyed by uuid.
+      const state = {
+        ...initialState,
+        selectedConversationId: '42',
+        selectedConversationData: makeConversation({
+          id: 42,
+          uuid: 'conv-uuid-42',
+          status: 'open',
+        }),
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', status: 'open' }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({
+          id: 'conv-uuid-42',
+          uuid: 'conv-uuid-42',
+          status: 'resolved',
+        }),
+      });
+
+      expect(nextState.conversations).toHaveLength(1);
+      expect(nextState.conversations[0].status).toBe('resolved');
+      expect(nextState.selectedConversationData?.status).toBe('resolved');
+    });
+
+    it('updates selectedConversationData on prepend race when the selected conv is not in the list yet', () => {
+      // Race: SELECT_CONVERSATION landed before SET_CONVERSATIONS completed,
+      // so the selected conversation is not in `conversations` yet. The
+      // UPDATE_CONVERSATION frame must still flow into `selectedConversationData`
+      // so the right panel doesn't fall behind the prepended row.
+      const state = {
+        ...initialState,
+        selectedConversationId: '99',
+        selectedConversationData: makeConversation({
+          id: 99,
+          uuid: 'conv-uuid-99',
+          status: 'open',
+        }),
+        conversations: [makeConversation({ id: 1, uuid: 'conv-uuid-1' })],
+        unreadCounts: { '99': 0 },
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({
+          id: 99,
+          uuid: 'conv-uuid-99',
+          status: 'resolved',
+          unread_count: 5,
+        }),
+      });
+
+      // Conv 99 prepended to the list, unread preserved at 0 (was marked read).
+      expect(nextState.conversations).toHaveLength(2);
+      expect(nextState.conversations[0].id).toBe(99);
+      expect(nextState.conversations[0].unread_count).toBe(0);
+      // Selected panel reflects the new status.
+      expect(nextState.selectedConversationData?.status).toBe('resolved');
+      expect(nextState.selectedConversationData?.unread_count).toBe(0);
+    });
+
+    it('preserves unread=0 when selection canonicalized to uuid while SET seeded unreadCounts by id', () => {
+      // `selectConversation` canonicalizes the selection key to `uuid` when
+      // available, while `SET_CONVERSATIONS` seeds `unreadCounts` by
+      // `String(conv.id)`. Both entries coexist for the same conv. An incoming
+      // UPDATE_CONVERSATION must honor the uuid-keyed `0` (the user just
+      // opened the conversation), not the stale id-keyed seed.
+      const state = {
+        ...initialState,
+        selectedConversationId: 'conv-uuid-42',
+        selectedConversationData: makeConversation({
+          id: 42,
+          uuid: 'conv-uuid-42',
+          unread_count: 0,
+        }),
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', unread_count: 5 }),
+        ],
+        unreadCounts: { '42': 5, 'conv-uuid-42': 0 },
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({
+          id: 'conv-uuid-42',
+          uuid: 'conv-uuid-42',
+          unread_count: 7,
+        }),
+      });
+
+      expect(nextState.conversations[0].unread_count).toBe(0);
+      expect(nextState.selectedConversationData?.unread_count).toBe(0);
+    });
+
+    it('preserves unread_count=0 for the selected conversation even when payload arrives by uuid', () => {
+      // Selection marked the conv as read (localUnread = 0). An incoming
+      // frame keyed by uuid must not reintroduce a non-zero unread_count.
+      const state = {
+        ...initialState,
+        selectedConversationId: '42',
+        selectedConversationData: makeConversation({
+          id: 42,
+          uuid: 'conv-uuid-42',
+          unread_count: 0,
+        }),
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', unread_count: 0 }),
+        ],
+        unreadCounts: { '42': 0 },
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_CONVERSATION',
+        payload: makeConversation({
+          id: 'conv-uuid-42',
+          uuid: 'conv-uuid-42',
+          unread_count: 9,
+        }),
+      });
+
+      expect(nextState.conversations[0].unread_count).toBe(0);
+      expect(nextState.selectedConversationData?.unread_count).toBe(0);
+    });
+  });
+
+  describe('REMOVE_CONVERSATION id/uuid (EVO-1145 M1)', () => {
+    it('removes the conversation when dispatched by uuid', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42' }),
+          makeConversation({ id: 99, uuid: 'conv-uuid-99' }),
+        ],
+        unreadCounts: { '42': 3, '99': 1 },
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'REMOVE_CONVERSATION',
+        payload: 'conv-uuid-42',
+      });
+
+      expect(nextState.conversations).toHaveLength(1);
+      expect(nextState.conversations[0].id).toBe(99);
+      expect(nextState.unreadCounts).not.toHaveProperty('42');
+      expect(nextState.unreadCounts['99']).toBe(1);
+    });
+  });
+
+  describe('UPDATE_UNREAD_COUNT id/uuid (EVO-1145 M1)', () => {
+    it('updates the conversation unread_count when dispatched by uuid', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', unread_count: 0 }),
+        ],
+      };
+
+      const nextState = conversationsReducer(state, {
+        type: 'UPDATE_UNREAD_COUNT',
+        payload: { conversationId: 'conv-uuid-42', count: 7 },
+      });
+
+      expect(nextState.conversations[0].unread_count).toBe(7);
+    });
+
+    it('clears the localStorage read marker when count rises above zero (mark-as-unread, F5 stability)', () => {
+      // Repro: user reads conv → reducer stamps localStorage. User marks the
+      // same conv unread → without clearing the marker, `SET_CONVERSATIONS`
+      // after F5 forces unread back to 0 because `wasMarkedAsRead` stays true.
+      localStorage.setItem(
+        'crm-chat-state',
+        JSON.stringify({ readConversations: { '42': true } }),
+      );
+
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({ id: 42, uuid: 'conv-uuid-42', unread_count: 0 }),
+        ],
+      };
+
+      conversationsReducer(state, {
+        type: 'UPDATE_UNREAD_COUNT',
+        payload: { conversationId: '42', count: 1 },
+      });
+
+      const saved = JSON.parse(localStorage.getItem('crm-chat-state') || '{}');
+      expect(saved.readConversations?.['42']).toBeUndefined();
+    });
+  });
+
+  describe('matchesConversationId guards', () => {
+    it('returns false for an empty idStr even when conv has a falsy uuid', () => {
+      // Regression: previously `String(conv.uuid || '') === ''` matched every
+      // conv whose uuid was null when callers passed an empty string by mistake.
+      expect(matchesConversationId({ id: 1, uuid: null }, '')).toBe(false);
+      expect(matchesConversationId({ id: 1, uuid: '' }, '')).toBe(false);
+      expect(matchesConversationId({ id: 1 }, '')).toBe(false);
+    });
+
+    it('returns false for null/undefined conversations', () => {
+      expect(matchesConversationId(null, 'anything')).toBe(false);
+      expect(matchesConversationId(undefined, 'anything')).toBe(false);
+    });
+
+    it('with an ambiguous match across distinct conversations, .some() reports a hit but consumers must beware', () => {
+      // Documents the current contract: if one conversation has `id=42` and a
+      // different one has `uuid="42"`, both pass `matchesConversationId(_, '42')`.
+      // Reducers using `.some()`+`.map()` then update BOTH rows with the same
+      // payload. Callers must keep their dispatched ids unambiguous.
+      const a = { id: 42, uuid: 'conv-uuid-a' };
+      const b = { id: 99, uuid: '42' };
+      expect(matchesConversationId(a, '42')).toBe(true);
+      expect(matchesConversationId(b, '42')).toBe(true);
+    });
   });
 });

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -17,6 +17,7 @@ import { isActionNotSupported } from '@/utils/chat/actionSupport';
 import { Contact, Conversation, ConversationListParams } from '@/types/chat/api';
 import { PaginationMeta } from '@/types/core';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { matchesConversationId } from '@/utils/chat/conversationMatcher';
 
 export function ConversationsProvider({ children }: { children: React.ReactNode }) {
   const { t } = useLanguage('chat');
@@ -32,11 +33,7 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
     (conversationId: string) => {
       const idStr = String(conversationId);
       return (
-        state.conversations.find(
-          conv =>
-            String(conv.id) === idStr ||
-            String(conv.uuid || '') === idStr,
-        ) || null
+        state.conversations.find(conv => matchesConversationId(conv, idStr)) || null
       );
     },
     [state.conversations],

--- a/src/contexts/chat/ConversationsContextReducer.ts
+++ b/src/contexts/chat/ConversationsContextReducer.ts
@@ -1,5 +1,6 @@
 import { ConversationsState, ConversationsAction } from '@/types/chat/conversations';
 import { Conversation } from '@/types/chat/api';
+import { matchesConversationId } from '@/utils/chat/conversationMatcher';
 
 // Helper para verificar se uma conversa foi marcada como lida no localStorage
 const getReadConversationsFromStorage = (): Record<string, boolean> => {
@@ -211,29 +212,54 @@ export function conversationsReducer(
 
       const conversationId = String(action.payload.id);
 
-      // Sincronizar unread_count do objeto com o estado unreadCounts
-      // Priorizar unreadCounts (estado local) sobre o valor do objeto
-      // Se a conversa está selecionada e foi marcada como lida (unreadCount = 0), sempre preservar isso
-      const isSelected = state.selectedConversationId === conversationId;
-      const localUnreadCount = state.unreadCounts[conversationId];
-
-      // Se está selecionada e foi marcada como lida, sempre usar 0
-      // Caso contrário, usar o valor local se existir, senão usar o valor do payload
-      const syncedUnreadCount = isSelected && localUnreadCount === 0
-        ? 0
-        : (localUnreadCount ?? action.payload.unread_count ?? 0);
-
       // Atualizar na lista de conversas
       const cleanConversations = state.conversations
         .filter(conv => conv !== null && conv !== undefined && conv.id);
 
-      const existsInList = cleanConversations.some(
-        conv => String(conv.id) === conversationId,
+      // Resolve the canonical conversation in state regardless of whether the
+      // payload arrived keyed by `id` or `uuid`. The reducer uses this to keep
+      // selection + unread bookkeeping aligned with the update.
+      const targetConv = cleanConversations.find(conv =>
+        matchesConversationId(conv, conversationId),
       );
+      const existsInList = targetConv != null;
+
+      // Check selection against the resolved conversation (not the raw payload
+      // id), so that a `selectedConversationId` stored as `id` still matches
+      // when the WebSocket frame is keyed by `uuid` (and vice versa).
+      // Race-safety: when the conv isn't in the list yet (e.g. SELECT_CONVERSATION
+      // landed before SET_CONVERSATIONS completed), fall back to direct
+      // comparison so `selectedConversationData` still tracks the incoming
+      // payload — matches the previous reducer behaviour.
+      const selectedIdStr = state.selectedConversationId
+        ? String(state.selectedConversationId)
+        : null;
+      const isSelected =
+        selectedIdStr != null &&
+        (targetConv != null
+          ? matchesConversationId(targetConv, selectedIdStr)
+          : selectedIdStr === conversationId);
+
+      // Sincronizar unread_count do objeto com o estado unreadCounts.
+      // `selectConversation` canonicaliza a selection para `uuid` quando ele
+      // existe, mas `SET_CONVERSATIONS` semeia `unreadCounts` por
+      // `String(conv.id)`. As duas entradas coexistem para a mesma conv, então
+      // checamos ambas — se qualquer uma marcar como lida (0) enquanto a conv
+      // está selecionada, preservamos o 0 contra um payload stale.
+      const canonicalKey = targetConv ? String(targetConv.id) : conversationId;
+      const localUnreadCount = state.unreadCounts[canonicalKey];
+      const selectedKeyUnreadCount =
+        selectedIdStr != null && selectedIdStr !== canonicalKey
+          ? state.unreadCounts[selectedIdStr]
+          : undefined;
+      const syncedUnreadCount =
+        isSelected && (localUnreadCount === 0 || selectedKeyUnreadCount === 0)
+          ? 0
+          : (localUnreadCount ?? selectedKeyUnreadCount ?? action.payload.unread_count ?? 0);
 
       const updatedConversationsList = existsInList
         ? cleanConversations.map(conv =>
-            String(conv.id) === conversationId
+            matchesConversationId(conv, conversationId)
               ? {
                   ...conv,
                   ...action.payload,
@@ -244,15 +270,13 @@ export function conversationsReducer(
         : [{ ...action.payload, unread_count: syncedUnreadCount }, ...cleanConversations];
 
       // Se é a conversa selecionada, atualizar os dados também
-      const updatedSelectedData =
-        state.selectedConversationId &&
-        String(state.selectedConversationId) === conversationId
-          ? {
-              ...state.selectedConversationData,
-              ...action.payload,
-              unread_count: syncedUnreadCount, // Sincronizar também aqui
-            }
-          : state.selectedConversationData;
+      const updatedSelectedData = isSelected
+        ? {
+            ...state.selectedConversationData,
+            ...action.payload,
+            unread_count: syncedUnreadCount, // Sincronizar também aqui
+          }
+        : state.selectedConversationData;
 
       return {
         ...state,
@@ -323,22 +347,20 @@ export function conversationsReducer(
         return state;
       }
 
-      // 🔒 PROTEÇÃO: Verificar se conversa já existe antes de adicionar
-      const existingIndex = state.conversations.findIndex(
-        conv => String(conv.id) === String(action.payload.id),
+      const incomingId = String(action.payload.id);
+
+      const existingIndex = state.conversations.findIndex(conv =>
+        matchesConversationId(conv, incomingId),
       );
 
       if (existingIndex >= 0) {
-        // Se já existe, atualizar ao invés de adicionar (com merge)
         const updatedConversation = { ...state.conversations[existingIndex], ...action.payload };
         return {
           ...state,
           conversations: state.conversations
             .filter(conv => conv !== null && conv !== undefined && conv.id)
             .map(conv =>
-              String(conv.id) === String(action.payload.id)
-                ? updatedConversation // Merge ao invés de substituir
-                : conv,
+              matchesConversationId(conv, incomingId) ? updatedConversation : conv,
             ),
         };
       }
@@ -350,12 +372,18 @@ export function conversationsReducer(
     }
 
     case 'REMOVE_CONVERSATION': {
+      const targetId = String(action.payload);
+      const removed = state.conversations.find(conv =>
+        matchesConversationId(conv, targetId),
+      );
       const filteredConversations = state.conversations.filter(
-        conv => String(conv.id) !== String(action.payload),
+        conv => !matchesConversationId(conv, targetId),
       );
 
-      // Remove from unread counts as well
-      const { [action.payload]: _removed, ...remainingUnreadCounts } = state.unreadCounts; // eslint-disable-line @typescript-eslint/no-unused-vars
+      // `unreadCounts` is keyed by the canonical `String(conv.id)`. When the
+      // caller dispatches by uuid we still want to drop the right key.
+      const unreadKey = removed ? String(removed.id) : targetId;
+      const { [unreadKey]: _removed, ...remainingUnreadCounts } = state.unreadCounts; // eslint-disable-line @typescript-eslint/no-unused-vars
 
       return {
         ...state,
@@ -383,10 +411,16 @@ export function conversationsReducer(
       const { conversationId, count } = action.payload;
       const conversationIdStr = String(conversationId);
 
-      // Se está marcando como lida (count = 0), salvar no localStorage
+      // Sync the persisted "read" marker so `SET_CONVERSATIONS` on the next
+      // page load honors the most recent intent. Without the `else` branch a
+      // mark-as-unread leaves a stale `readConversations[id] = true` behind
+      // and F5 silently zeroes the badge again.
+      const readConversations = getReadConversationsFromStorage();
       if (count === 0) {
-        const readConversations = getReadConversationsFromStorage();
         readConversations[conversationIdStr] = true;
+        saveReadConversationsToStorage(readConversations);
+      } else if (readConversations[conversationIdStr]) {
+        delete readConversations[conversationIdStr];
         saveReadConversationsToStorage(readConversations);
       }
 
@@ -401,7 +435,7 @@ export function conversationsReducer(
         conversations: state.conversations
           .filter(conv => conv !== null && conv !== undefined && conv.id)
           .map(conv =>
-            String(conv.id) === conversationIdStr
+            matchesConversationId(conv, conversationIdStr)
               ? { ...conv, unread_count: count }
               : conv,
           ),

--- a/src/utils/chat/conversationMatcher.ts
+++ b/src/utils/chat/conversationMatcher.ts
@@ -1,0 +1,16 @@
+type ConversationLike = {
+  id: string | number;
+  uuid?: string | null;
+};
+
+// Match a conversation by either its canonical numeric id or its uuid.
+// Both forms can arrive from the backend / WebSocket; comparing only against
+// `id` silently misses payloads keyed by `uuid` (root cause of EVO-1118 C3).
+export const matchesConversationId = (
+  conv: ConversationLike | null | undefined,
+  idStr: string,
+): boolean => {
+  if (!conv) return false;
+  if (!idStr) return false;
+  return String(conv.id) === idStr || String(conv.uuid || '') === idStr;
+};


### PR DESCRIPTION
## Summary

Follow-up to EVO-1118 / EVO-1062. WebSocket frames can arrive keyed either by `Conversation.id` or `Conversation.uuid`; comparing only against `id` silently misses uuid-keyed payloads and is the root cause of the duplicated rows the C3 review flagged on PR #58 (`evo-ai-frontend-community`).

- New `matchesConversationId` helper in `src/utils/chat/conversationMatcher.ts` (matches by `id || uuid`, guards null conv + empty `idStr`).
- `ConversationsContext.findConversationByAnyId` delegates to the helper so the reducer and the context lookup share a single contract.
- `UPDATE_CONVERSATION` resolves the canonical conversation first, then drives `isSelected`, `syncedUnreadCount`, and `updatedSelectedData` off it. The unread sync now consults BOTH the canonical-id key and the selection key, because `selectConversation` canonicalizes to `uuid` while `SET_CONVERSATIONS` seeds `unreadCounts` by `String(conv.id)`.
- `ADD_CONVERSATION`, `REMOVE_CONVERSATION`, and `UPDATE_UNREAD_COUNT` apply the same matcher; `REMOVE_CONVERSATION` also resolves the canonical `unreadCounts` key before pruning.
- `UPDATE_UNREAD_COUNT` now clears the persisted "marked as read" entry in `localStorage` when the count rises above zero — fixes the bug where mark-as-unread silently lost the badge after F5 (`SET_CONVERSATIONS` was honoring a stale `readConversations[id] = true`).

## Changed Files

- `src/utils/chat/conversationMatcher.ts` (new, 16 lines)
- `src/contexts/chat/ConversationsContext.tsx`
- `src/contexts/chat/ConversationsContextReducer.ts`
- `src/contexts/chat/ConversationsContext.spec.tsx` (new spec, 18 tests)

## Validation

- `pnpm exec tsc -b --noEmit` — clean.
- `pnpm lint` — no new errors on changed files (the existing repo-wide lint debt is out of scope; the only warning on `ConversationsContext.tsx` is pre-existing at line 816 and untouched by this patch).
- `pnpm exec vitest run src/contexts/chat/ConversationsContext.spec.tsx` — **18/18 passing**. Targeted run because the full vitest suite hangs locally (separate issue under triage).
- Manual smoke validated: open conv → badge clears; mark as unread → F5 → badge persists; resolve/snooze does not duplicate the row; selection by uuid keeps right panel in sync.

## Out of Scope (carry-forward)

The following lifecycle cases still match by `String(conv.id)` only and should follow the same normalization in a future card: `UPDATE_CONVERSATION_LAST_ACTIVITY`, `INCREMENT_UNREAD_COUNT`, `ADD_HIDDEN_CONVERSATION`, `REVEAL_HIDDEN_CONVERSATIONS`, `UPDATE_CONTACT_IN_CONVERSATIONS`, `CLEANUP_DUPLICATES`. The pre-existing `SELECT_CONVERSATION` reducer also fails to clear `conv.unread_count` on the list row when SELECT is canonicalized to uuid; downstream `UPDATE_CONVERSATION` frames now compensate, but the SELECT reducer itself should also be normalized in the follow-up.

## Linked Issue

- [EVO-1145](https://linear.app/evoai/issue/EVO-1145/evo-1118-follow-up-corrigir-iduuid-match-no-update-conversation)