### PR TITLE
fix(onboarding): add language selector and fix placeholder translation (EVO-1403)

### DIFF
--- a/src/i18n/locales/en/onboarding.json
+++ b/src/i18n/locales/en/onboarding.json
@@ -42,6 +42,13 @@
     },
     "footer": "Takes less than 1 minute · You can change this later in settings"
   },
+  "language": {
+    "portuguese": "Português",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français",
+    "italian": "Italiano"
+  },
   "createAccount": {
     "title": "Welcome!",
     "subtitle": "To start using the system, you need to create your first organization.",

--- a/src/i18n/locales/es/onboarding.json
+++ b/src/i18n/locales/es/onboarding.json
@@ -42,6 +42,13 @@
     },
     "footer": "Tarda menos de 1 minuto · Puedes cambiarlo después en la configuración"
   },
+  "language": {
+    "portuguese": "Português",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français",
+    "italian": "Italiano"
+  },
   "createAccount": {
     "title": "¡Bienvenido!",
     "subtitle": "Para comenzar a usar el sistema, necesita crear su primera organización.",

--- a/src/i18n/locales/fr/onboarding.json
+++ b/src/i18n/locales/fr/onboarding.json
@@ -42,6 +42,13 @@
     },
     "footer": "Prend moins d'1 minute · Vous pouvez modifier cela plus tard dans les paramètres"
   },
+  "language": {
+    "portuguese": "Português",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français",
+    "italian": "Italiano"
+  },
   "createAccount": {
     "title": "Bienvenue !",
     "subtitle": "Pour commencer à utiliser le système, vous devez créer votre première organisation.",

--- a/src/i18n/locales/it/onboarding.json
+++ b/src/i18n/locales/it/onboarding.json
@@ -42,6 +42,13 @@
     },
     "footer": "Richiede meno di 1 minuto · Puoi modificarlo nelle impostazioni in seguito"
   },
+  "language": {
+    "portuguese": "Português",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français",
+    "italian": "Italiano"
+  },
   "createAccount": {
     "title": "Benvenuto!",
     "subtitle": "Per iniziare a utilizzare il sistema, devi creare la tua prima organizzazione.",

--- a/src/i18n/locales/pt-BR/onboarding.json
+++ b/src/i18n/locales/pt-BR/onboarding.json
@@ -42,6 +42,13 @@
     },
     "footer": "Leva menos de 1 minuto · Você pode alterar depois nas configurações"
   },
+  "language": {
+    "portuguese": "Português",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français",
+    "italian": "Italiano"
+  },
   "createAccount": {
     "title": "Bem-vindo!",
     "subtitle": "Para começar a usar o sistema, você precisa criar sua primeira organização.",

--- a/src/i18n/locales/pt/onboarding.json
+++ b/src/i18n/locales/pt/onboarding.json
@@ -42,6 +42,13 @@
     },
     "footer": "Demora menos de 1 minuto · Pode alterar nas configurações mais tarde"
   },
+  "language": {
+    "portuguese": "Português",
+    "english": "English",
+    "spanish": "Español",
+    "french": "Français",
+    "italian": "Italiano"
+  },
   "createAccount": {
     "title": "Bem-vindo!",
     "subtitle": "Para começar a usar o sistema, você precisa criar sua primeira organização.",

--- a/src/pages/Setup/OnboardingPage.spec.tsx
+++ b/src/pages/Setup/OnboardingPage.spec.tsx
@@ -6,6 +6,8 @@ import OnboardingPage from './OnboardingPage';
 // Mock useLanguage
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({
+    currentLanguage: 'pt-BR',
+    changeLanguage: vi.fn(),
     t: (key: string) => {
       const map: Record<string, string> = {
         'survey.title': 'Configure seu workspace',
@@ -31,6 +33,11 @@ vi.mock('@/hooks/useLanguage', () => ({
         'survey.crm.options': ['Nenhuma', 'Básica', 'Intermediária', 'Avançada'],
         'survey.goal.label': 'Objetivo principal',
         'survey.goal.options': ['Vendas', 'Suporte', 'Marketing', 'Todos'],
+        'language.portuguese': 'Português',
+        'language.english': 'English',
+        'language.spanish': 'Español',
+        'language.french': 'Français',
+        'language.italian': 'Italiano',
       };
       return map[key] || key;
     },

--- a/src/pages/Setup/OnboardingPage.tsx
+++ b/src/pages/Setup/OnboardingPage.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
+import { type Locale } from '@/i18n/config';
 import { setupService } from '@/services/setup/setupService';
 import { surveyService } from '@/services/survey/surveyService';
 import { useAuth } from '@/contexts/AuthContext';
@@ -27,9 +28,10 @@ interface SelectFieldProps {
   value: string;
   options: string[];
   onChange: (value: string) => void;
+  placeholder?: string;
 }
 
-function SelectField({ label, id, value, options, onChange }: SelectFieldProps) {
+function SelectField({ label, id, value, options, onChange, placeholder = 'Select...' }: SelectFieldProps) {
   return (
     <div style={{ marginBottom: '1.1rem' }}>
       <label
@@ -76,7 +78,7 @@ function SelectField({ label, id, value, options, onChange }: SelectFieldProps) 
           }}
         >
           <option value="" style={{ background: '#18181b', color: '#52525b' }}>
-            Selecionar...
+            {placeholder}
           </option>
           {options.map((opt) => (
             <option key={opt} value={opt} style={{ background: '#18181b', color: '#fafafa' }}>
@@ -111,10 +113,31 @@ function SelectField({ label, id, value, options, onChange }: SelectFieldProps) 
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 
+const LANGUAGES: { value: Locale; labelKey: string }[] = [
+  { value: 'pt-BR', labelKey: 'language.portuguese' },
+  { value: 'en',    labelKey: 'language.english' },
+  { value: 'es',    labelKey: 'language.spanish' },
+  { value: 'fr',    labelKey: 'language.french' },
+  { value: 'it',    labelKey: 'language.italian' },
+];
+
 export default function OnboardingPage() {
   const navigate = useNavigate();
-  const { t } = useLanguage('onboarding');
+  const { t, currentLanguage, changeLanguage } = useLanguage('onboarding');
   const { isAuthenticated, refreshUser } = useAuth();
+
+  const [langOpen, setLangOpen] = useState(false);
+  const langRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (langRef.current && !langRef.current.contains(e.target as Node)) {
+        setLangOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const [form, setForm] = useState<OnboardingFormData>({
     teamSize: '',
@@ -261,6 +284,7 @@ export default function OnboardingPage() {
 
       <div
         style={{
+          position: 'relative',
           minHeight: '100vh',
           background: '#09090b',
           display: 'flex',
@@ -270,6 +294,125 @@ export default function OnboardingPage() {
           fontFamily: 'ui-sans-serif, system-ui, sans-serif',
         }}
       >
+        {/* Language selector */}
+        <div ref={langRef} style={{ position: 'absolute', top: '16px', right: '16px' }}>
+          <button
+            onClick={() => setLangOpen((o) => !o)}
+            aria-haspopup="listbox"
+            aria-expanded={langOpen}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              padding: '6px 10px',
+              background: langOpen ? '#1c1c1f' : 'transparent',
+              border: '0.5px solid',
+              borderColor: langOpen ? '#3f3f46' : '#27272a',
+              borderRadius: '6px',
+              color: '#a1a1aa',
+              fontSize: '13px',
+              fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+              cursor: 'pointer',
+              outline: 'none',
+              transition: 'background 0.15s, border-color 0.15s',
+              whiteSpace: 'nowrap',
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLButtonElement).style.borderColor = '#3f3f46';
+              (e.currentTarget as HTMLButtonElement).style.background = '#1c1c1f';
+            }}
+            onMouseLeave={(e) => {
+              if (!langOpen) {
+                (e.currentTarget as HTMLButtonElement).style.borderColor = '#27272a';
+                (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
+              }
+            }}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="2" y1="12" x2="22" y2="12" />
+              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+            </svg>
+            <span>{LANGUAGES.find((l) => l.value === currentLanguage)?.labelKey ? t(LANGUAGES.find((l) => l.value === currentLanguage)!.labelKey) : currentLanguage}</span>
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 10 10"
+              fill="none"
+              aria-hidden="true"
+              style={{ transition: 'transform 0.15s', transform: langOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+            >
+              <path d="M2 3.5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+
+          {langOpen && (
+            <div
+              role="listbox"
+              aria-label="Select language"
+              style={{
+                position: 'absolute',
+                top: 'calc(100% + 6px)',
+                right: 0,
+                background: '#18181b',
+                border: '0.5px solid #27272a',
+                borderRadius: '8px',
+                padding: '4px',
+                minWidth: '150px',
+                zIndex: 50,
+                boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+              }}
+            >
+              {LANGUAGES.map((lang) => {
+                const isSelected = lang.value === currentLanguage;
+                return (
+                  <button
+                    key={lang.value}
+                    role="option"
+                    aria-selected={isSelected}
+                    onClick={() => { changeLanguage(lang.value); setLangOpen(false); }}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      width: '100%',
+                      padding: '8px 10px',
+                      borderRadius: '5px',
+                      border: 'none',
+                      background: isSelected ? 'rgba(0,255,167,0.08)' : 'transparent',
+                      color: isSelected ? '#00ffa7' : '#a1a1aa',
+                      fontSize: '13px',
+                      fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+                      cursor: 'pointer',
+                      textAlign: 'left',
+                      transition: 'background 0.1s, color 0.1s',
+                    }}
+                    onMouseEnter={(e) => {
+                      if (!isSelected) {
+                        (e.currentTarget as HTMLButtonElement).style.background = 'rgba(255,255,255,0.05)';
+                        (e.currentTarget as HTMLButtonElement).style.color = '#fafafa';
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isSelected) {
+                        (e.currentTarget as HTMLButtonElement).style.background = 'transparent';
+                        (e.currentTarget as HTMLButtonElement).style.color = '#a1a1aa';
+                      }
+                    }}
+                  >
+                    <span>{t(lang.labelKey)}</span>
+                    {isSelected && (
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                        <path d="M2 6l3 3 5-5" stroke="#00ffa7" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
         <div
           style={{
             background: '#111113',
@@ -340,6 +483,7 @@ export default function OnboardingPage() {
                 value={form.teamSize}
                 options={Array.isArray(teamSizeOptions) ? teamSizeOptions : []}
                 onChange={set('teamSize')}
+                placeholder={t('survey.placeholder')}
               />
 
               <SelectField
@@ -348,6 +492,7 @@ export default function OnboardingPage() {
                 value={form.dailyVolume}
                 options={Array.isArray(dailyVolumeOptions) ? dailyVolumeOptions : []}
                 onChange={set('dailyVolume')}
+                placeholder={t('survey.placeholder')}
               />
 
               {/* Channel — with "Other" free text */}
@@ -441,6 +586,7 @@ export default function OnboardingPage() {
                 value={form.usesAI}
                 options={Array.isArray(aiOptions) ? aiOptions : []}
                 onChange={set('usesAI')}
+                placeholder={t('survey.placeholder')}
               />
 
               <SelectField
@@ -449,6 +595,7 @@ export default function OnboardingPage() {
                 value={form.biggestPain}
                 options={Array.isArray(painOptions) ? painOptions : []}
                 onChange={set('biggestPain')}
+                placeholder={t('survey.placeholder')}
               />
 
               <SelectField
@@ -457,6 +604,7 @@ export default function OnboardingPage() {
                 value={form.crmExperience}
                 options={Array.isArray(crmOptions) ? crmOptions : []}
                 onChange={set('crmExperience')}
+                placeholder={t('survey.placeholder')}
               />
 
               <SelectField
@@ -465,6 +613,7 @@ export default function OnboardingPage() {
                 value={form.mainGoal}
                 options={Array.isArray(goalOptions) ? goalOptions : []}
                 onChange={set('mainGoal')}
+                placeholder={t('survey.placeholder')}
               />
             </div>
           </div>

--- a/src/services/setup/setupService.ts
+++ b/src/services/setup/setupService.ts
@@ -53,6 +53,7 @@ export const setupService = {
         main_channel_other: form.mainChannelOther,
         uses_ai:            form.usesAI,
         biggest_pain:       form.biggestPain,
+        crm_experience:     form.crmExperience,
         main_goal:          form.mainGoal,
       },
       { headers: { 'X-Survey-Token': surveyToken } },


### PR DESCRIPTION
## Summary
- Add custom language selector to OnboardingPage (Globe icon + language name + animated chevron + styled dropdown with click-outside dismiss)
- Add `language.*` i18n keys to all 6 onboarding locale files (en, pt-BR, pt, es, fr, it)
- Fix `SelectField` placeholder hardcoded as Portuguese `"Selecionar..."` — now uses `t('survey.placeholder')` across all 6 field instances
- Fix missing `crm_experience` field in `setupService.saveSurvey` pre-login payload
- Update `OnboardingPage.spec.tsx` mock to include `currentLanguage` and `changeLanguage`

## Validation
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` ✅
- `evo-ai-frontend-community: pnpm exec eslint src/pages/Setup/OnboardingPage.tsx src/pages/Setup/OnboardingPage.spec.tsx` ✅

## Changed Files
- `src/pages/Setup/OnboardingPage.tsx`
- `src/pages/Setup/OnboardingPage.spec.tsx`
- `src/services/setup/setupService.ts`
- `src/i18n/locales/en/onboarding.json`
- `src/i18n/locales/pt-BR/onboarding.json`
- `src/i18n/locales/pt/onboarding.json`
- `src/i18n/locales/es/onboarding.json`
- `src/i18n/locales/fr/onboarding.json`
- `src/i18n/locales/it/onboarding.json`

## Linked Issue
- EVO-1403