### PR TITLE
fix(frontend): show warning banner when MFA backup codes were invalidated (EVO-1104)

### DIFF
--- a/src/components/shared/profile/TwoFactorSetup.spec.tsx
+++ b/src/components/shared/profile/TwoFactorSetup.spec.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import TwoFactorSetup from './TwoFactorSetup';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/profile/twoFactorService', () => ({
+  twoFactorService: {
+    enable: vi.fn(),
+    verify: vi.fn(),
+    disable: vi.fn(),
+    regenerateBackupCodes: vi.fn(),
+    sendEmailCode: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mockUseAuth = vi.fn();
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+describe('TwoFactorSetup — mfa_setup_incomplete warning banner (EVO-1104)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the setup incomplete warning when mfa_setup_incomplete is true and MFA is disabled', () => {
+    mockUseAuth.mockReturnValue({
+      user: { mfa_enabled: false, mfa_setup_incomplete: true },
+    });
+
+    render(<TwoFactorSetup />);
+
+    expect(screen.getByText('twoFactor.setupIncompleteWarning')).toBeInTheDocument();
+  });
+
+  it('does not show the warning when mfa_setup_incomplete is false', () => {
+    mockUseAuth.mockReturnValue({
+      user: { mfa_enabled: false, mfa_setup_incomplete: false },
+    });
+
+    render(<TwoFactorSetup />);
+
+    expect(screen.queryByText('twoFactor.setupIncompleteWarning')).not.toBeInTheDocument();
+  });
+
+  it('does not show the warning when MFA is fully enabled', () => {
+    mockUseAuth.mockReturnValue({
+      user: { mfa_enabled: true, mfa_setup_incomplete: true },
+    });
+
+    render(<TwoFactorSetup />);
+
+    expect(screen.queryByText('twoFactor.setupIncompleteWarning')).not.toBeInTheDocument();
+  });
+
+  it('does not show the warning when user has no mfa_setup_incomplete field', () => {
+    mockUseAuth.mockReturnValue({
+      user: { mfa_enabled: false },
+    });
+
+    render(<TwoFactorSetup />);
+
+    expect(screen.queryByText('twoFactor.setupIncompleteWarning')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/shared/profile/TwoFactorSetup.tsx
+++ b/src/components/shared/profile/TwoFactorSetup.tsx
@@ -36,6 +36,7 @@ const TwoFactorSetup = ({ onUpdate }: TwoFactorSetupProps) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const mfaEnabled = user?.mfa_enabled ?? false;
+  const mfaSetupIncomplete = user?.mfa_setup_incomplete ?? false;
 
   // Setup state
   const [setupDialogOpen, setSetupDialogOpen] = useState(false);
@@ -423,6 +424,14 @@ const TwoFactorSetup = ({ onUpdate }: TwoFactorSetupProps) => {
         <CardContent className="space-y-4">
           {!mfaEnabled ? (
             <>
+              {mfaSetupIncomplete && (
+                <Alert variant="destructive">
+                  <AlertTriangle className="h-4 w-4" />
+                  <AlertDescription>
+                    {t('twoFactor.setupIncompleteWarning')}
+                  </AlertDescription>
+                </Alert>
+              )}
               <Alert>
                 <Shield className="h-4 w-4" />
                 <AlertDescription>

--- a/src/i18n/locales/en/profile.json
+++ b/src/i18n/locales/en/profile.json
@@ -286,7 +286,8 @@
         "enable": "Enable Two-Factor Authentication",
         "disable": "Disable Two-Factor Authentication"
       },
-      "info": "Two-factor authentication adds an extra layer of security by requiring an additional code in addition to your password when logging in."
+      "info": "Two-factor authentication adds an extra layer of security by requiring an additional code in addition to your password when logging in.",
+      "setupIncompleteWarning": "Your two-factor authentication backup codes were invalidated due to a security upgrade. Please set up two-factor authentication again to restore your recovery access."
     },
     "common": {
       "cancel": "Cancel",

--- a/src/i18n/locales/es/profile.json
+++ b/src/i18n/locales/es/profile.json
@@ -272,7 +272,8 @@
         "enable": "Activar Autenticación de Dos Factores",
         "disable": "Desactivar Autenticación de Dos Factores"
       },
-      "info": "La autenticación de dos factores agrega una capa extra de seguridad exigiendo un código adicional además de su contraseña al iniciar sesión."
+      "info": "La autenticación de dos factores agrega una capa extra de seguridad exigiendo un código adicional además de su contraseña al iniciar sesión.",
+      "setupIncompleteWarning": "Sus códigos de recuperación de autenticación de dos factores fueron invalidados debido a una actualización de seguridad. Configure la autenticación de dos factores nuevamente para restaurar el acceso de recuperación."
     },
     "common": {
       "cancel": "Cancelar",

--- a/src/i18n/locales/fr/profile.json
+++ b/src/i18n/locales/fr/profile.json
@@ -272,7 +272,8 @@
         "enable": "Activer l'Authentification à Deux Facteurs",
         "disable": "Désactiver l'Authentification à Deux Facteurs"
       },
-      "info": "L'authentification à deux facteurs ajoute une couche de sécurité supplémentaire en exigeant un code supplémentaire en plus de votre mot de passe lors de la connexion."
+      "info": "L'authentification à deux facteurs ajoute une couche de sécurité supplémentaire en exigeant un code supplémentaire en plus de votre mot de passe lors de la connexion.",
+      "setupIncompleteWarning": "Vos codes de récupération d'authentification à deux facteurs ont été invalidés suite à une mise à jour de sécurité. Veuillez reconfigurer l'authentification à deux facteurs pour restaurer votre accès de récupération."
     },
     "common": {
       "cancel": "Annuler",

--- a/src/i18n/locales/it/profile.json
+++ b/src/i18n/locales/it/profile.json
@@ -272,7 +272,8 @@
         "enable": "Attiva autenticazione a due fattori",
         "disable": "Disattiva autenticazione a due fattori"
       },
-      "info": "L'autenticazione a due fattori aggiunge un ulteriore livello di sicurezza richiedendo un codice aggiuntivo oltre alla password durante l'accesso."
+      "info": "L'autenticazione a due fattori aggiunge un ulteriore livello di sicurezza richiedendo un codice aggiuntivo oltre alla password durante l'accesso.",
+      "setupIncompleteWarning": "I codici di recupero dell'autenticazione a due fattori sono stati invalidati a seguito di un aggiornamento di sicurezza. Riconfigura l'autenticazione a due fattori per ripristinare l'accesso di recupero."
     },
     "common": {
       "cancel": "Annulla",

--- a/src/i18n/locales/pt-BR/profile.json
+++ b/src/i18n/locales/pt-BR/profile.json
@@ -286,7 +286,8 @@
         "enable": "Ativar Autenticação de Dois Fatores",
         "disable": "Desativar Autenticação de Dois Fatores"
       },
-      "info": "A autenticação de dois fatores adiciona uma camada extra de segurança exigindo um código adicional além da sua senha ao fazer login."
+      "info": "A autenticação de dois fatores adiciona uma camada extra de segurança exigindo um código adicional além da sua senha ao fazer login.",
+      "setupIncompleteWarning": "Seus códigos de recuperação de autenticação de dois fatores foram invalidados devido a uma atualização de segurança. Configure a autenticação de dois fatores novamente para restaurar o acesso de recuperação."
     },
     "common": {
       "cancel": "Cancelar",

--- a/src/i18n/locales/pt/profile.json
+++ b/src/i18n/locales/pt/profile.json
@@ -272,7 +272,8 @@
         "enable": "Ativar Autenticação de Dois Fatores",
         "disable": "Desativar Autenticação de Dois Fatores"
       },
-      "info": "A autenticação de dois fatores adiciona uma camada extra de segurança exigindo um código adicional além da sua senha ao fazer login."
+      "info": "A autenticação de dois fatores adiciona uma camada extra de segurança exigindo um código adicional além da sua senha ao fazer login.",
+      "setupIncompleteWarning": "Os seus códigos de recuperação de autenticação de dois fatores foram invalidados devido a uma atualização de segurança. Configure a autenticação de dois fatores novamente para restaurar o acesso de recuperação."
     },
     "common": {
       "cancel": "Cancelar",

--- a/src/types/auth/auth.ts
+++ b/src/types/auth/auth.ts
@@ -119,6 +119,7 @@ export interface UserResponse {
   availability?: 'online' | 'offline' | 'busy';
   auto_offline?: boolean;
   mfa_enabled?: boolean;
+  mfa_setup_incomplete?: boolean;
   unconfirmed_email?: string | null;
   created_at?: string;
   custom_attributes?: Record<string, unknown>;

--- a/src/types/users/profile.ts
+++ b/src/types/users/profile.ts
@@ -20,6 +20,7 @@ export interface UserProfile {
   custom_attributes?: Record<string, unknown>;
   availability?: 'online' | 'offline' | 'busy';
   mfa_enabled?: boolean;
+  mfa_setup_incomplete?: boolean;
   confirmed?: boolean;
   unconfirmed_email?: string | null;
   created_at?: string;


### PR DESCRIPTION
## Summary

- Add `mfa_setup_incomplete` field to `UserResponse` and `UserProfile` TypeScript types
- Display destructive alert in `TwoFactorSetup` component when `mfa_setup_incomplete` is true, prompting users to re-configure 2FA after the backend migration invalidated their plaintext legacy backup codes
- Add `setupIncompleteWarning` i18n key in all 6 locales (en, pt-BR, pt, es, fr, it)

## How this closes the re-setup loop (answers Daniel's blocker)

Users affected by the backend migration (`mfa_confirmed_at: nil`, `otp_backup_codes: []`) can still log in because the backend's `mfa_enabled?` returns `false` for them — **no MFA challenge is issued** (`auth_controller#login:15`). The login response includes `mfa_setup_incomplete: true` in the user payload.

On the frontend side:
1. `authService.login()` sees no `mfa_required` flag → falls through to the "Normal login without MFA" branch (`Auth.tsx:214`) — no TOTP screen is shown.
2. The user data (with `mfa_setup_incomplete: true`) is stored in the auth store.
3. When the user navigates to Profile → Security, `TwoFactorSetup.tsx:427` renders a destructive alert banner: *"Your backup codes were invalidated — please reconfigure MFA."*
4. From there the user can re-enable TOTP normally via the existing setup flow.

The backend spec confirming this bypass is in `evo-auth-service-community` PR #34, `spec/requests/api/v1/auth_spec.rb`.

## Validation

- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit`
- `evo-ai-frontend-community: pnpm lint`

## Changed Files

- `src/components/shared/profile/TwoFactorSetup.tsx`
- `src/types/auth/auth.ts`
- `src/types/users/profile.ts`
- `src/i18n/locales/en/profile.json`
- `src/i18n/locales/pt-BR/profile.json`
- `src/i18n/locales/pt/profile.json`
- `src/i18n/locales/es/profile.json`
- `src/i18n/locales/fr/profile.json`
- `src/i18n/locales/it/profile.json`

## Related PRs

- Backend: https://github.com/evolution-foundation/evo-auth-service-community/pull/34

## Linked Issue

- EVO-1104