### PR TITLE
feat(EVO-1370): renderizar mensagens input_select (buttons/lists) no chat

### DIFF
--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -25,6 +25,7 @@ import MessageImage from '@/components/chat/messages/MessageImage';
 import MessageFile from '@/components/chat/messages/MessageFile';
 import MessageAudio from '@/components/chat/messages/MessageAudio';
 import MessageVideo from '@/components/chat/messages/MessageVideo';
+import MessageInputSelect from '@/components/chat/messages/MessageInputSelect';
 import MessageLocation from '@/components/chat/messages/MessageLocation';
 import MessageCarousel from '@/components/chat/messages/MessageCarousel';
 import MessageStatus from '@/components/chat/messages/MessageStatus';
@@ -265,6 +266,13 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
       case 'cards':
         return (
           <MessageCarousel
+            content={message.content}
+            contentAttributes={message.content_attributes}
+          />
+        );
+      case 'input_select':
+        return (
+          <MessageInputSelect
             content={message.content}
             contentAttributes={message.content_attributes}
           />

--- a/src/components/chat/messages/MessageInputSelect.tsx
+++ b/src/components/chat/messages/MessageInputSelect.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { List } from 'lucide-react';
+
+interface SelectItem {
+  title: string;
+  value: string;
+}
+
+interface MessageInputSelectProps {
+  content?: string;
+  contentAttributes?: Record<string, unknown>;
+}
+
+const MessageInputSelect: React.FC<MessageInputSelectProps> = ({
+  content,
+  contentAttributes,
+}) => {
+  const items: SelectItem[] = Array.isArray(contentAttributes?.items)
+    ? (contentAttributes.items as SelectItem[]).filter(
+        (item) => item && typeof item.title === 'string',
+      )
+    : [];
+
+  if (items.length === 0) {
+    return <p className="text-sm">{content || ''}</p>;
+  }
+
+  const isButtons = items.length <= 3;
+
+  return (
+    <div className="space-y-2">
+      {content && (
+        <p className="text-sm">{content}</p>
+      )}
+
+      {isButtons ? (
+        <div className="flex flex-wrap gap-1.5 mt-1">
+          {items.map((item, index) => (
+            <span
+              key={item.value || index}
+              className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-medium
+                bg-white/20 text-inherit border border-white/30 backdrop-blur-sm"
+            >
+              {item.title}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-1 rounded-lg border border-white/20 overflow-hidden backdrop-blur-sm"
+          style={{ maxWidth: 'min(280px, calc(100vw - 120px))' }}
+        >
+          <div className="flex items-center gap-2 px-3 py-2 bg-white/10 border-b border-white/20">
+            <List className="h-3.5 w-3.5 opacity-70" />
+            <span className="text-xs font-medium opacity-70">Menu</span>
+          </div>
+          <div className="divide-y divide-white/10">
+            {items.map((item, index) => (
+              <div
+                key={item.value || index}
+                className="px-3 py-2 text-sm"
+              >
+                {item.title}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MessageInputSelect;


### PR DESCRIPTION
## Resumo

O chat do CRM não possuía componente para renderizar mensagens interativas (`content_type=input_select`). O operador via apenas texto simples no lugar dos botões/opções que foram enviados ao cliente via WhatsApp. Esta PR adiciona o componente `MessageInputSelect` que renderiza essas mensagens visualmente.

---

### Problema

O `switch (message.content_type)` em `MessageBubble.tsx` (linha 245) não tinha `case 'input_select'`. Mensagens com items (botões ou lista) caíam no `default` que renderiza `<MessageText>` — exibindo apenas o `content` como texto puro, sem os items interativos.

O backend funciona corretamente (mensagens são criadas, salvas e enviadas ao WhatsApp com buttons/list). O gap era exclusivamente na camada de visualização do frontend.

### Componente MessageInputSelect (novo)

**Arquivo:** `src/components/chat/messages/MessageInputSelect.tsx` (72 linhas)

**Props:** `content` (string) + `contentAttributes` (Record com items)

**Dados consumidos:**
```json
{
  "content": "Escolha uma opção:",
  "content_attributes": {
    "items": [
      { "title": "Sim", "value": "sim" },
      { "title": "Não", "value": "nao" }
    ]
  }
}
```

**Renderização condicional:**
- **items.length <= 3** → chips horizontais (`rounded-full`, `bg-white/20`, `border-white/30`, `backdrop-blur-sm`). Simula aparência de reply buttons do WhatsApp.
- **items.length > 3** → lista vertical com header "Menu" (ícone `List` do lucide-react), divisórias entre items, fundo semi-transparente.
- **items vazio** → fallback para texto simples do `content`.

**Estilo:** Cores usam `text-inherit` e `bg-white/20` com `backdrop-blur`, herdando a cor do bubble pai. Funciona em bubbles outgoing (fundo primário), incoming (fundo muted) e dark mode.

### MessageBubble.tsx

**Arquivo:** `src/components/chat/messages/MessageBubble.tsx` (+8 linhas)

- Import do `MessageInputSelect`
- `case 'input_select'` no switch que passa `content` e `content_attributes`

---

## Plano de testes

- [x] `pnpm exec tsc --noEmit`: zero erros
- [x] Mensagem com 3 items renderiza como chips/botões visíveis (confirmado)
- [x] Mensagem com 4 items renderiza como lista com header Menu (confirmado)
- [x] Texto legível tanto em bubble outgoing quanto incoming (confirmado)
- [x] Dark mode: aparência consistente (confirmado)
- [x] 2 arquivos (1 novo + 1 modificado), branch dedicada, escopo EVO-1370

## Summary by Sourcery

Render interactive input_select messages in the chat UI instead of plain text.

New Features:
- Add MessageInputSelect component to display interactive input_select messages as buttons or lists based on the number of items.

Enhancements:
- Integrate MessageInputSelect into MessageBubble so input_select messages are rendered with appropriate styling and layout, including a text fallback when no items are present.