### PR TITLE
fix(frontend): unblock build — replace untyped subscriptions.remove (EVO-1386)

### DIFF
--- a/src/services/chat/websocket/BaseActionCableConnector.ts
+++ b/src/services/chat/websocket/BaseActionCableConnector.ts
@@ -183,7 +183,7 @@ export class BaseActionCableConnector {
     // Remover subscription antiga antes de criar nova
     if (this.subscription) {
       try {
-        this.consumer.subscriptions.remove(this.subscription);
+        this.subscription.unsubscribe();
       } catch {
         // Ignorar erros ao remover subscription stale
       }


### PR DESCRIPTION
## Summary

`pnpm build` (which runs `tsc -b && vite build`) is currently broken on `develop` with TS2339 on `src/services/chat/websocket/BaseActionCableConnector.ts:186`:

```
Property 'remove' does not exist on type
'{ create(channel: string | object, callbacks?: { … } | undefined): Subscription; }'.
```

Root cause: `@rails/actioncable@8.1.x` ships no `.d.ts`, so TypeScript only infers `create()` on `consumer.subscriptions` and never sees `.remove()` — even though the method exists at runtime and is invoked internally by `subscription.unsubscribe()`.

Fix: call `this.subscription.unsubscribe()` instead, which is the documented Rails ActionCable API. Internally it does exactly `this.consumer.subscriptions.remove(this)` (see `actioncable.esm.js:337-338` in the published bundle), so the runtime behavior is identical — only the typing path changes.

## Security

- No network surface change.
- No credentials, no input handling.
- Same teardown call as before, just typed correctly.

## Test plan

- [x] `pnpm exec tsc -b --noEmit` clean
- [x] `pnpm build` (`tsc -b && vite build`) succeeds end-to-end
- [x] `pnpm exec vitest run src/services/chat` — 12/12 tests passing
- [ ] Smoke: log into the CRM, open chat, simulate a WebSocket reconnect (e.g., kill the WS in DevTools) and confirm the old subscription is torn down and a new one connects without console errors

## Changed Files

- `src/services/chat/websocket/BaseActionCableConnector.ts`

## Linked Issue

- EVO-1386

## Summary by Sourcery

Enhancements:
- Align chat WebSocket subscription cleanup with the documented ActionCable `unsubscribe` API to avoid reliance on untyped internal subscription removal.