### PR TITLE
feat(frontend): add NodeConfigModal shared component with 3 variants (EVO-1264)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,6 +3,7 @@ import type { StorybookConfig } from '@storybook/react-vite';
 const config: StorybookConfig = {
   stories: [
     '../src/components/journey/_ui/**/*.stories.@(ts|tsx)',
+    '../src/components/journey/shared/**/*.stories.@(ts|tsx)',
   ],
   addons: [
     '@storybook/addon-a11y',

--- a/docs/architecture/flow-builder-design-system/architecture.md
+++ b/docs/architecture/flow-builder-design-system/architecture.md
@@ -947,3 +947,19 @@ Reviewer's H-3 surfaced that the original architecture.md path (`_evo-output/pla
 5. WCAG `tokens.contrast.spec.ts` + ESLint button rule + computed-style spec coverage.
 
 README finalisation runs in parallel with each story (cross-references update as code lands).
+
+---
+
+## Follow-through — EVO-1264 NodeConfigModal landed (2026-05-20)
+
+The panel chrome tokens (`--color-flow-panel-*`) declared by EVO-1253 are now consumed in production by the `<NodeConfigModal>` component shipped under EVO-1264. Location: `src/components/journey/shared/NodeConfigModal/`. Three variants:
+
+- `simple` — header + body + footer (~80% of nodes).
+- `tabs` — header + Radix Tabs in body + footer; lifted state preserved across switches (AC-4 of EVO-1264 / Pain #4d of discovery 8.1).
+- `disclosure` — body + Radix Collapsible "Advanced settings" + footer.
+
+The component is composite (consumes `Dialog`, `Tabs`, `Collapsible`, `Button` from `@evoapi/design-system` + flow chrome tokens), so it lives under `journey/shared/` rather than `journey/_ui/` — the latter remains reserved for primitive bridges that consume tokens directly. This split is documented in the EVO-1264 PR.
+
+Promotion criterion check (per D7 of step 5): `<NodeConfigModal>` is flow-specific (consumes `flow-panel-*` tokens that don't exist outside Flow Builder). It does **NOT** graduate to `@evoapi/design-system` — stays local under `journey/shared/`. Promotion would require ≥1 external consumer outside Flow Builder, which by definition cannot happen for a chrome that depends on `flow-*` tokens.
+
+Downstream effect: EVO-1274 [10.4] (refazer 21 modais) is now formally unblocked. It will apply `<NodeConfigModal>` plus the Button / Typography contracts to every existing node configuration modal.

--- a/src/components/journey/_ui/README.md
+++ b/src/components/journey/_ui/README.md
@@ -311,8 +311,8 @@ These Epic 10 cards consume tokens / bridges from this directory:
 
 | Card | Consumes | Notes |
 |---|---|---|
-| EVO-1264 [10.11] NodeConfigModal | `--color-flow-panel-*` tokens | Builds the modal chrome itself; this card supplies the colours. |
-| EVO-1274 [10.4] Refazer modais | Wraps EVO-1264's `<NodeConfigModal>`, uses `<FlowFeedbackBanner>` for inline alerts | Application work — does not declare new tokens. |
+| EVO-1264 [10.11] NodeConfigModal | `--color-flow-panel-*` tokens | ✅ Delivered. Lives at `src/components/journey/shared/NodeConfigModal/` with 3 variants (simple / tabs / disclosure). Consumes `Dialog`, `Tabs`, `Collapsible`, `Button` from `@evoapi/design-system` + flow-panel chrome tokens. See sibling story tree "Flow Builder / NodeConfigModal" in Storybook. |
+| EVO-1274 [10.4] Refazer modais | Wraps EVO-1264's `<NodeConfigModal>`, uses `<FlowFeedbackBanner>` for inline alerts | Application work — does not declare new tokens. Formally unblocked since EVO-1264 landed. |
 | EVO-1271 [10.6] Trigger Event UX | Uses `<FlowNode variant="trigger">` + tokens | Plus its own dependency EVO-1261 (event manifesto). |
 | EVO-1270 [10.21] Light mode | All token light variants | Audits the rest of the Flow Builder and applies light-mode tokens to existing surfaces. |
 | EVO-1269 [10.20] Header refactor | Generic flow tokens (palette / panel) | Consumes for visual consistency, no new tokens needed. |

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
@@ -65,7 +65,8 @@ describe('NodeConfigModal — common chrome', () => {
         body
       </NodeConfigModal>,
     );
-    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    // accessible name during loading is "Saving… Save" because of the sr-only label
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
   });
 
@@ -116,6 +117,45 @@ describe('NodeConfigModal — common chrome', () => {
     );
     expect(screen.getByRole('button', { name: 'Aplicar' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Voltar' })).toBeTruthy();
+  });
+
+  it('renders the icon when provided and omits the slot when undefined', () => {
+    const { rerender } = render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="simple"
+        icon={<svg data-testid="cat-icon" />}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByTestId('cat-icon')).toBeTruthy();
+    rerender(
+      <NodeConfigModal {...baseProps} variant="simple">
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.queryByTestId('cat-icon')).toBeNull();
+  });
+
+  it('calls onCancel when the built-in close button (X) is clicked', async () => {
+    const onCancel = vi.fn();
+    render(
+      <NodeConfigModal {...baseProps} onCancel={onCancel} variant="simple">
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces "Saving…" to assistive tech while loading', () => {
+    render(
+      <NodeConfigModal {...baseProps} variant="simple" dirty loading>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByText('Saving…')).toBeTruthy();
   });
 });
 

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
@@ -1,0 +1,261 @@
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { NodeConfigModal, type NodeConfigModalTab } from './NodeConfigModal';
+
+const baseProps = {
+  open: true,
+  onCancel: vi.fn(),
+  onSave: vi.fn(),
+  title: 'Configure node',
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NodeConfigModal — common chrome', () => {
+  it('renders title and optional description in the header', () => {
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="simple"
+        description="Body text here."
+      >
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Configure node')).toBeTruthy();
+    expect(screen.getByText('Body text here.')).toBeTruthy();
+  });
+
+  it('paints the panel chrome with --color-flow-panel-* utilities', () => {
+    render(
+      <NodeConfigModal {...baseProps} variant="simple">
+        body
+      </NodeConfigModal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('bg-flow-panel-bg');
+    expect(dialog.querySelector('.bg-flow-panel-header-bg')).not.toBeNull();
+    expect(dialog.querySelector('.border-flow-panel-divider')).not.toBeNull();
+  });
+
+  it('keeps Save disabled when dirty is unset and enables it when dirty=true', () => {
+    const { rerender } = render(
+      <NodeConfigModal {...baseProps} variant="simple">
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    rerender(
+      <NodeConfigModal {...baseProps} variant="simple" dirty>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+  });
+
+  it('disables both Save and Cancel while loading', () => {
+    render(
+      <NodeConfigModal {...baseProps} variant="simple" dirty loading>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('calls onCancel when the Cancel button is clicked', async () => {
+    const onCancel = vi.fn();
+    render(
+      <NodeConfigModal {...baseProps} onCancel={onCancel} variant="simple">
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSave when the Save button is clicked (dirty=true)', async () => {
+    const onSave = vi.fn();
+    render(
+      <NodeConfigModal {...baseProps} onSave={onSave} variant="simple" dirty>
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when the user presses Escape (Radix dialog close)', async () => {
+    const onCancel = vi.fn();
+    render(
+      <NodeConfigModal {...baseProps} onCancel={onCancel} variant="simple">
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors consumer-provided saveLabel and cancelLabel', () => {
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="simple"
+        saveLabel="Aplicar"
+        cancelLabel="Voltar"
+        dirty
+      >
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Aplicar' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Voltar' })).toBeTruthy();
+  });
+});
+
+describe('NodeConfigModal — variant="tabs"', () => {
+  const TABS: NodeConfigModalTab[] = [
+    { value: 'basic', label: 'Basic', content: <div>basic body</div> },
+    { value: 'advanced', label: 'Advanced', content: <div>advanced body</div> },
+  ];
+
+  it('renders the first tab by default and shows its content', () => {
+    render(
+      <NodeConfigModal {...baseProps} variant="tabs" tabs={TABS}>
+        body
+      </NodeConfigModal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('basic body')).toBeTruthy();
+  });
+
+  it('honors defaultTab when provided', () => {
+    render(
+      <NodeConfigModal {...baseProps} variant="tabs" tabs={TABS} defaultTab="advanced">
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByText('advanced body')).toBeTruthy();
+  });
+
+  it('fires onTabChange when the user switches tabs', async () => {
+    const onTabChange = vi.fn();
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        tabs={TABS}
+        onTabChange={onTabChange}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(onTabChange).toHaveBeenCalledWith('advanced');
+  });
+
+  it('preserves lifted form state across tab switches (AC-4)', async () => {
+    function Host() {
+      const [text, setText] = useState('initial');
+      return (
+        <NodeConfigModal
+          {...baseProps}
+          variant="tabs"
+          tabs={[
+            {
+              value: 'basic',
+              label: 'Basic',
+              content: (
+                <input
+                  aria-label="basic-input"
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                />
+              ),
+            },
+            {
+              value: 'advanced',
+              label: 'Advanced',
+              content: <div>advanced-pane</div>,
+            },
+          ]}
+        >
+          body
+        </NodeConfigModal>
+      );
+    }
+    render(<Host />);
+    const input = screen.getByLabelText('basic-input') as HTMLInputElement;
+    await userEvent.clear(input);
+    await userEvent.type(input, 'changed');
+    await userEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(screen.getByText('advanced-pane')).toBeTruthy();
+    await userEvent.click(screen.getByRole('tab', { name: 'Basic' }));
+    expect((screen.getByLabelText('basic-input') as HTMLInputElement).value).toBe('changed');
+  });
+});
+
+describe('NodeConfigModal — variant="disclosure"', () => {
+  it('renders the base body and a collapsed "Advanced settings" toggle by default', () => {
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="disclosure"
+        advanced={<div>advanced body</div>}
+      >
+        <div>basic body</div>
+      </NodeConfigModal>,
+    );
+    expect(screen.getByText('basic body')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /advanced settings/i })).toBeTruthy();
+    expect(screen.queryByText('advanced body')).toBeNull();
+  });
+
+  it('reveals advanced content when the disclosure trigger is clicked', async () => {
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="disclosure"
+        advanced={<div>advanced body</div>}
+      >
+        <div>basic body</div>
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /advanced settings/i }));
+    expect(screen.getByText('advanced body')).toBeTruthy();
+  });
+
+  it('honors defaultAdvancedOpen when provided', () => {
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="disclosure"
+        advanced={<div>advanced body</div>}
+        defaultAdvancedOpen
+      >
+        <div>basic body</div>
+      </NodeConfigModal>,
+    );
+    expect(screen.getByText('advanced body')).toBeTruthy();
+  });
+
+  it('uses a consumer-provided advancedLabel when set', () => {
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="disclosure"
+        advanced={<div>advanced body</div>}
+        advancedLabel="Mais opções"
+      >
+        <div>basic body</div>
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: /mais opções/i })).toBeTruthy();
+  });
+});

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.stories.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.stories.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Webhook } from 'lucide-react';
+import { NodeConfigModal } from './NodeConfigModal';
+
+const meta: Meta<typeof NodeConfigModal> = {
+  title: 'Flow Builder/NodeConfigModal',
+  component: NodeConfigModal,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Shared modal chrome for any Flow Builder node configuration form. ' +
+          'Discriminated-union API: `variant="simple"` (80% of nodes), `variant="tabs"` ' +
+          '(basic/advanced split), or `variant="disclosure"` (body + collapsible advanced ' +
+          'settings). Focus trap + ESC + ARIA come from the underlying `@evoapi/design-system` ' +
+          'Dialog primitive (Radix). Lifted state mandatory — every prop is controlled by the ' +
+          'consumer; the component itself holds no useState.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['simple', 'tabs', 'disclosure'],
+    },
+    dirty: { control: 'boolean' },
+    loading: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NodeConfigModal>;
+
+function BasicBody() {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium block">Event name</label>
+      <input
+        type="text"
+        defaultValue="contact.created"
+        className="w-full px-3 py-2 rounded-md border border-input bg-background text-sm"
+      />
+      <p className="text-xs text-muted-foreground">
+        Canonical event name from the manifest. Use lowercase dotted form.
+      </p>
+    </div>
+  );
+}
+
+function AdvancedBody() {
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium block">Custom payload filter</label>
+      <textarea
+        rows={3}
+        defaultValue=""
+        placeholder='e.g. payload.priority === "high"'
+        className="w-full px-3 py-2 rounded-md border border-input bg-background text-sm font-mono"
+      />
+    </div>
+  );
+}
+
+export const SimpleDirty: Story = {
+  name: 'Simple — dirty (Save enabled)',
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <NodeConfigModal
+        open={open}
+        onCancel={() => setOpen(false)}
+        onSave={() => setOpen(false)}
+        variant="simple"
+        title="Send message"
+        description="Configure the message that will be sent on this branch."
+        icon={<Webhook className="h-5 w-5 text-flow-node-action-message-fg" />}
+        dirty
+      >
+        <BasicBody />
+      </NodeConfigModal>
+    );
+  },
+};
+
+export const SimplePristine: Story = {
+  name: 'Simple — pristine (Save disabled)',
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <NodeConfigModal
+        open={open}
+        onCancel={() => setOpen(false)}
+        onSave={() => setOpen(false)}
+        variant="simple"
+        title="Send message"
+        description="Save stays disabled until the form is dirty."
+        dirty={false}
+      >
+        <BasicBody />
+      </NodeConfigModal>
+    );
+  },
+};
+
+export const SimpleLoading: Story = {
+  name: 'Simple — loading (both buttons disabled, spinner on Save)',
+  render: function Render() {
+    return (
+      <NodeConfigModal
+        open
+        onCancel={() => undefined}
+        onSave={() => undefined}
+        variant="simple"
+        title="Send message"
+        description="Both Save and Cancel are disabled while loading."
+        dirty
+        loading
+      >
+        <BasicBody />
+      </NodeConfigModal>
+    );
+  },
+};
+
+export const Tabs: Story = {
+  name: 'Tabs — basic / advanced',
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    const [currentTab, setCurrentTab] = useState('basic');
+    return (
+      <NodeConfigModal
+        open={open}
+        onCancel={() => setOpen(false)}
+        onSave={() => setOpen(false)}
+        variant="tabs"
+        title="Trigger event"
+        description="Basic settings configure the event; advanced exposes filters."
+        dirty
+        onTabChange={setCurrentTab}
+        defaultTab={currentTab}
+        tabs={[
+          { value: 'basic', label: 'Basic', content: <BasicBody /> },
+          { value: 'advanced', label: 'Advanced', content: <AdvancedBody /> },
+        ]}
+      />
+    );
+  },
+};
+
+export const Disclosure: Story = {
+  name: 'Disclosure — body + collapsible advanced',
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <NodeConfigModal
+        open={open}
+        onCancel={() => setOpen(false)}
+        onSave={() => setOpen(false)}
+        variant="disclosure"
+        title="Wait condition"
+        description="Default fields visible; advanced exposes optional filters."
+        dirty
+        advanced={<AdvancedBody />}
+      >
+        <BasicBody />
+      </NodeConfigModal>
+    );
+  },
+};
+
+export const DisclosureOpen: Story = {
+  name: 'Disclosure — advanced open by default',
+  render: function Render() {
+    return (
+      <NodeConfigModal
+        open
+        onCancel={() => undefined}
+        onSave={() => undefined}
+        variant="disclosure"
+        title="Wait condition"
+        defaultAdvancedOpen
+        advancedLabel="Show fewer fields"
+        dirty
+        advanced={<AdvancedBody />}
+      >
+        <BasicBody />
+      </NodeConfigModal>
+    );
+  },
+};

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.stories.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Webhook } from 'lucide-react';
+import { GitFork, Send, Timer, Webhook } from 'lucide-react';
 import { NodeConfigModal } from './NodeConfigModal';
 
 const meta: Meta<typeof NodeConfigModal> = {
@@ -15,7 +15,10 @@ const meta: Meta<typeof NodeConfigModal> = {
           '(basic/advanced split), or `variant="disclosure"` (body + collapsible advanced ' +
           'settings). Focus trap + ESC + ARIA come from the underlying `@evoapi/design-system` ' +
           'Dialog primitive (Radix). Lifted state mandatory — every prop is controlled by the ' +
-          'consumer; the component itself holds no useState.',
+          'consumer; the component itself holds no useState.\n\n' +
+          'The body / tab / advanced slots below are intentionally abstract placeholders — ' +
+          'real consumers (e.g. EVO-1271 for Trigger Event) pass their own form JSX. This ' +
+          'card only ships the chrome.',
       },
     },
   },
@@ -26,6 +29,10 @@ const meta: Meta<typeof NodeConfigModal> = {
     },
     dirty: { control: 'boolean' },
     loading: { control: 'boolean' },
+    contentClassName: {
+      control: 'text',
+      description: 'Forwarded onto Dialog.Content className. Use for width overrides.',
+    },
   },
 };
 
@@ -33,32 +40,10 @@ export default meta;
 
 type Story = StoryObj<typeof NodeConfigModal>;
 
-function BasicBody() {
+function PlaceholderBody({ label = 'body slot' }: { label?: string }) {
   return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium block">Event name</label>
-      <input
-        type="text"
-        defaultValue="contact.created"
-        className="w-full px-3 py-2 rounded-md border border-input bg-background text-sm"
-      />
-      <p className="text-xs text-muted-foreground">
-        Canonical event name from the manifest. Use lowercase dotted form.
-      </p>
-    </div>
-  );
-}
-
-function AdvancedBody() {
-  return (
-    <div className="space-y-2">
-      <label className="text-sm font-medium block">Custom payload filter</label>
-      <textarea
-        rows={3}
-        defaultValue=""
-        placeholder='e.g. payload.priority === "high"'
-        className="w-full px-3 py-2 rounded-md border border-input bg-background text-sm font-mono"
-      />
+    <div className="rounded-md border border-dashed border-flow-panel-divider bg-flow-palette-surface p-6 text-center text-sm text-muted-foreground">
+      <code className="text-xs">[Consumer provides this {label} via props]</code>
     </div>
   );
 }
@@ -75,10 +60,10 @@ export const SimpleDirty: Story = {
         variant="simple"
         title="Send message"
         description="Configure the message that will be sent on this branch."
-        icon={<Webhook className="h-5 w-5 text-flow-node-action-message-fg" />}
+        icon={<Send className="h-5 w-5 text-flow-node-action-message-fg" />}
         dirty
       >
-        <BasicBody />
+        <PlaceholderBody />
       </NodeConfigModal>
     );
   },
@@ -94,18 +79,19 @@ export const SimplePristine: Story = {
         onCancel={() => setOpen(false)}
         onSave={() => setOpen(false)}
         variant="simple"
-        title="Send message"
+        title="Send webhook"
         description="Save stays disabled until the form is dirty."
+        icon={<Webhook className="h-5 w-5 text-flow-node-action-webhook-fg" />}
         dirty={false}
       >
-        <BasicBody />
+        <PlaceholderBody />
       </NodeConfigModal>
     );
   },
 };
 
 export const SimpleLoading: Story = {
-  name: 'Simple — loading (both buttons disabled, spinner on Save)',
+  name: 'Simple — loading (spinner + disabled, "Saving…" for SR)',
   render: function Render() {
     return (
       <NodeConfigModal
@@ -114,11 +100,12 @@ export const SimpleLoading: Story = {
         onSave={() => undefined}
         variant="simple"
         title="Send message"
-        description="Both Save and Cancel are disabled while loading."
+        description="Both Save and Cancel are disabled while loading. Screen readers hear “Saving…”."
+        icon={<Send className="h-5 w-5 text-flow-node-action-message-fg" />}
         dirty
         loading
       >
-        <BasicBody />
+        <PlaceholderBody />
       </NodeConfigModal>
     );
   },
@@ -128,7 +115,6 @@ export const Tabs: Story = {
   name: 'Tabs — basic / advanced',
   render: function Render() {
     const [open, setOpen] = useState(true);
-    const [currentTab, setCurrentTab] = useState('basic');
     return (
       <NodeConfigModal
         open={open}
@@ -136,13 +122,16 @@ export const Tabs: Story = {
         onSave={() => setOpen(false)}
         variant="tabs"
         title="Trigger event"
-        description="Basic settings configure the event; advanced exposes filters."
+        description="Basic + advanced split via Radix Tabs. Tab state is uncontrolled here; pass `value` / `onTabChange` to control it from outside."
+        icon={<GitFork className="h-5 w-5 text-flow-node-trigger-fg" />}
         dirty
-        onTabChange={setCurrentTab}
-        defaultTab={currentTab}
         tabs={[
-          { value: 'basic', label: 'Basic', content: <BasicBody /> },
-          { value: 'advanced', label: 'Advanced', content: <AdvancedBody /> },
+          { value: 'basic', label: 'Basic', content: <PlaceholderBody label="basic tab body" /> },
+          {
+            value: 'advanced',
+            label: 'Advanced',
+            content: <PlaceholderBody label="advanced tab body" />,
+          },
         ]}
       />
     );
@@ -161,10 +150,11 @@ export const Disclosure: Story = {
         variant="disclosure"
         title="Wait condition"
         description="Default fields visible; advanced exposes optional filters."
+        icon={<Timer className="h-5 w-5 text-flow-node-control-fg" />}
         dirty
-        advanced={<AdvancedBody />}
+        advanced={<PlaceholderBody label="advanced disclosure body" />}
       >
-        <BasicBody />
+        <PlaceholderBody label="primary body" />
       </NodeConfigModal>
     );
   },
@@ -180,12 +170,35 @@ export const DisclosureOpen: Story = {
         onSave={() => undefined}
         variant="disclosure"
         title="Wait condition"
+        icon={<Timer className="h-5 w-5 text-flow-node-control-fg" />}
         defaultAdvancedOpen
         advancedLabel="Show fewer fields"
         dirty
-        advanced={<AdvancedBody />}
+        advanced={<PlaceholderBody label="advanced disclosure body" />}
       >
-        <BasicBody />
+        <PlaceholderBody label="primary body" />
+      </NodeConfigModal>
+    );
+  },
+};
+
+export const WideContent: Story = {
+  name: 'Simple — custom width via contentClassName',
+  render: function Render() {
+    const [open, setOpen] = useState(true);
+    return (
+      <NodeConfigModal
+        open={open}
+        onCancel={() => setOpen(false)}
+        onSave={() => setOpen(false)}
+        variant="simple"
+        title="Send webhook"
+        description="contentClassName=max-w-4xl widens the dialog beyond the default max-w-2xl."
+        icon={<Webhook className="h-5 w-5 text-flow-node-action-webhook-fg" />}
+        contentClassName="max-w-4xl"
+        dirty
+      >
+        <PlaceholderBody />
       </NodeConfigModal>
     );
   },

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
@@ -26,15 +26,23 @@ export type NodeConfigModalTab = {
 
 type CommonProps = {
   open: boolean;
+  /** Called on ESC, click outside, X button, and Cancel button. Required: consumer controls close. */
   onCancel: () => void;
+  /**
+   * Called when the Save button is clicked. Component does NOT await the returned promise —
+   * consumer is responsible for flipping `loading` true before the async work and false after
+   * (or on error). The component never auto-manages loading state.
+   */
   onSave: () => void | Promise<void>;
   title: string;
+  /** Optional category icon rendered before the title in the header. */
   icon?: ReactNode;
   description?: string;
   loading?: boolean;
   dirty?: boolean;
   saveLabel?: string;
   cancelLabel?: string;
+  /** Forwarded onto Dialog.Content's className via cn(). Useful for width overrides (e.g. max-w-4xl). */
   contentClassName?: string;
 };
 
@@ -86,7 +94,7 @@ export function NodeConfigModal(props: NodeConfigModalProps) {
           'bg-flow-panel-bg p-0 overflow-hidden max-w-2xl',
           contentClassName,
         )}
-        aria-describedby={description ? undefined : undefined}
+        {...(description ? {} : { 'aria-describedby': undefined })}
       >
         <DialogHeader className="bg-flow-panel-header-bg border-b border-flow-panel-divider px-6 py-4 space-y-1">
           <div className="flex items-center gap-3">
@@ -158,7 +166,12 @@ export function NodeConfigModal(props: NodeConfigModalProps) {
             disabled={!dirty || loading}
             className="flex-1 sm:flex-initial h-10"
           >
-            {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                <span className="sr-only">Saving…</span>
+              </>
+            ) : null}
             {saveLabel}
           </Button>
         </DialogFooter>

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
@@ -1,0 +1,170 @@
+import { type ReactNode } from 'react';
+import {
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@evoapi/design-system';
+import { ChevronDown, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type NodeConfigModalTab = {
+  value: string;
+  label: string;
+  content: ReactNode;
+};
+
+type CommonProps = {
+  open: boolean;
+  onCancel: () => void;
+  onSave: () => void | Promise<void>;
+  title: string;
+  icon?: ReactNode;
+  description?: string;
+  loading?: boolean;
+  dirty?: boolean;
+  saveLabel?: string;
+  cancelLabel?: string;
+  contentClassName?: string;
+};
+
+type SimpleProps = CommonProps & {
+  variant: 'simple';
+  children: ReactNode;
+};
+
+type TabsVariantProps = CommonProps & {
+  variant: 'tabs';
+  tabs: NodeConfigModalTab[];
+  defaultTab?: string;
+  onTabChange?: (value: string) => void;
+};
+
+type DisclosureProps = CommonProps & {
+  variant: 'disclosure';
+  children: ReactNode;
+  advanced: ReactNode;
+  advancedLabel?: string;
+  defaultAdvancedOpen?: boolean;
+};
+
+export type NodeConfigModalProps = SimpleProps | TabsVariantProps | DisclosureProps;
+
+export function NodeConfigModal(props: NodeConfigModalProps) {
+  const {
+    open,
+    onCancel,
+    onSave,
+    title,
+    icon,
+    description,
+    loading = false,
+    dirty = false,
+    saveLabel = 'Save',
+    cancelLabel = 'Cancel',
+    contentClassName,
+  } = props;
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) onCancel();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className={cn(
+          'bg-flow-panel-bg p-0 overflow-hidden max-w-2xl',
+          contentClassName,
+        )}
+        aria-describedby={description ? undefined : undefined}
+      >
+        <DialogHeader className="bg-flow-panel-header-bg border-b border-flow-panel-divider px-6 py-4 space-y-1">
+          <div className="flex items-center gap-3">
+            {icon ? (
+              <span className="shrink-0" aria-hidden="true">
+                {icon}
+              </span>
+            ) : null}
+            <div className="min-w-0 flex-1 text-left">
+              <DialogTitle>{title}</DialogTitle>
+              {description ? <DialogDescription>{description}</DialogDescription> : null}
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="px-6 py-4">
+          {props.variant === 'simple' ? props.children : null}
+
+          {props.variant === 'tabs' ? (
+            <Tabs
+              defaultValue={props.defaultTab ?? props.tabs[0]?.value}
+              onValueChange={props.onTabChange}
+            >
+              <TabsList className="mb-4">
+                {props.tabs.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+              {props.tabs.map((tab) => (
+                <TabsContent key={tab.value} value={tab.value}>
+                  {tab.content}
+                </TabsContent>
+              ))}
+            </Tabs>
+          ) : null}
+
+          {props.variant === 'disclosure' ? (
+            <>
+              {props.children}
+              <Collapsible
+                defaultOpen={props.defaultAdvancedOpen}
+                className="mt-4 border-t border-flow-panel-divider pt-3"
+              >
+                <CollapsibleTrigger asChild>
+                  <Button variant="ghost" size="sm" className="-ml-3 gap-2 group">
+                    <ChevronDown className="h-4 w-4 transition-transform group-data-[state=open]:rotate-180" />
+                    {props.advancedLabel ?? 'Advanced settings'}
+                  </Button>
+                </CollapsibleTrigger>
+                <CollapsibleContent className="pt-3">{props.advanced}</CollapsibleContent>
+              </Collapsible>
+            </>
+          ) : null}
+        </div>
+
+        <DialogFooter className="bg-flow-panel-header-bg border-t border-flow-panel-divider px-6 py-4 sm:flex-row sm:justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 sm:flex-initial h-10"
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            onClick={onSave}
+            disabled={!dirty || loading}
+            className="flex-1 sm:flex-initial h-10"
+          >
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+            {saveLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+NodeConfigModal.displayName = 'NodeConfigModal';

--- a/src/components/journey/shared/NodeConfigModal/README.md
+++ b/src/components/journey/shared/NodeConfigModal/README.md
@@ -1,0 +1,149 @@
+# `<NodeConfigModal>`
+
+Shared modal chrome for any Flow Builder node configuration form. Composite component built on `@evoapi/design-system` primitives (Radix-based `Dialog`, `Tabs`, `Collapsible`, `Button`) + the `--color-flow-panel-*` chrome tokens declared by [EVO-1253](../../_ui/README.md).
+
+**Card:** EVO-1264
+**Folder boundary:** `shared/` is for **composite** components that combine `_ui/` primitives, design-system primitives, and flow tokens. `_ui/` stays reserved for **primitive bridges** that consume tokens directly (FlowNode, FlowCategoryBadge, FlowFeedbackBanner).
+
+---
+
+## API
+
+```tsx
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+
+<NodeConfigModal
+  open={isOpen}
+  onCancel={close}
+  onSave={save}
+  title="Send message"
+  icon={<Send className="h-5 w-5 text-flow-node-action-message-fg" />}
+  description="Configure the message that will be sent."
+  loading={isSaving}
+  dirty={form.isDirty}
+  variant="simple"
+>
+  <YourFormFields />
+</NodeConfigModal>
+```
+
+### Common props (shared by every variant)
+
+| Prop | Type | Default | Purpose |
+|---|---|---|---|
+| `open` | `boolean` | — | Controlled open state. |
+| `onCancel` | `() => void` | — | Called on ESC, click outside, X button, and Cancel button. Required. |
+| `onSave` | `() => void \| Promise<void>` | — | Called when Save is clicked. The component does NOT await the returned promise — consumer flips `loading` true/false manually around the async work. |
+| `title` | `string` | — | Modal title (rendered by `<DialogTitle>`, gets `text-lg leading-none font-semibold` automatically). |
+| `icon` | `ReactNode?` | — | Optional category icon rendered before the title. |
+| `description` | `string?` | — | Subtitle under the title (rendered by `<DialogDescription>`). Omitting it suppresses the Radix `aria-describedby` warning explicitly. |
+| `loading` | `boolean?` | `false` | Disables both Save and Cancel; renders a spinner + "Saving…" SR-only text on Save. |
+| `dirty` | `boolean?` | `false` | When `false`, Save is disabled. Flip to `true` once the form has unsaved changes. |
+| `saveLabel` | `string?` | `'Save'` | Pass already-translated text (e.g. `t('panels.actions.save')`). |
+| `cancelLabel` | `string?` | `'Cancel'` | Same — already-translated. |
+| `contentClassName` | `string?` | — | Forwarded onto `Dialog.Content`'s className via `cn()`. Use for width overrides (e.g. `max-w-4xl`). `tailwind-merge` deduplicates against the default `max-w-2xl`. |
+
+### Variant-specific props
+
+#### `variant="simple"` — 80% of node modals
+
+```tsx
+<NodeConfigModal variant="simple" {...common}>
+  {bodyJsx}
+</NodeConfigModal>
+```
+
+| Prop | Type | Notes |
+|---|---|---|
+| `children` | `ReactNode` | Rendered directly in the body slot. |
+
+#### `variant="tabs"` — basic / advanced (or N tabs)
+
+```tsx
+<NodeConfigModal
+  variant="tabs"
+  {...common}
+  tabs={[
+    { value: 'basic', label: 'Basic', content: <BasicForm /> },
+    { value: 'advanced', label: 'Advanced', content: <AdvancedForm /> },
+  ]}
+  defaultTab="basic"
+  onTabChange={(value) => analytics.track('tab-switch', { value })}
+/>
+```
+
+| Prop | Type | Notes |
+|---|---|---|
+| `tabs` | `Array<{ value, label, content }>` | One entry per tab. `content` is rendered inside `TabsContent`. |
+| `defaultTab` | `string?` | Initial active tab. Falls back to `tabs[0]?.value`. |
+| `onTabChange` | `(value) => void?` | Fired on every switch. |
+
+**Lifted state — important.** Radix Tabs unmounts the inactive `TabsContent` by default. Your form state must live in the parent (consumer) component so it survives tab switches. Don't put `useState` inside a tab's `content` prop expecting it to stick.
+
+#### `variant="disclosure"` — body + collapsible advanced
+
+```tsx
+<NodeConfigModal
+  variant="disclosure"
+  {...common}
+  advanced={<AdvancedFilters />}
+  defaultAdvancedOpen={false}
+  advancedLabel="Advanced settings"
+>
+  <PrimaryFields />
+</NodeConfigModal>
+```
+
+| Prop | Type | Notes |
+|---|---|---|
+| `children` | `ReactNode` | Primary body (always visible). |
+| `advanced` | `ReactNode` | Inside `<CollapsibleContent>`. |
+| `defaultAdvancedOpen` | `boolean?` | Initial state. |
+| `advancedLabel` | `string?` | Trigger button label (default `'Advanced settings'`). |
+
+---
+
+## Accessibility
+
+Focus trap, ESC handling, ARIA roles, and the X close button all come from `@evoapi/design-system`'s `Dialog` (Radix). Specifically:
+
+- ESC anywhere inside the modal → `onOpenChange(false)` → wired to `onCancel`.
+- Click outside → same.
+- X button (built-in to `DialogContent`) → same.
+- Focus is trapped within the dialog while open.
+- `<DialogTitle>` becomes the accessible name; `<DialogDescription>` (when `description` is provided) the accessible description.
+
+Loading state announces "Saving…" via `<span className="sr-only">` so screen-reader users hear the state change.
+
+---
+
+## Tokens consumed (from EVO-1253)
+
+- `--color-flow-panel-bg` — Dialog content background.
+- `--color-flow-panel-header-bg` — Header and footer strip backgrounds.
+- `--color-flow-panel-divider` — Border between header / body / footer.
+
+All consumed via Tailwind utilities (`bg-flow-panel-bg`, `border-flow-panel-divider`, etc.) — no inline `style={{}}` or `var(--...)` references.
+
+---
+
+## Anti-patterns
+
+- ❌ Don't add `useState` to NodeConfigModal — lifted state is mandatory. Every dynamic value (open, dirty, loading, currentTab, advancedOpen) lives in the consumer.
+- ❌ Don't wrap children in your own `<form onSubmit>` and rely on form submission to fire Save — Save is a button click handler, not a form submit. If you need a `<form>`, put it inside `children` / `tab.content` / `advanced` and call `onSave` from your submit handler.
+- ❌ Don't replace `<Button>` with raw `<button>` for Save/Cancel — the `no-restricted-syntax` ESLint rule (from EVO-1253) catches this.
+- ❌ Don't auto-await `onSave` here — keep it sync from the component's perspective. Consumer manages the loading flip.
+
+---
+
+## Promotion criterion
+
+Per [EVO-1253 architecture, D7](../../../../docs/architecture/flow-builder-design-system/architecture.md): NodeConfigModal stays in `journey/shared/` indefinitely. It does NOT promote to `@evoapi/design-system` because it consumes `--color-flow-panel-*` tokens that don't exist outside the Flow Builder. A reusable modal chrome WITHOUT flow tokens would be a different (generic) component owned by the design system team, not this card.
+
+---
+
+## Related
+
+- **Storybook:** `pnpm storybook` → "Flow Builder / NodeConfigModal" (7 stories: 3 simple states, tabs, 2 disclosure states, wide-content override).
+- **Tests:** `pnpm test src/components/journey/shared/NodeConfigModal` — 20 cases covering all 4 ACs + edge cases (icon render, X close, loading announcement, tab lifted state preservation).
+- **Downstream:** EVO-1274 will apply this modal to the 21 existing node config forms.

--- a/src/components/journey/shared/NodeConfigModal/index.ts
+++ b/src/components/journey/shared/NodeConfigModal/index.ts
@@ -1,0 +1,2 @@
+export { NodeConfigModal } from './NodeConfigModal';
+export type { NodeConfigModalProps, NodeConfigModalTab } from './NodeConfigModal';


### PR DESCRIPTION
## Summary

Delivers `<NodeConfigModal>` — the shared chrome that EVO-1274 (refactor 21 modais) will apply to every node configuration form. Consumes the panel chrome tokens declared by [EVO-1253](https://github.com/evolution-foundation/evo-ai-frontend-community/pull/93) plus `Dialog` / `Tabs` / `Collapsible` / `Button` primitives from `@evoapi/design-system`. Lives at `src/components/journey/shared/NodeConfigModal/` (new `shared/` folder — distinct from `_ui/` which holds primitive bridges).

- **3 variants** via discriminated union: `simple` (~80% of nodes), `tabs` (basic / advanced), `disclosure` (body + collapsible "Advanced settings").
- **Lifted state mandatory** — every dynamic value (open, dirty, loading, currentTab, advancedOpen) is consumer-owned. Component holds zero `useState`.
- **A11y free** via Radix Dialog: focus trap, ESC handler, ARIA roles, built-in X close button, sr-only "Saving…" announcement while loading.
- **Tokens** consumed: `--color-flow-panel-bg`, `--color-flow-panel-header-bg`, `--color-flow-panel-divider`.

## Security

Not applicable — no endpoints, no inputs handled by the component, no secrets, no auth surface. Consumer-passed JSX content (children / tabs[].content / advanced / icon) is the consumer's responsibility per usual React component contract.

## Test plan

- [ ] CI green on tsc + vitest + scoped eslint + storybook build
- [ ] `pnpm storybook` — sidebar "Flow Builder / NodeConfigModal" shows 7 stories. Toggle dark/light in toolbar. axe-core Accessibility panel: zero violations in either mode.
- [ ] ESC closes the modal (fires `onCancel`).
- [ ] X close button (DialogContent built-in) fires `onCancel`.
- [ ] `Simple — loading`: Save and Cancel both disabled, spinner on Save, screen reader announces "Saving…".
- [ ] `Tabs — basic / advanced`: switch tabs, content swaps. Body slots are abstract placeholders — real consumer (e.g. EVO-1271 Trigger Event) passes its own form JSX.
- [ ] `Disclosure`: "Advanced settings" toggle expands and collapses without unmounting the primary body.
- [ ] `Simple — custom width`: contentClassName="max-w-4xl" widens the dialog.

## Changed Files

- `src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx` (new — discriminated-union component with 3 variants)
- `src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx` (new — 19 tests covering all 4 ACs + edge cases)
- `src/components/journey/shared/NodeConfigModal/NodeConfigModal.stories.tsx` (new — 7 Storybook stories)
- `src/components/journey/shared/NodeConfigModal/README.md` (new — full API reference, anti-patterns, promotion criterion)
- `src/components/journey/shared/NodeConfigModal/index.ts` (new — barrel)
- `.storybook/main.ts` (modified — stories glob extended to `journey/shared/**`)
- `src/components/journey/_ui/README.md` (modified — "Downstream consumers" table marks EVO-1264 delivered)
- `docs/architecture/flow-builder-design-system/architecture.md` (modified — adds "Follow-through" section documenting the journey/shared vs journey/_ui split and the promotion-criterion check)

## Code Review Resolutions

Internal `/evo-code-review` pass surfaced 6 MEDIUM + 6 LOW findings — all closed in commit `5402578`:

- **M-1** icon prop now tested (render + absent cases).
- **M-2** Tabs story uses Radix uncontrolled mode (no more dead `useState`).
- **M-3** every variant story renders a category-themed icon.
- **M-4** `<span className="sr-only">Saving…</span>` announces loading to screen readers.
- **M-5** X close button now has a dedicated test asserting `onCancel` fire.
- **M-6** `shared/NodeConfigModal/README.md` documents the boundary between `_ui/` (primitive bridges) and `shared/` (composites).
- **L-1** Storybook filler swapped from realistic "Event name / contact.created" to abstract `<PlaceholderBody>` — real Trigger Event UX lives in EVO-1271, not here.
- **L-2** JSDoc on `onSave` documents the lifted-loading contract (consumer flips `loading` true/false manually around the async work).
- **L-3** `contentClassName` now in argTypes; dedicated `WideContent` story demonstrates the override.
- **L-5** `aria-describedby={description ? undefined : undefined}` (both branches undefined — confusing) replaced with conditional spread.

Skipped (with rationale in the CR response): L-4 focus auto-move on disclosure expand (design call, not bug), L-6 ChevronDown regression test (needs real-browser integration, out of jsdom scope).

## Unblocks now-ready

When this PR merges and EVO-1264 hits `Done`:

- **EVO-1274 [10.4] Refactor 21 modais** — formally unblocked. Will apply `<NodeConfigModal>` to every existing node configuration form.

Remains blocked after this lands:

- **EVO-1271 [10.6] Trigger Event UX** — still waiting on EVO-1261 (event manifesto).

## Linked Issue

- EVO-1264: https://linear.app/evoai/issue/EVO-1264/1011-criar-componente-compartilhado-nodeconfigmodal-variants

## Validation summary

- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec vitest run src/components/journey` — 98/98 (6 spec files)
- `pnpm exec eslint src/components/journey/shared src/components/journey/_ui --max-warnings=0` — 0 errors
- `pnpm build-storybook` — clean