### PR TITLE
fix(frontend): unwrap envelope + defensive guards + ErrorBoundary in SessionsViewer (EVO-1254)

### DIFF
--- a/src/components/journey/SessionsViewer.spec.tsx
+++ b/src/components/journey/SessionsViewer.spec.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { SessionsViewer } from './SessionsViewer';
 
 vi.mock('@/services', () => ({
@@ -29,6 +29,11 @@ const baseProps = {
   onClose: () => undefined,
 };
 
+function statCount(testId: string) {
+  const card = screen.getByTestId(testId);
+  return within(card).getByText(/^\d+$/).textContent;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -52,11 +57,14 @@ describe('SessionsViewer — defensive stats handling', () => {
     render(<SessionsViewer {...baseProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText('12')).toBeTruthy();
+      expect(screen.getByTestId('sessions-stats-grid')).toBeTruthy();
     });
-    expect(screen.getByText('3')).toBeTruthy();
-    expect(screen.getByText('2')).toBeTruthy();
-    expect(screen.getByText('4')).toBeTruthy();
+    expect(statCount('sessions-stat-total')).toBe('12');
+    expect(statCount('sessions-stat-active')).toBe('3');
+    expect(statCount('sessions-stat-waiting')).toBe('2');
+    expect(statCount('sessions-stat-completed')).toBe('4');
+    expect(statCount('sessions-stat-failed')).toBe('1');
+    expect(statCount('sessions-stat-cancelled')).toBe('1');
   });
 
   it('does NOT crash when stats has no byStatus field and renders zeros instead', async () => {
@@ -70,11 +78,11 @@ describe('SessionsViewer — defensive stats handling', () => {
     expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
 
     await waitFor(() => {
-      const zeros = screen.getAllByText('0');
-      // total + 6 status cards (active, waiting, paused doesn't render in JSX
-      // but completed, failed, cancelled do — so 5 zero cards on top of `total`)
-      expect(zeros.length).toBeGreaterThanOrEqual(5);
+      expect(screen.getByTestId('sessions-stats-grid')).toBeTruthy();
     });
+    expect(statCount('sessions-stat-total')).toBe('0');
+    expect(statCount('sessions-stat-active')).toBe('0');
+    expect(statCount('sessions-stat-cancelled')).toBe('0');
   });
 
   it('does NOT crash when stats is an empty object and renders zeros', async () => {
@@ -88,8 +96,10 @@ describe('SessionsViewer — defensive stats handling', () => {
     expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
 
     await waitFor(() => {
-      expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(5);
+      expect(screen.getByTestId('sessions-stats-grid')).toBeTruthy();
     });
+    expect(statCount('sessions-stat-total')).toBe('0');
+    expect(statCount('sessions-stat-failed')).toBe('0');
   });
 
   it('does NOT crash when byStatus is partial (missing some statuses) — missing ones render as 0', async () => {
@@ -106,11 +116,38 @@ describe('SessionsViewer — defensive stats handling', () => {
     expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
 
     await waitFor(() => {
-      // Both `total: 5` and `byStatus.active: 5` render "5"
-      expect(screen.getAllByText('5').length).toBeGreaterThanOrEqual(2);
+      expect(screen.getByTestId('sessions-stats-grid')).toBeTruthy();
     });
-    // waiting, completed, failed, cancelled should all be 0
-    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(4);
+    expect(statCount('sessions-stat-total')).toBe('5');
+    expect(statCount('sessions-stat-active')).toBe('5');
+    expect(statCount('sessions-stat-waiting')).toBe('0');
+    expect(statCount('sessions-stat-completed')).toBe('0');
+    expect(statCount('sessions-stat-failed')).toBe('0');
+    expect(statCount('sessions-stat-cancelled')).toBe('0');
+  });
+
+  it('does NOT crash when the legacy envelope shape leaks through (regression: EVO-1254 root cause)', async () => {
+    // Simulates the pre-fix bug: journeyService forgot to unwrap the
+    // `{ success: true, data: ... }` envelope from the evo-flow
+    // ResponseTransformInterceptor. Even if a future regression undoes the
+    // service-side fix, the component MUST not crash — the defensive guards
+    // at the JSX level catch the missing `byStatus`.
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockResolvedValue({
+      data: { success: true, data: { total: 9, byStatus: { active: 9 } } } as never,
+    } as never);
+
+    expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sessions-stats-grid')).toBeTruthy();
+    });
+    // Counts are all 0 because the leaked envelope hides total/byStatus, but
+    // critically: no crash.
+    expect(statCount('sessions-stat-total')).toBe('0');
+    expect(statCount('sessions-stat-active')).toBe('0');
   });
 
   it('does NOT render the stats grid when the stats request fails (stats stays null)', async () => {
@@ -121,13 +158,10 @@ describe('SessionsViewer — defensive stats handling', () => {
       new Error('boom'),
     );
 
-    const { container } = render(<SessionsViewer {...baseProps} />);
+    render(<SessionsViewer {...baseProps} />);
 
     await waitFor(() => {
-      // The stats grid is conditional on `{stats && ...}` — when load fails,
-      // the grid simply doesn't render. We assert by checking that no
-      // `text-2xl font-bold` count card is in the DOM.
-      expect(container.querySelectorAll('.text-2xl.font-bold')).toHaveLength(0);
+      expect(screen.queryByTestId('sessions-stats-grid')).toBeNull();
     });
   });
 });

--- a/src/components/journey/SessionsViewer.spec.tsx
+++ b/src/components/journey/SessionsViewer.spec.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SessionsViewer } from './SessionsViewer';
+
+vi.mock('@/services', () => ({
+  journeyService: {
+    getJourneySessions: vi.fn(),
+    getJourneySessionStats: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    currentLanguage: 'pt-BR',
+    changeLanguage: () => undefined,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { journeyService } from '@/services';
+
+const baseProps = {
+  journeyId: 'journey-1',
+  journeyName: 'Test Journey',
+  onClose: () => undefined,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SessionsViewer — defensive stats handling', () => {
+  it('renders the correct counts when the backend returns a fully populated byStatus map', async () => {
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockResolvedValue({
+      data: {
+        total: 12,
+        byStatus: { active: 3, waiting: 2, paused: 1, completed: 4, failed: 1, cancelled: 1 },
+      },
+    } as never);
+
+    render(<SessionsViewer {...baseProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('12')).toBeTruthy();
+    });
+    expect(screen.getByText('3')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.getByText('4')).toBeTruthy();
+  });
+
+  it('does NOT crash when stats has no byStatus field and renders zeros instead', async () => {
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockResolvedValue({
+      data: { total: 0 },
+    } as never);
+
+    expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
+
+    await waitFor(() => {
+      const zeros = screen.getAllByText('0');
+      // total + 6 status cards (active, waiting, paused doesn't render in JSX
+      // but completed, failed, cancelled do — so 5 zero cards on top of `total`)
+      expect(zeros.length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  it('does NOT crash when stats is an empty object and renders zeros', async () => {
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockResolvedValue({
+      data: {},
+    } as never);
+
+    expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  it('does NOT crash when byStatus is partial (missing some statuses) — missing ones render as 0', async () => {
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockResolvedValue({
+      data: {
+        total: 5,
+        byStatus: { active: 5 },
+      },
+    } as never);
+
+    expect(() => render(<SessionsViewer {...baseProps} />)).not.toThrow();
+
+    await waitFor(() => {
+      // Both `total: 5` and `byStatus.active: 5` render "5"
+      expect(screen.getAllByText('5').length).toBeGreaterThanOrEqual(2);
+    });
+    // waiting, completed, failed, cancelled should all be 0
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('does NOT render the stats grid when the stats request fails (stats stays null)', async () => {
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockRejectedValue(
+      new Error('boom'),
+    );
+
+    const { container } = render(<SessionsViewer {...baseProps} />);
+
+    await waitFor(() => {
+      // The stats grid is conditional on `{stats && ...}` — when load fails,
+      // the grid simply doesn't render. We assert by checking that no
+      // `text-2xl font-bold` count card is in the DOM.
+      expect(container.querySelectorAll('.text-2xl.font-bold')).toHaveLength(0);
+    });
+  });
+});

--- a/src/components/journey/SessionsViewer.tsx
+++ b/src/components/journey/SessionsViewer.tsx
@@ -41,7 +41,7 @@ interface JourneySession {
   journeyId: string;
   contactId: string;
   accountId: string;
-  status: 'active' | 'waiting' | 'paused' | 'completed' | 'failed' | 'cancelled';
+  status: SessionStatus;
   currentNodeId?: string;
   variables: Record<string, any>;
   context?: Record<string, any>;
@@ -207,27 +207,27 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
 
         {/* Stats Cards */}
         {stats && (
-          <div className="p-6 border-b border-sidebar-border">
+          <div className="p-6 border-b border-sidebar-border" data-testid="sessions-stats-grid">
             <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
-              <Card className="bg-sidebar-accent">
+              <Card className="bg-sidebar-accent" data-testid="sessions-stat-total">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-sidebar-foreground">{stats.total ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.total')}</div>
                 </CardContent>
               </Card>
-              <Card className="bg-green-500/10 border-green-500/20">
+              <Card className="bg-green-500/10 border-green-500/20" data-testid="sessions-stat-active">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-green-500">{stats.byStatus?.active ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.active')}</div>
                 </CardContent>
               </Card>
-              <Card className="bg-blue-500/10 border-blue-500/20">
+              <Card className="bg-blue-500/10 border-blue-500/20" data-testid="sessions-stat-waiting">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-blue-500">{stats.byStatus?.waiting ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.waiting')}</div>
                 </CardContent>
               </Card>
-              <Card className="bg-emerald-500/10 border-emerald-500/20">
+              <Card className="bg-emerald-500/10 border-emerald-500/20" data-testid="sessions-stat-completed">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-emerald-500">
                     {stats.byStatus?.completed ?? 0}
@@ -235,13 +235,13 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.completed')}</div>
                 </CardContent>
               </Card>
-              <Card className="bg-red-500/10 border-red-500/20">
+              <Card className="bg-red-500/10 border-red-500/20" data-testid="sessions-stat-failed">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-red-500">{stats.byStatus?.failed ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.failed')}</div>
                 </CardContent>
               </Card>
-              <Card className="bg-gray-500/10 border-gray-500/20">
+              <Card className="bg-gray-500/10 border-gray-500/20" data-testid="sessions-stat-cancelled">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-gray-500">{stats.byStatus?.cancelled ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.cancelled')}</div>

--- a/src/components/journey/SessionsViewer.tsx
+++ b/src/components/journey/SessionsViewer.tsx
@@ -29,6 +29,13 @@ interface SessionsViewerProps {
   onClose: () => void;
 }
 
+type SessionStatus = 'active' | 'waiting' | 'paused' | 'completed' | 'failed' | 'cancelled';
+
+interface SessionStats {
+  total?: number;
+  byStatus?: Partial<Record<SessionStatus, number>>;
+}
+
 interface JourneySession {
   id: string;
   journeyId: string;
@@ -107,7 +114,7 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
 
   const statusConfig = getStatusConfig();
   const [sessions, setSessions] = useState<JourneySession[]>([]);
-  const [stats, setStats] = useState<any>(null);
+  const [stats, setStats] = useState<SessionStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [selectedSession, setSelectedSession] = useState<JourneySession | null>(null);
   const [filterStatus, setFilterStatus] = useState<string>('all');
@@ -204,39 +211,39 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
             <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
               <Card className="bg-sidebar-accent">
                 <CardContent className="p-4">
-                  <div className="text-2xl font-bold text-sidebar-foreground">{stats.total}</div>
+                  <div className="text-2xl font-bold text-sidebar-foreground">{stats.total ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.total')}</div>
                 </CardContent>
               </Card>
               <Card className="bg-green-500/10 border-green-500/20">
                 <CardContent className="p-4">
-                  <div className="text-2xl font-bold text-green-500">{stats.byStatus.active}</div>
+                  <div className="text-2xl font-bold text-green-500">{stats.byStatus?.active ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.active')}</div>
                 </CardContent>
               </Card>
               <Card className="bg-blue-500/10 border-blue-500/20">
                 <CardContent className="p-4">
-                  <div className="text-2xl font-bold text-blue-500">{stats.byStatus.waiting}</div>
+                  <div className="text-2xl font-bold text-blue-500">{stats.byStatus?.waiting ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.waiting')}</div>
                 </CardContent>
               </Card>
               <Card className="bg-emerald-500/10 border-emerald-500/20">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-emerald-500">
-                    {stats.byStatus.completed}
+                    {stats.byStatus?.completed ?? 0}
                   </div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.completed')}</div>
                 </CardContent>
               </Card>
               <Card className="bg-red-500/10 border-red-500/20">
                 <CardContent className="p-4">
-                  <div className="text-2xl font-bold text-red-500">{stats.byStatus.failed}</div>
+                  <div className="text-2xl font-bold text-red-500">{stats.byStatus?.failed ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.failed')}</div>
                 </CardContent>
               </Card>
               <Card className="bg-gray-500/10 border-gray-500/20">
                 <CardContent className="p-4">
-                  <div className="text-2xl font-bold text-gray-500">{stats.byStatus.cancelled}</div>
+                  <div className="text-2xl font-bold text-gray-500">{stats.byStatus?.cancelled ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.cancelled')}</div>
                 </CardContent>
               </Card>

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { BaseFlowEditor, type NodeType, type NodeCategory } from '@/components/base';
 import { EnvironmentManager, type JourneyVariable } from '@/components/journey/environment-manager';
 import { SessionsViewer } from '@/components/journey/SessionsViewer';
+import ErrorBoundary from '@/components/ErrorBoundary';
 
 // Importar todos os nodes da jornada por categoria
 import { JourneyTriggerNode } from '@/components/journey/nodes/trigger/JourneyTriggerNode';
@@ -87,7 +88,7 @@ import {
   Activity,
 } from 'lucide-react';
 
-export default function JourneyFlowEditor() {
+function JourneyFlowEditor() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { t } = useLanguage('journey');
@@ -781,5 +782,13 @@ export default function JourneyFlowEditor() {
         />
       )}
     </div>
+  );
+}
+
+export default function JourneyFlowEditorPage() {
+  return (
+    <ErrorBoundary>
+      <JourneyFlowEditor />
+    </ErrorBoundary>
   );
 }

--- a/src/services/journeys/journeyService.spec.ts
+++ b/src/services/journeys/journeyService.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { journeyService } from './journeyService';
+import apiEvoFlow from '@/services/core/apiEvoFlow';
+
+vi.mock('@/services/core/apiEvoFlow', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe('journeyService session methods — envelope unwrap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getJourneySessionStats unwraps the { success, data } envelope', async () => {
+    const innerPayload = {
+      total: 3,
+      byStatus: { active: 1, waiting: 0, paused: 0, completed: 2, failed: 0, cancelled: 0 },
+    };
+    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+      data: { success: true, data: innerPayload },
+    } as never);
+
+    const result = await journeyService.getJourneySessionStats('journey-1');
+
+    expect(apiEvoFlow.get).toHaveBeenCalledWith('/journeys/journey-1/sessions/stats');
+    expect(result.data).toEqual(innerPayload);
+    expect(result.data.byStatus.active).toBe(1);
+  });
+
+  it('getJourneySessionStats falls back to raw response when envelope is absent', async () => {
+    const rawPayload = {
+      total: 0,
+      byStatus: { active: 0, waiting: 0, paused: 0, completed: 0, failed: 0, cancelled: 0 },
+    };
+    vi.mocked(apiEvoFlow.get).mockResolvedValue({ data: rawPayload } as never);
+
+    const result = await journeyService.getJourneySessionStats('journey-1');
+
+    expect(result.data).toEqual(rawPayload);
+  });
+
+  it('getJourneySessions unwraps the envelope and surfaces the sessions array', async () => {
+    const inner = { sessions: [{ id: 's-1', status: 'active' }], total: 1, page: 1, pageSize: 20 };
+    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+      data: { success: true, data: inner },
+    } as never);
+
+    const result = await journeyService.getJourneySessions('journey-1', { page: 1, pageSize: 20 });
+
+    expect(apiEvoFlow.get).toHaveBeenCalledWith('/journeys/journey-1/sessions', {
+      params: { page: 1, pageSize: 20 },
+    });
+    expect(result.data.sessions).toHaveLength(1);
+    expect(result.data.total).toBe(1);
+  });
+
+  it('getJourneySession unwraps the envelope for a single session lookup', async () => {
+    const inner = { id: 's-1', status: 'active', journeyId: 'journey-1' };
+    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+      data: { success: true, data: inner },
+    } as never);
+
+    const result = await journeyService.getJourneySession('journey-1', 's-1');
+
+    expect(result.data).toEqual(inner);
+  });
+
+  it('cancelJourneySession unwraps the envelope on the post response', async () => {
+    const inner = { id: 's-1', status: 'cancelled' };
+    vi.mocked(apiEvoFlow.post).mockResolvedValue({
+      data: { success: true, data: inner },
+    } as never);
+
+    const result = await journeyService.cancelJourneySession('journey-1', 's-1');
+
+    expect(apiEvoFlow.post).toHaveBeenCalledWith(
+      '/journeys/journey-1/sessions/s-1/cancel',
+      {},
+    );
+    expect(result.data).toEqual(inner);
+  });
+
+  it('bulkDeleteJourneySessions unwraps the envelope on the bulk delete response', async () => {
+    vi.mocked(apiEvoFlow.delete).mockResolvedValue({
+      data: { success: true, data: { deleted: 5 } },
+    } as never);
+
+    const result = await journeyService.bulkDeleteJourneySessions('journey-1', 'completed');
+
+    expect(result.data.deleted).toBe(5);
+  });
+});

--- a/src/services/journeys/journeyService.ts
+++ b/src/services/journeys/journeyService.ts
@@ -204,7 +204,7 @@ class JourneyService {
         params,
       });
       return {
-        data: response.data,
+        data: extractData(response),
       };
     } catch (error: any) {
       console.error('Erro ao buscar sessões da jornada:', error);
@@ -216,7 +216,7 @@ class JourneyService {
     try {
       const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${journeyId}/sessions/stats`);
       return {
-        data: response.data,
+        data: extractData(response),
       };
     } catch (error: any) {
       console.error('Erro ao buscar estatísticas de sessões:', error);
@@ -233,7 +233,7 @@ class JourneyService {
         `${this.getBaseUrl()}/${journeyId}/sessions/${sessionId}`,
       );
       return {
-        data: response.data,
+        data: extractData(response),
       };
     } catch (error: any) {
       console.error('Erro ao buscar sessão:', error);
@@ -263,7 +263,7 @@ class JourneyService {
         {},
       );
       return {
-        data: response.data,
+        data: extractData(response),
       };
     } catch (error: any) {
       console.error('Erro ao cancelar sessão:', error);
@@ -280,7 +280,7 @@ class JourneyService {
         `${this.getBaseUrl()}/${journeyId}/sessions/bulk/${status}`,
       );
       return {
-        data: response.data,
+        data: extractData(response),
       };
     } catch (error: any) {
       console.error('Erro ao deletar sessões em lote:', error);

--- a/src/services/journeys/journeyService.ts
+++ b/src/services/journeys/journeyService.ts
@@ -212,7 +212,12 @@ class JourneyService {
     }
   }
 
-  async getJourneySessionStats(journeyId: string): Promise<{ data: any }> {
+  async getJourneySessionStats(journeyId: string): Promise<{
+    data: {
+      total?: number;
+      byStatus?: Partial<Record<'active' | 'waiting' | 'paused' | 'completed' | 'failed' | 'cancelled', number>>;
+    };
+  }> {
     try {
       const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${journeyId}/sessions/stats`);
       return {


### PR DESCRIPTION
## Summary

Fixes Pain #1 from the Flow Builder discovery (EVO-1237): the Sessions Viewer crashed with `TypeError: Cannot read properties of undefined (reading 'active')` when opened from the Journey Editor, leaving the page in a black-screen state.

Root cause was **not** the auth regression the card hypothesised. The evo-flow backend wraps every response in `{ success: true, data: ... }` via a global `ResponseTransformInterceptor` (`evo-flow/src/main.ts:134`). The core `journeyService` methods (`getJourneys`, `getJourney`) use the `extractData` helper to unwrap that envelope — but the session-related methods returned `response.data` raw, so `stats` ended up shaped as `{ success: true, data: { byStatus: {...} } }` instead of `{ byStatus: {...} }`. Line 213's access on `stats.byStatus.active` was reading `undefined.active`.

## What changed

- **Envelope unwrap** in `journeyService.getJourneySessions`, `getJourneySessionStats`, `getJourneySession`, `cancelJourneySession`, `bulkDeleteJourneySessions`. `deleteJourneySession` is unchanged (returns void).
- **Defensive JSX guards** on `SessionsViewer`: every `stats.byStatus.X` is now `stats.byStatus?.X ?? 0`; `stats.total` is `stats.total ?? 0`. Stats grid renders zeros instead of crashing when the payload is incomplete.
- **Typed stats state**: `stats: any` is replaced with a `SessionStats` interface (`total?: number; byStatus?: Partial<Record<SessionStatus, number>>`). `SessionStatus` is now a single type alias reused by both `JourneySession['status']` and `SessionStats['byStatus']`.
- **Explicit return type** on `getJourneySessionStats` mirrors the new `SessionStats` shape — self-documenting and forces callers to handle missing fields.
- **`<ErrorBoundary>` wrap** around the entire `JourneyFlowEditor` page using the shared component at `src/components/ErrorBoundary.tsx` (same one used by Chat). Internal `JourneyFlowEditor` stays as-is; a new outer `JourneyFlowEditorPage` is the default export and renders the boundary. Any uncaught error inside the canvas, palette, header, or node modals now shows the i18n fallback (`common.errorBoundary.*`) with a Retry button instead of a black screen.
- **`data-testid`** on every stats card (`sessions-stats-grid`, `sessions-stat-{total|active|waiting|completed|failed|cancelled}`) for stable selectors in tests and future automation.

## Security

- No new endpoints, no new authN/authZ surfaces, no new query patterns. Pure UI defensive layer + response shape handling.
- ErrorBoundary swallows runtime errors but does NOT swallow `console.error`, so dev telemetry remains intact.

## Test plan

- [x] `pnpm exec tsc -b --noEmit` — clean
- [x] `pnpm exec eslint src/components/journey/SessionsViewer.tsx src/services/journeys/ src/pages/Customer/Journey/JourneyFlowEditor.tsx` — no new errors; the 12 pre-existing `any` errors in `journeyService.ts` and `JourneyFlowEditor.tsx` are unchanged from `develop`.
- [x] `pnpm test src/services/journeys/journeyService src/components/journey/SessionsViewer` — **12/12 passing** (6 service + 6 component).
- [x] Manual smoke (user-confirmed): open journey → click "Ver Sessões" → modal renders with all 6 stats cards at 0, "No sessions found" empty state, no crash, no console errors.
- [x] AC #1 (no 401, request returns 200 with correct shape) — covered by service-level envelope unwrap test.
- [x] AC #2 (payload inesperado não crasha) — 5 spec cases cover `stats = {}`, `stats = { total: N }`, partial `byStatus`, rejected promise, and the **legacy envelope leak** (regression test that locks in defence-in-depth even if the service-side unwrap is undone in the future).
- [x] AC #3 (error boundary around Flow Builder) — verified by import + wrap; visual fallback inherited from the shared `<ErrorBoundary>`.
- [x] AC #4 (3 specs pass without flaky behaviour) — 12 cases, all hermetic (no real timers, no real network).

## Changed Files

- `src/services/journeys/journeyService.ts` — envelope unwrap on 5 session methods + typed return on stats
- `src/components/journey/SessionsViewer.tsx` — SessionStats interface, SessionStatus DRY type, defensive guards, data-testid attributes
- `src/components/journey/SessionsViewer.spec.tsx` — new, 6 component tests
- `src/services/journeys/journeyService.spec.ts` — new, 6 service tests
- `src/pages/Customer/Journey/JourneyFlowEditor.tsx` — ErrorBoundary wrap (renamed default export to `JourneyFlowEditorPage`, internal `JourneyFlowEditor` unchanged)

## QA Notes

Three adversarial code-review passes (`/evo-code-review`) were applied during development. The third pass surfaced a regression-resistance gap and tightening opportunities — all addressed inline before requesting review:

- **First pass:** envelope handling was the real bug (not auth as the card description suspected). Plan adjusted to swap auth investigation for envelope unwrap.
- **Second pass:** all 8 first-pass findings shipped in the implementation commits.
- **Third pass (6 findings):** added an envelope-leak regression test, tightened typing on `getJourneySessionStats`, DRY'd the SessionStatus type, swapped brittle text-based test selectors for `data-testid`-scoped queries. One observation (paused stats card missing from grid) is **pre-existing in develop** and filed separately as EVO-1417 so this PR stays focused.

## Out of scope (deferred)

- **Auth regression investigation** — the card hypothesised a client-side auth bug; investigation showed the same axios instance is used by working journey methods. The "401" symptom in the discovery doc was likely a transient session-expiry mixed with the envelope crash. If a real 401 reappears on this route, it would be a separate auth-service issue.
- **Sentry/logger integration** — the card mentions "envia erro para logger configurado"; the project has no Sentry config (no `@sentry/*` imports anywhere). ErrorBoundary keeps the existing `console.error` behaviour. If telemetry is added later, it lives in `ErrorBoundary.tsx`.
- **Paused stats card missing** — filed as [EVO-1417](https://linear.app/evoai/issue/EVO-1417/sessionsviewer-stats-grid-is-missing-the-paused-counter-card), separate UI card.

## Linked Issue

- https://linear.app/evoai/issue/EVO-1254/101-corrigir-401-no-sessions-viewer-crash-js-error-boundary

## Summary by Sourcery

Handle wrapped session stats responses and harden the Sessions Viewer and Flow Editor against runtime crashes.

Bug Fixes:
- Unwrap the evo-flow response envelope for journey session APIs so the Sessions Viewer receives correctly shaped stats data.
- Prevent Sessions Viewer from crashing when session stats are missing, partially populated, or returned in an unexpected envelope shape.

Enhancements:
- Type the session stats and status model shared between services and SessionsViewer to better reflect optional fields and reduce reliance on any.
- Wrap the Journey Flow Editor page in a shared ErrorBoundary so unexpected errors render a recoverable fallback instead of a blank screen.
- Add data-testid attributes to session stats cards to support stable, targeted testing of the stats grid.

Tests:
- Add component tests for SessionsViewer covering defensive handling of empty, partial, and malformed stats responses, as well as stats request failures.
- Add service-level tests around journey session APIs to validate correct unwrapping and shaping of stats responses.