### PR TITLE
fix(pipeline): invalidate conv pipeline cache after partial allSettled failure (EVO-1127)

### DIFF
--- a/src/components/chat/chat-header/ChatHeader.spec.tsx
+++ b/src/components/chat/chat-header/ChatHeader.spec.tsx
@@ -135,6 +135,17 @@ const openPipelineAndSelectStage = async (
 };
 
 describe('ChatHeader pipeline', () => {
+  const makeItem = (id: string, pipelineId: string) => ({
+    id,
+    item_id: '42',
+    stage_id: `stage-${pipelineId}`,
+    pipeline_id: pipelineId,
+    type: 'conversation',
+    is_lead: false,
+    created_at: '',
+    updated_at: '',
+  });
+
   it('loads pipelines on mount and calls getPipelinesByConversation when menu opens', async () => {
     const pipeline = makePipeline('p1', [{ id: 'stage-1', name: 'Lead' }]);
     vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
@@ -270,16 +281,6 @@ describe('ChatHeader pipeline', () => {
   });
 
   it('removes ALL pipelines when conversation is in 2+ pipelines before adding to new one (H1)', async () => {
-    const makeItem = (id: string, pipelineId: string) => ({
-      id,
-      item_id: '42',
-      stage_id: `stage-${pipelineId}`,
-      pipeline_id: pipelineId,
-      type: 'conversation',
-      is_lead: false,
-      created_at: '',
-      updated_at: '',
-    });
     const pOld1 = makePipeline('p-old1', [{ id: 'stage-p-old1', name: 'StageA' }], [makeItem('item-1', 'p-old1')]);
     const pOld2 = makePipeline('p-old2', [{ id: 'stage-p-old2', name: 'StageB' }], [makeItem('item-2', 'p-old2')]);
     const pNew  = makePipeline('p-new',  [{ id: 'stage-new',    name: 'StageC' }]);
@@ -333,6 +334,30 @@ describe('ChatHeader pipeline', () => {
     await waitFor(() => {
       expect(screen.getByText('pipeline.loading')).toBeInTheDocument();
       expect(screen.queryByText('Lead')).not.toBeInTheDocument();
+    });
+  });
+
+  it('reloads conv pipeline data when a cross-pipeline remove fails partially', async () => {
+    const pOld1 = makePipeline('p-old1', [{ id: 'stage-p-old1', name: 'StageA' }], [makeItem('item-1', 'p-old1')]);
+    const pOld2 = makePipeline('p-old2', [{ id: 'stage-p-old2', name: 'StageB' }], [makeItem('item-2', 'p-old2')]);
+    const pNew  = makePipeline('p-new',  [{ id: 'stage-new',    name: 'StageC' }]);
+
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pOld1, pOld2, pNew] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pOld1, pOld2]);
+    vi.mocked(pipelinesService.removeItemFromPipeline)
+      .mockResolvedValueOnce({ success: true, message: '' })
+      .mockRejectedValueOnce(new Error('network'));
+
+    render(<ChatHeader {...defaultProps} />);
+    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    await openPipelineAndSelectStage(user, 'Pipeline p-new', 'StageC');
+
+    await waitFor(() => {
+      expect(pipelinesService.addItemToPipeline).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith('pipeline.removeError');
+      expect(pipelinesService.getPipelinesByConversation.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -119,6 +119,8 @@ const ChatHeader = ({
   const [convPipelineData, setConvPipelineData] = useState<ConvPipelineData | null>(null);
   const [isLoadingConvPipelines, setIsLoadingConvPipelines] = useState(false);
   const pipelineFetchCountRef = useRef(0);
+  const isMountedRef = useRef(true);
+  useEffect(() => () => { isMountedRef.current = false; }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -140,9 +142,7 @@ const ChatHeader = ({
     setConvPipelineData(null);
   }, [conversation.id]);
 
-  useEffect(() => {
-    if (!menuOpen) return;
-
+  const reloadConvPipelineData = useCallback(() => {
     const fetchId = ++pipelineFetchCountRef.current;
     setIsLoadingConvPipelines(true);
     (async () => {
@@ -150,19 +150,24 @@ const ChatHeader = ({
         const pipelines = await pipelinesService.getPipelinesByConversation(
           String(conversation.id),
         );
-        if (pipelineFetchCountRef.current !== fetchId) return;
+        if (!isMountedRef.current || pipelineFetchCountRef.current !== fetchId) return;
         setConvPipelineData({ pipelines });
       } catch {
-        if (pipelineFetchCountRef.current === fetchId) {
+        if (isMountedRef.current && pipelineFetchCountRef.current === fetchId) {
           setConvPipelineData({ pipelines: [] });
         }
       } finally {
-        if (pipelineFetchCountRef.current === fetchId) {
+        if (isMountedRef.current && pipelineFetchCountRef.current === fetchId) {
           setIsLoadingConvPipelines(false);
         }
       }
     })();
-  }, [menuOpen, conversation.id]);
+  }, [conversation.id]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    reloadConvPipelineData();
+  }, [menuOpen, conversation.id, reloadConvPipelineData]);
 
   const refreshConversationBadge = useCallback(async () => {
     try {
@@ -217,6 +222,7 @@ const ChatHeader = ({
           );
           if (removeResults.some(r => r.status === 'rejected')) {
             toast.error(t('pipeline.removeError'));
+            reloadConvPipelineData();
             return;
           }
         }
@@ -233,7 +239,7 @@ const ChatHeader = ({
         }
       }
     },
-    [convPipelineData, conversation.id, t, refreshConversationBadge],
+    [convPipelineData, conversation.id, t, refreshConversationBadge, reloadConvPipelineData],
   );
 
   const handleRemoveFromPipeline = useCallback(

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -143,6 +143,7 @@ const ChatHeader = ({
   }, [conversation.id]);
 
   const reloadConvPipelineData = useCallback(() => {
+    if (!isMountedRef.current) return;
     const fetchId = ++pipelineFetchCountRef.current;
     setIsLoadingConvPipelines(true);
     (async () => {
@@ -179,7 +180,7 @@ const ChatHeader = ({
         const pipelines = await pipelinesService.getPipelinesByConversation(
           String(conversation.id),
         );
-        setConvPipelineData({ pipelines });
+        if (isMountedRef.current) setConvPipelineData({ pipelines });
       }
     } catch {
       // badge refresh is best-effort

--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ChatSidebar from './ChatSidebar';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import chatService from '@/services/chat/chatService';
 import { toast } from 'sonner';
 
 vi.mock('@/services/pipelines/pipelinesService', () => ({
@@ -18,6 +19,8 @@ vi.mock('@/services/pipelines/pipelinesService', () => ({
 vi.mock('@/services/chat/chatService', () => ({
   default: { getConversation: vi.fn() },
 }));
+
+const mockUpdateConversation = vi.fn();
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -120,7 +123,7 @@ const makeMockContext = () => ({
     getUnreadCount: () => 0,
     loadConversations: vi.fn().mockResolvedValue(undefined),
     loadMoreConversations: vi.fn().mockResolvedValue(undefined),
-    updateConversation: vi.fn(),
+    updateConversation: mockUpdateConversation,
   },
   filters: {
     state: { activeFilters: [], isApplyingFilters: false },
@@ -155,6 +158,10 @@ const defaultProps = {
   onAssignTeam: vi.fn(),
   onAssignTag: vi.fn(),
   onDeleteConversation: vi.fn(),
+  selectedConversationIds: new Set<string>(),
+  onToggleSelect: vi.fn(),
+  onClearSelection: vi.fn(),
+  onBulkResolve: vi.fn().mockResolvedValue(undefined),
 };
 
 beforeEach(() => {
@@ -189,6 +196,17 @@ const openContextMenuPipelineStage = async (
 };
 
 describe('ChatSidebar pipeline', () => {
+  const makeItem = (id: string, pipelineId: string) => ({
+    id,
+    item_id: '42',
+    stage_id: `stage-${pipelineId}`,
+    pipeline_id: pipelineId,
+    type: 'conversation',
+    is_lead: false,
+    created_at: '',
+    updated_at: '',
+  });
+
   it('shows loading label in stage submenu while getPipelinesByConversation is pending (isLoadingConvPipelines guard)', async () => {
     const pipeline = makePipeline('p1', [{ id: 'stage-1', name: 'Lead' }]);
     vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
@@ -226,17 +244,60 @@ describe('ChatSidebar pipeline', () => {
     });
   });
 
-  it('removes ALL pipelines when conversation is in 2+ pipelines before adding to new one (H1)', async () => {
-    const makeItem = (id: string, pipelineId: string) => ({
-      id,
-      item_id: '42',
-      stage_id: `stage-${pipelineId}`,
-      pipeline_id: pipelineId,
-      type: 'conversation',
-      is_lead: false,
-      created_at: '',
-      updated_at: '',
+  it('dispatches updateConversation after pipeline action via right-click', async () => {
+    const pipeline = makePipeline('p1', [{ id: 'stage-1', name: 'Lead' }]);
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([]);
+    vi.mocked(pipelinesService.addItemToPipeline).mockResolvedValue({} as never);
+    const updatedConv = makeConversation('42');
+    vi.mocked(chatService.getConversation).mockResolvedValue({ data: updatedConv } as never);
+
+    render(<ChatSidebar {...defaultProps} />);
+    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    await openContextMenuPipelineStage(user, 'Pipeline p1', 'Lead');
+
+    await waitFor(() => {
+      expect(mockUpdateConversation).toHaveBeenCalledWith(updatedConv);
     });
+  });
+
+  it('blocks addItemToPipeline when any cross-pipeline remove fails', async () => {
+    const pOld1 = makePipeline(
+      'p-old1',
+      [{ id: 'stage-p-old1', name: 'StageA' }],
+      [makeItem('item-1', 'p-old1')],
+    );
+    const pOld2 = makePipeline(
+      'p-old2',
+      [{ id: 'stage-p-old2', name: 'StageB' }],
+      [makeItem('item-2', 'p-old2')],
+    );
+    const pNew = makePipeline('p-new', [{ id: 'stage-new', name: 'StageC' }]);
+
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({
+      data: [pOld1, pOld2, pNew],
+    } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pOld1, pOld2]);
+    vi.mocked(pipelinesService.removeItemFromPipeline)
+      .mockResolvedValueOnce({ success: true, message: '' })
+      .mockRejectedValueOnce(new Error('network'));
+
+    render(<ChatSidebar {...defaultProps} />);
+    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    await openContextMenuPipelineStage(user, 'Pipeline p-new', 'StageC');
+
+    await waitFor(() => {
+      expect(pipelinesService.addItemToPipeline).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith('pipeline.removeError');
+      expect(pipelinesService.getPipelinesByConversation.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  it('removes ALL pipelines when conversation is in 2+ pipelines before adding to new one (H1)', async () => {
     const pOld1 = makePipeline(
       'p-old1',
       [{ id: 'stage-p-old1', name: 'StageA' }],

--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -259,6 +259,11 @@ describe('ChatSidebar pipeline', () => {
     await openContextMenuPipelineStage(user, 'Pipeline p1', 'Lead');
 
     await waitFor(() => {
+      expect(pipelinesService.addItemToPipeline).toHaveBeenCalledWith('p1', {
+        item_id: '42',
+        type: 'conversation',
+        pipeline_stage_id: 'stage-1',
+      });
       expect(mockUpdateConversation).toHaveBeenCalledWith(updatedConv);
     });
   });

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -277,6 +277,7 @@ const ChatSidebar = ({
           );
           if (removeResults.some(r => r.status === 'rejected')) {
             toast.error(t('pipeline.removeError'));
+            void loadConversationPipelineState(convId);
             return;
           }
         }


### PR DESCRIPTION
## Summary
- **ChatHeader**: extracted `reloadConvPipelineData` callback (monotonic fetch counter + `isMountedRef` unmount guard), replacing `setConvPipelineData(null)` — user now sees a loading spinner and gets fresh server data immediately after a partial `removeItemFromPipeline` failure
- **ChatSidebar**: call `void loadConversationPipelineState(convId)` before early return in the `Promise.allSettled` partial failure branch, using the existing monotonic guard
- **ChatSidebar.spec**: 2 new tests — `updateConversation` dispatch after right-click action, and `addItemToPipeline` blocking when any cross-pipeline remove fails; fixed missing `defaultProps` (`selectedConversationIds`, `onToggleSelect`, `onClearSelection`, `onBulkResolve`); extracted shared `makeItem` helper to describe scope
- **ChatHeader.spec**: 1 new test for cache reload after partial remove failure; extracted shared `makeItem` helper to describe scope

## Validation
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit`
- `evo-ai-frontend-community: pnpm exec vitest run src/components/chat/chat-header/ChatHeader.spec.tsx` — 9/9
- `evo-ai-frontend-community: pnpm exec vitest run src/components/chat/chat-sidebar/ChatSidebar.spec.tsx` — 4/4

## Changed Files
- `src/components/chat/chat-header/ChatHeader.tsx`
- `src/components/chat/chat-header/ChatHeader.spec.tsx`
- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/chat/chat-sidebar/ChatSidebar.spec.tsx`

## Linked Issue
- EVO-1127

## Summary by Sourcery

Handle partial pipeline removal failures by reloading conversation pipeline data and preventing inconsistent state when moving conversations between pipelines.

Bug Fixes:
- Reload conversation pipeline data in ChatHeader after partial cross-pipeline remove failures to avoid stale or inconsistent UI state.
- Prevent ChatSidebar from adding a conversation to a new pipeline when any cross-pipeline removal fails, while still reloading the pipeline state.

Enhancements:
- Guard ChatHeader pipeline reloads against unmounted component updates using a mounted ref and monotonic fetch counter.
- Ensure ChatSidebar dispatches conversation updates after pipeline actions triggered via right-click.

Tests:
- Add ChatHeader tests covering pipeline data reload behavior after partial remove failures and share a test helper for pipeline items.
- Extend ChatSidebar tests to cover right-click pipeline actions, blocking add-on failure, and add missing default props and shared item helper.