### PR TITLE
fix(frontend): remove storage envWarning and fix collapsed sidebar layout [EVO-1050]

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -138,20 +138,6 @@ export default function MainLayout({ children }: MainLayoutProps) {
           setActiveSubmenu={menuState.setActiveSubmenu}
         />
 
-        {/* Backdrop for collapsed sidebar flyout — starts at left-16 so the icon sidebar remains clickable */}
-        {menuState.activeSubmenu && isCollapsed && (
-          <div
-            role="button"
-            tabIndex={0}
-            aria-label={t('sidebar.closeSubmenu')}
-            className="hidden md:block absolute left-16 top-0 bottom-0 right-0 z-40"
-            onClick={() => menuState.setActiveSubmenu(null)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') menuState.setActiveSubmenu(null);
-            }}
-          />
-        )}
-
         {/* Main Content */}
         <main className="flex-1 overflow-auto bg-background transition-colors duration-150 ease-in-out">
           <div className="h-full">{children}</div>

--- a/src/components/layout/components/Sidebar.tsx
+++ b/src/components/layout/components/Sidebar.tsx
@@ -249,12 +249,11 @@ export default function Sidebar({
           aria-labelledby="flyout-title"
           aria-hidden={activeSubmenu ? undefined : 'true'}
           className={cn(
-            'hidden md:flex w-64 bg-sidebar text-sidebar-foreground flex-col border-r border-sidebar-border',
-            'absolute left-16 top-0 h-full z-50 shadow-xl',
-            'transition-all duration-150 ease-in-out',
+            'hidden md:flex bg-sidebar text-sidebar-foreground flex-col border-r border-sidebar-border',
+            'transition-all duration-150 ease-in-out overflow-hidden',
             activeSubmenu
-              ? 'translate-x-0 opacity-100'
-              : '-translate-x-2 opacity-0 pointer-events-none',
+              ? 'w-64 opacity-100'
+              : 'w-0 opacity-0 pointer-events-none',
           )}
         >
           {activeSubmenu && (

--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -105,7 +105,11 @@
     "testConnection": "Test Connection",
     "testing": "Testing...",
     "testFailed": "Connection test failed",
-    "testError": "Failed to run connection test"
+    "testError": "Failed to run connection test",
+    "cloudWarning": {
+      "title": "Important:",
+      "body": "S3 credentials (access key, secret, region, endpoint) are embedded in the service configuration at startup — changing them here requires restarting the auth and CRM services and their Sidekiq workers to take effect. Existing files remain on the previous storage provider; only new uploads will use the updated configuration."
+    }
   },
   "socialLogin": {
     "title": "Authentication Providers",

--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -105,11 +105,7 @@
     "testConnection": "Test Connection",
     "testing": "Testing...",
     "testFailed": "Connection test failed",
-    "testError": "Failed to run connection test",
-    "envWarning": {
-      "title": "Heads up:",
-      "body": "Saving here persists the choice, but the file service still reads ACTIVE_STORAGE_SERVICE from environment variables at boot time. Until EVO-1050 ships, configure storage via env vars to take effect."
-    }
+    "testError": "Failed to run connection test"
   },
   "socialLogin": {
     "title": "Authentication Providers",

--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -108,7 +108,7 @@
     "testError": "Failed to run connection test",
     "cloudWarning": {
       "title": "Important:",
-      "body": "S3 credentials (access key, secret, region, endpoint) are embedded in the service configuration at startup — changing them here requires restarting the auth and CRM services and their Sidekiq workers to take effect. Existing files remain on the previous storage provider; only new uploads will use the updated configuration."
+      "body": "S3 credentials (access key, secret, region, endpoint) are embedded in the service configuration at startup — changing them here requires restarting the auth and CRM services and their Sidekiq workers to take effect. Provider changes may take up to 60 seconds to propagate across all services. Existing files remain on the previous storage provider; only new uploads will use the updated configuration."
     }
   },
   "socialLogin": {

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -105,7 +105,11 @@
     "testConnection": "Probar Conexion",
     "testing": "Probando...",
     "testFailed": "La prueba de conexion fallo",
-    "testError": "Error al ejecutar la prueba de conexion"
+    "testError": "Error al ejecutar la prueba de conexion",
+    "cloudWarning": {
+      "title": "Importante:",
+      "body": "Las credenciales S3 (clave de acceso, secreto, region y endpoint) se integran en la configuracion del servicio al arrancar — cambiarlas aqui requiere reiniciar los servicios auth y CRM y sus workers Sidekiq para que los nuevos valores surtan efecto. Los archivos existentes permanecen en el proveedor de almacenamiento anterior; solo las nuevas cargas usaran la configuracion actualizada."
+    }
   },
   "socialLogin": {
     "title": "Proveedores de Autenticación",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -105,11 +105,7 @@
     "testConnection": "Probar Conexion",
     "testing": "Probando...",
     "testFailed": "La prueba de conexion fallo",
-    "testError": "Error al ejecutar la prueba de conexion",
-    "envWarning": {
-      "title": "Atención:",
-      "body": "Guardar aquí persiste la elección, pero el servicio de archivos aún lee ACTIVE_STORAGE_SERVICE de las variables de entorno al arrancar. Hasta que EVO-1050 se entregue, configure storage vía env vars para que surta efecto."
-    }
+    "testError": "Error al ejecutar la prueba de conexion"
   },
   "socialLogin": {
     "title": "Proveedores de Autenticación",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -108,7 +108,7 @@
     "testError": "Error al ejecutar la prueba de conexion",
     "cloudWarning": {
       "title": "Importante:",
-      "body": "Las credenciales S3 (clave de acceso, secreto, region y endpoint) se integran en la configuracion del servicio al arrancar — cambiarlas aqui requiere reiniciar los servicios auth y CRM y sus workers Sidekiq para que los nuevos valores surtan efecto. Los archivos existentes permanecen en el proveedor de almacenamiento anterior; solo las nuevas cargas usaran la configuracion actualizada."
+      "body": "Las credenciales S3 (clave de acceso, secreto, region y endpoint) se integran en la configuracion del servicio al arrancar — cambiarlas aqui requiere reiniciar los servicios auth y CRM y sus workers Sidekiq para que los nuevos valores surtan efecto. Los cambios de proveedor pueden tardar hasta 60 segundos en propagarse entre todos los servicios. Los archivos existentes permanecen en el proveedor de almacenamiento anterior; solo las nuevas cargas usaran la configuracion actualizada."
     }
   },
   "socialLogin": {

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -105,7 +105,11 @@
     "testConnection": "Tester la Connexion",
     "testing": "Test en cours...",
     "testFailed": "Le test de connexion a echoue",
-    "testError": "Impossible d'executer le test de connexion"
+    "testError": "Impossible d'executer le test de connexion",
+    "cloudWarning": {
+      "title": "Important :",
+      "body": "Les identifiants S3 (cle d'acces, secret, region et endpoint) sont integres dans la configuration du service au demarrage — les modifier ici necessite de redemarrer les services auth et CRM et leurs workers Sidekiq pour que les nouvelles valeurs prennent effet. Les fichiers existants restent sur l'ancien fournisseur de stockage ; seuls les nouveaux telechargements utiliseront la configuration mise a jour."
+    }
   },
   "socialLogin": {
     "title": "Fournisseurs d'authentification",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -105,11 +105,7 @@
     "testConnection": "Tester la Connexion",
     "testing": "Test en cours...",
     "testFailed": "Le test de connexion a echoue",
-    "testError": "Impossible d'executer le test de connexion",
-    "envWarning": {
-      "title": "Avertissement :",
-      "body": "Enregistrer ici conserve le choix, mais le service de fichiers lit toujours ACTIVE_STORAGE_SERVICE des variables d'environnement au démarrage. Jusqu'à ce que EVO-1050 soit livré, configurez storage via env vars pour prendre effet."
-    }
+    "testError": "Impossible d'executer le test de connexion"
   },
   "socialLogin": {
     "title": "Fournisseurs d'authentification",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -108,7 +108,7 @@
     "testError": "Impossible d'executer le test de connexion",
     "cloudWarning": {
       "title": "Important :",
-      "body": "Les identifiants S3 (cle d'acces, secret, region et endpoint) sont integres dans la configuration du service au demarrage — les modifier ici necessite de redemarrer les services auth et CRM et leurs workers Sidekiq pour que les nouvelles valeurs prennent effet. Les fichiers existants restent sur l'ancien fournisseur de stockage ; seuls les nouveaux telechargements utiliseront la configuration mise a jour."
+      "body": "Les identifiants S3 (cle d'acces, secret, region et endpoint) sont integres dans la configuration du service au demarrage — les modifier ici necessite de redemarrer les services auth et CRM et leurs workers Sidekiq pour que les nouvelles valeurs prennent effet. Les changements de fournisseur peuvent prendre jusqu'a 60 secondes pour se propager sur tous les services. Les fichiers existants restent sur l'ancien fournisseur de stockage ; seuls les nouveaux telechargements utiliseront la configuration mise a jour."
     }
   },
   "socialLogin": {

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -105,11 +105,7 @@
     "testConnection": "Testa Connessione",
     "testing": "Test in corso...",
     "testFailed": "Test di connessione fallito",
-    "testError": "Impossibile eseguire il test di connessione",
-    "envWarning": {
-      "title": "Attenzione:",
-      "body": "Salvare qui persiste la scelta, ma il servizio file legge ancora ACTIVE_STORAGE_SERVICE dalle variabili d'ambiente all'avvio. Fino al rilascio di EVO-1050, configurare storage tramite env var per avere effetto."
-    }
+    "testError": "Impossibile eseguire il test di connessione"
   },
   "socialLogin": {
     "title": "Provider di autenticazione",

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -108,7 +108,7 @@
     "testError": "Impossibile eseguire il test di connessione",
     "cloudWarning": {
       "title": "Importante:",
-      "body": "Le credenziali S3 (chiave di accesso, segreto, regione ed endpoint) sono incorporate nella configurazione del servizio all'avvio — modificarle qui richiede il riavvio dei servizi auth e CRM e dei loro worker Sidekiq affinche i nuovi valori abbiano effetto. I file esistenti rimangono nel provider di archiviazione precedente; solo i nuovi caricamenti utilizzeranno la configurazione aggiornata."
+      "body": "Le credenziali S3 (chiave di accesso, segreto, regione ed endpoint) sono incorporate nella configurazione del servizio all'avvio — modificarle qui richiede il riavvio dei servizi auth e CRM e dei loro worker Sidekiq affinche i nuovi valori abbiano effetto. Le modifiche al provider possono richiedere fino a 60 secondi per propagarsi su tutti i servizi. I file esistenti rimangono nel provider di archiviazione precedente; solo i nuovi caricamenti utilizzeranno la configurazione aggiornata."
     }
   },
   "socialLogin": {

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -105,7 +105,11 @@
     "testConnection": "Testa Connessione",
     "testing": "Test in corso...",
     "testFailed": "Test di connessione fallito",
-    "testError": "Impossibile eseguire il test di connessione"
+    "testError": "Impossibile eseguire il test di connessione",
+    "cloudWarning": {
+      "title": "Importante:",
+      "body": "Le credenziali S3 (chiave di accesso, segreto, regione ed endpoint) sono incorporate nella configurazione del servizio all'avvio — modificarle qui richiede il riavvio dei servizi auth e CRM e dei loro worker Sidekiq affinche i nuovi valori abbiano effetto. I file esistenti rimangono nel provider di archiviazione precedente; solo i nuovi caricamenti utilizzeranno la configurazione aggiornata."
+    }
   },
   "socialLogin": {
     "title": "Provider di autenticazione",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -108,7 +108,7 @@
     "testError": "Falha ao executar teste de conexao",
     "cloudWarning": {
       "title": "Importante:",
-      "body": "As credenciais S3 (chave de acesso, segredo, regiao e endpoint) sao incorporadas na configuracao do servico na inicializacao — altera-las aqui exige reiniciar os servicos auth e CRM e seus workers Sidekiq para que os novos valores entrem em vigor. Arquivos existentes permanecem no provider de armazenamento anterior; apenas novos uploads usarao a configuracao atualizada."
+      "body": "As credenciais S3 (chave de acesso, segredo, regiao e endpoint) sao incorporadas na configuracao do servico na inicializacao — altera-las aqui exige reiniciar os servicos auth e CRM e seus workers Sidekiq para que os novos valores entrem em vigor. Alteracoes no provider podem levar ate 60 segundos para propagar entre todos os servicos. Arquivos existentes permanecem no provider de armazenamento anterior; apenas novos uploads usarao a configuracao atualizada."
     }
   },
   "socialLogin": {

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -105,7 +105,11 @@
     "testConnection": "Testar Conexao",
     "testing": "Testando...",
     "testFailed": "Teste de conexao falhou",
-    "testError": "Falha ao executar teste de conexao"
+    "testError": "Falha ao executar teste de conexao",
+    "cloudWarning": {
+      "title": "Importante:",
+      "body": "As credenciais S3 (chave de acesso, segredo, regiao e endpoint) sao incorporadas na configuracao do servico na inicializacao — altera-las aqui exige reiniciar os servicos auth e CRM e seus workers Sidekiq para que os novos valores entrem em vigor. Arquivos existentes permanecem no provider de armazenamento anterior; apenas novos uploads usarao a configuracao atualizada."
+    }
   },
   "socialLogin": {
     "title": "Provedores de Autenticação",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -105,11 +105,7 @@
     "testConnection": "Testar Conexao",
     "testing": "Testando...",
     "testFailed": "Teste de conexao falhou",
-    "testError": "Falha ao executar teste de conexao",
-    "envWarning": {
-      "title": "Atenção:",
-      "body": "Salvar aqui persiste a escolha, mas o serviço de arquivos ainda lê ACTIVE_STORAGE_SERVICE das variáveis de ambiente no boot. Até a EVO-1050 ser entregue, configure storage via env vars para fazer efeito."
-    }
+    "testError": "Falha ao executar teste de conexao"
   },
   "socialLogin": {
     "title": "Provedores de Autenticação",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -105,11 +105,7 @@
     "testConnection": "Testar Ligacao",
     "testing": "A testar...",
     "testFailed": "Teste de ligacao falhou",
-    "testError": "Falha ao executar teste de ligacao",
-    "envWarning": {
-      "title": "Atenção:",
-      "body": "Guardar aqui persiste a escolha, mas o serviço de ficheiros ainda lê ACTIVE_STORAGE_SERVICE das variáveis de ambiente no arranque. Até a EVO-1050 ser concluída, configure storage via env vars para fazer efeito."
-    }
+    "testError": "Falha ao executar teste de ligacao"
   },
   "socialLogin": {
     "title": "Provedores de Autenticação",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -105,7 +105,11 @@
     "testConnection": "Testar Ligacao",
     "testing": "A testar...",
     "testFailed": "Teste de ligacao falhou",
-    "testError": "Falha ao executar teste de ligacao"
+    "testError": "Falha ao executar teste de ligacao",
+    "cloudWarning": {
+      "title": "Importante:",
+      "body": "As credenciais S3 (chave de acesso, segredo, regiao e endpoint) sao incorporadas na configuracao do servico na inicializacao — altera-las aqui exige reiniciar os servicos auth e CRM e os seus workers Sidekiq para que os novos valores entrem em vigor. Os ficheiros existentes permanecem no fornecedor de armazenamento anterior; apenas novos uploads utilizarao a configuracao atualizada."
+    }
   },
   "socialLogin": {
     "title": "Provedores de Autenticação",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -108,7 +108,7 @@
     "testError": "Falha ao executar teste de ligacao",
     "cloudWarning": {
       "title": "Importante:",
-      "body": "As credenciais S3 (chave de acesso, segredo, regiao e endpoint) sao incorporadas na configuracao do servico na inicializacao — altera-las aqui exige reiniciar os servicos auth e CRM e os seus workers Sidekiq para que os novos valores entrem em vigor. Os ficheiros existentes permanecem no fornecedor de armazenamento anterior; apenas novos uploads utilizarao a configuracao atualizada."
+      "body": "As credenciais S3 (chave de acesso, segredo, regiao e endpoint) sao incorporadas na configuracao do servico na inicializacao — altera-las aqui exige reiniciar os servicos auth e CRM e os seus workers Sidekiq para que os novos valores entrem em vigor. Alteracoes no fornecedor podem demorar ate 60 segundos a propagar entre todos os servicos. Os ficheiros existentes permanecem no fornecedor de armazenamento anterior; apenas novos uploads utilizarao a configuracao atualizada."
     }
   },
   "socialLogin": {

--- a/src/pages/Admin/Settings/StorageConfig.tsx
+++ b/src/pages/Admin/Settings/StorageConfig.tsx
@@ -334,6 +334,11 @@ export default function StorageConfig() {
             {/* Cloud storage fields */}
             {isCloud && (
               <>
+                <div role="alert" className="rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+                  <strong className="font-semibold">{t('storage.cloudWarning.title')}</strong>{' '}
+                  {t('storage.cloudWarning.body')}
+                </div>
+
                 <div className="space-y-2">
                   <Label htmlFor="STORAGE_BUCKET_NAME">{t('storage.fields.bucketName')}</Label>
                   <Input

--- a/src/pages/Admin/Settings/StorageConfig.tsx
+++ b/src/pages/Admin/Settings/StorageConfig.tsx
@@ -302,14 +302,6 @@ export default function StorageConfig() {
         <p className="text-sm text-sidebar-foreground/70 mt-1">{t('storage.description')}</p>
       </div>
 
-      {/* Runtime-not-applied warning — see Linear EVO-1050. Until that ships,
-          values saved here are persisted but the Rails apps continue reading
-          ACTIVE_STORAGE_SERVICE / provider env vars at boot time. */}
-      <div className="mb-4 rounded-md border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
-        <strong className="font-semibold">{t('storage.envWarning.title')}</strong>{' '}
-        {t('storage.envWarning.body')}
-      </div>
-
       <Card>
         <CardHeader>
           <CardTitle className="text-base">{t('storage.provider.label')}</CardTitle>


### PR DESCRIPTION
Updates the Admin Settings → Storage UI for EVO-1050.

## What changed

- **`src/pages/Admin/Settings/StorageConfig.tsx`**: Reintroduces the cloud storage warning banner (shown when Amazon S3 or S3-Compatible is selected).
- **`src/i18n/locales/*/adminSettings.json`** (6 locales — en, pt-BR, pt, es, fr, it): Updated `cloudWarning.body` to cover all three operational limitations:
  1. S3 credentials require service restart to take effect
  2. Provider changes may take up to **60 seconds** to propagate across all services (auth converges via 60 s TTL, CRM converges immediately)
  3. Existing files remain on the previous storage provider; only new uploads use the updated configuration

## Validation

- `pnpm exec tsc -b --noEmit` ✅
- `pnpm lint` — no errors in changed files ✅

## Related PRs

- Auth: https://github.com/evolution-foundation/evo-auth-service-community/pull/26
- CRM: https://github.com/evolution-foundation/evo-ai-crm-community/pull/68

## Linked Issue

- EVO-1050