### PR TITLE
Fix/mejorar i18n webchat widget

### DIFF
--- a/src/components/channels/settings/PreChatFields.tsx
+++ b/src/components/channels/settings/PreChatFields.tsx
@@ -155,7 +155,7 @@ export default function PreChatFields({ preChatFields, onUpdate }: PreChatFields
               {/* Placeholder Input */}
               <TableCell className="p-2">
                 <Input
-                  value={field.placeholder}
+                  value={field.placeholder || ''}
                   onChange={(e) => handlePlaceholderChange(field.name, e.target.value)}
                   disabled={isFieldEditable(field)}
                   className="text-sm"

--- a/src/components/channels/settings/PreChatForm.tsx
+++ b/src/components/channels/settings/PreChatForm.tsx
@@ -11,6 +11,7 @@ import {
 } from '@evoapi/design-system';
 import { MessageSquare, Info, Settings, Eye } from 'lucide-react';
 import { toast } from 'sonner';
+import { useLanguage } from '@/hooks/useLanguage';
 
 import PreChatFields from './PreChatFields';
 import {
@@ -56,6 +57,7 @@ export default function PreChatForm({
   preChatFormOptions,
   onUpdate,
 }: PreChatFormProps) {
+  const { t, currentLanguage } = useLanguage('channels');
   const [isFormEnabled, setIsFormEnabled] = useState(preChatFormEnabled);
   const [preChatMessage, setPreChatMessage] = useState('');
   const [preChatFields, setPreChatFields] = useState<PreChatField[]>([]);
@@ -72,6 +74,7 @@ export default function PreChatForm({
       // Always format fields when loading from backend to ensure proper formatting
       const formattedFields = getFormattedPreChatFields({
         preChatFields: preChatFormOptions.pre_chat_fields || [],
+        language: currentLanguage,
       });
       setPreChatFields(formattedFields);
     } else {
@@ -79,15 +82,16 @@ export default function PreChatForm({
       const defaultConfig = getPreChatFields({
         preChatFormOptions: {
           pre_chat_message: '',
-          pre_chat_fields: getDefaultPreChatFields(),
+          pre_chat_fields: getDefaultPreChatFields(currentLanguage),
         },
         customAttributes: mockCustomAttributes,
+        language: currentLanguage,
       });
 
       setPreChatMessage(defaultConfig.pre_chat_message);
       setPreChatFields(defaultConfig.pre_chat_fields);
     }
-  }, [preChatFormEnabled, preChatFormOptions]);
+  }, [preChatFormEnabled, preChatFormOptions, currentLanguage]);
 
   // Handle fields update
   const handleFieldsUpdate = useCallback((updatedFields: PreChatField[]) => {
@@ -112,10 +116,10 @@ export default function PreChatForm({
         await onUpdate(updateData);
       }
 
-      toast.success('Configurações do formulário pré-chat atualizadas com sucesso!');
+      toast.success(t('settings.preChatForm.success'));
     } catch (error) {
       console.error('Error updating pre-chat form:', error);
-      toast.error('Erro ao atualizar configurações do formulário pré-chat');
+      toast.error(t('settings.preChatForm.error'));
     } finally {
       setIsUpdating(false);
     }
@@ -136,9 +140,9 @@ export default function PreChatForm({
                 <MessageSquare className="w-5 h-5 text-purple-700 dark:text-purple-400" />
               </div>
               <div>
-                <h4 className="font-semibold text-foreground">Formulário Pré-Chat</h4>
+                <h4 className="font-semibold text-foreground">{t('settings.preChatForm.title')}</h4>
                 <p className="text-sm text-muted-foreground">
-                  Colete informações dos visitantes antes de iniciar a conversa
+                  {t('settings.preChatForm.description')}
                 </p>
               </div>
             </div>
@@ -152,37 +156,37 @@ export default function PreChatForm({
               <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-muted/30 rounded-lg">
                 <div className="text-center">
                   <div className="text-2xl font-bold text-foreground">{preChatFields.length}</div>
-                  <div className="text-sm text-muted-foreground">Total de Campos</div>
+                  <div className="text-sm text-muted-foreground">{t('settings.preChatForm.totalFields')}</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-green-600">{enabledFieldsCount}</div>
-                  <div className="text-sm text-muted-foreground">Campos Ativos</div>
+                  <div className="text-sm text-muted-foreground">{t('settings.preChatForm.activeFields')}</div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-orange-600">{requiredFieldsCount}</div>
-                  <div className="text-sm text-muted-foreground">Campos Obrigatórios</div>
+                  <div className="text-sm text-muted-foreground">{t('settings.preChatForm.requiredFields')}</div>
                 </div>
               </div>
 
               {/* Pre-Chat Message */}
               <div className="space-y-3">
                 <label className="text-sm font-medium text-foreground">
-                  Mensagem de Boas-vindas
+                  {t('settings.preChatForm.welcomeMessage')}
                 </label>
                 <Textarea
                   value={preChatMessage}
                   onChange={e => setPreChatMessage(e.target.value)}
-                  placeholder="Olá! Para melhor atendê-lo, por favor preencha as informações abaixo:"
+                  placeholder={t('settings.preChatForm.welcomeMessagePlaceholder')}
                   className="min-h-[80px]"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Esta mensagem será exibida no topo do formulário pré-chat.
+                  {t('settings.preChatForm.welcomeMessageHelp')}
                 </p>
               </div>
 
               {/* Preview Toggle */}
               <div className="flex items-center justify-between">
-                <h5 className="text-sm font-medium text-foreground">Configuração dos Campos</h5>
+                <h5 className="text-sm font-medium text-foreground">{t('settings.preChatForm.fieldConfiguration')}</h5>
                 <Button
                   variant="outline"
                   size="sm"
@@ -190,7 +194,7 @@ export default function PreChatForm({
                   className="flex items-center gap-2"
                 >
                   <Eye className="h-4 w-4" />
-                  {showPreview ? 'Ocultar Preview' : 'Ver Preview'}
+                  {showPreview ? t('settings.preChatForm.hidePreview') : t('settings.preChatForm.showPreview')}
                 </Button>
               </div>
 
@@ -199,7 +203,7 @@ export default function PreChatForm({
                 <div className="space-y-4 p-4 border border-border rounded-lg bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-950/20 dark:to-purple-950/20">
                   <div className="flex items-center gap-2 text-sm font-medium text-foreground">
                     <Settings className="h-4 w-4" />
-                    Preview do Formulário
+                    {t('settings.preChatForm.formPreview')}
                   </div>
 
                   {preChatMessage && (
@@ -219,20 +223,20 @@ export default function PreChatForm({
                           </label>
                           {field.type === 'textarea' ? (
                             <Textarea
-                              placeholder={field.placeholder}
+                              placeholder={field.placeholder || ''}
                               disabled
                               className="bg-white dark:bg-card"
                             />
                           ) : field.type === 'select' ? (
                             <Select disabled>
                               <SelectTrigger className="bg-white dark:bg-card">
-                                <SelectValue placeholder={field.placeholder} />
+                                <SelectValue placeholder={field.placeholder || ''} />
                               </SelectTrigger>
                             </Select>
                           ) : (
                             <input
                               type={field.type}
-                              placeholder={field.placeholder}
+                              placeholder={field.placeholder || ''}
                               disabled
                               className="w-full px-3 py-2 border border-border rounded-md bg-white dark:bg-card text-sm"
                             />
@@ -243,7 +247,7 @@ export default function PreChatForm({
 
                   {enabledFieldsCount === 0 && (
                     <div className="text-center py-4 text-muted-foreground">
-                      Nenhum campo ativo para exibir
+                      {t('settings.preChatForm.noActiveFields')}
                     </div>
                   )}
                 </div>
@@ -259,13 +263,13 @@ export default function PreChatForm({
                 <Info className="w-5 h-5 text-blue-700 dark:text-blue-400 mt-0.5 flex-shrink-0" />
                 <div className="text-sm">
                   <h6 className="font-medium text-blue-700 dark:text-blue-300 mb-1">
-                    Como funciona o formulário pré-chat
+                    {t('settings.preChatForm.howItWorksTitle')}
                   </h6>
                   <div className="text-blue-600 dark:text-blue-400 space-y-1">
-                    <p>• O formulário é exibido antes do cliente iniciar a conversa</p>
-                    <p>• Informações coletadas são anexadas ao perfil do contato</p>
-                    <p>• Campos obrigatórios devem ser preenchidos para continuar</p>
-                    <p>• Use a função arrastar para reordenar os campos</p>
+                    <p>• {t('settings.preChatForm.howItWorks.point1')}</p>
+                    <p>• {t('settings.preChatForm.howItWorks.point2')}</p>
+                    <p>• {t('settings.preChatForm.howItWorks.point3')}</p>
+                    <p>• {t('settings.preChatForm.howItWorks.point4')}</p>
                   </div>
                 </div>
               </div>
@@ -276,9 +280,9 @@ export default function PreChatForm({
           {!isFormEnabled && (
             <div className="text-center py-8">
               <MessageSquare className="w-12 h-12 text-muted-foreground mx-auto mb-3" />
-              <h5 className="font-medium text-foreground mb-1">Formulário pré-chat desabilitado</h5>
+              <h5 className="font-medium text-foreground mb-1">{t('settings.preChatForm.disabledTitle')}</h5>
               <p className="text-sm text-muted-foreground">
-                Ative para coletar informações dos visitantes antes de iniciar a conversa.
+                {t('settings.preChatForm.disabledDescription')}
               </p>
             </div>
           )}
@@ -286,7 +290,7 @@ export default function PreChatForm({
           {/* Save Button */}
           <div className="flex justify-end pt-4 border-t border-border">
             <Button onClick={handleUpdate} disabled={isUpdating} className="min-w-32">
-              {isUpdating ? 'Salvando...' : 'Salvar Configurações'}
+              {isUpdating ? t('settings.preChatForm.saving') : t('settings.preChatForm.save')}
             </Button>
           </div>
         </CardContent>

--- a/src/components/channels/settings/helpers/preChatHelpers.ts
+++ b/src/components/channels/settings/helpers/preChatHelpers.ts
@@ -1,17 +1,7 @@
-// Types for Pre-Chat Form
 import i18n from '@/i18n/config';
-export interface PreChatField {
-  name: string;
-  type: string;
-  label: string;
-  placeholder: string;
-  required: boolean;
-  enabled: boolean;
-  values?: string[];
-  field_type?: string;
-  regex_pattern?: string;
-  regex_cue?: string;
-}
+import type { PreChatField } from '@/types/settings';
+
+export type { PreChatField };
 
 export interface PreChatFormOptions {
   pre_chat_message: string;
@@ -30,21 +20,21 @@ export interface CustomAttribute {
 }
 
 // Standard field definitions
-export const getStandardFieldKeys = () => ({
+export const getStandardFieldKeys = (language?: string) => ({
   emailAddress: {
     key: 'EMAIL_ADDRESS',
-    label: i18n.t('channels:settings.preChatHelpers.standardFields.email.label'),
-    placeholder: i18n.t('channels:settings.preChatHelpers.standardFields.email.placeholder'),
+    label: i18n.t('channels:settings.preChatHelpers.standardFields.email.label', { lng: language }),
+    placeholder: i18n.t('channels:settings.preChatHelpers.standardFields.email.placeholder', { lng: language }),
   },
   fullName: {
     key: 'FULL_NAME',
-    label: i18n.t('channels:settings.preChatHelpers.standardFields.fullName.label'),
-    placeholder: i18n.t('channels:settings.preChatHelpers.standardFields.fullName.placeholder'),
+    label: i18n.t('channels:settings.preChatHelpers.standardFields.fullName.label', { lng: language }),
+    placeholder: i18n.t('channels:settings.preChatHelpers.standardFields.fullName.placeholder', { lng: language }),
   },
   phoneNumber: {
     key: 'PHONE_NUMBER',
-    label: i18n.t('channels:settings.preChatHelpers.standardFields.phoneNumber.label'),
-    placeholder: i18n.t('channels:settings.preChatHelpers.standardFields.phoneNumber.placeholder'),
+    label: i18n.t('channels:settings.preChatHelpers.standardFields.phoneNumber.label', { lng: language }),
+    placeholder: i18n.t('channels:settings.preChatHelpers.standardFields.phoneNumber.placeholder', { lng: language }),
   },
 });
 
@@ -61,8 +51,8 @@ export const FIELD_TYPES = {
 } as const;
 
 // Default pre-chat fields
-export const getDefaultPreChatFields = (): PreChatField[] => {
-  const standardFields = getStandardFieldKeys();
+export const getDefaultPreChatFields = (language?: string): PreChatField[] => {
+  const standardFields = getStandardFieldKeys(language);
   return [
     {
       name: 'fullName',
@@ -71,6 +61,7 @@ export const getDefaultPreChatFields = (): PreChatField[] => {
       placeholder: standardFields.fullName.placeholder,
       required: true,
       enabled: true,
+      field_type: 'standard' as const,
     },
     {
       name: 'emailAddress',
@@ -79,6 +70,7 @@ export const getDefaultPreChatFields = (): PreChatField[] => {
       placeholder: standardFields.emailAddress.placeholder,
       required: true,
       enabled: true,
+      field_type: 'standard' as const,
     },
     {
       name: 'phoneNumber',
@@ -87,21 +79,24 @@ export const getDefaultPreChatFields = (): PreChatField[] => {
       placeholder: standardFields.phoneNumber.placeholder,
       required: false,
       enabled: false,
+      field_type: 'standard' as const,
     },
   ];
 };
 
 // Get label with translations
-export const getLabel = ({ key, label }: { key: string; label: string }): string => {
-  const standardField = Object.values(getStandardFieldKeys()).find(field => field.key === key);
-  return standardField ? standardField.label : label;
+export const getLabel = ({ key, label, language }: { key: string; label: string; language?: string }): string => {
+  const standardFields = getStandardFieldKeys(language);
+  const field = standardFields[key as keyof typeof standardFields];
+  return field ? field.label : label;
 };
 
 // Get placeholder with translations
-export const getPlaceHolder = ({ key, placeholder, label }: { key: string; placeholder: string; label?: string }): string => {
-  const standardField = Object.values(getStandardFieldKeys()).find(field => field.key === key);
-  const translatedPlaceholder = standardField ? standardField.placeholder : placeholder;
-  return translatedPlaceholder || label || placeholder;
+export const getPlaceHolder = ({ key, placeholder, label, language }: { key: string; placeholder: string; label?: string; language?: string }): string => {
+  const standardFields = getStandardFieldKeys(language);
+  const field = standardFields[key as keyof typeof standardFields];
+  if (field && field.placeholder) return field.placeholder;
+  return placeholder || label || placeholder;
 };
 
 // Convert custom attributes to pre-chat fields
@@ -125,9 +120,9 @@ export const getCustomFields = ({
         label: attribute.attribute_display_name,
         placeholder: attribute.attribute_display_name,
         name: attribute.attribute_key,
-        type: attribute.attribute_display_type,
+        type: attribute.attribute_display_type as PreChatField['type'],
         values: attribute.attribute_values,
-        field_type: attribute.attribute_model,
+        field_type: attribute.attribute_model as PreChatField['field_type'],
         regex_pattern: attribute.regex_pattern,
         regex_cue: attribute.regex_cue,
         required: false,
@@ -140,11 +135,12 @@ export const getCustomFields = ({
 };
 
 // Format pre-chat fields with proper labels and placeholders
-export const getFormattedPreChatFields = ({ preChatFields }: { preChatFields: PreChatField[] }): PreChatField[] => {
+export const getFormattedPreChatFields = ({ preChatFields, language }: { preChatFields: PreChatField[]; language?: string }): PreChatField[] => {
   return preChatFields.map(item => {
     const formattedLabel = getLabel({
       key: item.name,
       label: item.label || item.name,
+      language,
     });
     return {
       ...item,
@@ -153,6 +149,7 @@ export const getFormattedPreChatFields = ({ preChatFields }: { preChatFields: Pr
         key: item.name,
         placeholder: item.placeholder || '',
         label: formattedLabel,
+        language,
       }),
     };
   });
@@ -162,14 +159,17 @@ export const getFormattedPreChatFields = ({ preChatFields }: { preChatFields: Pr
 export const getPreChatFields = ({
   preChatFormOptions = {},
   customAttributes = [],
+  language,
 }: {
   preChatFormOptions?: Partial<PreChatFormOptions>;
   customAttributes?: CustomAttribute[];
+  language?: string;
 }): PreChatFormOptions => {
-  const { pre_chat_message = '', pre_chat_fields = getDefaultPreChatFields() } = preChatFormOptions;
+  const { pre_chat_message = '', pre_chat_fields = getDefaultPreChatFields(language) } = preChatFormOptions;
 
   const formattedPreChatFields = getFormattedPreChatFields({
     preChatFields: pre_chat_fields,
+    language,
   });
 
   const customFields = getCustomFields({

--- a/src/components/widget/MessageList.tsx
+++ b/src/components/widget/MessageList.tsx
@@ -1,6 +1,6 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useMemo } from 'react';
 import { formatDistanceToNow } from 'date-fns';
-import { ptBR } from 'date-fns/locale';
+import { enUS, es, fr, it, pt, ptBR } from 'date-fns/locale';
 import { useLanguage } from '@/hooks/useLanguage';
 
 import type { AttachmentFile } from '@/types/core';
@@ -79,9 +79,14 @@ const MessageList: React.FC<MessageListProps> = ({
   hasMore = true,
   onEmailSubmitted,
 }) => {
-  const { t } = useLanguage('widget');
+  const { t, currentLanguage } = useLanguage('widget');
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const shouldScrollToBottom = useRef(true);
+
+  const dateLocale = useMemo(() => {
+    const map: Record<string, typeof enUS> = { en: enUS, es, fr, it, pt, 'pt-BR': ptBR };
+    return map[currentLanguage] ?? enUS;
+  }, [currentLanguage]);
 
   const sanitizeMessageHTML = (html: string): string => {
     if (!html) return '';
@@ -326,7 +331,7 @@ const MessageList: React.FC<MessageListProps> = ({
               >
                 <span className="text-[10px] text-slate-400">
                   {m.ts
-                    ? formatDistanceToNow(new Date(m.ts), { addSuffix: true, locale: ptBR })
+                    ? formatDistanceToNow(new Date(m.ts), { addSuffix: true, locale: dateLocale })
                     : ''}
                 </span>
                 {m.type === 'out' && m.status === 'sending' && (

--- a/src/components/widget/PreChatForm.tsx
+++ b/src/components/widget/PreChatForm.tsx
@@ -22,7 +22,14 @@ interface PreChatFormProps {
   widgetColor?: string;
   onSubmit: (data: PreChatSubmissionData) => void;
   isLoading?: boolean;
+  serverErrors?: Record<string, string[]>;
 }
+
+const SERVER_TO_FORM_FIELD: Record<string, string> = {
+  email: 'emailAddress',
+  phone_number: 'phoneNumber',
+  name: 'fullName',
+};
 
 // Validation schema factory
 const createValidationSchema = (fields: PreChatField[], hasActiveCampaign: boolean, t: (key: string) => string) => {
@@ -107,8 +114,9 @@ export const PreChatForm: React.FC<PreChatFormProps> = ({
   widgetColor = '#1f93ff',
   onSubmit,
   isLoading = false,
+  serverErrors,
 }) => {
-  const { t } = useLanguage('channels');
+  const { t } = useLanguage('widget');
   const [formFields, setFormFields] = useState<PreChatField[]>([]);
 
   const hasActiveCampaign = !!activeCampaign?.id;
@@ -149,10 +157,19 @@ export const PreChatForm: React.FC<PreChatFormProps> = ({
     control,
     handleSubmit,
     formState: { errors },
+    setError,
   } = useForm<PreChatFormData>({
     resolver: zodResolver(validationSchema),
     defaultValues: {},
   });
+
+  useEffect(() => {
+    if (!serverErrors || Object.keys(serverErrors).length === 0) return;
+    Object.entries(serverErrors).forEach(([field, messages]) => {
+      const formField = SERVER_TO_FORM_FIELD[field] || field;
+      setError(formField as any, { type: 'server', message: messages[0] });
+    });
+  }, [serverErrors, setError]);
 
   useEffect(() => {
     setFormFields(filteredPreChatFields);

--- a/src/components/widget/PreChatForm.tsx
+++ b/src/components/widget/PreChatForm.tsx
@@ -6,6 +6,7 @@ import { Button, Input, Textarea, Checkbox } from '@evoapi/design-system';
 import { useLanguage } from '@/hooks/useLanguage';
 import { PhoneInput } from '@/components/shared/PhoneInput';
 import '@/components/shared/PhoneInput.css';
+import { getLabel, getPlaceHolder } from '@/components/channels/settings/helpers/preChatHelpers';
 import type {
   PreChatField,
   PreChatFormData,
@@ -116,7 +117,7 @@ export const PreChatForm: React.FC<PreChatFormProps> = ({
   isLoading = false,
   serverErrors,
 }) => {
-  const { t } = useLanguage('widget');
+  const { t, currentLanguage } = useLanguage('widget');
   const [formFields, setFormFields] = useState<PreChatField[]>([]);
 
   const hasActiveCampaign = !!activeCampaign?.id;
@@ -171,9 +172,39 @@ export const PreChatForm: React.FC<PreChatFormProps> = ({
     });
   }, [serverErrors, setError]);
 
+  // Standard field names that should be translated
+  const STANDARD_FIELD_NAMES = ['emailAddress', 'fullName', 'phoneNumber'];
+
+  // Translate standard field labels and placeholders
+  const translatedPreChatFields = useMemo(() => {
+    return filteredPreChatFields.map(field => {
+      // Hybrid approach: use field_type if correct, fallback to name check
+      const isStandard = field.field_type === 'standard' || STANDARD_FIELD_NAMES.includes(field.name);
+      if (isStandard) {
+        const translatedLabel = getLabel({
+          key: field.name,
+          label: field.label,
+          language: currentLanguage,
+        });
+        const translatedPlaceholder = getPlaceHolder({
+          key: field.name,
+          placeholder: field.placeholder || '',
+          label: translatedLabel,
+          language: currentLanguage,
+        });
+        return {
+          ...field,
+          label: translatedLabel,
+          placeholder: translatedPlaceholder,
+        };
+      }
+      return field;
+    });
+  }, [filteredPreChatFields, currentLanguage]);
+
   useEffect(() => {
-    setFormFields(filteredPreChatFields);
-  }, [filteredPreChatFields]);
+    setFormFields(translatedPreChatFields);
+  }, [translatedPreChatFields]);
 
   // Get field value
   const getValue = (field: PreChatField, formData: PreChatFormData) => {

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1661,6 +1661,34 @@
       "success": {
         "channelCreated": "Channel created successfully"
       }
+    },
+    "preChatForm": {
+      "title": "Pre-Chat Form",
+      "description": "Collect visitor information before starting the conversation",
+      "totalFields": "Total Fields",
+      "activeFields": "Active Fields",
+      "requiredFields": "Required Fields",
+      "welcomeMessage": "Welcome Message",
+      "welcomeMessagePlaceholder": "Hello! To better assist you, please complete the information below:",
+      "welcomeMessageHelp": "This message will be displayed at the top of the pre-chat form.",
+      "fieldConfiguration": "Field Configuration",
+      "hidePreview": "Hide Preview",
+      "showPreview": "Show Preview",
+      "formPreview": "Form Preview",
+      "noActiveFields": "No active fields to display",
+      "howItWorksTitle": "How the pre-chat form works",
+      "howItWorks": {
+        "point1": "The form is displayed before the client starts the conversation",
+        "point2": "Collected information is attached to the contact profile",
+        "point3": "Required fields must be completed to continue",
+        "point4": "Use the drag function to reorder fields"
+      },
+      "disabledTitle": "Pre-chat form disabled",
+      "disabledDescription": "Enable to collect visitor information before starting the conversation.",
+      "saving": "Saving...",
+      "save": "Save Settings",
+      "success": "Pre-chat form settings updated successfully",
+      "error": "Error updating pre-chat form settings"
     }
   },
   "deleteDialog": {

--- a/src/i18n/locales/en/widget.json
+++ b/src/i18n/locales/en/widget.json
@@ -129,5 +129,23 @@
     "invalidEmail": "Please enter a valid email",
     "success": "Email saved successfully!",
     "error": "Error saving email. Please try again."
+  },
+  "preChatForm": {
+    "message": "Message",
+    "messagePlaceholder": "Type your message here...",
+    "startConversation": "Start Conversation",
+    "starting": "Starting...",
+    "selectOption": "Select an option",
+    "provideDetails": "Please provide your details to continue",
+    "validation": {
+      "invalidEmail": "Invalid email address",
+      "invalidPhone": "Invalid phone. Use international format (e.g. +12125551234)",
+      "invalidUrl": "Invalid URL",
+      "invalidNumber": "Invalid number",
+      "invalidDate": "Invalid date",
+      "invalidFormat": "Invalid format",
+      "required": "This field is required",
+      "messageRequired": "Message is required"
+    }
   }
 }

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1578,6 +1578,34 @@
       "success": {
         "channelCreated": "Canal creado con éxito"
       }
+    },
+    "preChatForm": {
+      "title": "Formulario Pre-Chat",
+      "description": "Recopile información de los visitantes antes de iniciar la conversación",
+      "totalFields": "Total de Campos",
+      "activeFields": "Campos Activos",
+      "requiredFields": "Campos Obligatorios",
+      "welcomeMessage": "Mensaje de Bienvenida",
+      "welcomeMessagePlaceholder": "¡Hola! Para atenderle mejor, por favor complete la información a continuación:",
+      "welcomeMessageHelp": "Este mensaje se mostrará en la parte superior del formulario pre-chat.",
+      "fieldConfiguration": "Configuración de Campos",
+      "hidePreview": "Ocultar Vista Previa",
+      "showPreview": "Ver Vista Previa",
+      "formPreview": "Vista Previa del Formulario",
+      "noActiveFields": "Ningún campo activo para mostrar",
+      "howItWorksTitle": "Cómo funciona el formulario pre-chat",
+      "howItWorks": {
+        "point1": "El formulario se muestra antes de que el cliente inicie la conversación",
+        "point2": "La información recopilada se adjunta al perfil del contacto",
+        "point3": "Los campos obligatorios deben completarse para continuar",
+        "point4": "Use la función arrastrar para reordenar los campos"
+      },
+      "disabledTitle": "Formulario pre-chat deshabilitado",
+      "disabledDescription": "Active para recopilar información de los visitantes antes de iniciar la conversación.",
+      "saving": "Guardando...",
+      "save": "Guardar Configuraciones",
+      "success": "Configuraciones del formulario pre-chat actualizadas con éxito",
+      "error": "Error al actualizar configuraciones del formulario pre-chat"
     }
   },
   "deleteDialog": {

--- a/src/i18n/locales/es/widget.json
+++ b/src/i18n/locales/es/widget.json
@@ -129,5 +129,23 @@
     "invalidEmail": "Por favor, ingrese un email válido",
     "success": "Email guardado con éxito!",
     "error": "Error al guardar email. Intente nuevamente."
+  },
+  "preChatForm": {
+    "message": "Mensaje",
+    "messagePlaceholder": "Escriba su mensaje aquí...",
+    "startConversation": "Iniciar conversación",
+    "starting": "Iniciando...",
+    "selectOption": "Seleccione una opción",
+    "provideDetails": "Por favor, proporcione sus datos para continuar",
+    "validation": {
+      "invalidEmail": "Dirección de email inválida",
+      "invalidPhone": "Teléfono inválido. Use formato internacional (ej. +5491112345678)",
+      "invalidUrl": "URL inválida",
+      "invalidNumber": "Número inválido",
+      "invalidDate": "Fecha inválida",
+      "invalidFormat": "Formato inválido",
+      "required": "Este campo es obligatorio",
+      "messageRequired": "El mensaje es obligatorio"
+    }
   }
 }

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1597,6 +1597,34 @@
       "success": {
         "channelCreated": "Canal créé avec succès"
       }
+    },
+    "preChatForm": {
+      "title": "Formulaire Pré-Chat",
+      "description": "Recueillir les informations des visiteurs avant de commencer la conversation",
+      "totalFields": "Total des Champs",
+      "activeFields": "Champs Actifs",
+      "requiredFields": "Champs Obligatoires",
+      "welcomeMessage": "Message de Bienvenue",
+      "welcomeMessagePlaceholder": "Bonjour! Pour mieux vous servir, veuillez compléter les informations ci-dessous:",
+      "welcomeMessageHelp": "Ce message sera affiché en haut du formulaire pré-chat.",
+      "fieldConfiguration": "Configuration des Champs",
+      "hidePreview": "Masquer l'Aperçu",
+      "showPreview": "Voir l'Aperçu",
+      "formPreview": "Aperçu du Formulaire",
+      "noActiveFields": "Aucun champ actif à afficher",
+      "howItWorksTitle": "Comment fonctionne le formulaire pré-chat",
+      "howItWorks": {
+        "point1": "Le formulaire est affiché avant que le client ne commence la conversation",
+        "point2": "Les informations collectées sont jointes au profil du contact",
+        "point3": "Les champs obligatoires doivent être remplis pour continuer",
+        "point4": "Utilisez la fonction glisser pour réorganiser les champs"
+      },
+      "disabledTitle": "Formulaire pré-chat désactivé",
+      "disabledDescription": "Activez pour collecter les informations des visiteurs avant de commencer la conversation.",
+      "saving": "Enregistrement...",
+      "save": "Enregistrer les Paramètres",
+      "success": "Paramètres du formulaire pré-chat mis à jour avec succès",
+      "error": "Erreur lors de la mise à jour des paramètres du formulaire pré-chat"
     }
   },
   "deleteDialog": {

--- a/src/i18n/locales/fr/widget.json
+++ b/src/i18n/locales/fr/widget.json
@@ -129,5 +129,23 @@
     "invalidEmail": "Veuillez entrer un email valide",
     "success": "Email enregistré avec succès !",
     "error": "Erreur lors de l'enregistrement. Veuillez réessayer."
+  },
+  "preChatForm": {
+    "message": "Message",
+    "messagePlaceholder": "Écrivez votre message ici...",
+    "startConversation": "Démarrer la conversation",
+    "starting": "Démarrage...",
+    "selectOption": "Sélectionner une option",
+    "provideDetails": "Veuillez fournir vos coordonnées pour continuer",
+    "validation": {
+      "invalidEmail": "Adresse email invalide",
+      "invalidPhone": "Téléphone invalide. Utilisez le format international (ex : +33612345678)",
+      "invalidUrl": "URL invalide",
+      "invalidNumber": "Nombre invalide",
+      "invalidDate": "Date invalide",
+      "invalidFormat": "Format invalide",
+      "required": "Ce champ est obligatoire",
+      "messageRequired": "Le message est obligatoire"
+    }
   }
 }

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1536,6 +1536,34 @@
       "success": {
         "channelCreated": "Canale creato con successo"
       }
+    },
+    "preChatForm": {
+      "title": "Modulo Pre-Chat",
+      "description": "Raccogli informazioni dei visitatori prima di iniziare la conversazione",
+      "totalFields": "Totale Campi",
+      "activeFields": "Campi Attivi",
+      "requiredFields": "Campi Obbligatori",
+      "welcomeMessage": "Messaggio di Benvenuto",
+      "welcomeMessagePlaceholder": "Ciao! Per servirti meglio, completa le informazioni qui sotto:",
+      "welcomeMessageHelp": "Questo messaggio verrà visualizzato in alto nel modulo pre-chat.",
+      "fieldConfiguration": "Configurazione Campi",
+      "hidePreview": "Nascondi Anteprima",
+      "showPreview": "Mostra Anteprima",
+      "formPreview": "Anteprima Modulo",
+      "noActiveFields": "Nessun campo attivo da visualizzare",
+      "howItWorksTitle": "Come funziona il modulo pre-chat",
+      "howItWorks": {
+        "point1": "Il modulo viene visualizzato prima che il cliente inizi la conversazione",
+        "point2": "Le informazioni raccolte vengono allegate al profilo del contatto",
+        "point3": "I campi obbligatori devono essere compilati per continuare",
+        "point4": "Usa la funzione trascina per riordinare i campi"
+      },
+      "disabledTitle": "Modulo pre-chat disabilitato",
+      "disabledDescription": "Attiva per raccogliere informazioni dei visitatori prima di iniziare la conversazione.",
+      "saving": "Salvataggio...",
+      "save": "Salva Impostazioni",
+      "success": "Impostazioni modulo pre-chat aggiornate con successo",
+      "error": "Errore nell'aggiornamento delle impostazioni del modulo pre-chat"
     }
   },
   "deleteDialog": {

--- a/src/i18n/locales/it/widget.json
+++ b/src/i18n/locales/it/widget.json
@@ -129,5 +129,23 @@
     "invalidEmail": "Per favore inserisci un'email valida",
     "success": "Email salvata con successo!",
     "error": "Errore nel salvataggio dell'email. Riprova."
+  },
+  "preChatForm": {
+    "message": "Messaggio",
+    "messagePlaceholder": "Scrivi il tuo messaggio qui...",
+    "startConversation": "Avvia conversazione",
+    "starting": "Avvio in corso...",
+    "selectOption": "Seleziona un'opzione",
+    "provideDetails": "Fornisci i tuoi dati per continuare",
+    "validation": {
+      "invalidEmail": "Indirizzo email non valido",
+      "invalidPhone": "Telefono non valido. Usa il formato internazionale (es: +39312345678)",
+      "invalidUrl": "URL non valido",
+      "invalidNumber": "Numero non valido",
+      "invalidDate": "Data non valida",
+      "invalidFormat": "Formato non valido",
+      "required": "Questo campo è obbligatorio",
+      "messageRequired": "Il messaggio è obbligatorio"
+    }
   }
 }

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1601,6 +1601,34 @@
         "channelCreated": "Canal criado com sucesso"
       }
     },
+    "preChatForm": {
+      "title": "Formulário Pré-Chat",
+      "description": "Colete informações dos visitantes antes de iniciar a conversa",
+      "totalFields": "Total de Campos",
+      "activeFields": "Campos Ativos",
+      "requiredFields": "Campos Obrigatórios",
+      "welcomeMessage": "Mensagem de Boas-vindas",
+      "welcomeMessagePlaceholder": "Olá! Para melhor atendê-lo, por favor preencha as informações abaixo:",
+      "welcomeMessageHelp": "Esta mensagem será exibida no topo do formulário pré-chat.",
+      "fieldConfiguration": "Configuração dos Campos",
+      "hidePreview": "Ocultar Preview",
+      "showPreview": "Ver Preview",
+      "formPreview": "Preview do Formulário",
+      "noActiveFields": "Nenhum campo ativo para exibir",
+      "howItWorksTitle": "Como funciona o formulário pré-chat",
+      "howItWorks": {
+        "point1": "O formulário é exibido antes do cliente iniciar a conversa",
+        "point2": "Informações coletadas são anexadas ao perfil do contato",
+        "point3": "Campos obrigatórios devem ser preenchidos para continuar",
+        "point4": "Use a função arrastar para reordenar os campos"
+      },
+      "disabledTitle": "Formulário pré-chat desabilitado",
+      "disabledDescription": "Ative para coletar informações dos visitantes antes de iniciar a conversa.",
+      "saving": "Salvando...",
+      "save": "Salvar Configurações",
+      "success": "Configurações do formulário pré-chat atualizadas com sucesso",
+      "error": "Erro ao atualizar configurações do formulário pré-chat"
+    },
     "moderation": {
       "title": "Moderação de Comentários",
       "description": "Revise e modere comentários do Facebook que requerem aprovação",

--- a/src/i18n/locales/pt-BR/widget.json
+++ b/src/i18n/locales/pt-BR/widget.json
@@ -129,5 +129,23 @@
     "invalidEmail": "Por favor, insira um email válido",
     "success": "Email salvo com sucesso!",
     "error": "Erro ao salvar email. Tente novamente."
+  },
+  "preChatForm": {
+    "message": "Mensagem",
+    "messagePlaceholder": "Digite sua mensagem aqui...",
+    "startConversation": "Iniciar conversa",
+    "starting": "Iniciando...",
+    "selectOption": "Selecione uma opção",
+    "provideDetails": "Por favor, informe seus dados para continuar",
+    "validation": {
+      "invalidEmail": "Endereço de e-mail inválido",
+      "invalidPhone": "Telefone inválido. Use o formato internacional (ex: +5511999999999)",
+      "invalidUrl": "URL inválida",
+      "invalidNumber": "Número inválido",
+      "invalidDate": "Data inválida",
+      "invalidFormat": "Formato inválido",
+      "required": "Este campo é obrigatório",
+      "messageRequired": "A mensagem é obrigatória"
+    }
   }
 }

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1595,6 +1595,34 @@
       "success": {
         "channelCreated": "Canal criado com sucesso"
       }
+    },
+    "preChatForm": {
+      "title": "Formulário Pré-Chat",
+      "description": "Colete informações dos visitantes antes de iniciar a conversa",
+      "totalFields": "Total de Campos",
+      "activeFields": "Campos Ativos",
+      "requiredFields": "Campos Obrigatórios",
+      "welcomeMessage": "Mensagem de Boas-vindas",
+      "welcomeMessagePlaceholder": "Olá! Para melhor atendê-lo, por favor preencha as informações abaixo:",
+      "welcomeMessageHelp": "Esta mensagem será exibida no topo do formulário pré-chat.",
+      "fieldConfiguration": "Configuração dos Campos",
+      "hidePreview": "Ocultar Preview",
+      "showPreview": "Ver Preview",
+      "formPreview": "Preview do Formulário",
+      "noActiveFields": "Nenhum campo ativo para exibir",
+      "howItWorksTitle": "Como funciona o formulário pré-chat",
+      "howItWorks": {
+        "point1": "O formulário é exibido antes do cliente iniciar a conversa",
+        "point2": "Informações coletadas são anexadas ao perfil do contato",
+        "point3": "Campos obrigatórios devem ser preenchidos para continuar",
+        "point4": "Use a função arrastar para reordenar os campos"
+      },
+      "disabledTitle": "Formulário pré-chat desabilitado",
+      "disabledDescription": "Ative para coletar informações dos visitantes antes de iniciar a conversa.",
+      "saving": "Salvando...",
+      "save": "Salvar Configurações",
+      "success": "Configurações do formulário pré-chat atualizadas com sucesso",
+      "error": "Erro ao atualizar configurações do formulário pré-chat"
     }
   },
   "deleteDialog": {

--- a/src/i18n/locales/pt/widget.json
+++ b/src/i18n/locales/pt/widget.json
@@ -129,5 +129,23 @@
     "invalidEmail": "Por favor, insira um email válido",
     "success": "Email guardado com sucesso!",
     "error": "Erro ao guardar email. Tente novamente."
+  },
+  "preChatForm": {
+    "message": "Mensagem",
+    "messagePlaceholder": "Escreva a sua mensagem aqui...",
+    "startConversation": "Iniciar conversa",
+    "starting": "A iniciar...",
+    "selectOption": "Selecione uma opção",
+    "provideDetails": "Por favor, forneça os seus dados para continuar",
+    "validation": {
+      "invalidEmail": "Endereço de email inválido",
+      "invalidPhone": "Telefone inválido. Use formato internacional (ex: +351912345678)",
+      "invalidUrl": "URL inválido",
+      "invalidNumber": "Número inválido",
+      "invalidDate": "Data inválida",
+      "invalidFormat": "Formato inválido",
+      "required": "Este campo é obrigatório",
+      "messageRequired": "A mensagem é obrigatória"
+    }
   }
 }

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -49,6 +49,9 @@ export default function Widget() {
   const [hasMoreMessages, setHasMoreMessages] = useState(true);
   const [oldestMessageId, setOldestMessageId] = useState<string | null>(null);
 
+  // Pre-chat server validation errors
+  const [preChatServerErrors, setPreChatServerErrors] = useState<Record<string, string[]>>({});
+
   // Toast notification state
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [toastType, setToastType] = useState<'success' | 'error' | 'info'>('info');
@@ -1377,7 +1380,15 @@ export default function Widget() {
 
         // Always transition to chat interface after successful conversation creation
         setHasStarted(true);
-      } catch (apiError) {
+      } catch (apiError: any) {
+        // Handle server-side validation errors (422)
+        const status = apiError?.response?.status ?? apiError?.status;
+        const data = apiError?.response?.data ?? apiError?.data;
+        if (status === 422 && data?.code === 'PRE_CHAT_VALIDATION_ERROR' && data?.errors) {
+          setPreChatServerErrors(data.errors);
+          return;
+        }
+
         // If HTTP API fails (e.g., CORS), rely on WebSocket events for state transition
         // The WebSocket will handle setting hasStarted when conversation.created event arrives
         console.warn('Widget: API call failed, relying on WebSocket events:', apiError);
@@ -1615,8 +1626,9 @@ export default function Widget() {
                 currentUser={currentUser}
                 activeCampaign={activeCampaign}
                 widgetColor={ui.color || '#00d4aa'}
-                onSubmit={handlePreChatSubmit}
+                onSubmit={(data) => { setPreChatServerErrors({}); handlePreChatSubmit(data); }}
                 isLoading={isCreatingConversation}
+                serverErrors={preChatServerErrors}
               />
             </div>
           );

--- a/src/services/widget/widgetService.ts
+++ b/src/services/widget/widgetService.ts
@@ -231,7 +231,9 @@ class WidgetService {
 
       const locale = this.normalizeWidgetLocale(websiteConfig.locale);
       if (locale && i18n.language !== locale) {
-        await i18n.changeLanguage(locale).catch(() => undefined);
+        await i18n.changeLanguage(locale).catch((err) => {
+          console.error('[Widget] Failed to change language:', err);
+        });
       }
 
       return {

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -89,21 +89,7 @@ export interface Inbox {
   };
   // Pre-chat form
   pre_chat_form_enabled?: boolean;
-  pre_chat_form_options?: {
-    pre_chat_message: string;
-    pre_chat_fields: Array<{
-      name: string;
-      type: string;
-      label: string;
-      placeholder: string;
-      required: boolean;
-      enabled: boolean;
-      values?: string[];
-      field_type?: string;
-      regex_pattern?: string;
-      regex_cue?: string;
-    }>;
-  };
+  pre_chat_form_options?: import('@/components/channels/settings/helpers/preChatHelpers').PreChatFormOptions;
   web_widget_script?: string;
   default_conversation_status?: string;
 }

--- a/src/types/settings/preChat.ts
+++ b/src/types/settings/preChat.ts
@@ -1,11 +1,11 @@
 export interface PreChatField {
   name: string;
-  type: 'text' | 'email' | 'phone' | 'select' | 'checkbox' | 'date' | 'url' | 'number';
+  type: 'text' | 'email' | 'phone' | 'select' | 'checkbox' | 'date' | 'url' | 'number' | 'textarea';
   label: string;
   placeholder?: string;
   required: boolean;
   enabled: boolean;
-  field_type: 'contact_attribute' | 'conversation_attribute';
+  field_type: 'contact_attribute' | 'conversation_attribute' | 'standard';
   values?: string[]; // Para select
   regex_pattern?: string;
   regex_cue?: string;


### PR DESCRIPTION
## Summary
- Show backend validation errors in the webchat widget (pre‑chat form), localized to the current language.
- Use dynamic `date-fns` locales for message timestamps (no more hardcoded `ptBR`).
- Add missing `widget` translation keys (preChatForm) across supported locales.
- Unify the `PreChatField` TypeScript type, remove duplicates, and correctly handle optional `placeholder`.
- Hybrid detection of standard fields in the widget: use `field_type === 'standard'` or fallback to name in `STANDARD_FIELD_NAMES` for backward compatibility.
- Minor cleanup: remove debug logs and duplicated translation sections.

## Root cause
- The widget did not map backend 422 validation errors to form fields, so users could not see server‑side error messages (e.g., invalid phone/email).
- `date-fns` locale was hardcoded to Portuguese (`ptBR`) in message timestamps.
- The pre‑chat settings and widget components used different i18n namespaces and were missing translation keys for labels/placeholders and validation messages.
- `PreChatField` type was defined in multiple places; optional `placeholder` handling was inconsistent.

## Changes

### 1) Pre‑chat validation errors and dynamic timestamps
- `src/pages/Widget/index.tsx`
  - Extract backend 422 errors with code `PRE_CHAT_VALIDATION_ERROR` and map them into `preChatServerErrors` state
  - Pass `serverErrors` prop down to `PreChatForm`
  - Reset errors on new submit

- `src/components/widget/PreChatForm.tsx`
  - Switch i18n namespace from `'channels'` to `'widget'`
  - Accept and display `serverErrors` under the appropriate fields
  - Map server keys to form keys: `email` → `emailAddress`, `phone_number` → `phoneNumber`, `name` → `fullName`

- `src/components/widget/MessageList.tsx`
  - Import locales: `enUS, es, fr, it, pt, ptBR`
  - Select locale at runtime based on `currentLanguage` and pass to date formatters (no more hardcoded `ptBR`)

### 2) Translation files
- `src/i18n/locales/*/widget.json`
  - Add `preChatForm` keys (message, placeholders, actions, validation strings)
  - Example (es):
```json
"preChatForm": {
  "message": "Mensaje",
  "messagePlaceholder": "Escribe tu mensaje aquí...",
  "startConversation": "Iniciar conversación",
  "starting": "Iniciando...",
  "selectOption": "Selecciona una opción",
  "provideDetails": "Por favor proporciona tus datos para continuar",
  "validation": {
    "invalidEmail": "Email inválido",
    "invalidPhone": "Teléfono inválido. Use formato internacional (ej. +5491112345678)",
    "invalidUrl": "URL inválida",
    "invalidNumber": "Número inválido",
    "invalidDate": "Fecha inválida",
    "invalidFormat": "Formato inválido",
    "required": "Este campo es requerido",
    "messageRequired": "El mensaje es requerido"
  }
}
```

### 3) Types unification and settings UI
- `src/types/settings/preChat.ts`
  - Unify `PreChatField`, add `'textarea'` to `type` union, keep `placeholder?: string`

- `src/components/channels/settings/helpers/preChatHelpers.ts`
  - Remove local `PreChatField` definition and import the central type
  - Add `field_type: 'standard'` in default fields for consistency

- `src/components/channels/settings/PreChatFields.tsx` and `src/components/channels/settings/PreChatForm.tsx`
  - Handle optional `placeholder` safely using `field.placeholder || ''`

### 4) Hybrid standard‑field detection (widget)
- `src/components/widget/PreChatForm.tsx`
```ts
const isStandard = field.field_type === 'standard' || STANDARD_FIELD_NAMES.includes(field.name);
if (isStandard) {
  // translate label/placeholder dynamically from widget namespace
}
```
- Works with both new normalized data (`field_type: 'standard'`) and legacy data (fallback by `name`).

### 5) Cleanup
- Remove duplicated translation sections under `channels.json`
- Remove debug logs from `widgetService`

## Design decisions
- Prefer displaying server‑side validation to avoid drifting rules between frontend and backend.
- Keep a single source of truth for `PreChatField` to prevent TS divergence.
- Hybrid detection ensures smooth rollout while backend normalization lands.
- Dynamic `date-fns` locale aligns timestamps with the active UI language.

## Test checklist
- Build/lint: `npm run build` and `npx tsc --noEmit` — zero type errors
- Pre‑chat form:
  - With Spanish locale, submit invalid phone ("123") and invalid email ("test@")
  - Expect localized errors under the corresponding fields
  - Clear errors on new submit
- Timestamps:
  - Switch languages (es, fr, it, pt, en) and verify localized relative times
- Settings (channel UI):
  - Edit pre‑chat fields; preview shows placeholders correctly
  - Save and verify widget renders translated labels/placeholders
- Types:
  - No duplicate `PreChatField` definitions; optional `placeholder` handled safely

## Known limitations
- Requires backend to return 422 with `PRE_CHAT_VALIDATION_ERROR` and per‑field messages; otherwise falls back to client validations.

## Related
- Backend branch (normalization + i18n): [evolution-foundation/evo-ai-crm-community#[80](https://github.com/evolution-foundation/evo-ai-crm-community/pull/80)
- Frontend branch (this PR): https://github.com/miltonsosa-info-unlp/evo-ai-frontend-community/tree/fix/mejorar-i18n-webchat-widget

## Reviewer guide
- Check that `widget.json` keys are complete and match UI usage
- Verify mapping of backend error keys → form fields
- Confirm `date-fns` locale selection logic per language code
- Ensure no regressions in settings preview

## Checklist
- [x] Conventional Commit in title
- [x] Translations added for `widget.preChatForm` in all supported locales
- [x] Types unified and imports updated
- [x] Error mapping and UI rendering tested
- [x] Build and typecheck clean
- [x] CONTRIBUTING guidelines followed
