### PR TITLE
fix(EVO-1085): reconexão ativa do WebSocket com toast de sucesso + backoff em background

### DIFF
--- a/src/hooks/chat/useWebSocket.ts
+++ b/src/hooks/chat/useWebSocket.ts
@@ -110,6 +110,15 @@ export const useWebSocket = (
         setIsConnected(false);
         originalOnDisconnected();
       };
+
+      // Sobrescrever onReconnected para atualizar estado React
+      const originalOnReconnected = connectorRef.current['onReconnected'].bind(
+        connectorRef.current,
+      );
+      connectorRef.current['onReconnected'] = () => {
+        setIsConnected(true);
+        originalOnReconnected();
+      };
     } catch (error) {
       console.error('❌ Erro ao conectar WebSocket:', error);
       setIsConnected(false);

--- a/src/services/chat/websocket/BaseActionCableConnector.ts
+++ b/src/services/chat/websocket/BaseActionCableConnector.ts
@@ -1,7 +1,9 @@
 import { createConsumer, Consumer, Subscription } from '@rails/actioncable';
 
 const PRESENCE_INTERVAL = 20000; // 20 segundos
-const RECONNECT_INTERVAL = 1000; // 1 segundo
+const INITIAL_RECONNECT_INTERVAL = 1000; // 1 segundo
+const MAX_RECONNECT_INTERVAL = 30000; // 30 segundos (teto do backoff)
+const MAX_RECONNECT_ATTEMPTS = 50; // desiste após 50 tentativas (~5 min com backoff)
 
 export interface WebSocketEvent {
   event: string;
@@ -31,6 +33,7 @@ export class BaseActionCableConnector {
   protected presenceTimer: NodeJS.Timeout | null = null;
   protected connectionParams: ConnectionParams;
   protected websocketURL?: string;
+  protected reconnectAttempts = 0;
 
   static isDisconnected = false;
 
@@ -69,10 +72,15 @@ export class BaseActionCableConnector {
 
           // Conectado com sucesso
           connected: () => {
+            const wasReconnecting = this.reconnectAttempts > 0;
             BaseActionCableConnector.isDisconnected = false;
+            this.reconnectAttempts = 0;
             this.onConnected();
             this.startPresenceInterval();
             this.clearReconnectTimer();
+            if (wasReconnecting) {
+              this.onReconnected();
+            }
           },
 
           // Desconectado
@@ -145,35 +153,78 @@ export class BaseActionCableConnector {
   }
 
   /**
-   * Verificar status da conexão e tentar reconectar
+   * Tentar reconectar ativamente ao WebSocket.
+   * Remove a subscription stale e chama connect() para criar nova.
+   * Usa backoff exponencial: 1s → 2s → 4s → 8s → ... → 30s (teto).
    */
-  protected checkConnection(): void {
+  protected attemptReconnect(): void {
     if (!this.consumer) {
       console.warn('⚠️ Consumer não disponível');
+      return;
+    }
+
+    // Incrementar tentativas ANTES do check de visibilidade para que
+    // o backoff funcione mesmo com tab em background (evita loop de 1s).
+    this.reconnectAttempts += 1;
+
+    // Não tentar reconectar com tab oculta — agendar para quando voltar
+    if (typeof document !== 'undefined' && document.hidden) {
       this.initReconnectTimer();
       return;
     }
 
-    const isReconnected = BaseActionCableConnector.isDisconnected && this.subscription;
-
-    if (isReconnected) {
-      this.clearReconnectTimer();
-      this.onReconnected();
-      BaseActionCableConnector.isDisconnected = false;
-    } else if (BaseActionCableConnector.isDisconnected) {
-      this.initReconnectTimer();
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      console.error(`❌ WebSocket: desistiu após ${MAX_RECONNECT_ATTEMPTS} tentativas de reconexão`);
+      return;
     }
+
+    console.info(`🔄 WebSocket: tentativa de reconexão ${this.reconnectAttempts}...`);
+
+    // Remover subscription antiga antes de criar nova
+    if (this.subscription) {
+      try {
+        this.consumer.subscriptions.remove(this.subscription);
+      } catch {
+        // Ignorar erros ao remover subscription stale
+      }
+      this.subscription = null;
+    }
+
+    // Reconectar ativamente
+    this.connect();
   }
 
   /**
-   * Iniciar timer de reconexão
+   * Verificar status e decidir próxima ação.
+   * Chamado pelo timer de reconexão.
+   */
+  protected checkConnection(): void {
+    if (!BaseActionCableConnector.isDisconnected) {
+      // Conexão restaurada — nada a fazer (onReconnected já foi chamado
+      // pelo callback connected: via wasReconnecting)
+      this.clearReconnectTimer();
+      return;
+    }
+
+    // Ainda desconectado — tentar reconexão ativa
+    this.attemptReconnect();
+  }
+
+  /**
+   * Agendar tentativa de reconexão com backoff exponencial.
+   * Intervalo dobra a cada tentativa: 1s → 2s → 4s → ... → 30s (teto).
    */
   protected initReconnectTimer(): void {
     this.clearReconnectTimer();
 
+    const backoffInterval = Math.min(
+      INITIAL_RECONNECT_INTERVAL * Math.pow(2, this.reconnectAttempts),
+      MAX_RECONNECT_INTERVAL,
+    );
+
     this.reconnectTimer = setTimeout(() => {
       this.checkConnection();
-    }, RECONNECT_INTERVAL);
+    }, backoffInterval);
   }
 
   /**


### PR DESCRIPTION
## Resumo

Corrige os 3 achados do code review sobre a reconexão WebSocket: toast de sucesso que não disparava (HIGH), loop de 1s com tab oculta (MEDIUM), e idioma dos comentários (MEDIUM).

---

### HIGH — Toast de reconexão nunca disparava

**Análise:** O `onReconnected()` (que exibe o toast verde "Conexão restabelecida") era invocado exclusivamente por `checkConnection()` no ramo `!isDisconnected`. Porém, o callback `connected()` do ActionCable executava `clearReconnectTimer()` sincronamente após setar `isDisconnected = false` — cancelando o timer pendente que chamaria `checkConnection`. O ramo era inalcançável.

**Correção:** No callback `connected()`, capturamos `wasReconnecting = this.reconnectAttempts > 0` antes de zerar o contador. Após `onConnected()` e `clearReconnectTimer()`, chamamos `onReconnected()` condicionalmente:

```ts
connected: () => {
  const wasReconnecting = this.reconnectAttempts > 0;
  BaseActionCableConnector.isDisconnected = false;
  this.reconnectAttempts = 0;
  this.onConnected();
  this.startPresenceInterval();
  this.clearReconnectTimer();
  if (wasReconnecting) {
    this.onReconnected();  // toast verde dispara aqui
  }
},
```

O `onReconnected()` agora é chamado deterministicamente quando a conexão é restaurada após uma ou mais tentativas de reconexão — sem depender do timer.

---

### MEDIUM — Loop de 1s com tab oculta

**Análise:** `attemptReconnect()` verificava `document.hidden` e delegava para `initReconnectTimer()` sem incrementar `reconnectAttempts`. O cálculo de backoff `Math.pow(2, 0) * 1000` resultava em 1s fixo — loop contínuo a cada segundo enquanto a aba estivesse em background.

**Correção:** `reconnectAttempts` é incrementado antes do check de visibilidade. O backoff é calculado corretamente mesmo com tab oculta:

```ts
this.reconnectAttempts += 1;  // antes do hidden check

if (typeof document !== 'undefined' && document.hidden) {
  this.initReconnectTimer();  // agora usa 2^attempts corretamente
  return;
}
```

---

### MEDIUM — Idioma dos comentários

Todos os comentários e mensagens de log traduzidos para português, mantendo consistência com o padrão do arquivo.

---

## Reconexão ativa (causa raiz original da EVO-1085)

O mecanismo anterior era passivo — `checkConnection()` fazia polling do estado a 1s sem jamais chamar `connect()`. A reconexão só funcionava via Page Visibility API (sair e voltar ao tab).

Agora `attemptReconnect()` remove a subscription stale e chama `connect()` ativamente com backoff exponencial (1s → 2s → 4s → 8s → ... → 30s), máximo 50 tentativas.

## Arquivos

- `src/services/chat/websocket/BaseActionCableConnector.ts` (+60/-11)
- `src/hooks/chat/useWebSocket.ts` (+9)

## Plano de testes — cada comportamento verificado individualmente

- [x] `pnpm exec tsc --noEmit`: zero erros
- [x] CRM parado por 30s → toast "Tentando reconectar automaticamente" apareceu (amarelo)
- [x] CRM reiniciado → toast "Conexão restabelecida" apareceu (verde)
- [x] Mensagens fluindo sem F5 após reconexão
- [x] 2 arquivos, branch dedicada, escopo EVO-1085

## Summary by Sourcery

Implement active WebSocket reconnection with exponential backoff and ensure reconnection events correctly update UI state.

New Features:
- Add active WebSocket reconnection that recreates the subscription and reconnects with exponential backoff capped at 30 seconds and 50 attempts.

Bug Fixes:
- Ensure the reconnection success handler is invoked after a successful reconnect so the user sees the reconnection success toast.
- Fix the background tab reconnection loop by correctly incrementing reconnect attempts before visibility checks so backoff timing applies even when the tab is hidden.

Enhancements:
- Update the React WebSocket hook to set the connection state back to connected when a reconnection occurs.
- Standardize WebSocket-related log messages and comments to Portuguese for consistency with the rest of the file.