### PR TITLE
feat(sidebar): show app version in footer (git describe + build-arg)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ ENV VITE_WS_URL=VITE_WS_URL_PLACEHOLDER
 ENV VITE_EVOAI_API_URL=VITE_EVOAI_API_URL_PLACEHOLDER
 ENV VITE_AGENT_PROCESSOR_URL=VITE_AGENT_PROCESSOR_URL_PLACEHOLDER
 
+# App version (release tag, e.g. v1.0.0-rc3). Pass via:
+#   docker build --build-arg APP_VERSION=$(git describe --tags --always --dirty) ...
+# The .git directory is not copied into the build context, so vite.config.ts
+# cannot run `git describe` from inside the container — the build-arg is the
+# only signal. Falls back to 'dev' if not provided.
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
 # Build the application
 RUN npm run build
 

--- a/src/components/layout/components/Sidebar.tsx
+++ b/src/components/layout/components/Sidebar.tsx
@@ -215,6 +215,11 @@ export default function Sidebar({
                 <div className="text-xs text-muted-foreground mt-1">
                   {t('sidebar.footer.copyright', { year: currentYear })}
                 </div>
+                {__APP_VERSION__ !== 'dev' && (
+                  <div className="text-xs text-muted-foreground/70 mt-1">
+                    {__APP_VERSION__}
+                  </div>
+                )}
                 <div className="mt-2 flex flex-col gap-1 text-xs">
                   <a
                     href="https://docs.evolutionfoundation.com.br/"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string;
+
 declare module '*.json' {
   const value: Record<string, unknown>;
   export default value;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,25 @@ import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
 import { copyFile, mkdir } from 'node:fs/promises';
 import { createReadStream, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 import type { Plugin } from 'vite';
 
 const FFMPEG_CORE_DIR = path.resolve(__dirname, 'node_modules/@ffmpeg/core/dist');
 const FFMPEG_FILES = ['ffmpeg-core.js', 'ffmpeg-core.wasm', 'ffmpeg-core.worker.js'];
+
+// Resolution order: APP_VERSION env (CI/release) → `git describe` → 'dev'.
+// Env wins because the release pipeline knows the canonical tag better than
+// the local working tree (e.g. detached HEAD on CI).
+function resolveAppVersion(): string {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION;
+  try {
+    return execSync('git describe --tags --always --dirty', {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim();
+  } catch {
+    return 'dev';
+  }
+}
 
 /**
  * Serves /ffmpeg/* from @ffmpeg/core/dist in dev and copies files to dist/ffmpeg/ on build.
@@ -43,6 +58,9 @@ function ffmpegCorePlugin(): Plugin {
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(resolveAppVersion()),
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary

Show the running app version in the sidebar footer, below the copyright line. Renders as a single muted text line; hidden in collapsed mode and when the version resolves to \`dev\` (so local \`npm run dev\` stays clean).

## How the version is resolved (at build time)

Order of precedence:

1. **\`APP_VERSION\` env var** — wins when set. The release pipeline / CI knows the canonical tag better than the local working tree (detached HEAD on CI, shallow clones, etc.).
2. **\`git describe --tags --always --dirty\`** — fallback for local builds and any environment that has a real git tree. Produces strings like \`v1.0.0-rc3\` on a clean tag, \`v1.0.0-rc3-12-g4411498\` mid-cycle, or \`...-dirty\` with uncommitted changes.
3. **\`'dev'\`** — final fallback. Hidden in the UI.

## Files

- \`vite.config.ts\` — \`resolveAppVersion()\` helper; injects \`__APP_VERSION__\` via Vite's \`define\`.
- \`src/vite-env.d.ts\` — declare \`__APP_VERSION__: string\` for TypeScript.
- \`src/components/layout/components/Sidebar.tsx\` — render below the copyright; only when \`__APP_VERSION__ !== 'dev'\` and the sidebar is not collapsed.
- \`Dockerfile\` — \`ARG APP_VERSION\` + \`ENV APP_VERSION=\$APP_VERSION\`. The \`.git\` tree isn't in the container build context, so the build-arg is the only signal inside the image.

## How to consume

**Local build (no extra setup):**
\`\`\`bash
npm run build  # picks up git describe automatically
\`\`\`

**Docker build (e.g. release pipeline):**
\`\`\`bash
docker build \\
  --build-arg APP_VERSION=\$(git describe --tags --always --dirty) \\
  -t evo-ai-frontend:\$(git describe --tags --always) .
\`\`\`

**CI override (any tag string):**
\`\`\`bash
APP_VERSION=v1.0.0-rc3 npm run build
\`\`\`

## Test plan

- \`npx tsc -b --noEmit\` — passes
- \`npm run build\` — passes; verified the version string is embedded in \`dist/assets/index-*.js\` (grepped \`v1.0.0-rc3-12-g4411498-dirty\` from the bundle on this branch).
- Visual: sidebar footer shows \`v1.0.0-rc3-12-g4411498-dirty\` muted below the copyright.

## Follow-up (separate change)

Update the \`evo-release-rc\` skill so that when it tags a new RC, it also rebuilds the front docker image with \`--build-arg APP_VERSION=\$TAG\`. Out of scope for this PR.

## Summary by Sourcery

Expose the built application version in the sidebar footer and propagate a build-time version value through Vite, TypeScript, and Docker configuration.

New Features:
- Display the current app version string in the sidebar footer when available and not in development mode.

Enhancements:
- Resolve an APP_VERSION value at build time via environment variable, git describe, or a dev fallback and inject it into the frontend bundle via Vite global definition.
- Declare a global __APP_VERSION__ type in the Vite TypeScript environment definitions to support the injected version constant.

Build:
- Add Docker build arguments and environment wiring so APP_VERSION can be passed into container builds when the git metadata is not available.