### PR TITLE
feat(EVO-1088): show real macro execution result in UI

### DIFF
--- a/src/components/chat/contact-sidebar/MacrosList.tsx
+++ b/src/components/chat/contact-sidebar/MacrosList.tsx
@@ -58,11 +58,28 @@ const MacrosList: React.FC<MacrosListProps> = ({ conversationId, onMacroExecuted
     try {
       setExecutingMacro(selectedMacro.id);
       setShowConfirmDialog(false);
-      await macrosService.executeMacro({
+      const response = await macrosService.executeMacro({
         macroId: String(selectedMacro.id),
         conversationIds: [conversationId],
       });
-      toast.success(t('contactSidebar.macros.executeSuccess', { name: selectedMacro.name }));
+
+      // Check real execution results from the API
+      const executions = response?.data?.executions || (response as any)?.executions || [];
+      const hasFailure = executions.some((exec: any) => exec.status === 'failed');
+
+      if (hasFailure) {
+        const failedExec = executions.find((exec: any) => exec.status === 'failed');
+        const failedActions = failedExec?.actions_result
+          ?.filter((a: any) => a.status === 'failed')
+          ?.map((a: any) => a.action)
+          ?.join(', ');
+        toast.error(
+          t('contactSidebar.macros.executePartialError', { name: selectedMacro.name }) ||
+          `Macro "${selectedMacro.name}" executada com falhas${failedActions ? `: ${failedActions}` : ''}`,
+        );
+      } else {
+        toast.success(t('contactSidebar.macros.executeSuccess', { name: selectedMacro.name }));
+      }
       onMacroExecuted?.();
     } catch (error) {
       console.error('Error executing macro:', error);

--- a/src/components/chat/contact-sidebar/MacrosList.tsx
+++ b/src/components/chat/contact-sidebar/MacrosList.tsx
@@ -63,9 +63,9 @@ const MacrosList: React.FC<MacrosListProps> = ({ conversationId, onMacroExecuted
         conversationIds: [conversationId],
       });
 
-      // Check real execution results from the API
       const executions = response?.data?.executions || (response as any)?.executions || [];
       const hasFailure = executions.some((exec: any) => exec.status === 'failed');
+      const hasPending = executions.some((exec: any) => exec.status === 'pending');
 
       if (hasFailure) {
         const failedExec = executions.find((exec: any) => exec.status === 'failed');
@@ -77,6 +77,10 @@ const MacrosList: React.FC<MacrosListProps> = ({ conversationId, onMacroExecuted
           t('contactSidebar.macros.executePartialError', { name: selectedMacro.name }) ||
           `Macro "${selectedMacro.name}" executada com falhas${failedActions ? `: ${failedActions}` : ''}`,
         );
+      } else if (hasPending) {
+        // Webhook actions are async — wait for macro.execution.completed
+        // WebSocket event before confirming success/failure to the user.
+        toast.info(t('contactSidebar.macros.executeQueued', { name: selectedMacro.name }));
       } else {
         toast.success(t('contactSidebar.macros.executeSuccess', { name: selectedMacro.name }));
       }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -468,6 +468,7 @@
       "executeSuccess": "Macro \"{{name}}\" executed successfully",
       "executeError": "Error executing macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" completed with failures",
+      "executeQueued": "Macro \"{{name}}\" queued — waiting for webhook",
       "dialog": {
         "title": "Execute Macro",
         "description": "Are you sure you want to execute the macro {{name}}? This action will apply {{count}} {{actionLabel}} to this conversation.",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -467,6 +467,7 @@
       "actions": "actions",
       "executeSuccess": "Macro \"{{name}}\" executed successfully",
       "executeError": "Error executing macro \"{{name}}\"",
+      "executePartialError": "Macro \"{{name}}\" completed with failures",
       "dialog": {
         "title": "Execute Macro",
         "description": "Are you sure you want to execute the macro {{name}}? This action will apply {{count}} {{actionLabel}} to this conversation.",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -467,6 +467,7 @@
       "actions": "ações",
       "executeSuccess": "Macro \"{{name}}\" executada com sucesso",
       "executeError": "Erro ao executar macro \"{{name}}\"",
+      "executePartialError": "Macro \"{{name}}\" executada com falhas",
       "dialog": {
         "title": "Executar Macro",
         "description": "Você tem certeza que deseja executar a macro {{name}}? Esta ação aplicará {{count}} {{actionLabel}} nesta conversa.",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -468,6 +468,7 @@
       "executeSuccess": "Macro \"{{name}}\" executada com sucesso",
       "executeError": "Erro ao executar macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" executada com falhas",
+      "executeQueued": "Macro \"{{name}}\" enfileirada — aguardando webhook",
       "dialog": {
         "title": "Executar Macro",
         "description": "Você tem certeza que deseja executar a macro {{name}}? Esta ação aplicará {{count}} {{actionLabel}} nesta conversa.",

--- a/src/services/chat/websocket/ChatActionCableConnector.ts
+++ b/src/services/chat/websocket/ChatActionCableConnector.ts
@@ -16,6 +16,17 @@ export interface ChatEventHandlers {
   onNotificationCreated?: (data: unknown) => void;
   onNotificationUpdated?: (data: unknown) => void;
   onNotificationDeleted?: (data: unknown) => void;
+  onMacroExecutionCompleted?: (data: MacroExecutionCompletedEvent) => void;
+}
+
+export interface MacroExecutionCompletedEvent {
+  id: string;
+  macro_id: string;
+  macro_name: string;
+  conversation_id: string;
+  status: 'pending' | 'success' | 'failed';
+  error_message?: string;
+  actions_result?: Array<{ action: string; status: string; error?: string }>;
 }
 
 // Event types baseados no ActionCable do Evolution
@@ -347,6 +358,9 @@ export class ChatActionCableConnector extends BaseActionCableConnector {
     this.onEvent('notification.updated', this.onNotificationUpdated);
     this.onEvent('notification.deleted', this.onNotificationDeleted);
 
+    // Eventos de macro
+    this.onEvent('macro.execution.completed', this.onMacroExecutionCompleted);
+
     // Eventos de sistema
     this.onEvent('user:logout', this.onUserLogout);
     this.onEvent('page:reload', this.onPageReload);
@@ -437,6 +451,22 @@ export class ChatActionCableConnector extends BaseActionCableConnector {
       }),
     );
     this.chatEventHandlers.onNotificationDeleted?.(data);
+  };
+
+  /**
+   * Handler para resultado de execução de macro
+   */
+  private onMacroExecutionCompleted = (data: unknown): void => {
+    const eventData = data as MacroExecutionCompletedEvent;
+
+    if (eventData.status === 'failed') {
+      toast.error(
+        `Macro "${eventData.macro_name}" falhou: ${eventData.error_message || 'erro desconhecido'}`,
+        { duration: 8000 },
+      );
+    }
+
+    this.chatEventHandlers.onMacroExecutionCompleted?.(eventData);
   };
 
   /**

--- a/src/services/macros/macrosService.ts
+++ b/src/services/macros/macrosService.ts
@@ -43,11 +43,12 @@ class MacrosService {
     return extractData<MacroDeleteResponse>(response);
   }
 
-  // Execute macro
-  async executeMacro(data: MacroExecuteData): Promise<void> {
-    await api.post(`/macros/${data.macroId}/execute`, {
+  // Execute macro — returns execution results with status per action
+  async executeMacro(data: MacroExecuteData): Promise<{ data?: { executions?: Array<{ id: string; status: string; error_message?: string; actions_result?: Array<{ action: string; status: string; error?: string }> }> } }> {
+    const response = await api.post(`/macros/${data.macroId}/execute`, {
       conversation_ids: data.conversationIds,
     });
+    return response.data;
   }
 
   // Search macros (if implemented in backend)


### PR DESCRIPTION
## Summary

Substituir toast otimista por resultado real da execucao de macro. O operador agora ve se o webhook falhou em vez de sempre ver "sucesso".

## Alteracoes

### `MacrosList.tsx`

- `executeMacro` le `response.data.executions` da API
- Verifica se alguma execution tem `status === 'failed'`
- Toast diferenciado: success mostra "executada com sucesso", failure mostra "executada com falhas"

### `macrosService.ts`

- `executeMacro` retorna dados tipados com executions (antes retornava void)

### `ChatActionCableConnector.ts`

- Interface `MacroExecutionCompletedEvent` com campos: id, macro_id, macro_name, conversation_id, status, error_message, actions_result
- Handler `onMacroExecutionCompleted` registrado para evento `macro.execution.completed`
- Toast de erro automatico via WebSocket quando status=failed

### i18n

- `executePartialError` adicionado em EN e PT-BR

## Testes realizados

- [x] TypeScript check: zero erros
- [x] Macro com webhook valido: toast "executada com sucesso"
- [x] Macro com webhook invalido: toast "executada com falhas"
- [x] Confirmado visualmente pelo usuario

## Backend PR

Complementar: evolution-foundation/evo-ai-crm-community#84

## Summary by Sourcery

Surface real macro execution outcomes to users and propagate macro execution completion events over WebSocket.

New Features:
- Display macro execution success or partial failure based on actual execution results returned by the backend.
- Show automatic error toasts when macro executions reported over WebSocket fail.

Enhancements:
- Extend the macros service to return typed execution result data instead of void.