### PR TITLE
fix(EVO-1146): adicionar 9+ chaves i18n missing em 6 locales

### DIFF
--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -61,7 +61,11 @@
     "testConnection": "Test Connection",
     "testing": "Testing...",
     "testFailed": "Connection test failed",
-    "testError": "Failed to run connection test"
+    "testError": "Failed to run connection test",
+    "envWarning": {
+      "title": "Heads up:",
+      "body": "Saving here persists the values, but the email service still reads SMTP credentials from environment variables at boot time. Until EVO-1049 ships, configure SMTP via env vars to take effect."
+    }
   },
   "storage": {
     "title": "Storage Configuration",
@@ -266,6 +270,16 @@
       },
       "saveSuccess": "Twitter configuration saved successfully",
       "saveError": "Failed to save Twitter configuration"
+    },
+    "clearConfig": {
+      "button": "Clear Configuration",
+      "dialogTitle": "Clear Configuration",
+      "dialogDescription": "Are you sure? This will remove all credentials for this provider. The provider will stop working until you reconfigure it.",
+      "cancel": "Cancel",
+      "confirm": "Clear",
+      "clearing": "Clearing...",
+      "success": "Configuration cleared successfully",
+      "error": "Failed to clear configuration"
     },
     "messages": {
       "loadError": "Failed to load channel configuration"

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -848,7 +848,10 @@
           "callRejectionMessage": "Call rejection message",
           "callRejectionPlaceholder": "Message when rejecting calls",
           "saveSettings": "Save Settings",
+          "loading": "Loading instance settings...",
           "errors": {
+            "title": "Configuration Error",
+            "loadFailed": "Failed to load instance status. Check your connection settings.",
             "nameNotFound": "Instance name not found",
             "qrCodeError": "Error generating QR Code",
             "updateError": "Error updating instance settings"
@@ -919,6 +922,10 @@
             "apiUrlPlaceholder": "https://api.evolution.com",
             "adminTokenLabel": "API Key",
             "adminTokenPlaceholder": "Enter the new API Key",
+            "usingGlobalConfig": "Using Admin Settings defaults",
+            "usingGlobalConfigHint": "The API URL and Token are configured globally in Admin Settings. Fill the fields below only to override the global values for this channel.",
+            "apiUrlGlobalPlaceholder": "Using global config — fill to override",
+            "adminTokenGlobalPlaceholder": "Using global config — fill to override",
             "saveButton": "Save Connection Settings",
             "success": {
               "updated": "Connection settings updated successfully!"

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -40,7 +40,8 @@
         "description": "Are you sure you want to delete this message? This action cannot be undone and the message will be permanently removed from the conversation.",
         "cancel": "Cancel",
         "confirm": "Delete message"
-      }
+      },
+      "deletedPlaceholder": "This message was deleted"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -61,7 +61,11 @@
     "testConnection": "Probar Conexion",
     "testing": "Probando...",
     "testFailed": "La prueba de conexion fallo",
-    "testError": "Error al ejecutar la prueba de conexion"
+    "testError": "Error al ejecutar la prueba de conexion",
+    "envWarning": {
+      "title": "Atención:",
+      "body": "Guardar aquí persiste los valores, pero el servicio de email aún lee las credenciales SMTP de las variables de entorno al arrancar. Hasta que EVO-1049 se entregue, configure SMTP vía env vars para que surta efecto."
+    }
   },
   "storage": {
     "title": "Configuracion de Almacenamiento",
@@ -266,6 +270,16 @@
       },
       "saveSuccess": "Configuracion de Twitter guardada exitosamente",
       "saveError": "Error al guardar la configuracion de Twitter"
+    },
+    "clearConfig": {
+      "button": "Limpiar Configuración",
+      "dialogTitle": "Limpiar Configuración",
+      "dialogDescription": "¿Está seguro? Esto eliminará todas las credenciales de este proveedor. El proveedor dejará de funcionar hasta que lo reconfigure.",
+      "cancel": "Cancelar",
+      "confirm": "Limpiar",
+      "clearing": "Limpiando...",
+      "success": "Configuración limpiada con éxito",
+      "error": "Error al limpiar la configuración"
     },
     "messages": {
       "loadError": "Error al cargar la configuracion de canales"

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -826,7 +826,10 @@
           "callRejectionMessage": "Mensaje de rechazo de llamada",
           "callRejectionPlaceholder": "Mensaje al rechazar llamadas",
           "saveSettings": "Guardar Configuraciones",
+          "loading": "Cargando configuraciones de la instancia...",
           "errors": {
+            "title": "Error de Configuración",
+            "loadFailed": "Error al cargar el estado de la instancia. Verifique sus configuraciones de conexión.",
             "nameNotFound": "Nombre de la instancia no encontrado",
             "qrCodeError": "Error al generar código QR",
             "updateError": "Error al actualizar configuraciones de la instancia"
@@ -897,6 +900,10 @@
             "apiUrlPlaceholder": "https://api.evolution.com",
             "adminTokenLabel": "API Key",
             "adminTokenPlaceholder": "Ingrese la nueva API Key",
+            "usingGlobalConfig": "Usando configuraciones globales del Admin",
+            "usingGlobalConfigHint": "La URL de la API y el Token están configurados globalmente en las Configuraciones de Admin. Complete los campos a continuación solo para sustituir los valores globales para este canal.",
+            "apiUrlGlobalPlaceholder": "Usando config global — complete para sustituir",
+            "adminTokenGlobalPlaceholder": "Usando config global — complete para sustituir",
             "saveButton": "Guardar Configuración de Conexión",
             "success": {
               "updated": "¡Configuración de conexión actualizada con éxito!"

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -39,7 +39,8 @@
         "description": "¿Está seguro de que desea eliminar este mensaje? Esta acción no se puede deshacer y el mensaje se eliminará permanentemente de la conversación.",
         "cancel": "Cancelar",
         "confirm": "Eliminar mensaje"
-      }
+      },
+      "deletedPlaceholder": "Este mensaje fue eliminado"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -61,7 +61,11 @@
     "testConnection": "Tester la Connexion",
     "testing": "Test en cours...",
     "testFailed": "Le test de connexion a echoue",
-    "testError": "Impossible d'executer le test de connexion"
+    "testError": "Impossible d'executer le test de connexion",
+    "envWarning": {
+      "title": "Avertissement :",
+      "body": "Enregistrer ici conserve les valeurs, mais le service email lit toujours les identifiants SMTP des variables d'environnement au démarrage. Jusqu'à ce que EVO-1049 soit livré, configurez SMTP via env vars pour prendre effet."
+    }
   },
   "storage": {
     "title": "Configuration du Stockage",
@@ -266,6 +270,16 @@
       },
       "saveSuccess": "Configuration Twitter enregistree avec succes",
       "saveError": "Echec de l'enregistrement de la configuration Twitter"
+    },
+    "clearConfig": {
+      "button": "Effacer la Configuration",
+      "dialogTitle": "Effacer la Configuration",
+      "dialogDescription": "Êtes-vous sûr ? Cela supprimera toutes les identifiants de ce fournisseur. Le fournisseur cessera de fonctionner jusqu'à ce que vous le reconfiguriez.",
+      "cancel": "Annuler",
+      "confirm": "Effacer",
+      "clearing": "Effacement...",
+      "success": "Configuration effacée avec succès",
+      "error": "Échec de l'effacement de la configuration"
     },
     "messages": {
       "loadError": "Echec du chargement de la configuration des canaux"

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -786,7 +786,10 @@
           "callRejectionMessage": "Message de rejet d'appel",
           "callRejectionPlaceholder": "Message lors du rejet d'appels",
           "saveSettings": "Enregistrer les Paramètres",
+          "loading": "Chargement des paramètres de l'instance...",
           "errors": {
+            "title": "Erreur de Configuration",
+            "loadFailed": "Échec du chargement du statut de l'instance. Vérifiez vos paramètres de connexion.",
             "nameNotFound": "Nom de l'instance non trouvé",
             "qrCodeError": "Erreur lors de la génération du QR Code",
             "updateError": "Erreur lors de la mise à jour des paramètres de l'instance"
@@ -857,6 +860,10 @@
             "apiUrlPlaceholder": "https://api.evolution.com",
             "adminTokenLabel": "Clé API",
             "adminTokenPlaceholder": "Entrez la nouvelle clé API",
+            "usingGlobalConfig": "Utilisation des paramètres Admin par défaut",
+            "usingGlobalConfigHint": "L'URL de l'API et le Token sont configurés globalement dans les Paramètres Admin. Remplissez les champs ci-dessous uniquement pour remplacer les valeurs globales pour ce canal.",
+            "apiUrlGlobalPlaceholder": "Utilise la config globale — remplir pour remplacer",
+            "adminTokenGlobalPlaceholder": "Utilise la config globale — remplir pour remplacer",
             "saveButton": "Enregistrer les Paramètres de Connexion",
             "success": {
               "updated": "Paramètres de connexion mis à jour avec succès !"

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -39,7 +39,8 @@
         "description": "Êtes-vous sûr de vouloir supprimer ce message ? Cette action ne peut pas être annulée et le message sera définitivement supprimé de la conversation.",
         "cancel": "Annuler",
         "confirm": "Supprimer le message"
-      }
+      },
+      "deletedPlaceholder": "Ce message a été supprimé"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -61,7 +61,11 @@
     "testConnection": "Testa Connessione",
     "testing": "Test in corso...",
     "testFailed": "Test di connessione fallito",
-    "testError": "Impossibile eseguire il test di connessione"
+    "testError": "Impossibile eseguire il test di connessione",
+    "envWarning": {
+      "title": "Attenzione:",
+      "body": "Salvare qui persiste i valori, ma il servizio email legge ancora le credenziali SMTP dalle variabili d'ambiente all'avvio. Fino al rilascio di EVO-1049, configurare SMTP tramite env var per avere effetto."
+    }
   },
   "storage": {
     "title": "Configurazione Archiviazione",
@@ -266,6 +270,16 @@
       },
       "saveSuccess": "Configurazione Twitter salvata con successo",
       "saveError": "Salvataggio della configurazione Twitter non riuscito"
+    },
+    "clearConfig": {
+      "button": "Cancella Configurazione",
+      "dialogTitle": "Cancella Configurazione",
+      "dialogDescription": "Sei sicuro? Questo rimuoverà tutte le credenziali per questo provider. Il provider smetterà di funzionare fino a quando non lo riconfigurerai.",
+      "cancel": "Annulla",
+      "confirm": "Cancella",
+      "clearing": "Cancellazione...",
+      "success": "Configurazione cancellata con successo",
+      "error": "Impossibile cancellare la configurazione"
     },
     "messages": {
       "loadError": "Caricamento della configurazione dei canali non riuscito"

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -786,7 +786,10 @@
           "callRejectionMessage": "Messaggio di rifiuto chiamata",
           "callRejectionPlaceholder": "Messaggio quando si rifiutano le chiamate",
           "saveSettings": "Salva Impostazioni",
+          "loading": "Caricamento impostazioni dell'istanza...",
           "errors": {
+            "title": "Errore di Configurazione",
+            "loadFailed": "Impossibile caricare lo stato dell'istanza. Verifica le impostazioni di connessione.",
             "nameNotFound": "Nome dell'istanza non trovato",
             "qrCodeError": "Errore durante la generazione del codice QR",
             "updateError": "Errore durante l'aggiornamento delle impostazioni dell'istanza"
@@ -857,6 +860,10 @@
             "apiUrlPlaceholder": "https://api.evolution.com",
             "adminTokenLabel": "Chiave API",
             "adminTokenPlaceholder": "Inserisci la nuova chiave API",
+            "usingGlobalConfig": "Utilizzo delle impostazioni predefinite dell'Admin",
+            "usingGlobalConfigHint": "L'URL dell'API e il Token sono configurati globalmente nelle Impostazioni Admin. Compila i campi sottostanti solo per sovrascrivere i valori globali per questo canale.",
+            "apiUrlGlobalPlaceholder": "Usa config globale — compila per sovrascrivere",
+            "adminTokenGlobalPlaceholder": "Usa config globale — compila per sovrascrivere",
             "saveButton": "Salva Impostazioni di Connessione",
             "success": {
               "updated": "Impostazioni di connessione aggiornate con successo!"

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -39,7 +39,8 @@
         "description": "Sei sicuro di voler eliminare questo messaggio? Questa azione non può essere annullata e il messaggio sarà permanentemente rimosso dalla conversazione.",
         "cancel": "Annulla",
         "confirm": "Elimina messaggio"
-      }
+      },
+      "deletedPlaceholder": "Questo messaggio è stato eliminato"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -61,7 +61,11 @@
     "testConnection": "Testar Conexao",
     "testing": "Testando...",
     "testFailed": "Teste de conexao falhou",
-    "testError": "Falha ao executar teste de conexao"
+    "testError": "Falha ao executar teste de conexao",
+    "envWarning": {
+      "title": "Atenção:",
+      "body": "Salvar aqui persiste os valores, mas o serviço de email ainda lê as credenciais SMTP das variáveis de ambiente no boot. Até a EVO-1049 ser entregue, configure SMTP via env vars para fazer efeito."
+    }
   },
   "storage": {
     "title": "Configuracao de Armazenamento",
@@ -266,6 +270,16 @@
       },
       "saveSuccess": "Configuracao do Twitter salva com sucesso",
       "saveError": "Falha ao salvar configuracao do Twitter"
+    },
+    "clearConfig": {
+      "button": "Limpar Configuração",
+      "dialogTitle": "Limpar Configuração",
+      "dialogDescription": "Tem certeza? Isso removerá todas as credenciais deste provedor. O provedor deixará de funcionar até que você o reconfigure.",
+      "cancel": "Cancelar",
+      "confirm": "Limpar",
+      "clearing": "Limpando...",
+      "success": "Configuração limpa com sucesso",
+      "error": "Falha ao limpar configuração"
     },
     "messages": {
       "loadError": "Falha ao carregar configuracao dos canais"

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -848,7 +848,10 @@
           "callRejectionMessage": "Mensagem de rejeição de chamada",
           "callRejectionPlaceholder": "Mensagem quando rejeitar chamadas",
           "saveSettings": "Salvar Configurações",
+          "loading": "Carregando configurações da instância...",
           "errors": {
+            "title": "Erro de Configuração",
+            "loadFailed": "Falha ao carregar status da instância. Verifique suas configurações de conexão.",
             "nameNotFound": "Nome da instância não encontrado",
             "qrCodeError": "Erro ao gerar QR Code",
             "updateError": "Erro ao atualizar configurações da instância"
@@ -919,6 +922,10 @@
             "apiUrlPlaceholder": "https://api.evolution.com",
             "adminTokenLabel": "API Key",
             "adminTokenPlaceholder": "Insira a nova API Key",
+            "usingGlobalConfig": "Usando configurações globais do Admin",
+            "usingGlobalConfigHint": "A URL da API e o Token estão configurados globalmente nas Configurações de Admin. Preencha os campos abaixo apenas para substituir os valores globais para este canal.",
+            "apiUrlGlobalPlaceholder": "Usando config global — preencha para substituir",
+            "adminTokenGlobalPlaceholder": "Usando config global — preencha para substituir",
             "saveButton": "Salvar Configurações de Conexão",
             "success": {
               "updated": "Configurações de conexão atualizadas com sucesso!"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -40,7 +40,8 @@
         "description": "Tem certeza de que deseja excluir esta mensagem? Esta ação não pode ser desfeita e a mensagem será permanentemente removida da conversa.",
         "cancel": "Cancelar",
         "confirm": "Excluir mensagem"
-      }
+      },
+      "deletedPlaceholder": "Esta mensagem foi excluída"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -61,7 +61,11 @@
     "testConnection": "Testar Ligacao",
     "testing": "A testar...",
     "testFailed": "Teste de ligacao falhou",
-    "testError": "Falha ao executar teste de ligacao"
+    "testError": "Falha ao executar teste de ligacao",
+    "envWarning": {
+      "title": "Atenção:",
+      "body": "Guardar aqui persiste os valores, mas o serviço de email ainda lê as credenciais SMTP das variáveis de ambiente no arranque. Até a EVO-1049 ser concluída, configure SMTP via env vars para fazer efeito."
+    }
   },
   "storage": {
     "title": "Configuracao de Armazenamento",
@@ -266,6 +270,16 @@
       },
       "saveSuccess": "Configuracao do Twitter guardada com sucesso",
       "saveError": "Falha ao guardar configuracao do Twitter"
+    },
+    "clearConfig": {
+      "button": "Limpar Configuração",
+      "dialogTitle": "Limpar Configuração",
+      "dialogDescription": "Tem a certeza? Isto removerá todas as credenciais deste fornecedor. O fornecedor deixará de funcionar até que o reconfigure.",
+      "cancel": "Cancelar",
+      "confirm": "Limpar",
+      "clearing": "A limpar...",
+      "success": "Configuração limpa com sucesso",
+      "error": "Falha ao limpar configuração"
     },
     "messages": {
       "loadError": "Falha ao carregar configuracao dos canais"

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -843,7 +843,10 @@
           "callRejectionMessage": "Mensagem de rejeição de chamada",
           "callRejectionPlaceholder": "Mensagem quando rejeitar chamadas",
           "saveSettings": "Salvar Configurações",
+          "loading": "A carregar configurações da instância...",
           "errors": {
+            "title": "Erro de Configuração",
+            "loadFailed": "Falha ao carregar estado da instância. Verifique as configurações de conexão.",
             "nameNotFound": "Nome da instância não encontrado",
             "qrCodeError": "Erro ao gerar QR Code",
             "updateError": "Erro ao atualizar configurações da instância"
@@ -914,6 +917,10 @@
             "apiUrlPlaceholder": "https://api.evolution.com",
             "adminTokenLabel": "API Key",
             "adminTokenPlaceholder": "Insira a nova API Key",
+            "usingGlobalConfig": "A utilizar configurações globais do Admin",
+            "usingGlobalConfigHint": "O URL da API e o Token estão configurados globalmente nas Configurações de Admin. Preencha os campos abaixo apenas para substituir os valores globais para este canal.",
+            "apiUrlGlobalPlaceholder": "A usar config global — preencha para substituir",
+            "adminTokenGlobalPlaceholder": "A usar config global — preencha para substituir",
             "saveButton": "Guardar Configurações de Conexão",
             "success": {
               "updated": "Configurações de conexão atualizadas com sucesso!"

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -39,7 +39,8 @@
         "description": "Tem certeza de que deseja excluir esta mensagem? Esta ação não pode ser desfeita e a mensagem será permanentemente removida da conversa.",
         "cancel": "Cancelar",
         "confirm": "Excluir mensagem"
-      }
+      },
+      "deletedPlaceholder": "Esta mensagem foi eliminada"
     },
     "moderation": {
       "banner": {


### PR DESCRIPTION
## Resumo

9 chaves i18n referenciadas no código com fallback inline em inglês nunca foram adicionadas nos locales. Usuários em PT-BR/ES/FR/IT/PT viam texto em inglês.

### Chaves adicionadas

**chat.json** (1 chave, 6 locales):
- `messages.messageBubble.deletedPlaceholder` — "Esta mensagem foi excluída"

**channels.json** (7 chaves, 6 locales):
- `settings.configuration.whatsapp.instance.connection.usingGlobalConfig`
- `settings.configuration.whatsapp.instance.connection.usingGlobalConfigHint`
- `settings.configuration.whatsapp.instance.connection.apiUrlGlobalPlaceholder`
- `settings.configuration.whatsapp.instance.connection.adminTokenGlobalPlaceholder`
- `settings.configuration.whatsapp.instance.loading`
- `settings.configuration.whatsapp.instance.errors.title`
- `settings.configuration.whatsapp.instance.errors.loadFailed`

**adminSettings.json** (8 chaves clearConfig, 6 locales):
- `channels.clearConfig.button/dialogTitle/dialogDescription/cancel/confirm/clearing/success/error`

### Testes
- [x] pnpm exec tsc --noEmit: zero erros
- [x] Texto "Esta mensagem foi excluída" em PT-BR confirmado
- [x] 18 arquivos de locale, branch dedicada, escopo EVO-1146

## Summary by Sourcery

Add missing internationalization entries for chat, channel configuration, and admin clear-configuration flows across supported locales.

Bug Fixes:
- Ensure deleted chat message placeholder text is properly localized instead of falling back to inline English across all locales.
- Provide localized strings for WhatsApp instance configuration settings that previously relied on English fallbacks.
- Localize admin channel clear-configuration dialog texts in all supported locales to avoid English fallbacks.