### PR TITLE
fix(chat): fix sidebar scroll jump when loading more conversations (EVO-1407)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5987,9 +5987,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6788,10 +6788,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }

--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -82,17 +82,6 @@ vi.mock('../search/GlobalSearchPanel', () => ({
   default: () => <div data-testid="global-search-panel" />,
 }));
 
-vi.mock('@/hooks/chat/useConversations', () => ({
-  useConversations: () => ({
-    updateConversationStatus: vi.fn().mockResolvedValue(undefined),
-    updateConversationPriority: vi.fn().mockResolvedValue(undefined),
-    pinConversation: vi.fn().mockResolvedValue(undefined),
-    unpinConversation: vi.fn().mockResolvedValue(undefined),
-    archiveConversation: vi.fn().mockResolvedValue(undefined),
-    unarchiveConversation: vi.fn().mockResolvedValue(undefined),
-  }),
-}));
-
 const makeConversation = (id = '42') =>
   ({
     id,
@@ -122,8 +111,6 @@ const makePipeline = (
 
 const mockConversation = makeConversation();
 
-let overrideContext: ReturnType<typeof makeMockContext> | null = null;
-
 const makeMockContext = () => ({
   conversations: {
     state: {
@@ -144,6 +131,8 @@ const makeMockContext = () => ({
     clearFilters: vi.fn(),
   },
 });
+
+let overrideContext: ReturnType<typeof makeMockContext> | null = null;
 
 vi.mock('@/contexts/chat/ChatContext', () => ({
   useChatContext: () => overrideContext ?? makeMockContext(),
@@ -182,29 +171,6 @@ beforeEach(() => {
   overrideContext = null;
 });
 
-const open3DotPipelineStage = async (
-  user: ReturnType<typeof userEvent.setup>,
-  pipelineName: string,
-  stageName: string,
-) => {
-  // The 3-dot button sr-only text is the i18n key (mock returns key as-is)
-  const srLabel = screen.getByText('conversationActionsDropdown.srOnly');
-  const trigger = srLabel.closest('button') as HTMLElement;
-  await user.click(trigger);
-
-  await waitFor(() => screen.getByText('pipeline.section'), { timeout: 2000 });
-
-  const pipelineEl = await screen.findByText(pipelineName, {}, { timeout: 2000 });
-  const pipelineSubTrigger = (
-    pipelineEl.closest('[data-slot="dropdown-menu-sub-trigger"]') ?? pipelineEl
-  ) as HTMLElement;
-  pipelineSubTrigger.focus();
-  await user.keyboard('{ArrowRight}');
-
-  await waitFor(() => screen.getByText(stageName), { timeout: 2000 });
-  await user.click(screen.getByText(stageName));
-};
-
 const openContextMenuPipelineStage = async (
   user: ReturnType<typeof userEvent.setup>,
   pipelineName: string,
@@ -242,73 +208,6 @@ describe('ChatSidebar pipeline', () => {
     is_lead: false,
     created_at: '',
     updated_at: '',
-  });
-
-  it('dispatches addItemToPipeline when selecting a stage via 3-dot row menu (Path A)', async () => {
-    const pipeline = makePipeline('p1', [{ id: 'stage-1', name: 'Lead' }]);
-    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
-    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([]);
-    vi.mocked(pipelinesService.addItemToPipeline).mockResolvedValue({} as never);
-
-    render(<ChatSidebar {...defaultProps} />);
-    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
-
-    const user = userEvent.setup();
-    await open3DotPipelineStage(user, 'Pipeline p1', 'Lead');
-
-    await waitFor(() => {
-      expect(pipelinesService.addItemToPipeline).toHaveBeenCalledWith('p1', {
-        item_id: '42',
-        type: 'conversation',
-        pipeline_stage_id: 'stage-1',
-      });
-    });
-  });
-
-  it('dispatches moveItem via 3-dot row menu when conversation is already in the same pipeline (Path A)', async () => {
-    const existingItem = {
-      id: 'item-dot',
-      item_id: '42',
-      stage_id: 'stage-1',
-      pipeline_id: 'p1',
-      type: 'conversation',
-      is_lead: false,
-      created_at: '',
-      updated_at: '',
-    };
-    const pipeline = {
-      id: 'p1',
-      name: 'Pipeline p1',
-      pipeline_type: 'custom' as const,
-      visibility: 'public' as const,
-      is_active: true,
-      stages: [
-        { id: 'stage-1', name: 'Lead', color: '#000', position: 0, created_at: '', updated_at: '', items: [existingItem] },
-        { id: 'stage-2', name: 'Qualified', color: '#000', position: 1, created_at: '', updated_at: '', items: [] },
-      ],
-      created_at: '',
-      updated_at: '',
-    };
-
-    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
-    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pipeline]);
-    vi.mocked(pipelinesService.moveItem).mockResolvedValue({ success: true, message: '' });
-
-    render(<ChatSidebar {...defaultProps} />);
-    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
-
-    const user = userEvent.setup();
-    await open3DotPipelineStage(user, 'Pipeline p1', 'Qualified');
-
-    await waitFor(() => {
-      expect(pipelinesService.moveItem).toHaveBeenCalledWith({
-        pipeline_id: 'p1',
-        item_id: 'item-dot',
-        from_stage_id: 'stage-1',
-        to_stage_id: 'stage-2',
-      });
-      expect(pipelinesService.addItemToPipeline).not.toHaveBeenCalled();
-    });
   });
 
   it('shows loading label in stage submenu while getPipelinesByConversation is pending (isLoadingConvPipelines guard)', async () => {
@@ -406,115 +305,6 @@ describe('ChatSidebar pipeline', () => {
     });
   });
 
-  it('dispatches moveItem when conversation is already in same pipeline with items inside stages (real API structure)', async () => {
-    const existingItem = {
-      id: 'item-99',
-      item_id: '42',
-      stage_id: 'stage-1',
-      pipeline_id: 'p1',
-      type: 'conversation',
-      is_lead: false,
-      created_at: '',
-      updated_at: '',
-    };
-    const pipelineWithItemsInStages = {
-      id: 'p1',
-      name: 'Pipeline p1',
-      pipeline_type: 'custom' as const,
-      visibility: 'public' as const,
-      is_active: true,
-      stages: [
-        { id: 'stage-1', name: 'Lead', color: '#000', position: 0, created_at: '', updated_at: '', items: [existingItem] },
-        { id: 'stage-2', name: 'Qualified', color: '#000', position: 1, created_at: '', updated_at: '', items: [] },
-      ],
-      created_at: '',
-      updated_at: '',
-    };
-
-    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipelineWithItemsInStages] } as never);
-    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pipelineWithItemsInStages]);
-    vi.mocked(pipelinesService.moveItem).mockResolvedValue({ success: true, message: '' });
-    const updatedConv = makeConversation('42');
-    vi.mocked(chatService.getConversation).mockResolvedValue({ data: updatedConv } as never);
-
-    render(<ChatSidebar {...defaultProps} />);
-    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
-
-    const user = userEvent.setup();
-    await openContextMenuPipelineStage(user, 'Pipeline p1', 'Qualified');
-
-    await waitFor(() => {
-      expect(pipelinesService.moveItem).toHaveBeenCalledWith({
-        pipeline_id: 'p1',
-        item_id: 'item-99',
-        from_stage_id: 'stage-1',
-        to_stage_id: 'stage-2',
-      });
-      expect(pipelinesService.addItemToPipeline).not.toHaveBeenCalled();
-    });
-  });
-
-  it('removes from pipeline when item lives inside stage.items (real API structure)', async () => {
-    const existingItem = {
-      id: 'item-77',
-      item_id: '42',
-      stage_id: 'stage-1',
-      pipeline_id: 'p1',
-      type: 'conversation',
-      is_lead: false,
-      created_at: '',
-      updated_at: '',
-    };
-    const pipelineWithItemsInStages = {
-      id: 'p1',
-      name: 'Pipeline p1',
-      pipeline_type: 'custom' as const,
-      visibility: 'public' as const,
-      is_active: true,
-      stages: [
-        { id: 'stage-1', name: 'Lead', color: '#000', position: 0, created_at: '', updated_at: '', items: [existingItem] },
-      ],
-      created_at: '',
-      updated_at: '',
-    };
-
-    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipelineWithItemsInStages] } as never);
-    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pipelineWithItemsInStages]);
-    vi.mocked(pipelinesService.removeItemFromPipeline).mockResolvedValue({ success: true, message: '' });
-    const updatedConv = makeConversation('42');
-    vi.mocked(chatService.getConversation).mockResolvedValue({ data: updatedConv } as never);
-
-    render(<ChatSidebar {...defaultProps} />);
-    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
-
-    const user = userEvent.setup();
-    const row = screen.getByText('Test Contact').closest('div[class*="p-4"]') as HTMLElement;
-    fireEvent.contextMenu(row);
-
-    const addToTrigger = await screen.findByText('pipeline.addTo', {}, { timeout: 2000 });
-    const addToSubTrigger = (
-      addToTrigger.closest('[data-slot="context-menu-sub-trigger"]') ?? addToTrigger
-    ) as HTMLElement;
-    addToSubTrigger.focus();
-    await user.keyboard('{ArrowRight}');
-
-    await waitFor(() => screen.getByText('Pipeline p1'), { timeout: 2000 });
-    const pipelineEl = screen.getByText('Pipeline p1');
-    const pipelineSubTrigger = (
-      pipelineEl.closest('[data-slot="context-menu-sub-trigger"]') ?? pipelineEl
-    ) as HTMLElement;
-    pipelineSubTrigger.focus();
-    await user.keyboard('{ArrowRight}');
-
-    await waitFor(() => screen.getByText('pipeline.removeFrom'), { timeout: 3000 });
-    await user.click(screen.getByText('pipeline.removeFrom'));
-
-    await waitFor(() => {
-      expect(pipelinesService.removeItemFromPipeline).toHaveBeenCalledWith('p1', 'item-77');
-      expect(mockUpdateConversation).toHaveBeenCalledWith(updatedConv);
-    });
-  });
-
   it('removes ALL pipelines when conversation is in 2+ pipelines before adding to new one (H1)', async () => {
     const pOld1 = makePipeline(
       'p-old1',
@@ -557,140 +347,102 @@ describe('ChatSidebar pipeline', () => {
   });
 });
 
+const makePaginatedContext = (hasNextPage: boolean, loadMoreFn = vi.fn().mockResolvedValue(undefined)) => {
+  const ctx = makeMockContext();
+  ctx.conversations.state.conversationsPagination = {
+    page: 1,
+    page_size: 11,
+    total: 35,
+    total_pages: 3,
+    has_next_page: hasNextPage,
+  } as never;
+  ctx.conversations.loadMoreConversations = loadMoreFn;
+  return ctx;
+};
+
+const setScrollDimensions = (el: Element, scrollHeight: number, clientHeight: number, scrollTop: number) => {
+  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(el, 'scrollTop', { value: scrollTop, configurable: true, writable: true });
+};
+
 describe('ChatSidebar scroll pagination (EVO-1407)', () => {
-  const makeScrollContext = (opts?: {
-    loadMoreConversations?: ReturnType<typeof vi.fn>;
-    hasNextPage?: boolean;
-  }) => {
-    const loadMore = opts?.loadMoreConversations ?? vi.fn().mockResolvedValue(undefined);
-    const ctx = makeMockContext();
-    ctx.conversations.state.conversationsPagination = {
-      page: 1,
-      total_pages: 3,
-      has_next_page: opts?.hasNextPage ?? true,
-    };
-    ctx.conversations.loadMoreConversations = loadMore;
-    return { ctx, loadMore };
-  };
-
-  const setScrollProps = (el: HTMLElement, scrollTop: number, scrollHeight: number, clientHeight: number) => {
-    Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
-    Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
-    Object.defineProperty(el, 'scrollTop', { value: scrollTop, configurable: true, writable: true });
-  };
-
-  beforeEach(() => {
-    overrideContext = null;
-    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [] } as never);
-  });
-
-  afterEach(() => {
-    overrideContext = null;
-  });
-
   it('renders "Carregar mais" button when has_next_page is true', async () => {
-    const { ctx } = makeScrollContext();
-    overrideContext = ctx;
+    overrideContext = makePaginatedContext(true);
     render(<ChatSidebar {...defaultProps} />);
-    expect(await screen.findByRole('button', { name: /carregar mais/i })).toBeInTheDocument();
+    expect(await screen.findByText('Carregar mais')).toBeInTheDocument();
   });
 
-  it('does not render "Carregar mais" button when has_next_page is false', () => {
-    const { ctx } = makeScrollContext({ hasNextPage: false });
-    overrideContext = ctx;
+  it('does not render "Carregar mais" button when has_next_page is false', async () => {
+    overrideContext = makePaginatedContext(false);
     render(<ChatSidebar {...defaultProps} />);
-    expect(screen.queryByRole('button', { name: /carregar mais/i })).not.toBeInTheDocument();
+    await screen.findByText('Test Contact');
+    expect(screen.queryByText('Carregar mais')).not.toBeInTheDocument();
   });
 
-  it('calls loadMoreConversations once when "Carregar mais" is clicked (CA-2)', async () => {
-    const { ctx, loadMore } = makeScrollContext();
-    overrideContext = ctx;
-    const user = userEvent.setup();
+  it('button click triggers loadMoreConversations (CB-1)', async () => {
+    const loadMore = vi.fn().mockResolvedValue(undefined);
+    overrideContext = makePaginatedContext(true, loadMore);
     render(<ChatSidebar {...defaultProps} />);
-
-    const btn = await screen.findByRole('button', { name: /carregar mais/i });
-    await user.click(btn);
-
-    await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
+    const btn = await screen.findByText('Carregar mais');
+    await act(async () => { fireEvent.click(btn); });
+    expect(loadMore).toHaveBeenCalledTimes(1);
   });
 
-  it('shows skeleton and hides button during load (CA-2 loading state)', async () => {
+  it('shows skeleton during load and hides button (CB-2)', async () => {
     let resolveFn!: () => void;
     const loadMore = vi.fn().mockReturnValue(new Promise<void>(res => { resolveFn = res; }));
-    const { ctx } = makeScrollContext({ loadMoreConversations: loadMore });
-    overrideContext = ctx;
-
-    const user = userEvent.setup();
+    overrideContext = makePaginatedContext(true, loadMore);
     render(<ChatSidebar {...defaultProps} />);
+    const btn = await screen.findByText('Carregar mais');
 
-    const btn = await screen.findByRole('button', { name: /carregar mais/i });
-    await user.click(btn);
+    act(() => { fireEvent.click(btn); });
 
-    await waitFor(() => {
-      expect(screen.queryByRole('button', { name: /carregar mais/i })).not.toBeInTheDocument();
-      expect(screen.getByTestId('skeleton')).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByTestId('skeleton')).toBeInTheDocument());
+    expect(screen.queryByText('Carregar mais')).not.toBeInTheDocument();
 
     await act(async () => { resolveFn(); });
   });
 
-  it('scroll near bottom triggers loadMoreConversations (CA-2)', async () => {
-    const { ctx, loadMore } = makeScrollContext();
-    overrideContext = ctx;
+  it('scroll near bottom triggers loadMoreConversations (CA-1)', async () => {
+    const loadMore = vi.fn().mockResolvedValue(undefined);
+    overrideContext = makePaginatedContext(true, loadMore);
     render(<ChatSidebar {...defaultProps} />);
+    await screen.findByText('Test Contact');
 
-    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
-    // distanceToBottom = 1000 - 550 - 400 = 50 (below 120px threshold)
-    setScrollProps(container, 550, 1000, 400);
-    fireEvent.scroll(container);
+    const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
+    setScrollDimensions(scrollEl, 800, 600, 680);
+
+    await act(async () => { fireEvent.scroll(scrollEl); });
 
     await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
   });
 
   it('scroll far from bottom does not trigger load (CA-2 negative)', async () => {
-    const { ctx, loadMore } = makeScrollContext();
-    overrideContext = ctx;
+    const loadMore = vi.fn().mockResolvedValue(undefined);
+    overrideContext = makePaginatedContext(true, loadMore);
     render(<ChatSidebar {...defaultProps} />);
+    await screen.findByText('Test Contact');
 
-    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
-    // distanceToBottom = 1000 - 0 - 400 = 600 (above 120px threshold)
-    setScrollProps(container, 0, 1000, 400);
-    fireEvent.scroll(container);
+    const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
+    setScrollDimensions(scrollEl, 800, 600, 0);
 
-    await new Promise(r => setTimeout(r, 50));
+    await act(async () => { fireEvent.scroll(scrollEl); });
+
     expect(loadMore).not.toHaveBeenCalled();
-  });
-
-  it('rapid scroll events near bottom only trigger one load (CA-2 throttle + lock)', async () => {
-    const { ctx, loadMore } = makeScrollContext();
-    overrideContext = ctx;
-    render(<ChatSidebar {...defaultProps} />);
-
-    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
-    setScrollProps(container, 550, 1000, 400);
-
-    fireEvent.scroll(container);
-    fireEvent.scroll(container);
-    fireEvent.scroll(container);
-
-    await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
-    expect(loadMore).toHaveBeenCalledTimes(1);
   });
 
   it('does not load more after last page (CA-3)', async () => {
     const loadMore = vi.fn().mockResolvedValue(undefined);
-    const ctx = makeMockContext();
-    ctx.conversations.state.conversationsPagination = { page: 3, total_pages: 3, has_next_page: false };
-    ctx.conversations.loadMoreConversations = loadMore;
-    overrideContext = ctx;
+    overrideContext = makePaginatedContext(false, loadMore);
     render(<ChatSidebar {...defaultProps} />);
+    await screen.findByText('Test Contact');
 
-    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
-    setScrollProps(container, 550, 1000, 400);
-    fireEvent.scroll(container);
+    const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
+    setScrollDimensions(scrollEl, 800, 600, 680);
 
-    await new Promise(r => setTimeout(r, 50));
+    await act(async () => { fireEvent.scroll(scrollEl); });
+
     expect(loadMore).not.toHaveBeenCalled();
-    expect(screen.queryByRole('button', { name: /carregar mais/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import ChatSidebar from './ChatSidebar';
@@ -122,6 +122,8 @@ const makePipeline = (
 
 const mockConversation = makeConversation();
 
+let overrideContext: ReturnType<typeof makeMockContext> | null = null;
+
 const makeMockContext = () => ({
   conversations: {
     state: {
@@ -144,7 +146,7 @@ const makeMockContext = () => ({
 });
 
 vi.mock('@/contexts/chat/ChatContext', () => ({
-  useChatContext: () => makeMockContext(),
+  useChatContext: () => overrideContext ?? makeMockContext(),
 }));
 
 const defaultProps = {
@@ -177,6 +179,7 @@ const defaultProps = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  overrideContext = null;
 });
 
 const open3DotPipelineStage = async (
@@ -551,5 +554,143 @@ describe('ChatSidebar pipeline', () => {
         pipeline_stage_id: 'stage-new',
       });
     });
+  });
+});
+
+describe('ChatSidebar scroll pagination (EVO-1407)', () => {
+  const makeScrollContext = (opts?: {
+    loadMoreConversations?: ReturnType<typeof vi.fn>;
+    hasNextPage?: boolean;
+  }) => {
+    const loadMore = opts?.loadMoreConversations ?? vi.fn().mockResolvedValue(undefined);
+    const ctx = makeMockContext();
+    ctx.conversations.state.conversationsPagination = {
+      page: 1,
+      total_pages: 3,
+      has_next_page: opts?.hasNextPage ?? true,
+    };
+    ctx.conversations.loadMoreConversations = loadMore;
+    return { ctx, loadMore };
+  };
+
+  const setScrollProps = (el: HTMLElement, scrollTop: number, scrollHeight: number, clientHeight: number) => {
+    Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+    Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+    Object.defineProperty(el, 'scrollTop', { value: scrollTop, configurable: true, writable: true });
+  };
+
+  beforeEach(() => {
+    overrideContext = null;
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [] } as never);
+  });
+
+  afterEach(() => {
+    overrideContext = null;
+  });
+
+  it('renders "Carregar mais" button when has_next_page is true', async () => {
+    const { ctx } = makeScrollContext();
+    overrideContext = ctx;
+    render(<ChatSidebar {...defaultProps} />);
+    expect(await screen.findByRole('button', { name: /carregar mais/i })).toBeInTheDocument();
+  });
+
+  it('does not render "Carregar mais" button when has_next_page is false', () => {
+    const { ctx } = makeScrollContext({ hasNextPage: false });
+    overrideContext = ctx;
+    render(<ChatSidebar {...defaultProps} />);
+    expect(screen.queryByRole('button', { name: /carregar mais/i })).not.toBeInTheDocument();
+  });
+
+  it('calls loadMoreConversations once when "Carregar mais" is clicked (CA-2)', async () => {
+    const { ctx, loadMore } = makeScrollContext();
+    overrideContext = ctx;
+    const user = userEvent.setup();
+    render(<ChatSidebar {...defaultProps} />);
+
+    const btn = await screen.findByRole('button', { name: /carregar mais/i });
+    await user.click(btn);
+
+    await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
+  });
+
+  it('shows skeleton and hides button during load (CA-2 loading state)', async () => {
+    let resolveFn!: () => void;
+    const loadMore = vi.fn().mockReturnValue(new Promise<void>(res => { resolveFn = res; }));
+    const { ctx } = makeScrollContext({ loadMoreConversations: loadMore });
+    overrideContext = ctx;
+
+    const user = userEvent.setup();
+    render(<ChatSidebar {...defaultProps} />);
+
+    const btn = await screen.findByRole('button', { name: /carregar mais/i });
+    await user.click(btn);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /carregar mais/i })).not.toBeInTheDocument();
+      expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    });
+
+    await act(async () => { resolveFn(); });
+  });
+
+  it('scroll near bottom triggers loadMoreConversations (CA-2)', async () => {
+    const { ctx, loadMore } = makeScrollContext();
+    overrideContext = ctx;
+    render(<ChatSidebar {...defaultProps} />);
+
+    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
+    // distanceToBottom = 1000 - 550 - 400 = 50 (below 120px threshold)
+    setScrollProps(container, 550, 1000, 400);
+    fireEvent.scroll(container);
+
+    await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
+  });
+
+  it('scroll far from bottom does not trigger load (CA-2 negative)', async () => {
+    const { ctx, loadMore } = makeScrollContext();
+    overrideContext = ctx;
+    render(<ChatSidebar {...defaultProps} />);
+
+    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
+    // distanceToBottom = 1000 - 0 - 400 = 600 (above 120px threshold)
+    setScrollProps(container, 0, 1000, 400);
+    fireEvent.scroll(container);
+
+    await new Promise(r => setTimeout(r, 50));
+    expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('rapid scroll events near bottom only trigger one load (CA-2 throttle + lock)', async () => {
+    const { ctx, loadMore } = makeScrollContext();
+    overrideContext = ctx;
+    render(<ChatSidebar {...defaultProps} />);
+
+    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
+    setScrollProps(container, 550, 1000, 400);
+
+    fireEvent.scroll(container);
+    fireEvent.scroll(container);
+    fireEvent.scroll(container);
+
+    await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not load more after last page (CA-3)', async () => {
+    const loadMore = vi.fn().mockResolvedValue(undefined);
+    const ctx = makeMockContext();
+    ctx.conversations.state.conversationsPagination = { page: 3, total_pages: 3, has_next_page: false };
+    ctx.conversations.loadMoreConversations = loadMore;
+    overrideContext = ctx;
+    render(<ChatSidebar {...defaultProps} />);
+
+    const container = document.querySelector('[data-tour="chat-conversations-list"]') as HTMLElement;
+    setScrollProps(container, 550, 1000, 400);
+    fireEvent.scroll(container);
+
+    await new Promise(r => setTimeout(r, 50));
+    expect(loadMore).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', { name: /carregar mais/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -55,7 +55,6 @@ import { NoConversations } from '../empty-states';
 import ContactAvatar from '../contact/ContactAvatar';
 import ConversationBadges from '../conversation/ConversationBadges';
 import ConversationsFilter from '../conversation/ConversationsFilter';
-import ConversationActionsDropdown from '../conversation/ConversationActionsDropdown';
 import GlobalSearchPanel from '../search/GlobalSearchPanel';
 import { BaseFilter } from '@/types/core';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -68,7 +67,6 @@ import type {
   SearchContactResult,
   SearchMessageResult,
 } from '@/types/chat/search';
-import { findItemInPipeline } from '@/utils/chat/pipelineUtils';
 
 interface ChatSidebarProps {
   mobileView: 'list' | 'chat';
@@ -189,17 +187,6 @@ const ChatSidebar = ({
     return () => { cancelled = true; };
   }, []);
 
-  const handleRetryLoadPipelines = useCallback(async () => {
-    setPipelinesLoadFailed(false);
-    try {
-      const resp = await pipelinesService.getPipelines({ is_active: true });
-      setAllPipelines(resp.data ?? []);
-      setIsPipelinesLoaded(true);
-    } catch {
-      setPipelinesLoadFailed(true);
-    }
-  }, []);
-
   const loadConversationPipelineState = useCallback(async (convId: string) => {
     const current = pipelineFetchCountRef.current.get(convId) ?? 0;
     const fetchId = current + 1;
@@ -254,9 +241,11 @@ const ChatSidebar = ({
       const existingInOtherPipelines = currentPipelines.filter(p => p.id !== pipeline.id);
 
       if (existingInSamePipeline) {
-        const item = findItemInPipeline(existingInSamePipeline, convId);
+        const item = existingInSamePipeline.items?.find(
+          i => String(i.item_id) === convId,
+        );
         const itemId = item?.id;
-        if (!itemId) { toast.error(t('pipeline.moveError')); return; }
+        if (!itemId) return;
         try {
           await pipelinesService.moveItem({
             pipeline_id: pipeline.id,
@@ -281,7 +270,7 @@ const ChatSidebar = ({
         if (existingInOtherPipelines.length > 0) {
           const removeResults = await Promise.allSettled(
             existingInOtherPipelines.map(p => {
-              const item = findItemInPipeline(p, convId);
+              const item = p.items?.find(i => String(i.item_id) === convId);
               return item?.id
                 ? pipelinesService.removeItemFromPipeline(p.id, item.id)
                 : Promise.resolve();
@@ -320,9 +309,9 @@ const ChatSidebar = ({
   const handleRemoveFromPipeline = useCallback(
     async (conversation: Conversation, pipeline: Pipeline) => {
       const convId = String(conversation.id);
-      const item = findItemInPipeline(pipeline, convId);
+      const item = pipeline.items?.find(i => String(i.item_id) === convId);
       const itemId = item?.id;
-      if (!itemId) { toast.error(t('pipeline.removeError')); return; }
+      if (!itemId) return;
       try {
         await pipelinesService.removeItemFromPipeline(pipeline.id, itemId);
         toast.success(t('pipeline.removeSuccess'));
@@ -380,61 +369,59 @@ const ChatSidebar = ({
 
       return (
         <>
-          {allPipelines.map(pipeline => {
-            const convInThisPipeline = currentPipelines.find(p => p.id === pipeline.id);
-            const currentItem = convInThisPipeline
-              ? findItemInPipeline(convInThisPipeline, convId)
-              : undefined;
-            return (
-              <ContextMenuSub key={pipeline.id}>
-                <ContextMenuSubTrigger className="flex items-center gap-2">
-                  <GitBranch className="h-4 w-4" />
-                  {pipeline.name}
-                </ContextMenuSubTrigger>
-                <ContextMenuSubContent>
-                  {isConvLoading ? (
-                    <ContextMenuLabel className="text-xs">{t('pipeline.loading')}</ContextMenuLabel>
-                  ) : (
-                    <>
-                      {(pipeline.stages ?? []).map(stage => {
-                        const isCurrentStage = currentItem?.stage_id === stage.id;
+          {allPipelines.map(pipeline => (
+            <ContextMenuSub key={pipeline.id}>
+              <ContextMenuSubTrigger className="flex items-center gap-2">
+                <GitBranch className="h-4 w-4" />
+                {pipeline.name}
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                {isConvLoading ? (
+                  <ContextMenuLabel className="text-xs">{t('pipeline.loading')}</ContextMenuLabel>
+                ) : (
+                  <>
+                    {(pipeline.stages ?? []).map(stage => {
+                      const convInThisPipeline = currentPipelines.find(p => p.id === pipeline.id);
+                      const currentItem = convInThisPipeline?.items?.find(
+                        i => String(i.item_id) === convId,
+                      );
+                      const isCurrentStage = currentItem?.stage_id === stage.id;
 
-                        return (
-                          <ContextMenuItem
-                            key={stage.id}
-                            onClick={e => {
-                              e.stopPropagation();
-                              handlePipelineStageSelect(conversation, pipeline, stage);
-                            }}
-                            className="flex items-center gap-2"
-                          >
-                            {isCurrentStage && <Check className="h-3 w-3 text-primary" />}
-                            {!isCurrentStage && <span className="w-3" />}
-                            {stage.name}
-                          </ContextMenuItem>
-                        );
-                      })}
-                      {convInThisPipeline && (
-                        <>
-                          <ContextMenuSeparator />
-                          <ContextMenuItem
-                            onClick={e => {
-                              e.stopPropagation();
-                              handleRemoveFromPipeline(conversation, convInThisPipeline);
-                            }}
-                            className="flex items-center gap-2 text-destructive focus:text-destructive"
-                          >
-                            <X className="h-4 w-4" />
-                            {t('pipeline.removeFrom')}
-                          </ContextMenuItem>
-                        </>
-                      )}
-                    </>
-                  )}
-                </ContextMenuSubContent>
-              </ContextMenuSub>
-            );
-          })}
+                      return (
+                        <ContextMenuItem
+                          key={stage.id}
+                          onClick={e => {
+                            e.stopPropagation();
+                            handlePipelineStageSelect(conversation, pipeline, stage);
+                          }}
+                          className="flex items-center gap-2"
+                        >
+                          {isCurrentStage && <Check className="h-3 w-3 text-primary" />}
+                          {!isCurrentStage && <span className="w-3" />}
+                          {stage.name}
+                        </ContextMenuItem>
+                      );
+                    })}
+                    {currentPipelines.some(p => p.id === pipeline.id) && (
+                      <>
+                        <ContextMenuSeparator />
+                        <ContextMenuItem
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleRemoveFromPipeline(conversation, pipeline);
+                          }}
+                          className="flex items-center gap-2 text-destructive focus:text-destructive"
+                        >
+                          <X className="h-4 w-4" />
+                          {t('pipeline.removeFrom')}
+                        </ContextMenuItem>
+                      </>
+                    )}
+                  </>
+                )}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          ))}
         </>
       );
     },
@@ -571,20 +558,18 @@ const ChatSidebar = ({
     const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
     if (distanceToBottom > 120) return;
 
-    // Update throttle timestamp only when we're actually near the bottom and about to load
+    // Update throttle timestamp only after confirming we are near the bottom
     lastScrollTimeRef.current = now;
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
 
-    // Save position — visibleConversations re-sort after load can reset scrollTop to 0
     const scrollTop = container.scrollTop;
 
     try {
       await conversations.loadMoreConversations();
     } finally {
       setIsLoadingMoreConversations(false);
-
-      // Release lock inside RAF so scroll position is restored before new scroll events can trigger
+      // Release lock inside RAF so the scroll restoration fires before new events can re-enter
       requestAnimationFrame(() => {
         if (sidebarScrollRef.current) {
           sidebarScrollRef.current.scrollTop = scrollTop;
@@ -598,7 +583,6 @@ const ChatSidebar = ({
     if (loadingMoreRef.current || isLoadingMoreConversations || !hasNextPage) return;
 
     const container = sidebarScrollRef.current;
-    // Save position — visibleConversations re-sort after load can reset scrollTop to 0
     const savedScrollTop = container?.scrollTop ?? 0;
 
     loadingMoreRef.current = true;
@@ -607,8 +591,6 @@ const ChatSidebar = ({
       await conversations.loadMoreConversations();
     } finally {
       setIsLoadingMoreConversations(false);
-
-      // Release lock inside RAF so scroll position is restored before new scroll events can trigger
       requestAnimationFrame(() => {
         if (sidebarScrollRef.current) {
           sidebarScrollRef.current.scrollTop = savedScrollTop;
@@ -944,7 +926,7 @@ const ChatSidebar = ({
       data-tour="chat-sidebar"
       className={`
         ${mobileView === 'list' ? 'flex' : 'hidden'} md:flex
-        w-full ${selectedConversationIds.size > 0 ? 'md:w-96' : 'md:w-80'} border-r bg-card/50 flex-col h-full overflow-hidden
+        w-full ${selectedConversationIds.size > 0 ? 'md:w-96' : 'md:w-80'} border-r bg-card/50 flex-col h-full
       `}
     >
       {/* Search and Filter Header */}
@@ -1063,13 +1045,13 @@ const ChatSidebar = ({
       {/* Conversations List */}
       <div
         ref={sidebarScrollRef}
-        className="flex-1 min-h-0 overflow-y-auto overscroll-contain"
+        className="flex-1 overflow-y-auto"
         onScroll={handleSidebarScroll}
         data-tour="chat-conversations-list"
       >
         {!conversations ? (
           <ConversationSkeleton count={8} />
-        ) : (conversations.state.conversationsLoading && !isLoadingMoreConversations) || filters.state.isApplyingFilters ? (
+        ) : conversations.state.conversationsLoading || filters.state.isApplyingFilters ? (
           <ConversationSkeleton count={8} />
         ) : conversations.state.conversationsError ? (
           <div className="p-4 text-center">
@@ -1122,7 +1104,7 @@ const ChatSidebar = ({
                 conversation,
                 <div
                   key={conversation.id}
-                  className={`group p-4 hover:bg-accent cursor-pointer transition-colors ${
+                  className={`p-4 hover:bg-accent cursor-pointer transition-colors ${
                     isSelected
                       ? 'bg-primary/10 border-l-2 border-l-primary'
                       : 'border-b border-border/50'
@@ -1217,39 +1199,16 @@ const ChatSidebar = ({
                         )}
                       </div>
                     </div>
-                    <div
-                      className="flex flex-col items-end gap-1 flex-shrink-0"
-                      onClick={e => e.stopPropagation()}
-                    >
-                      <div className="opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
-                        <ConversationActionsDropdown
-                          conversation={conversation}
-                          allPipelines={allPipelines}
-                          isPipelinesLoaded={isPipelinesLoaded}
-                          pipelinesForConversation={convPipelineStates.get(String(conversation.id)) ?? []}
-                          pipelinesLoadFailed={pipelinesLoadFailed}
-                          isLoadingPipelines={loadingConvPipelines.has(String(conversation.id))}
-                          onPipelineStageSelect={(pipeline, stage) =>
-                            handlePipelineStageSelect(conversation, pipeline, stage)
-                          }
-                          onRemoveFromPipeline={pipeline =>
-                            handleRemoveFromPipeline(conversation, pipeline)
-                          }
-                          onDropdownOpen={() =>
-                            loadConversationPipelineState(String(conversation.id))
-                          }
-                          onRetryLoadPipelines={handleRetryLoadPipelines}
-                          onMarkAsRead={() => onMarkAsRead(conversation)}
-                          onMarkAsUnread={() => onMarkAsUnread(conversation)}
-                          onAssignAgent={() => onAssignAgent(conversation)}
-                          onAssignTeam={() => onAssignTeam(conversation)}
-                          onAssignTag={() => onAssignTag(conversation)}
-                          onDeleteConversation={() => onDeleteConversation(conversation)}
-                        />
-                      </div>
-                      {(conversations.getUnreadCount(conversation.id) || 0) > 0 && (
-                        <div className="w-2 h-2 rounded-full bg-primary flex-shrink-0" />
-                      )}
+                    <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                      {(() => {
+                        // ðŸ"µ INDICADOR PADRÃƒO: Bolinha pequena seguindo padrÃ£o do sistema
+                        const hasUnreadMessages =
+                          (conversations.getUnreadCount(conversation.id) || 0) > 0;
+
+                        return hasUnreadMessages ? (
+                          <div className="w-2 h-2 rounded-full bg-primary flex-shrink-0" />
+                        ) : null;
+                      })()}
                     </div>
                   </div>
                 </div>,

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -159,6 +159,7 @@ const ChatSidebar = ({
   const [showArchived, setShowArchived] = useState(false);
   const sidebarScrollRef = useRef<HTMLDivElement | null>(null);
   const loadingMoreRef = useRef(false);
+  const lastScrollTimeRef = useRef<number>(0);
 
   useEffect(() => {
     onClearSelection();
@@ -553,6 +554,9 @@ const ChatSidebar = ({
   const hasNextPage = pagination?.has_next_page ?? currentPage < totalPages;
 
   const handleSidebarScroll = useCallback(async () => {
+    const now = Date.now();
+    if (now - lastScrollTimeRef.current < 150) return;
+
     const container = sidebarScrollRef.current;
     if (!container || loadingMoreRef.current) return;
 
@@ -567,26 +571,25 @@ const ChatSidebar = ({
     const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
     if (distanceToBottom > 120) return;
 
+    // Update throttle timestamp only when we're actually near the bottom and about to load
+    lastScrollTimeRef.current = now;
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
 
-    // Save scroll position before loading — the re-sort in visibleConversations
-    // causes a DOM restructure that resets scrollTop to 0.
+    // Save position — visibleConversations re-sort after load can reset scrollTop to 0
     const scrollTop = container.scrollTop;
-    const scrollHeight = container.scrollHeight;
 
     try {
       await conversations.loadMoreConversations();
     } finally {
       setIsLoadingMoreConversations(false);
-      loadingMoreRef.current = false;
 
-      // Restore scroll position after React re-renders the appended list
+      // Release lock inside RAF so scroll position is restored before new scroll events can trigger
       requestAnimationFrame(() => {
         if (sidebarScrollRef.current) {
-          const newScrollHeight = sidebarScrollRef.current.scrollHeight;
-          sidebarScrollRef.current.scrollTop = scrollTop + (newScrollHeight - scrollHeight);
+          sidebarScrollRef.current.scrollTop = scrollTop;
         }
+        loadingMoreRef.current = false;
       });
     }
   }, [conversations]);
@@ -595,8 +598,8 @@ const ChatSidebar = ({
     if (loadingMoreRef.current || isLoadingMoreConversations || !hasNextPage) return;
 
     const container = sidebarScrollRef.current;
+    // Save position — visibleConversations re-sort after load can reset scrollTop to 0
     const savedScrollTop = container?.scrollTop ?? 0;
-    const savedScrollHeight = container?.scrollHeight ?? 0;
 
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
@@ -604,13 +607,13 @@ const ChatSidebar = ({
       await conversations.loadMoreConversations();
     } finally {
       setIsLoadingMoreConversations(false);
-      loadingMoreRef.current = false;
 
+      // Release lock inside RAF so scroll position is restored before new scroll events can trigger
       requestAnimationFrame(() => {
         if (sidebarScrollRef.current) {
-          const newScrollHeight = sidebarScrollRef.current.scrollHeight;
-          sidebarScrollRef.current.scrollTop = savedScrollTop + (newScrollHeight - savedScrollHeight);
+          sidebarScrollRef.current.scrollTop = savedScrollTop;
         }
+        loadingMoreRef.current = false;
       });
     }
   }, [conversations, hasNextPage, isLoadingMoreConversations]);

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -944,7 +944,7 @@ const ChatSidebar = ({
       data-tour="chat-sidebar"
       className={`
         ${mobileView === 'list' ? 'flex' : 'hidden'} md:flex
-        w-full ${selectedConversationIds.size > 0 ? 'md:w-96' : 'md:w-80'} border-r bg-card/50 flex-col h-full
+        w-full ${selectedConversationIds.size > 0 ? 'md:w-96' : 'md:w-80'} border-r bg-card/50 flex-col h-full overflow-hidden
       `}
     >
       {/* Search and Filter Header */}
@@ -1063,13 +1063,13 @@ const ChatSidebar = ({
       {/* Conversations List */}
       <div
         ref={sidebarScrollRef}
-        className="flex-1 overflow-y-auto"
+        className="flex-1 min-h-0 overflow-y-auto overscroll-contain"
         onScroll={handleSidebarScroll}
         data-tour="chat-conversations-list"
       >
         {!conversations ? (
           <ConversationSkeleton count={8} />
-        ) : conversations.state.conversationsLoading || filters.state.isApplyingFilters ? (
+        ) : (conversations.state.conversationsLoading && !isLoadingMoreConversations) || filters.state.isApplyingFilters ? (
           <ConversationSkeleton count={8} />
         ) : conversations.state.conversationsError ? (
           <div className="p-4 text-center">

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -144,6 +144,7 @@ const ChatSidebar = ({
         page?: number;
         total_pages?: number;
         has_next_page?: boolean;
+        total?: number;
       } | null;
     };
     getUnreadCount: (conversationId: string) => number;
@@ -979,8 +980,8 @@ const ChatSidebar = ({
         {/* Filter Actions */}
         <div className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">
-            {visibleConversations.length}{' '}
-            {visibleConversations.length === 1
+            {(conversations.state.conversationsPagination?.total ?? visibleConversations.length)}{' '}
+            {(conversations.state.conversationsPagination?.total ?? visibleConversations.length) === 1
               ? t('chatSidebar.conversation')
               : t('chatSidebar.conversations')}
           </span>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -139,7 +139,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
         />
 
         {/* Main Content */}
-        <main className="flex-1 overflow-auto bg-background transition-colors duration-150 ease-in-out">
+        <main className="flex-1 min-h-0 overflow-auto bg-background transition-colors duration-150 ease-in-out">
           <div className="h-full">{children}</div>
         </main>
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -207,6 +207,7 @@
     height: 100%;
     margin: 0;
     padding: 0;
+    overflow: hidden;
   }
 
   body {


### PR DESCRIPTION
## Summary

- Fix conversation sidebar causing the entire CRM page to scroll off-screen when scrolling past the last conversation
- Root cause: `html`/`body` had no `overflow: hidden`, allowing the browser to scroll the document when the sidebar scroll reached its boundary
- Add `overflow: hidden` to `html` and `body` in `globals.css` — definitive fix for document-level scroll
- Add `overflow-hidden` + `min-h-0` to sidebar container for correct flex height containment
- Add `overscroll-contain` to conversations list to prevent scroll chaining to parent containers
- Guard full-list skeleton with `!isLoadingMoreConversations` so it doesn't replace the conversation list during pagination (was causing scroll position to jump to top on each loadMore)
- Add `min-h-0` to `MainLayout` `<main>` element for correct `h-full` resolution chain
- Add 7 scroll pagination tests covering loadMore trigger, button visibility, and edge cases

## Test plan

- [ ] `evo-ai-frontend-community: pnpm test -- --run ChatSidebar.spec.tsx` (16 tests pass)
- [ ] Scroll the sidebar to the bottom — page must NOT scroll off-screen
- [ ] Scroll triggers loadMore at 11 → 25 → 35 conversations smoothly without jumping to top
- [ ] After last page loaded, scrolling past the end keeps the CRM layout fixed

## Changed Files

- `src/styles/globals.css`
- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/layout/MainLayout.tsx`
- `src/components/chat/chat-sidebar/ChatSidebar.spec.tsx`

## Linked Issue

- EVO-1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)