### PR TITLE
feat(contacts): add working delete-contact action (EVO-1189)

### DIFF
--- a/src/components/contacts/ContactCard.tsx
+++ b/src/components/contacts/ContactCard.tsx
@@ -1,6 +1,6 @@
 import { useLanguage } from '@/hooks/useLanguage';
 import { Button, Card, CardContent } from '@evoapi/design-system';
-import { Edit, MessageSquare, Eye } from 'lucide-react';
+import { Edit, MessageSquare, Eye, Trash } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
 import { formatContactPhone } from '@/utils/contact/formatContactPhone';
@@ -14,6 +14,7 @@ type ContactCardProps = {
   onViewDetails?: (contact: Contact) => void;
   onStartConversation?: (contact: Contact) => void;
   onEdit?: (contact: Contact) => void;
+  onDelete?: (contact: Contact) => void;
 };
 
 export default function ContactCard({
@@ -21,6 +22,7 @@ export default function ContactCard({
   onViewDetails,
   onStartConversation,
   onEdit,
+  onDelete,
 }: ContactCardProps) {
   const { t } = useLanguage('contacts');
 
@@ -103,6 +105,22 @@ export default function ContactCard({
           >
             <Edit className="h-4 w-4" />
           </Button>
+          {onDelete && (
+            <>
+              <div className="w-px bg-sidebar-border" />
+              <Button
+                variant="ghost"
+                className="rounded-none h-12 px-3 text-destructive/70 hover:text-destructive hover:bg-destructive/10"
+                onClick={e => {
+                  e.stopPropagation();
+                  onDelete(contact);
+                }}
+                title={t('card.actions.delete')}
+              >
+                <Trash className="h-4 w-4" />
+              </Button>
+            </>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/src/components/contacts/ContactDetails.tsx
+++ b/src/components/contacts/ContactDetails.tsx
@@ -37,6 +37,7 @@ import {
   // CalendarClock,
   GitBranch,
   Merge,
+  Trash,
 } from 'lucide-react';
 // import { ScheduledActionsList } from '@/components/scheduledActions';
 import { Contact } from '@/types/contacts';
@@ -52,6 +53,7 @@ interface ContactDetailsProps {
   contact: Contact | null;
   onEdit: (contact: Contact) => void;
   onStartConversation: (contact: Contact) => void;
+  onDelete?: (contact: Contact) => void;
   onNavigateToContact?: (contactId: string) => void;
   onContactUpdated?: () => void;
 }
@@ -62,6 +64,7 @@ export default function ContactDetails({
   contact,
   onEdit,
   onStartConversation,
+  onDelete,
   onNavigateToContact,
   onContactUpdated,
 }: ContactDetailsProps) {
@@ -227,6 +230,17 @@ export default function ContactDetails({
                 <Button variant="outline" size="sm" onClick={handleMergeClick}>
                   <Merge className="h-4 w-4 mr-2" />
                   {t('header.mergeContacts')}
+                </Button>
+              )}
+              {onDelete && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive hover:bg-destructive/10 border-destructive/30"
+                  onClick={() => onDelete(contact)}
+                >
+                  <Trash className="h-4 w-4 mr-2" />
+                  {t('actions.delete')}
                 </Button>
               )}
             </div>

--- a/src/components/contacts/ContactsTable.tsx
+++ b/src/components/contacts/ContactsTable.tsx
@@ -1,5 +1,5 @@
 import { useLanguage } from '@/hooks/useLanguage';
-import { MessageSquare, Edit, Users } from 'lucide-react';
+import { MessageSquare, Edit, Trash, Users } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import { BaseTable, TableColumn, TableAction } from '@/components/base';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
@@ -17,6 +17,7 @@ interface ContactsTableProps {
   onContactClick: (contact: Contact) => void;
   onStartConversation: (contact: Contact) => void;
   onEditContact: (contact: Contact) => void;
+  onDeleteContact?: (contact: Contact) => void;
   onCreateContact?: () => void;
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
@@ -31,6 +32,7 @@ export default function ContactsTable({
   onContactClick,
   onStartConversation,
   onEditContact,
+  onDeleteContact,
   onCreateContact,
   sortBy,
   sortOrder,
@@ -122,6 +124,16 @@ export default function ContactsTable({
       icon: <Edit className="h-4 w-4" />,
       onClick: onEditContact,
     },
+    ...(onDeleteContact
+      ? [
+          {
+            label: t('table.actions.delete'),
+            icon: <Trash className="h-4 w-4" />,
+            onClick: onDeleteContact,
+            variant: 'destructive' as const,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -68,6 +68,8 @@ export default function Contacts() {
   const [state, setState] = useState<ContactsState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [contactToDelete, setContactToDelete] = useState<Contact | null>(null);
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [editingContact, setEditingContact] = useState<Contact | null>(null);
   const [conversationModalOpen, setConversationModalOpen] = useState(false);
@@ -468,6 +470,56 @@ export default function Contacts() {
     setConversationModalOpen(true);
   };
 
+  const handleDeleteContact = (contact: Contact) => {
+    setContactToDelete(contact);
+    setDeleteDialogOpen(true);
+  };
+
+  const confirmDeleteContact = async () => {
+    if (!contactToDelete) return;
+
+    setState(prev => ({ ...prev, loading: { ...prev.loading, delete: true } }));
+
+    try {
+      await contactsService.deleteContact(contactToDelete.id);
+      toast.success(t('messages.deleteSuccess'));
+
+      const deletedId = contactToDelete.id;
+      const wasDetailsOpen = detailsContact?.id === deletedId;
+
+      setDeleteDialogOpen(false);
+      setContactToDelete(null);
+
+      if (wasDetailsOpen) {
+        setDetailsModalOpen(false);
+        setDetailsContact(null);
+      }
+
+      setState(prev => {
+        const newTotal = Math.max(0, prev.meta.pagination.total - 1);
+        const pageSize = prev.meta.pagination.page_size;
+        return {
+          ...prev,
+          contacts: prev.contacts.filter(c => c.id !== deletedId),
+          selectedContactIds: prev.selectedContactIds.filter(id => id !== deletedId),
+          meta: {
+            ...prev.meta,
+            pagination: {
+              ...prev.meta.pagination,
+              total: newTotal,
+              total_pages: Math.ceil(newTotal / pageSize),
+            },
+          },
+        };
+      });
+    } catch (error) {
+      console.error('Error deleting contact:', error);
+      toast.error(t('messages.deleteError'));
+    } finally {
+      setState(prev => ({ ...prev, loading: { ...prev.loading, delete: false } }));
+    }
+  };
+
   // Bulk actions
   const handleBulkDelete = () => {
     setBulkDeleteDialogOpen(true);
@@ -777,6 +829,7 @@ export default function Contacts() {
                 onViewDetails={handleContactClick}
                 onStartConversation={handleStartConversation}
                 onEdit={handleEditContact}
+                onDelete={can('contacts', 'delete') ? handleDeleteContact : undefined}
               />
             ))}
           </div>
@@ -796,6 +849,7 @@ export default function Contacts() {
             onContactClick={handleContactClick}
             onStartConversation={handleStartConversation}
             onEditContact={handleEditContact}
+            onDeleteContact={can('contacts', 'delete') ? handleDeleteContact : undefined}
             onCreateContact={handleCreateContact}
             sortBy={state.sortBy}
             sortOrder={state.sortOrder}
@@ -858,6 +912,37 @@ export default function Contacts() {
         </DialogContent>
       </Dialog>
 
+      {/* Single Contact Delete Dialog */}
+      <Dialog open={deleteDialogOpen} onOpenChange={open => {
+        if (!open && !state.loading.delete) {
+          setDeleteDialogOpen(false);
+          setContactToDelete(null);
+        }
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('dialog.deleteContact.title')}</DialogTitle>
+            <DialogDescription>
+              {t('dialog.deleteContact.description', { name: contactToDelete?.name ?? '' })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => { setDeleteDialogOpen(false); setContactToDelete(null); }}
+              disabled={state.loading.delete}
+            >
+              {t('dialog.deleteContact.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={confirmDeleteContact} disabled={state.loading.delete}>
+              {state.loading.delete
+                ? t('dialog.deleteContact.deleting')
+                : t('dialog.deleteContact.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       {/* Contact Modal */}
       <ContactModal
         open={contactModalOpen}
@@ -893,6 +978,7 @@ export default function Contacts() {
           setConversationContact(contact);
           setConversationModalOpen(true);
         }}
+        onDelete={can('contacts', 'delete') ? handleDeleteContact : undefined}
         onNavigateToContact={async contactId => {
           try {
             const response = await contactsService.getContact(contactId);


### PR DESCRIPTION
## Summary

- Add **Delete contact** action to three UI surfaces: ContactCard hover bar, ContactsTable row dropdown, and ContactDetails drawer
- All surfaces are gated by `contacts.delete` permission (button hidden for unauthorized roles)
- Confirmation dialog shows the contact name and is non-dismissible while the API call is in flight
- On success: contact removed from local state immediately, `meta.pagination.total` decremented, drawer auto-closed if the deleted contact was open

## Cascade / deletion policy

Hard delete with cascade. The backend (`contacts_controller#destroy`) calls `cleanup_contact_dependent_records` before `contact.destroy!`, which explicitly destroys:
- All linked conversations (and their pipeline items, Facebook comment moderations)
- All `ContactInbox` rows
- All notes, CSAT survey responses, and messages sent by the contact
- All pipeline items linked to the contact

This policy was chosen to avoid orphaned conversation data. No soft-delete mechanism is implemented on the backend; deletion is permanent and irreversible.

## Validation

- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` → clean
- `evo-ai-frontend-community: pnpm lint` → no new errors in modified files

## Changed Files

- `src/components/contacts/ContactCard.tsx`
- `src/components/contacts/ContactDetails.tsx`
- `src/components/contacts/ContactsTable.tsx`
- `src/pages/Customer/Contacts/Contacts.tsx`

## Linked Issue

- EVO-1189