### PR TITLE
docs(frontend): add Plugin host runtime category and bump EXTENSION_POINTS.md to v2.1.0 (EVO-1387)

### DIFF
--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -263,19 +263,22 @@ returns `undefined`.
 
 The nine slot identifiers below are part of the v2.1.0 contract.
 Adding a new slot id is a minor bump; renaming or removing one is a
-major bump.
+major bump. The **Status** column reflects which slots currently have
+a `<PluginSlot>` wired into the community shell — reserved slots are
+part of the contract (the host accepts contributions to them) but the
+community does not render them yet; a future story may wire them.
 
-| Slot id                | Rendered at                                                |
-|------------------------|------------------------------------------------------------|
-| `app.providers`        | Wraps the application tree (consumer-supplied providers)   |
-| `header.left`          | Left section of the top header (desktop and mobile)        |
-| `header.right`         | Right section of the top header (desktop and mobile)       |
-| `sidebar.afterMain`    | After the main sidebar nav (desktop and mobile Sheet)      |
-| `admin.nav`            | Admin-area navigation                                      |
-| `admin.routes`         | Admin-area route container (used via `PluginRoutes`)       |
-| `settings.sections`    | User settings page sections                                |
-| `dashboard.widgets`    | Dashboard widget grid                                      |
-| `notifications.banner` | Top-of-app notification banner                             |
+| Slot id                | Status   | Rendered at                                              |
+|------------------------|----------|----------------------------------------------------------|
+| `app.providers`        | Reserved | (`PluginHostProvider` composes consumer providers through `PluginManifest.providers`; this slot id is intended for a future imperative provider slot) |
+| `header.left`          | Wired    | Left section of the top header (mobile)                  |
+| `header.right`         | Wired    | Right section of the top header (desktop and mobile)     |
+| `sidebar.afterMain`    | Wired    | After the main sidebar nav (desktop and mobile Sheet)    |
+| `admin.nav`            | Reserved | Admin-area navigation (no `<PluginSlot>` mount yet)      |
+| `admin.routes`         | Reserved | (admin routes are registered via `PluginRoute.namespace = 'admin'`; this slot id is reserved for a future admin-area UI container) |
+| `settings.sections`    | Reserved | User settings page sections (no `<PluginSlot>` mount yet)|
+| `dashboard.widgets`    | Reserved | Dashboard widget grid (no `<PluginSlot>` mount yet)      |
+| `notifications.banner` | Wired    | Top-of-app notification banner                           |
 
 #### Route namespaces
 

--- a/EXTENSION_POINTS.md
+++ b/EXTENSION_POINTS.md
@@ -1,6 +1,6 @@
 # Extension Points
 
-**Contract version:** `2.0.0` (SemVer)
+**Contract version:** `2.1.0` (SemVer)
 
 This document is the public contract between `evo-ai-frontend-community`
 and any external consumer that wants to plug into it without forking or
@@ -13,7 +13,7 @@ ships with a working no-op default; a consumer can **replace** the
 default implementation of one or more of them without modifying files
 under `src/`.
 
-If you are about to change any of the four categories below, read the
+If you are about to change any of the five categories below, read the
 [Compatibility Promise](#compatibility-promise) first.
 
 ---
@@ -50,13 +50,15 @@ bump never triggers an aggregate bump.
 
 ## Extension points
 
-The four categories below are exposed under the `@evoai/extension-points`
-namespace (delivered as part of the React library in a follow-up
-change — until then, this document is the canonical contract). The
-`--evo-*` CSS variable prefix is reserved exclusively for this contract;
-the rest of the codebase keeps using its existing shadcn / Tailwind v4
-CSS variables (`--primary`, `--background`, etc.), and those are
-**not** part of this contract.
+The five categories below are exposed under the `@evoai/extension-points`
+namespace. Sections 1, 2, 4 and 5 ship today; section 3
+(`useCapabilityFallback`) is contract-only at v2.1.0 and is implemented
+in a follow-up story. The in-tree alias for plugin host imports during
+local development is `@/plugin-host`. The `--evo-*` CSS variable prefix
+is reserved exclusively for this contract; the rest of the codebase
+keeps using its existing shadcn / Tailwind v4 CSS variables
+(`--primary`, `--background`, etc.), and those are **not** part of
+this contract.
 
 ### 1. CSS variable tokens
 
@@ -114,8 +116,18 @@ getPlugins(): readonly string[];
 
 **Default behavior.** `registerPlugin` stores registrations in an
 in-memory list and invokes `onBoot` callbacks at the end of app boot.
-`getPlugins()` returns the registered `id`s. The community itself
-registers nothing.
+`getPlugins()` returns the registered `id`s. Re-registering an
+existing `id` is idempotent: the second manifest is dropped, a
+`console.warn` is logged and `onBoot` is not invoked again. The
+community itself registers nothing.
+
+**Extended manifest (v2.1.0+).** The `Plugin` type above is the
+minimal shape required by section 2 and remains valid forever. As of
+v2.1.0 the registry also accepts the richer `PluginManifest` declared
+by [§5 Plugin host runtime](#5-plugin-host-runtime), which adds
+optional `providers`, `slots`, `routes`, `navItems`, `guard` and
+`runtimeContext` fields. A consumer that does not use the plugin host
+keeps writing the v2.0.0 `{ id, onBoot }` shape and is unaffected.
 
 A future evolution that introduces remote / runtime plugin loading
 MUST require a signature or allowlist check at the registry level; the
@@ -146,6 +158,16 @@ Hook that lets the community decide whether to render a capability when
 no external implementation is installed. It is **not** a licensing
 mechanism; it is a fallback used by community components so they can
 render sensible defaults regardless of whether a consumer is attached.
+
+**Implementation status (v2.1.0).** The hook signature below is part
+of the v2.0.0 contract and is honored by this document, but the
+runtime symbols (`useCapabilityFallback` /
+`replaceUseCapabilityFallback`) have not yet shipped in `src/`.
+Consumers can declare a typings-only dependency on the contract
+today; the runtime implementation lands in a follow-up story.
+Consumers that need a working capability check at v2.1.0 should use
+the `PluginGuard` mechanism documented in [§5 Plugin host
+runtime](#5-plugin-host-runtime) instead.
 
 ```ts
 import { useCapabilityFallback } from '@evoai/extension-points';
@@ -213,12 +235,280 @@ i18n.addResourceBundle(
 listed above, or renaming a translation key inside it, is a major bump.
 Adding new namespaces or new keys is a minor bump.
 
+### 5. Plugin host runtime
+
+**Version:** `2.1.0`
+
+A React runtime that lets a consumer mount providers, slots, routes,
+nav items, guards and a runtime-context bridge into the community
+shell without forking. The host is no-op when no plugin is registered;
+the community release ships with an empty registry, all slots render
+their fallback (or nothing) and `usePluginRuntimeContext()` returns
+`undefined`.
+
+A consumer wires its contributions via the same `registerPlugin`
+function declared in [§2 Plugin registry](#2-plugin-registry); the
+`Plugin` argument accepts the richer `PluginManifest` shape declared
+below.
+
+**Default behavior.** Empty registry. `PluginSlot` short-circuits to
+its `fallback` when the slot has no contributions. `PluginRoutes`
+returns an empty array of `<Route>` elements. `PluginGuard` evaluation
+returns `false` when a route declares `requiredCapability` /
+`requiredRole` but no guard has been registered (deny-by-default —
+never silent privilege escalation). `usePluginRuntimeContext()`
+returns `undefined`.
+
+#### Slot ids
+
+The nine slot identifiers below are part of the v2.1.0 contract.
+Adding a new slot id is a minor bump; renaming or removing one is a
+major bump.
+
+| Slot id                | Rendered at                                                |
+|------------------------|------------------------------------------------------------|
+| `app.providers`        | Wraps the application tree (consumer-supplied providers)   |
+| `header.left`          | Left section of the top header (desktop and mobile)        |
+| `header.right`         | Right section of the top header (desktop and mobile)       |
+| `sidebar.afterMain`    | After the main sidebar nav (desktop and mobile Sheet)      |
+| `admin.nav`            | Admin-area navigation                                      |
+| `admin.routes`         | Admin-area route container (used via `PluginRoutes`)       |
+| `settings.sections`    | User settings page sections                                |
+| `dashboard.widgets`    | Dashboard widget grid                                      |
+| `notifications.banner` | Top-of-app notification banner                             |
+
+#### Route namespaces
+
+| Namespace  | Default wrapping                                       |
+|------------|--------------------------------------------------------|
+| `admin`    | `PrivateRoute` + `MainLayout` (or bare when `layout: 'none'`) |
+| `customer` | `PrivateRoute` + `CustomerRoute` + `MainLayout`         |
+| `public`   | Bare — no layout, no auth guard                        |
+
+#### Public types
+
+```ts
+import type {
+  PluginManifest,
+  PluginSlotContribution,
+  PluginSlotComponentProps,
+  PluginRoute,
+  PluginNavItem,
+  PluginProvider,
+  PluginGuard,
+  PluginGuardArgs,
+  PluginRuntimeContextDescriptor,
+  RuntimeContextValue,
+  RouteNamespace,
+  SlotId,
+} from '@evoai/extension-points';
+import { RUNTIME_CONTEXT_CHANGED_EVENT } from '@evoai/extension-points';
+
+interface PluginManifest {
+  id: string;
+  onBoot?: () => void;
+  providers?: PluginProvider[];
+  slots?: Partial<Record<SlotId, PluginSlotContribution[]>>;
+  routes?: PluginRoute[];
+  navItems?: PluginNavItem[];
+  guard?: PluginGuard;
+  runtimeContext?: PluginRuntimeContextDescriptor;
+}
+
+interface PluginSlotContribution {
+  id: string;
+  order?: number; // ascending; ties broken by `id.localeCompare`
+  component: ComponentType<PluginSlotComponentProps>;
+  fallback?: ReactNode;
+}
+
+interface PluginSlotComponentProps {
+  runtimeContext: RuntimeContextValue;
+}
+
+interface PluginRoute {
+  id: string;
+  path: string;
+  namespace?: RouteNamespace; // defaults to 'customer'
+  layout?: 'main' | 'none';
+  element: () => Promise<{ default: ComponentType }>;
+  requiredCapability?: string;
+  requiredRole?: string;
+  fallback?: ReactNode;
+}
+
+interface PluginNavItem {
+  id: string;
+  label: string;
+  href: string;
+  icon?: ComponentType<{ className?: string }>;
+  order?: number;
+}
+
+type PluginProvider = ComponentType<{ children: ReactNode }>;
+
+interface PluginGuardArgs {
+  requiredCapability?: string;
+  requiredRole?: string;
+  runtimeContext: RuntimeContextValue;
+}
+
+type PluginGuard = (args: PluginGuardArgs) => boolean;
+
+interface PluginRuntimeContextDescriptor {
+  Provider: ComponentType<{ children: ReactNode }>;
+  useValue: () => RuntimeContextValue;
+}
+
+type RuntimeContextValue = unknown;
+type RouteNamespace = 'admin' | 'customer' | 'public';
+type SlotId =
+  | 'app.providers' | 'header.left' | 'header.right'
+  | 'sidebar.afterMain' | 'admin.nav' | 'admin.routes'
+  | 'settings.sections' | 'dashboard.widgets' | 'notifications.banner';
+
+const RUNTIME_CONTEXT_CHANGED_EVENT: 'runtimeContextChanged';
+```
+
+`runtimeContext` is opaque to the host: the registering plugin owns
+the shape end-to-end and the host only re-emits a
+`runtimeContextChanged` event when the reference returned by
+`useValue` changes. Consumers SHOULD treat the value as immutable and
+MUST NOT expose mutators through it; if a plugin needs to expose
+actions, it does so through its own internal context, not through
+`usePluginRuntimeContext`.
+
+**At most one plugin may register a `runtimeContext` descriptor.** The
+host resolves the descriptor at registration time (first wins);
+subsequent registrations are dropped and a `console.warn` is logged
+identifying the plugin that was ignored.
+
+#### Public components
+
+```ts
+import {
+  PluginHostProvider,
+  PluginSlot,
+  PluginRoutes,
+  PluginErrorBoundary,
+  PluginRuntimeContextProvider,
+} from '@evoai/extension-points';
+
+<PluginHostProvider>{children}</PluginHostProvider>
+<PluginSlot id="header.right" fallback={null} />
+PluginRoutes({ namespace: 'admin', wrap: (el, route) => ... }): ReactElement[]
+<PluginErrorBoundary pluginId="..." fallback={null}>{children}</PluginErrorBoundary>
+<PluginRuntimeContextProvider>{children}</PluginRuntimeContextProvider>
+```
+
+**`PluginRoutes` is a plain function, not a component.** It returns an
+array of `<Route>` elements that MUST be splatted directly inside a
+react-router `<Routes>` parent — react-router walks `<Routes>`
+children via `React.Children` and only accepts `<Route>` or
+`<Fragment>` nodes. Wrapping `PluginRoutes` in a component breaks
+react-router.
+
+**MVP timing constraint for `PluginRoutes`.** The function returns
+routes that reflect the registry at call time only. Because it cannot
+subscribe to registry updates (`<Routes>` rejects non-`<Route>`
+children, so `useSyncExternalStore` cannot be used here), plugins
+MUST register before `<AppRouter />` mounts. Hot-registering routes
+after the router has mounted is not supported in the MVP and becomes
+visible only when the surrounding tree re-renders for some unrelated
+reason. In-tree plugins that register at module-init time (the MVP
+scope) are unaffected.
+
+#### Public hooks
+
+```ts
+import {
+  usePluginRoutes,
+  usePluginRuntimeContext,
+} from '@evoai/extension-points';
+
+function usePluginRoutes(namespace?: RouteNamespace): PluginRoute[];
+function usePluginRuntimeContext(): RuntimeContextValue;
+```
+
+#### Public registry and helper functions
+
+```ts
+import {
+  registerPlugin,
+  getPlugins,
+  getRegisteredPlugins,
+  getSlotContributions,
+  getRoutes,
+  getProviders,
+  getGuards,
+  getRuntimeContextDescriptor,
+  bootAllPlugins,
+  subscribe,
+  onRuntimeContextChanged,
+  evaluateRouteAccess,
+} from '@evoai/extension-points';
+```
+
+`registerPlugin` accepts the extended `PluginManifest` shape above and
+is otherwise unchanged from §2. `subscribe(listener)` returns an
+unsubscribe function and is invoked by `PluginSlot` / `usePluginRoutes`
+internally. `onRuntimeContextChanged(listener)` lets a non-React
+consumer react to context changes off the React tree.
+
+#### Security model
+
+- `emitRuntimeContextChanged` exists in the implementation but is
+  **NOT** exported from `@evoai/extension-points`. Any caller of that
+  function can dispatch a `runtimeContextChanged` event with an
+  arbitrary payload that every listener attached via
+  `onRuntimeContextChanged` would react to. Only the internal
+  `RuntimeContextBridge` is expected to invoke it. If a consumer
+  needs to push context from outside the React tree, register a
+  `runtimeContext` descriptor on a plugin manifest instead.
+- Every slot contribution is wrapped in a per-contribution
+  `PluginErrorBoundary` keyed by contribution `id`. A crash in one
+  plugin's component cannot take down sibling contributions, the
+  shell, or another plugin's routes.
+- `evaluateRouteAccess` defaults to **deny** when the route declares
+  a `requiredCapability` or `requiredRole` but no guard has been
+  registered, preventing silent privilege escalation when a consumer
+  forgets to install its guard.
+
+#### Default behavior summary
+
+- Standalone (no plugin registered): registry is empty;
+  `PluginHostProvider` passes children through unchanged;
+  `PluginSlot` renders its `fallback` (or nothing) for every slot id;
+  `PluginRoutes(...)` returns `[]`; `usePluginRuntimeContext()`
+  returns `undefined`; `onRuntimeContextChanged` listeners receive
+  nothing.
+- Duplicate `registerPlugin({ id })` calls on the same `id` are
+  idempotent: the second manifest is dropped, a `console.warn` is
+  logged and that manifest's `onBoot` is not invoked.
+
+#### Remote loader
+
+The MVP host loads only in-tree plugins through a synchronous
+`registerPlugin(manifest)` call made from the consumer's entry module.
+There is no remote fetch, no `eval`, no dynamic `import()` of
+arbitrary URLs. The contract a future remote loader MUST satisfy
+(origin allowlist, detached signature, SRI, manifest schema
+validation, opt-in permission scope, error-boundary isolation) is
+recorded in `src/plugin-host/remote-loader.md` in this repository.
+
+**Breaking-change policy.** Renaming or removing any `SlotId`,
+`RouteNamespace`, public type, component, hook or function listed
+above is a major bump. Changing the arity or shape of an existing
+`PluginManifest` field is a major bump. Adding a new slot id,
+namespace, hook or optional field is a minor bump. Bug fixes that
+preserve the contract are patch bumps.
+
 ---
 
 ## How to use as a consumer
 
 Each extension point is independently overridable; a consumer picks
-only what it needs. The four mini-examples below are intentionally
+only what it needs. The five mini-examples below are intentionally
 isolated — combine them as appropriate for the consumer.
 
 Theme tokens:
@@ -253,6 +543,36 @@ import i18n from 'i18next';
 i18n.addResourceBundle('pt-BR', 'my-consumer', { greeting: 'Olá' }, true, false);
 ```
 
+Plugin host registration (slot + route + guard):
+
+```tsx
+import { registerPlugin } from '@evoai/extension-points';
+
+registerPlugin({
+  id: 'my-consumer',
+  slots: {
+    'header.right': [
+      {
+        id: 'my-consumer.header-action',
+        component: () => <button>Action</button>,
+      },
+    ],
+  },
+  routes: [
+    {
+      id: 'my-consumer.admin-panel',
+      path: '/admin/my-consumer',
+      namespace: 'admin',
+      element: () => import('./pages/AdminPanel'),
+      requiredCapability: 'my-consumer.admin',
+      fallback: <div>Not available</div>,
+    },
+  ],
+  guard: ({ requiredCapability }) =>
+    requiredCapability === 'my-consumer.admin' ? true : !requiredCapability,
+});
+```
+
 A consumer is expected to declare the community version range it
 supports in its own `package.json` (e.g. a custom `evoCommunityRange`
 field), so that incompatible versions can be detected at install time.
@@ -276,6 +596,12 @@ field), so that incompatible versions can be detected at install time.
 
 ## Versioning history
 
+- `2.1.0` — Added "Plugin host runtime" category (additive minor
+  bump). Extends §2 `Plugin` to accept the new optional fields
+  (`providers`, `slots`, `routes`, `navItems`, `guard`,
+  `runtimeContext`); the minimal `{ id, onBoot }` shape from v2.0.0
+  remains valid. §3 marked as contract-only pending implementation.
+  §1 CSS tokens and §4 i18n conventions unchanged.
 - `2.0.0` — Renamed `useFeatureFallback` /
   `replaceUseFeatureFallback` to `useCapabilityFallback` /
   `replaceUseCapabilityFallback`. CSS tokens, plugin registry shape


### PR DESCRIPTION
## Summary

The plugin host runtime merged in EVO-1379 (commit `4da709f`) introduced a large new public surface — `PluginManifest`, `PluginSlot`, `PluginRoutes`, `usePluginRuntimeContext`, `onRuntimeContextChanged`, 9 `SlotId` values, 3 `RouteNamespace` values — that was not declared in the canonical `EXTENSION_POINTS.md`. Without this update, downstream stories that consume the host (0.11, 2.6, 5.2 UI, 9.3-9.6, 9.12-9.13) would have to read source code as spec.

This change is purely additive (minor bump v2.0.0 → v2.1.0):

- Header `Contract version` bumped from `2.0.0` to `2.1.0`.
- New `### 5. Plugin host runtime` section declaring the full v2.1.0 surface: 9 `SlotId` values with rendering locations (including a `Status` column distinguishing Wired vs Reserved slots), 3 `RouteNamespace` values with wrapping layouts, all 12 public types with signatures, all public components / hooks / functions, the default no-op behavior, the security model (why `emitRuntimeContextChanged` is internal, per-plugin error boundary, deny-by-default guard evaluation), the MVP timing constraint on `PluginRoutes` (registration must happen before `<AppRouter />` mounts), the single-plugin restriction on `runtimeContext` descriptors, and the per-EP breaking-change policy.
- §2 Plugin registry: documented that `Plugin` now accepts the richer `PluginManifest` shape (cross-references §5). The minimal `{ id, onBoot }` shape from v2.0.0 remains valid and unchanged. Idempotent re-registration behavior also documented.
- §3 `useCapabilityFallback`: marked as contract-only at v2.1.0 with a callout pointing consumers to the `PluginGuard` mechanism in §5 for working capability checks today.
- `How to use as a consumer`: added a fifth mini-example showing plugin host registration with a slot, a route and a guard.
- Versioning history: appended a `2.1.0` entry summarizing the additive change.

## Security

- Documents that `emitRuntimeContextChanged` is NOT exported from `@evoai/extension-points` — any caller could otherwise spoof `runtimeContextChanged` events with arbitrary payloads that every listener attached via `onRuntimeContextChanged` would react to.
- Documents the per-contribution `PluginErrorBoundary` isolation model so a crashing plugin cannot take down the shell or sibling contributions.
- Documents that `evaluateRouteAccess` defaults to deny when a route declares `requiredCapability` / `requiredRole` but no guard is registered, preventing silent privilege escalation.

## Test plan

- `evo-ai-frontend-community: head -3 EXTENSION_POINTS.md` shows `**Contract version:** `2.1.0` (SemVer)`.
- `evo-ai-frontend-community: grep -c "^### 5\. Plugin host runtime" EXTENSION_POINTS.md` returns `1`.
- `evo-ai-frontend-community: grep -c '`2.1.0` — Added "Plugin host runtime"' EXTENSION_POINTS.md` returns `1`.
- `evo-ai-frontend-community: git diff develop -- ':!EXTENSION_POINTS.md'` is empty (doc-only).
- `evo-ai-frontend-community: grep -i -E "enterprise|agency|whitelabel|paid|subscription|tier|tenant|billing" EXTENSION_POINTS.md` returns 0 matches.

## Changed Files

- `EXTENSION_POINTS.md`

## QA Notes

- The slot id table gained a `Status` column distinguishing **Wired** slots (`header.left`, `header.right`, `sidebar.afterMain`, `notifications.banner`) actually mounted via `<PluginSlot>` in the shell from **Reserved** slots (`app.providers`, `admin.nav`, `admin.routes`, `settings.sections`, `dashboard.widgets`) declared in the contract but not yet rendered. Without this distinction a consumer could ship a contribution to a reserved slot and have it silently never render.
- The `admin.routes` slot id is intentionally Reserved — admin routes are registered via `PluginRoute.namespace = 'admin'` and rendered by `PluginRoutes`, not by a `<PluginSlot id="admin.routes" />` mount.
- §3 `useCapabilityFallback` was already documented in v2.0.0 but the runtime symbols never shipped in `src/`; this PR documents that gap explicitly (contract-only) and points consumers to `PluginGuard` as the working alternative.

## Linked Issue

- https://linear.app/evoai/issue/EVO-1387

## Related PRs

- Implements the documentation gap left by `evolution-foundation/evo-ai-frontend-community#79` (EVO-1379, merged as `4da709f`).