### PR TITLE
feat(menu): hide enterprise-only entries from the community sidebar

### DIFF
--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -20,12 +20,12 @@ import {
   Workflow,
   Settings,
   List,
-  GraduationCap,
+  // GraduationCap, // hidden enterprise menu — see below
   Shield,
   Package,
-  Filter,
-  Megaphone,
-  Route,
+  // Filter, // hidden enterprise menu — see below
+  // Megaphone, // hidden enterprise menu — see below
+  // Route, // hidden enterprise menu — see below
   ShieldCheck,
 } from 'lucide-react';
 
@@ -120,20 +120,21 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
     resource: 'automation_rules',
     action: 'read',
   },
-  {
-    name: t('menu.customer.journeys'),
-    href: '/journeys',
-    icon: Route,
-    resource: 'journeys',
-    action: 'read',
-  },
-  {
-    name: t('menu.customer.campaigns'),
-    href: '/campaigns',
-    icon: Megaphone,
-    resource: 'campaigns',
-    action: 'read',
-  },
+  // Hidden in community — these features ship with the enterprise edition.
+  // {
+  //   name: t('menu.customer.journeys'),
+  //   href: '/journeys',
+  //   icon: Route,
+  //   resource: 'journeys',
+  //   action: 'read',
+  // },
+  // {
+  //   name: t('menu.customer.campaigns'),
+  //   href: '/campaigns',
+  //   icon: Megaphone,
+  //   resource: 'campaigns',
+  //   action: 'read',
+  // },
   {
     id: 'customer-agents',
     name: t('menu.customer.agents'),
@@ -172,11 +173,12 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
     resource: 'channels',
     action: 'read',
   },
-  {
-    name: t('menu.customer.tutorials'),
-    href: '/tutorials',
-    icon: GraduationCap,
-  },
+  // Hidden in community — tutorials experience ships with the enterprise edition.
+  // {
+  //   name: t('menu.customer.tutorials'),
+  //   href: '/tutorials',
+  //   icon: GraduationCap,
+  // },
   {
     id: 'customer-settings',
     name: t('menu.customer.settings'),
@@ -217,13 +219,14 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         resource: 'custom_attribute_definitions',
         action: 'read',
       },
-      {
-        name: t('menu.settings.segments'),
-        href: '/settings/segments',
-        icon: Filter,
-        resource: 'segments',
-        action: 'read',
-      },
+      // Hidden in community — segments ship with the enterprise edition.
+      // {
+      //   name: t('menu.settings.segments'),
+      //   href: '/settings/segments',
+      //   icon: Filter,
+      //   resource: 'segments',
+      //   action: 'read',
+      // },
       {
         name: t('menu.settings.cannedResponses'),
         href: '/settings/canned-responses',


### PR DESCRIPTION
## Summary

Hide four menu items in the community build that should only show in the
enterprise edition:

- `Journeys` (main sidebar)
- `Campaigns` (main sidebar)
- `Tutorials` (main sidebar)
- `Segments` (sub-item under Settings)

All four entries (and their lucide icon imports) are **commented out**,
not deleted, so the enterprise build can re-enable them by reverting the
comments in a single file.

## Test plan

- `pnpm exec tsc -b --noEmit` — passes (icons commented out so
  `noUnusedLocals` doesn't fire)
- `pnpm exec eslint src/components/layout/config/menuItems.ts` — passes
- Manual: load the customer dashboard and confirm the four entries are gone
  from the sidebar and the Settings drawer

## Changed files

- `src/components/layout/config/menuItems.ts`

## Summary by Sourcery

Enhancements:
- Comment out Journeys, Campaigns, Tutorials, and Segments menu entries so they no longer appear in the community UI but can be quickly restored for enterprise builds.