### PR TITLE
feat(widget): render Typebot choice blocks as interactive button list

### DIFF
--- a/src/components/widget/MessageList.tsx
+++ b/src/components/widget/MessageList.tsx
@@ -40,6 +40,8 @@ export interface MessageItem {
   };
   contentType?: string;
   submittedEmail?: string;
+  items?: Array<{ title?: string; value?: string }>;
+  submittedValues?: any;
   contentAttributes?: {
     email?: {
       html_content?: {
@@ -61,6 +63,7 @@ interface MessageListProps {
   inboundAvatarUrl?: string;
   onRetry?: (id: string, text: string) => void;
   onReply?: (message: MessageItem) => void;
+  onSelectOption?: (message: MessageItem, item: { title?: string; value?: string }) => void;
   widgetColor?: string;
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
@@ -73,6 +76,7 @@ const MessageList: React.FC<MessageListProps> = ({
   inboundAvatarUrl,
   onRetry,
   onReply,
+  onSelectOption,
   widgetColor = '#00d4aa',
   onLoadMore,
   isLoadingMore = false,
@@ -99,6 +103,26 @@ const MessageList: React.FC<MessageListProps> = ({
   };
 
   const hasHtmlTags = (text: string): boolean => /<\/?[a-z][\s\S]*>/i.test(text);
+
+  const stripSelectFromText = (text: string, items: Array<{ title?: string }>) => {
+    if (!text) return '';
+    if (!items?.length) return text;
+
+    const lines = text.split('\n');
+    let removed = 0;
+
+    while (lines.length > 0) {
+      const last = lines[lines.length - 1]?.trim() || '';
+      const m = last.match(/^(\d+)\.\s+(.*)$/);
+      if (!m) break;
+      lines.pop();
+      removed += 1;
+    }
+
+    if (removed === 0) return text;
+    const pruned = lines.join('\n').trim();
+    return pruned || text;
+  };
 
   // Handle scroll event for loading more messages
   useEffect(() => {
@@ -155,6 +179,10 @@ const MessageList: React.FC<MessageListProps> = ({
       {items.map(m => {
         const hasAvatar = !!(m.avatarUrl || inboundAvatarUrl);
         const isEmailCollect = m.contentType === 'input_email';
+        const isSelect =
+          m.contentType === 'input_select' && Array.isArray(m.items) && m.items.length > 0;
+        const selectDisabled = isSelect && !!m.submittedValues;
+        const selectText = isSelect ? stripSelectFromText(m.text, m.items || []) : m.text;
 
         // Render email collect input as a special interactive message
         if (isEmailCollect) {
@@ -293,7 +321,7 @@ const MessageList: React.FC<MessageListProps> = ({
                 )}
 
                 {/* Text content */}
-                {m.text && (
+                {selectText && (
                   <div className={m.attachments?.length ? 'mt-2' : ''}>
                     {/* Render HTML for incoming email messages */}
                     {m.contentType === 'incoming_email' &&
@@ -313,15 +341,40 @@ const MessageList: React.FC<MessageListProps> = ({
                         }}
                       />
                     ) : (
-                      hasHtmlTags(m.text) ? (
+                      hasHtmlTags(selectText) ? (
                         <div
                           className="whitespace-pre-wrap break-words rich-content"
-                          dangerouslySetInnerHTML={{ __html: sanitizeMessageHTML(m.text) }}
+                          dangerouslySetInnerHTML={{ __html: sanitizeMessageHTML(selectText) }}
                         />
                       ) : (
-                        <div className="whitespace-pre-wrap break-words">{m.text}</div>
+                        <div className="whitespace-pre-wrap break-words">{selectText}</div>
                       )
                     )}
+                  </div>
+                )}
+
+                {isSelect && (
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {m.items?.map((item, idx) => {
+                      const title = (item?.title || '').trim();
+                      if (!title) return null;
+
+                      return (
+                        <button
+                          key={`${m.id}-opt-${idx}`}
+                          type="button"
+                          disabled={selectDisabled || !onSelectOption}
+                          onClick={() => onSelectOption?.(m, item)}
+                          className={`px-3 py-2 rounded-md border text-[13px] leading-tight transition-colors ${
+                            selectDisabled || !onSelectOption
+                              ? 'bg-slate-100 border-slate-200 text-slate-400 cursor-not-allowed'
+                              : 'bg-white border-slate-200 text-slate-700 hover:bg-slate-50'
+                          }`}
+                        >
+                          {title}
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -71,6 +71,26 @@ export default function Widget() {
   const transformMessage = (m: any, list: any[] = []): MessageItem => {
     const messageId = String(m.id ?? Math.random());
     const isSystemMessage = m.message_type === 2 || m.message_type === 3;
+    const normalizeContentType = (value: any) => {
+      if (typeof value === 'string') return value;
+      if (typeof value !== 'number') return undefined;
+
+      const map: Record<number, string> = {
+        0: 'text',
+        1: 'input_text',
+        2: 'input_textarea',
+        3: 'input_email',
+        4: 'input_select',
+        5: 'cards',
+        6: 'form',
+        7: 'article',
+        8: 'incoming_email',
+        9: 'input_csat',
+        10: 'integrations',
+        11: 'sticker',
+      };
+      return map[value] || undefined;
+    };
 
     // Process reply-to information
     let replyTo = undefined;
@@ -123,8 +143,10 @@ export default function Widget() {
           }))
         : undefined,
       // Email HTML support
-      contentType: m.content_type,
+      contentType: normalizeContentType(m.content_type),
       submittedEmail: m.submitted_email || undefined,
+      items: Array.isArray(m.content_attributes?.items) ? m.content_attributes.items : undefined,
+      submittedValues: m.content_attributes?.submitted_values || undefined,
       contentAttributes: m.content_attributes?.email
         ? {
             email: {
@@ -684,9 +706,11 @@ export default function Widget() {
 
                     // Handle different message types
                     if (data?.message_type === 1) {
-                      // message_type 1 = outgoing - but check if it's from an agent
+                      // message_type 1 = outgoing - but check if it's from an agent or bot
                       const isFromAgent =
-                        data?.performer?.type === 'user' || data?.sender_type === null;
+                        data?.performer?.type === 'user' ||
+                        data?.sender_type === null ||
+                        data?.sender_type === 'AgentBot';
 
                       if (isFromAgent) {
                         // This is a message from an agent, add as incoming message
@@ -1261,6 +1285,36 @@ export default function Widget() {
     })();
   };
 
+  const handleSelectOption = async (message: MessageItem, item: { title?: string; value?: string }) => {
+    const title = (item.title || '').trim();
+    const value = (item.value || '').trim();
+    const selectedText = title || value;
+    if (!selectedText) return;
+
+    setMessages(prev =>
+      prev.map(m =>
+        m.id === message.id ? { ...m, submittedValues: { name: 'choice', title, value: value || title } } : m,
+      ),
+    );
+
+    handleSend(selectedText);
+
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const token = params.get('website_token') || '';
+      if (!token) return;
+
+      const messageId = message.originalId || message.id;
+      await widgetService.updateMessageSubmittedValues(token, messageId, {
+        name: 'choice',
+        title,
+        value: value || title,
+      });
+    } catch (e) {
+      return;
+    }
+  };
+
   const handlePreChatSubmit = async (preChatData: PreChatSubmissionData) => {
     const params = new URLSearchParams(window.location.search);
     const token = params.get('website_token') || '';
@@ -1642,6 +1696,7 @@ export default function Widget() {
                   inboundAvatarUrl={ui.avatarUrl}
                   onRetry={(_id, text) => handleSend(text)}
                   onReply={handleReplyToMessage}
+                  onSelectOption={handleSelectOption}
                   widgetColor={ui.color || '#00d4aa'}
                   onLoadMore={loadOlderMessages}
                   isLoadingMore={isLoadingOlderMessages}
@@ -1726,4 +1781,3 @@ export default function Widget() {
     </div>
   );
 }
-

--- a/src/services/widget/widgetService.ts
+++ b/src/services/widget/widgetService.ts
@@ -595,6 +595,31 @@ class WidgetService {
     return extractData<any>(response);
   }
 
+  async updateMessageSubmittedValues(
+    websiteToken: string,
+    messageId: string | number,
+    submittedValues: { name: string; title: string; value: string },
+  ) {
+    const response = await this.requestWithBaseFallback((client) =>
+      client.patch(
+        `/widget/messages/${messageId}`,
+        {
+          message: {
+            submitted_values: submittedValues,
+          },
+        },
+        {
+          params: { website_token: websiteToken },
+          headers: {
+            ...this.getAuthHeader(websiteToken),
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+    return extractData<any>(response);
+  }
+
   async toggleConversationStatus(websiteToken: string, status: 'open' | 'resolved' = 'resolved') {
     const response = await this.requestWithBaseFallback((client) =>
       client.get('/widget/conversations/toggle_status', {


### PR DESCRIPTION
## Summary

Renders `input_select` messages from Typebot as interactive button groups
in the web widget. When the user clicks an option, the selection is sent as
a text message and the buttons disable to prevent double submission.

## Dependencies

> Requires evolution-foundation/evo-ai-crm-community#86 to be merged first
> (creates messages with `content_type: input_select` and
> `content_attributes: {items: [...]}`).

## Changes

### `src/components/widget/MessageList.tsx`
- Renders a flex button grid below the message bubble when
  `message.contentType === 'input_select'` and `items` are present.
- Buttons disable automatically once the user has submitted a choice
  (`submittedValues` is set) or when the `onSelectOption` callback is absent.
- Style: neutral bordered buttons that turn to muted/disabled state after
  selection.

### `src/pages/Widget/index.tsx`
- `normalizeContentType`: maps the numeric `content_type` enum the API may
  return (e.g. `4`) to its string equivalent (`"input_select"`), since the
  serializer can return either format.
- `transformMessage`: propagates `items` from `content_attributes.items` and
  `submittedValues` from `content_attributes.submitted_values` to the local
  `MessageItem` type.
- `sender_type` guard extended to include `'AgentBot'` so that bot replies are
  treated as inbound messages and rendered on the left side of the widget.
- `handleSelectOption`: marks the chosen item in local state, calls
  `handleSend` with the option text, and persists the selection via
  `widgetService.updateMessageSubmittedValues`.

### `src/services/widget/widgetService.ts`
- New `updateMessageSubmittedValues(websiteToken, messageId, submittedValues)`:
  sends a `PATCH /widget/messages/:id` request with `submitted_values` to
  persist the user's choice on the message record.

## Notes

- Backward-compatible: messages without `content_type: input_select` or
  without `items` render exactly as before.
- The `normalizeContentType` guard handles both legacy numeric and current
  string serialization of `content_type`.

## Summary by Sourcery

Render Typebot input_select messages as interactive choice buttons in the web widget and persist user selections.

New Features:
- Display input_select messages as button groups beneath the corresponding message bubble and send the chosen option as a text reply.
- Support numeric and string content_type values from the API via a normalization layer for widget messages.

Enhancements:
- Propagate select items and submitted values into MessageItem to support richer interactive rendering.
- Treat AgentBot messages as inbound so bot replies appear on the left side like other incoming messages.

Chores:
- Persist user choice selections to the backend via a new widgetService.updateMessageSubmittedValues helper.