### PR TITLE
fix(EVO-1044): per-field GlobalConfig fallback detection for Connection Settings banner

### DIFF
--- a/src/components/channels/settings/ConfigurationForm.tsx
+++ b/src/components/channels/settings/ConfigurationForm.tsx
@@ -501,10 +501,13 @@ const EvolutionWhatsAppConfig: React.FC<{
   const hasGlobalConfig = isEvolutionGo
     ? globalConfig.hasEvolutionGoConfig === true
     : globalConfig.hasEvolutionConfig === true;
-  const usingGlobalFallback =
-    hasGlobalConfig &&
-    !inbox?.provider_config?.api_url &&
-    !inbox?.provider_config?.admin_token;
+  // Per-field fallback detection — mirrors backend EvolutionConcern which
+  // resolves api_url and admin_token independently (each falls back to
+  // GlobalConfig separately). The banner shows when ANY field uses fallback;
+  // placeholders are conditional per field.
+  const apiUrlUsesGlobal = hasGlobalConfig && !inbox?.provider_config?.api_url;
+  const adminTokenUsesGlobal = hasGlobalConfig && !inbox?.provider_config?.admin_token;
+  const usingGlobalFallback = apiUrlUsesGlobal || adminTokenUsesGlobal;
 
   const [isLoadingSettings, setIsLoadingSettings] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -1380,7 +1383,7 @@ const EvolutionWhatsAppConfig: React.FC<{
                   onChange={e =>
                     setConnectionSettings(prev => ({ ...prev, apiUrl: e.target.value }))
                   }
-                  placeholder={usingGlobalFallback
+                  placeholder={apiUrlUsesGlobal
                     ? t('settings.configuration.whatsapp.instance.connection.apiUrlGlobalPlaceholder', 'Using global config — fill to override')
                     : t('settings.configuration.whatsapp.instance.connection.apiUrlPlaceholder')}
                 />
@@ -1396,7 +1399,7 @@ const EvolutionWhatsAppConfig: React.FC<{
                   onChange={e =>
                     setConnectionSettings(prev => ({ ...prev, adminToken: e.target.value }))
                   }
-                  placeholder={usingGlobalFallback
+                  placeholder={adminTokenUsesGlobal
                     ? t('settings.configuration.whatsapp.instance.connection.adminTokenGlobalPlaceholder', 'Using global config — fill to override')
                     : t('settings.configuration.whatsapp.instance.connection.adminTokenPlaceholder')}
                 />


### PR DESCRIPTION
## Resumo

Corrige inconsistência visual entre banner e placeholders na aba Connection Settings. A detecção de fallback agora é per-field, espelhando a granularidade do backend EvolutionConcern.

## Análise técnica

O backend `EvolutionConcern` (linhas 12-24) resolve `api_url` e `admin_token` independentemente — cada campo faz fallback ao GlobalConfig separadamente. Um canal pode ter `api_url` preenchido mas `admin_token` vazio (resolvido via GlobalConfig).

**Antes:** `usingGlobalFallback` usava AND (`!api_url && !admin_token`). No cenário parcial (1 campo preenchido + 1 vazio), o banner não aparecia mas o placeholder do campo vazio indicava "Using global config" — inconsistência visual.

**Depois:** Detecção per-field alinhada com backend:
```ts
const apiUrlUsesGlobal = hasGlobalConfig && !provider_config.api_url;
const adminTokenUsesGlobal = hasGlobalConfig && !provider_config.admin_token;
const usingGlobalFallback = apiUrlUsesGlobal || adminTokenUsesGlobal;
```

- Banner: aparece quando **qualquer** campo usa fallback (OR)
- Placeholders: condicionais por campo individual
- Eliminado cenário de placeholder "global config" sem banner correspondente

## Arquivo

`src/components/channels/settings/ConfigurationForm.tsx` (1 arquivo, +9/-6)

## Plano de testes

- [x] `pnpm exec tsc --noEmit`: zero erros
- [x] Canal com ambos preenchidos: sem banner, placeholders normais (confirmado)
- [x] Texto "A key is already configured" aparece no admin_token (confirmado)
- [x] Lógica per-field validada contra backend EvolutionConcern (linhas 12-24)
- [x] 1 arquivo, branch dedicada, escopo EVO-1044

## Summary by Sourcery

Bug Fixes:
- Fix inconsistent behavior where the Connection Settings banner could be hidden while individual fields still showed 'Using global config' placeholders by detecting fallback per field instead of jointly.