### PR TITLE
feat(frontend): refactor 21 node config modals to NodeConfigModal + design tokens (EVO-1274)

### DIFF
--- a/src/components/journey/nodes/actions/add-label/AddLabelPanel.tsx
+++ b/src/components/journey/nodes/actions/add-label/AddLabelPanel.tsx
@@ -1,17 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
 } from '@evoapi/design-system';
 import { Tag } from 'lucide-react';
 import { AddLabelNodeData } from './AddLabelNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { labelsService } from '@/services/contacts/labelsService';
 import type { Label as LabelType } from '@/types/settings';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -25,9 +24,8 @@ interface AddLabelPanelProps {
 
 export function AddLabelPanel({ nodeId, data, onUpdate, onClose }: AddLabelPanelProps) {
   const { t } = useLanguage('journey');
-  const [formData, setFormData] = useState<AddLabelNodeData>({
-    ...data,
-  });
+  const [originalData] = useState<AddLabelNodeData>(() => ({ ...data }));
+  const [formData, setFormData] = useState<AddLabelNodeData>({ ...data });
   const [labels, setLabels] = useState<LabelType[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,12 +54,6 @@ export function AddLabelPanel({ nodeId, data, onUpdate, onClose }: AddLabelPanel
   };
 
   const handleSave = () => {
-    // Validação básica
-    if (!formData.labelId) {
-      alert(t('panels.addLabel.selectLabelAlert'));
-      return;
-    }
-
     onUpdate(nodeId, formData);
     onClose();
   };
@@ -77,31 +69,34 @@ export function AddLabelPanel({ nodeId, data, onUpdate, onClose }: AddLabelPanel
     }));
   };
 
-  const isValid = formData.labelId && formData.labelName;
+  const isValid = Boolean(formData.labelId && formData.labelName);
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.addLabel.title')}
-      icon={<Tag className="w-5 h-5 text-green-500" />}
-      onClose={onClose}
-      width="w-[600px]"
+      icon={<Tag className="h-5 w-5 text-flow-node-action-label-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.addLabel.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.addLabel.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               <li>{t('panels.addLabel.selectLabel')}</li>
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Seleção da etiqueta */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.addLabel.labelToAdd')}</Label>
           <Select
@@ -139,17 +134,15 @@ export function AddLabelPanel({ nodeId, data, onUpdate, onClose }: AddLabelPanel
           </Select>
         </div>
 
-        {/* Erro ao carregar */}
         {error && (
-          <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
-            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-          </div>
+          <FlowFeedbackBanner variant="error">
+            <p>{error}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Preview da etiqueta selecionada */}
         {formData.labelId && formData.labelName && (
-          <div className="p-4 rounded-lg bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/30">
-            <p className="text-sm text-green-800 dark:text-green-200 mb-2">
+          <FlowFeedbackBanner variant="success">
+            <p className="mb-2">
               <strong>{t('panels.addLabel.selectedLabel')}:</strong>
             </p>
             <div className="flex items-center gap-2">
@@ -159,29 +152,17 @@ export function AddLabelPanel({ nodeId, data, onUpdate, onClose }: AddLabelPanel
               />
               <span className="font-medium">{formData.labelName}</span>
             </div>
-            <p className="text-xs text-green-600 dark:text-green-400 mt-2">
-              {t('panels.addLabel.description')}
-            </p>
-          </div>
+            <p className="text-xs mt-2">{t('panels.addLabel.description')}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Ajuda */}
-        <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
-            <strong>💡 {t('panels.addLabel.tip')}:</strong> {t('panels.addLabel.tipDescription')}
+        <FlowFeedbackBanner variant="info">
+          <p>
+            <strong>💡 {t('panels.addLabel.tip')}:</strong>{' '}
+            {t('panels.addLabel.tipDescription')}
           </p>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid ? t('panels.actions.save') : t('panels.addLabel.selectLabelButton')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/assign-agent/AssignAgentPanel.tsx
+++ b/src/components/journey/nodes/actions/assign-agent/AssignAgentPanel.tsx
@@ -1,17 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Button,
   Label,
 } from '@evoapi/design-system';
 import { User } from 'lucide-react';
 import { AssignAgentNodeData } from './AssignAgentNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface AssignAgentPanelProps {
@@ -24,6 +24,7 @@ interface AssignAgentPanelProps {
 export function AssignAgentPanel({ nodeId, data, onUpdate, onClose }: AssignAgentPanelProps) {
   const { t } = useLanguage('journey');
   const [agentId, setAgentId] = useState<string>(data.agent_id?.toString() || '');
+  const [originalAgentId] = useState<string>(() => data.agent_id?.toString() || '');
   const [formDataOptions, setFormDataOptions] = useState<{
     agents: any[];
   }>({
@@ -31,7 +32,6 @@ export function AssignAgentPanel({ nodeId, data, onUpdate, onClose }: AssignAgen
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -64,7 +64,6 @@ export function AssignAgentPanel({ nodeId, data, onUpdate, onClose }: AssignAgen
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.agents.length > 0) {
       const updatedData: AssignAgentNodeData = {
@@ -75,79 +74,78 @@ export function AssignAgentPanel({ nodeId, data, onUpdate, onClose }: AssignAgen
     }
   }, [formDataOptions, data, nodeId, onUpdate]);
 
-  return (
-    <BaseFlowPanel
-      title={t('panels.assignAgent.title')}
-      icon={<User className="w-5 h-5 text-blue-500" />}
-      onClose={onClose}
-      width="w-[420px]"
-    >
-      {/* Seleção de Agente */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.assignAgent.user')}
-        </Label>
-        <Select value={agentId} onValueChange={setAgentId} disabled={loading}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
-            <SelectValue
-              placeholder={
-                loading ? t('panels.assignAgent.loadingUsers') : t('panels.assignAgent.selectUser')
-              }
-            />
-          </SelectTrigger>
-          <SelectContent className="bg-sidebar border-sidebar-border">
-            {formDataOptions.agents.map(agent => (
-              <SelectItem
-                key={agent.id}
-                value={agent.id.toString()}
-                className="text-sidebar-foreground"
-              >
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 rounded-full bg-blue-500 flex items-center justify-center text-white text-xs font-medium">
-                    {agent.name.charAt(0).toUpperCase()}
-                  </div>
-                  <div>
-                    <div className="font-medium">{agent.name}</div>
-                    <div className="text-xs text-sidebar-foreground/60">{agent.email}</div>
-                  </div>
-                </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+  const dirty = useMemo(() => agentId !== originalAgentId, [agentId, originalAgentId]);
+  const isValid = Boolean(agentId);
 
-        {!loading && formDataOptions.agents.length === 0 && (
-          <p className="text-sm text-sidebar-foreground/60">
-            {t('panels.assignAgent.noUsersFound')}
-          </p>
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.assignAgent.title')}
+      icon={<User className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.assignAgent.user')}
+          </Label>
+          <Select value={agentId} onValueChange={setAgentId} disabled={loading}>
+            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectValue
+                placeholder={
+                  loading ? t('panels.assignAgent.loadingUsers') : t('panels.assignAgent.selectUser')
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {formDataOptions.agents.map(agent => (
+                <SelectItem
+                  key={agent.id}
+                  value={agent.id.toString()}
+                  className="text-sidebar-foreground"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-full bg-flow-node-action-pipeline-bg text-flow-node-action-pipeline-fg flex items-center justify-center text-xs font-medium">
+                      {agent.name.charAt(0).toUpperCase()}
+                    </div>
+                    <div>
+                      <div className="font-medium">{agent.name}</div>
+                      <div className="text-xs text-sidebar-foreground/60">{agent.email}</div>
+                    </div>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {!loading && formDataOptions.agents.length === 0 && (
+            <p className="text-sm text-sidebar-foreground/60">
+              {t('panels.assignAgent.noUsersFound')}
+            </p>
+          )}
+        </div>
+
+        {agentId && (
+          <FlowFeedbackBanner variant="info">
+            <div className="flex items-center gap-2">
+              <User className="w-4 h-4" />
+              <span>
+                {t('panels.assignAgent.conversationWillBeAssigned')}{' '}
+                <strong>
+                  {formDataOptions.agents.find(a => a.id.toString() === agentId)?.name ||
+                    `${t('panels.assignAgent.agent')} #${agentId}`}
+                </strong>
+              </span>
+            </div>
+          </FlowFeedbackBanner>
         )}
       </div>
-
-      {/* Preview da ação */}
-      {agentId && (
-        <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <div className="flex items-center gap-2 text-sm">
-            <User className="w-4 h-4 text-blue-600" />
-            <span className="text-blue-800 dark:text-blue-200">
-              {t('panels.assignAgent.conversationWillBeAssigned')}{' '}
-              <strong>
-                {formDataOptions.agents.find(a => a.id.toString() === agentId)?.name ||
-                  `${t('panels.assignAgent.agent')} #${agentId}`}
-              </strong>
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!agentId || loading}>
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/assign-bot/AssignBotPanel.tsx
+++ b/src/components/journey/nodes/actions/assign-bot/AssignBotPanel.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Bot, Inbox } from 'lucide-react';
-import { BaseFlowPanel } from '@/components/base';
-import { Button, Separator } from '@evoapi/design-system';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 export interface AssignBotPanelProps {
@@ -24,12 +24,14 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
   const { t } = useLanguage('journey');
   const [selectedBotId, setSelectedBotId] = useState<string>(data.bot_id || '');
   const [selectedInboxId, setSelectedInboxId] = useState<string>(data.inbox_id || '');
+  const [originalSnapshot] = useState(() => ({
+    botId: data.bot_id || '',
+    inboxId: data.inbox_id || '',
+  }));
 
-  // Opções disponíveis
   const availableBots = data.formDataOptions?.bots || [];
   const availableInboxes = data.formDataOptions?.inboxes || [];
 
-  // Encontrar nomes pelos IDs
   const selectedBot = availableBots.find(bot => bot.id.toString() === selectedBotId);
   const selectedInbox = availableInboxes.find(inbox => inbox.id.toString() === selectedInboxId);
 
@@ -55,30 +57,35 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
     onClose();
   };
 
-  const canSave = selectedBotId && selectedInboxId;
+  const dirty = useMemo(
+    () => selectedBotId !== originalSnapshot.botId || selectedInboxId !== originalSnapshot.inboxId,
+    [selectedBotId, selectedInboxId, originalSnapshot],
+  );
+  const canSave = Boolean(selectedBotId && selectedInboxId);
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.assignBot.title')}
-      icon={<Bot className="w-5 h-5 text-purple-500" />}
-      onClose={onClose}
-      width="w-[500px]"
+      icon={<Bot className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={handleCancel}
+      onSave={handleSave}
+      dirty={dirty && canSave}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-6">
-        {/* Descrição */}
-        <div className="p-3 bg-purple-50 dark:bg-purple-950/20 rounded-lg border border-purple-200 dark:border-purple-800/30">
-          <p className="text-sm text-purple-800 dark:text-purple-200">
+        <FlowFeedbackBanner variant="info">
+          <p>
             <strong>{t('panels.assignBot.title')}:</strong> {t('panels.assignBot.description')}
           </p>
-        </div>
+        </FlowFeedbackBanner>
 
-        {/* Seleção do Bot */}
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Bot className="w-4 h-4 text-purple-500" />
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            <Bot className="w-4 h-4 text-flow-node-action-pipeline-fg" />
+            <label className="text-sm font-medium text-foreground">
               {t('panels.assignBot.selectBot')}
             </label>
           </div>
@@ -86,9 +93,7 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
           <select
             value={selectedBotId}
             onChange={e => setSelectedBotId(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md
-                     bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
-                     focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+            className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:ring-2 focus:ring-ring focus:border-ring"
           >
             <option value="">{t('panels.assignBot.selectBotPlaceholder')}</option>
             {availableBots.map(bot => (
@@ -99,8 +104,8 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
           </select>
 
           {selectedBot && (
-            <div className="p-2 bg-gray-50 dark:bg-gray-800 rounded border">
-              <p className="text-xs text-gray-600 dark:text-gray-400">
+            <div className="p-2 bg-muted rounded border border-border">
+              <p className="text-xs text-muted-foreground">
                 <strong>{t('panels.assignBot.type')}:</strong> {selectedBot.bot_type || 'webhook'}
                 {selectedBot.description && (
                   <>
@@ -114,17 +119,16 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
           )}
 
           {availableBots.length === 0 && (
-            <div className="p-2 text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/20 rounded">
-              ⚠ {t('panels.assignBot.noBotsAvailable')}
-            </div>
+            <FlowFeedbackBanner variant="warn">
+              <p className="text-xs">⚠ {t('panels.assignBot.noBotsAvailable')}</p>
+            </FlowFeedbackBanner>
           )}
         </div>
 
-        {/* Seleção do Inbox */}
         <div className="space-y-3">
           <div className="flex items-center gap-2">
-            <Inbox className="w-4 h-4 text-blue-500" />
-            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            <Inbox className="w-4 h-4 text-flow-node-action-message-fg" />
+            <label className="text-sm font-medium text-foreground">
               {t('panels.assignBot.selectInbox')}
             </label>
           </div>
@@ -132,9 +136,7 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
           <select
             value={selectedInboxId}
             onChange={e => setSelectedInboxId(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md
-                     bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100
-                     focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground focus:ring-2 focus:ring-ring focus:border-ring"
           >
             <option value="">{t('panels.assignBot.selectInboxPlaceholder')}</option>
             {availableInboxes.map(inbox => (
@@ -145,8 +147,8 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
           </select>
 
           {selectedInbox && (
-            <div className="p-2 bg-gray-50 dark:bg-gray-800 rounded border">
-              <p className="text-xs text-gray-600 dark:text-gray-400">
+            <div className="p-2 bg-muted rounded border border-border">
+              <p className="text-xs text-muted-foreground">
                 <strong>{t('panels.assignBot.channel')}:</strong>{' '}
                 {selectedInbox.channel_type || t('panels.assignBot.unknown')}
                 {selectedInbox.website_url && (
@@ -160,24 +162,21 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
           )}
 
           {availableInboxes.length === 0 && (
-            <div className="p-2 text-sm text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950/20 rounded">
-              ⚠ {t('panels.assignBot.noInboxesAvailable')}
-            </div>
+            <FlowFeedbackBanner variant="warn">
+              <p className="text-xs">⚠ {t('panels.assignBot.noInboxesAvailable')}</p>
+            </FlowFeedbackBanner>
           )}
         </div>
 
-        {/* Preview da atribuição */}
         {selectedBot && selectedInbox && (
-          <div className="p-3 bg-green-50 dark:bg-green-950/20 rounded-lg border border-green-200 dark:border-green-800/30">
+          <FlowFeedbackBanner variant="success">
             <div className="flex items-start gap-2">
-              <div className="flex-shrink-0 w-5 h-5 bg-green-500 rounded-full flex items-center justify-center mt-0.5">
-                <span className="text-xs text-white font-bold">✓</span>
+              <div className="flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center mt-0.5 bg-flow-feedback-success-fg text-flow-feedback-success-bg">
+                <span className="text-xs font-bold">✓</span>
               </div>
               <div>
-                <p className="text-sm font-medium text-green-800 dark:text-green-200">
-                  {t('panels.assignBot.assignmentConfigured')}
-                </p>
-                <p className="text-xs text-green-700 dark:text-green-300 mt-1">
+                <p className="font-medium">{t('panels.assignBot.assignmentConfigured')}</p>
+                <p className="text-xs mt-1">
                   {t('panels.assignBot.assignmentPreview', {
                     botName: selectedBot.name,
                     inboxName: selectedInbox.name,
@@ -185,32 +184,19 @@ export function AssignBotPanel({ nodeId, data, onUpdate, onClose }: AssignBotPan
                 </p>
               </div>
             </div>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Notas importantes */}
-        <div className="p-3 bg-blue-50 dark:bg-blue-950/20 rounded-lg border border-blue-200 dark:border-blue-800/30">
-          <h4 className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2">
-            ℹ️ {t('panels.assignBot.importantNotes')}
-          </h4>
-          <ul className="text-xs text-blue-700 dark:text-blue-300 space-y-1">
+        <FlowFeedbackBanner variant="info">
+          <h4 className="text-sm font-medium mb-2">ℹ️ {t('panels.assignBot.importantNotes')}</h4>
+          <ul className="text-xs space-y-1">
             <li>• {t('panels.assignBot.note1')}</li>
             <li>• {t('panels.assignBot.note2')}</li>
             <li>• {t('panels.assignBot.note3')}</li>
             <li>• {t('panels.assignBot.note4')}</li>
           </ul>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={handleCancel} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!canSave}>
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/assign-team/AssignTeamPanel.tsx
+++ b/src/components/journey/nodes/actions/assign-team/AssignTeamPanel.tsx
@@ -1,17 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Button,
   Label,
 } from '@evoapi/design-system';
 import { Users } from 'lucide-react';
 import { AssignTeamNodeData } from './AssignTeamNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface AssignTeamPanelProps {
@@ -24,6 +24,7 @@ interface AssignTeamPanelProps {
 export function AssignTeamPanel({ nodeId, data, onUpdate, onClose }: AssignTeamPanelProps) {
   const { t } = useLanguage('journey');
   const [teamId, setTeamId] = useState<string>(data.team_id?.toString() || '');
+  const [originalTeamId] = useState<string>(() => data.team_id?.toString() || '');
   const [formDataOptions, setFormDataOptions] = useState<{
     teams: any[];
   }>({
@@ -31,7 +32,6 @@ export function AssignTeamPanel({ nodeId, data, onUpdate, onClose }: AssignTeamP
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -64,7 +64,6 @@ export function AssignTeamPanel({ nodeId, data, onUpdate, onClose }: AssignTeamP
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.teams.length > 0) {
       const updatedData: AssignTeamNodeData = {
@@ -75,79 +74,80 @@ export function AssignTeamPanel({ nodeId, data, onUpdate, onClose }: AssignTeamP
     }
   }, [formDataOptions, data, nodeId, onUpdate]);
 
+  const dirty = useMemo(() => teamId !== originalTeamId, [teamId, originalTeamId]);
+  const isValid = Boolean(teamId);
+
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.assignTeam.title')}
-      icon={<Users className="w-5 h-5 text-indigo-500" />}
-      onClose={onClose}
-      width="w-[420px]"
+      icon={<Users className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      {/* Seleção de Equipe */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">{t('panels.assignTeam.team')}</Label>
-        <Select value={teamId} onValueChange={setTeamId} disabled={loading}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
-            <SelectValue
-              placeholder={
-                loading ? t('panels.assignTeam.loadingTeams') : t('panels.assignTeam.selectTeam')
-              }
-            />
-          </SelectTrigger>
-          <SelectContent className="bg-sidebar border-sidebar-border">
-            {formDataOptions.teams.map(team => (
-              <SelectItem
-                key={team.id}
-                value={team.id.toString()}
-                className="text-sidebar-foreground"
-              >
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 rounded-full bg-indigo-500 flex items-center justify-center text-white text-xs font-medium">
-                    <Users className="w-4 h-4" />
-                  </div>
-                  <div>
-                    <div className="font-medium">{team.name}</div>
-                    <div className="text-xs text-sidebar-foreground/60">
-                      {team.description || t('panels.assignTeam.defaultDescription')}
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.assignTeam.team')}
+          </Label>
+          <Select value={teamId} onValueChange={setTeamId} disabled={loading}>
+            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectValue
+                placeholder={
+                  loading ? t('panels.assignTeam.loadingTeams') : t('panels.assignTeam.selectTeam')
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {formDataOptions.teams.map(team => (
+                <SelectItem
+                  key={team.id}
+                  value={team.id.toString()}
+                  className="text-sidebar-foreground"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-full bg-flow-node-action-pipeline-bg text-flow-node-action-pipeline-fg flex items-center justify-center text-xs font-medium">
+                      <Users className="w-4 h-4" />
+                    </div>
+                    <div>
+                      <div className="font-medium">{team.name}</div>
+                      <div className="text-xs text-sidebar-foreground/60">
+                        {team.description || t('panels.assignTeam.defaultDescription')}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-        {!loading && formDataOptions.teams.length === 0 && (
-          <p className="text-sm text-sidebar-foreground/60">
-            {t('panels.assignTeam.noTeamsFound')}
-          </p>
+          {!loading && formDataOptions.teams.length === 0 && (
+            <p className="text-sm text-sidebar-foreground/60">
+              {t('panels.assignTeam.noTeamsFound')}
+            </p>
+          )}
+        </div>
+
+        {teamId && (
+          <FlowFeedbackBanner variant="info">
+            <div className="flex items-center gap-2">
+              <Users className="w-4 h-4" />
+              <span>
+                {t('panels.assignTeam.conversationWillBeAssigned')}{' '}
+                <strong>
+                  {formDataOptions.teams.find(team => team.id.toString() === teamId)?.name ||
+                    `${t('panels.assignTeam.team')} #${teamId}`}
+                </strong>
+              </span>
+            </div>
+          </FlowFeedbackBanner>
         )}
       </div>
-
-      {/* Preview da ação */}
-      {teamId && (
-        <div className="p-3 rounded-lg bg-indigo-50 dark:bg-indigo-950/20 border border-indigo-200 dark:border-indigo-800/30">
-          <div className="flex items-center gap-2 text-sm">
-            <Users className="w-4 h-4 text-indigo-600" />
-            <span className="text-indigo-800 dark:text-indigo-200">
-              {t('panels.assignTeam.conversationWillBeAssigned')}{' '}
-              <strong>
-                {formDataOptions.teams.find(t => t.id.toString() === teamId)?.name ||
-                  `${t('panels.assignTeam.team')} #${teamId}`}
-              </strong>
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!teamId || loading}>
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/change-priority/ChangePriorityPanel.tsx
+++ b/src/components/journey/nodes/actions/change-priority/ChangePriorityPanel.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
@@ -11,7 +10,8 @@ import {
 import { AlertTriangle } from 'lucide-react';
 import { ChangePriorityNodeData } from './ChangePriorityNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface ChangePriorityPanelProps {
@@ -24,6 +24,7 @@ interface ChangePriorityPanelProps {
 export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangePriorityPanelProps) {
   const { t } = useLanguage('journey');
   const [priority, setPriority] = useState<string>(data.priority || '');
+  const [originalPriority] = useState<string>(() => data.priority || '');
   const [formDataOptions, setFormDataOptions] = useState<{
     priorities: Array<{ value: string; label: string }>;
   }>({
@@ -31,7 +32,6 @@ export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangeP
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -47,7 +47,6 @@ export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangeP
         });
       } catch (error) {
         console.error(t('panels.changePriority.loadDataError'), error);
-        // Use defaults if API fails
         setFormDataOptions({
           priorities: [
             { value: 'low', label: t('panels.changePriority.priorities.low') },
@@ -69,7 +68,6 @@ export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangeP
       ...data,
       priority: priority as 'low' | 'medium' | 'high' | 'urgent',
       formDataOptions,
-      // Backend compatibility - priority as params array
       action_params: priority ? [priority] : [],
     };
 
@@ -77,7 +75,6 @@ export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangeP
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.priorities.length > 0) {
       const updatedData: ChangePriorityNodeData = {
@@ -98,76 +95,66 @@ export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangeP
     return icons[value] || '❓';
   };
 
-  const getPriorityColor = (value: string) => {
-    const colors: { [key: string]: string } = {
-      low: 'text-blue-600 dark:text-blue-400',
-      medium: 'text-yellow-600 dark:text-yellow-400',
-      high: 'text-orange-600 dark:text-orange-400',
-      urgent: 'text-red-600 dark:text-red-400',
-    };
-    return colors[value] || 'text-gray-600 dark:text-gray-400';
-  };
+  const dirty = useMemo(() => priority !== originalPriority, [priority, originalPriority]);
+  const isValid = Boolean(priority);
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.changePriority.title')}
-      icon={<AlertTriangle className="w-5 h-5 text-indigo-500" />}
-      onClose={onClose}
-      width="w-[400px]"
+      icon={<AlertTriangle className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      {/* Seleção de prioridade */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.changePriority.newPriority')}
-        </Label>
-        <Select value={priority} onValueChange={setPriority} disabled={loading}>
-          <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
-            <SelectValue placeholder={t('panels.changePriority.selectPriority')} />
-          </SelectTrigger>
-          <SelectContent>
-            {(formDataOptions.priorities || []).map(priorityOption => (
-              <SelectItem key={priorityOption.value} value={priorityOption.value}>
-                <div className="flex items-center gap-2">
-                  <span>{getPriorityIcon(priorityOption.value)}</span>
-                  <span>{priorityOption.label}</span>
-                </div>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.changePriority.newPriority')}
+          </Label>
+          <Select value={priority} onValueChange={setPriority} disabled={loading}>
+            <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectValue placeholder={t('panels.changePriority.selectPriority')} />
+            </SelectTrigger>
+            <SelectContent>
+              {(formDataOptions.priorities || []).map(priorityOption => (
+                <SelectItem key={priorityOption.value} value={priorityOption.value}>
+                  <div className="flex items-center gap-2">
+                    <span>{getPriorityIcon(priorityOption.value)}</span>
+                    <span>{priorityOption.label}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-        <p className="text-xs text-sidebar-foreground/60">
-          {t('panels.changePriority.priorityAffectsOrder')}
-        </p>
-      </div>
+          <p className="text-xs text-sidebar-foreground/60">
+            {t('panels.changePriority.priorityAffectsOrder')}
+          </p>
+        </div>
 
-      {/* Preview da configuração */}
-      {priority && (
-        <div className="p-3 rounded-lg bg-indigo-50 dark:bg-indigo-950/20 border border-indigo-200 dark:border-indigo-800/30">
-          <div className="text-sm text-indigo-800 dark:text-indigo-200">
-            <div className="font-medium mb-2">
-              🎯 {t('panels.changePriority.configurationTitle')}
-            </div>
+        {priority && (
+          <FlowFeedbackBanner variant="info">
+            <div className="font-medium mb-2">🎯 {t('panels.changePriority.configurationTitle')}</div>
             <div className="flex items-center gap-3">
               <span className="text-2xl">{getPriorityIcon(priority)}</span>
               <div className="space-y-1">
-                <div className={`text-sm font-medium ${getPriorityColor(priority)}`}>
+                <div className="text-sm font-medium">
                   {formDataOptions.priorities.find(p => p.value === priority)?.label || priority}
                 </div>
-                <div className="text-xs text-indigo-700 dark:text-indigo-300">
-                  {t('panels.changePriority.conversationMarked')}
-                </div>
+                <div className="text-xs">{t('panels.changePriority.conversationMarked')}</div>
               </div>
             </div>
-          </div>
-        </div>
-      )}
+          </FlowFeedbackBanner>
+        )}
 
-      {/* Informações sobre prioridades */}
-      <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-        <div className="text-xs text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="info">
           <div className="font-medium mb-2">💡 {t('panels.changePriority.aboutPriorities')}</div>
-          <div className="space-y-2">
+          <div className="space-y-2 text-xs">
             <div className="flex items-center gap-2">
               <span>🔵</span>
               <span>
@@ -197,31 +184,18 @@ export function ChangePriorityPanel({ nodeId, data, onUpdate, onClose }: ChangeP
               </span>
             </div>
           </div>
-        </div>
-      </div>
+        </FlowFeedbackBanner>
 
-      {/* Casos de uso */}
-      <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/30">
-        <div className="text-xs text-amber-800 dark:text-amber-200">
+        <FlowFeedbackBanner variant="warn">
           <div className="font-medium mb-1">📋 {t('panels.changePriority.useCases')}</div>
-          <div className="space-y-1">
+          <div className="space-y-1 text-xs">
             <div>• {t('panels.changePriority.useCase1')}</div>
             <div>• {t('panels.changePriority.useCase2')}</div>
             <div>• {t('panels.changePriority.useCase3')}</div>
             <div>• {t('panels.changePriority.useCase4')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!priority || loading}>
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Button,
   Label,
@@ -8,7 +8,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
   Badge,
   Tabs,
   TabsContent,
@@ -17,7 +16,8 @@ import {
 } from '@evoapi/design-system';
 import { GitBranch, Plus, Trash2, Copy } from 'lucide-react';
 import { ConditionalNodeData, ConditionalPath, Condition } from './ConditionalNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableInput, VariableSelect } from '@/components/journey/environment-manager';
 import { v4 as uuidv4 } from 'uuid';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -30,12 +30,6 @@ interface ConditionalPanelProps {
   journeyId: string;
 }
 
-// Operadores serão traduzidos dinamicamente no componente
-
-// Campos de condição serão traduzidos dinamicamente no componente
-
-// Cores dos caminhos serão traduzidas dinamicamente no componente
-
 export function ConditionalPanel({
   nodeId,
   data,
@@ -44,12 +38,13 @@ export function ConditionalPanel({
   journeyId,
 }: ConditionalPanelProps) {
   const { t } = useLanguage('journey');
-  const [formData, setFormData] = useState<ConditionalNodeData>({
+  const initialFormData: ConditionalNodeData = {
     ...data,
     paths: data.paths || [],
-  });
+  };
+  const [originalData] = useState<ConditionalNodeData>(() => initialFormData);
+  const [formData, setFormData] = useState<ConditionalNodeData>(initialFormData);
 
-  // Constantes traduzidas dinamicamente
   const OPERATORS = [
     { value: 'equals', label: t('panels.conditional.operators.equals') },
     { value: 'not_equals', label: t('panels.conditional.operators.notEquals') },
@@ -79,7 +74,6 @@ export function ConditionalPanel({
       paths: data.paths || [],
     });
 
-    // Set first path as active if exists
     if (data.paths && data.paths.length > 0) {
       setActivePathId(data.paths[0].id);
     }
@@ -120,7 +114,6 @@ export function ConditionalPanel({
       paths: prev.paths.filter(path => path.id !== pathId),
     }));
 
-    // Set a new active path if we deleted the current one
     if (activePathId === pathId && formData.paths.length > 1) {
       const remainingPaths = formData.paths.filter(p => p.id !== pathId);
       if (remainingPaths.length > 0) {
@@ -192,6 +185,11 @@ export function ConditionalPanel({
     return !['is_empty', 'is_not_empty'].includes(operator);
   };
 
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
+
   const renderCondition = (pathId: string, condition: Condition, index: number) => {
     const path = formData.paths.find(p => p.id === pathId);
     if (!path) return null;
@@ -201,7 +199,6 @@ export function ConditionalPanel({
         key={condition.id}
         className="p-3 rounded-lg bg-sidebar-accent/10 border border-sidebar-border/30 space-y-3"
       >
-        {/* Operador lógico entre condições */}
         {index > 0 && (
           <div className="flex items-center gap-2 pb-2 border-b border-sidebar-border/30">
             <Badge variant="outline" className="text-xs">
@@ -213,7 +210,6 @@ export function ConditionalPanel({
         )}
 
         <div className="grid grid-cols-12 gap-2 items-end">
-          {/* Campo */}
           <div className="col-span-4">
             <Label className="text-xs">{t('panels.conditional.field')}</Label>
             <VariableSelect
@@ -226,7 +222,6 @@ export function ConditionalPanel({
             />
           </div>
 
-          {/* Operador */}
           <div className="col-span-3">
             <Label className="text-xs">{t('panels.conditional.operator')}</Label>
             <Select
@@ -250,7 +245,6 @@ export function ConditionalPanel({
             </Select>
           </div>
 
-          {/* Valor */}
           <div className="col-span-4">
             <Label className="text-xs">{t('panels.conditional.value')}</Label>
             {needsValue(condition.operator) ? (
@@ -265,19 +259,18 @@ export function ConditionalPanel({
                 }}
               />
             ) : (
-              <div className="h-10 flex items-center text-xs text-gray-500 italic px-3">
+              <div className="h-10 flex items-center text-xs text-muted-foreground italic px-3">
                 {t('panels.conditional.notNecessary')}
               </div>
             )}
           </div>
 
-          {/* Botão remover */}
           <div className="col-span-1">
             <Button
               variant="ghost"
               size="sm"
               onClick={() => removeCondition(pathId, condition.id)}
-              className="h-10 w-10 p-0 text-red-500 hover:text-red-700"
+              className="h-10 w-10 p-0 text-flow-feedback-error-fg hover:text-flow-feedback-error-fg"
             >
               <Trash2 className="w-4 h-4" />
             </Button>
@@ -292,7 +285,6 @@ export function ConditionalPanel({
 
     return (
       <div className="space-y-4">
-        {/* Header do Caminho */}
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="w-3 h-3 rounded-full" style={{ backgroundColor: pathColor.hex }} />
@@ -342,14 +334,13 @@ export function ConditionalPanel({
               variant="ghost"
               size="sm"
               onClick={() => removePath(path.id)}
-              className="h-8 w-8 p-0 text-red-500 hover:text-red-700"
+              className="h-8 w-8 p-0 text-flow-feedback-error-fg hover:text-flow-feedback-error-fg"
             >
               <Trash2 className="w-4 h-4" />
             </Button>
           </div>
         </div>
 
-        {/* Operador Lógico do Caminho */}
         <div className="flex items-center gap-2">
           <Label className="text-sm">
             {t('panels.conditional.logicalOperatorBetweenConditions')}
@@ -372,7 +363,6 @@ export function ConditionalPanel({
           </Select>
         </div>
 
-        {/* Botões para adicionar condições */}
         <div className="flex gap-2">
           <Button variant="outline" size="sm" onClick={() => addCondition(path.id, 'trigger')}>
             <Plus className="w-4 h-4 mr-1" />
@@ -392,14 +382,15 @@ export function ConditionalPanel({
           </Button>
         </div>
 
-        {/* Lista de Condições */}
         <div className="space-y-3">
           {path.conditions.length > 0 ? (
             path.conditions.map((condition, index) => renderCondition(path.id, condition, index))
           ) : (
-            <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
-              <p className="text-gray-500 text-sm">{t('panels.conditional.noConditionsAdded')}</p>
-              <p className="text-xs text-gray-400 mt-1">
+            <div className="p-4 rounded-lg border-2 border-dashed border-border bg-muted/40 text-center">
+              <p className="text-muted-foreground text-sm">
+                {t('panels.conditional.noConditionsAdded')}
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
                 {t('panels.conditional.clickButtonsToAdd')}
               </p>
             </div>
@@ -410,16 +401,19 @@ export function ConditionalPanel({
   };
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.conditional.title')}
-      icon={<GitBranch className="w-5 h-5 text-yellow-500" />}
-      onClose={onClose}
-      width="w-[800px]"
+      icon={<GitBranch className="h-5 w-5 text-flow-node-condition-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty}
+      saveLabel={t('actions.save')}
+      cancelLabel={t('actions.cancel')}
+      contentClassName="max-w-4xl"
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Gerenciamento de Caminhos */}
         <div className="flex items-center justify-between">
           <Label className="text-sidebar-foreground font-medium">
             {t('panels.conditional.pathsTitle')}
@@ -432,7 +426,6 @@ export function ConditionalPanel({
 
         {formData.paths.length > 0 ? (
           <>
-            {/* Tabs para navegar entre caminhos */}
             <Tabs value={activePathId} onValueChange={setActivePathId}>
               <TabsList
                 className="grid w-full"
@@ -461,9 +454,8 @@ export function ConditionalPanel({
               ))}
             </Tabs>
 
-            {/* Resumo */}
-            <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-              <Label className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2 block">
+            <FlowFeedbackBanner variant="info">
+              <Label className="text-sm font-medium mb-2 block">
                 {t('panels.conditional.summary.title')}
               </Label>
               <div className="space-y-2">
@@ -476,56 +468,46 @@ export function ConditionalPanel({
                           className="w-2 h-2 rounded-full"
                           style={{ backgroundColor: color.hex }}
                         />
-                        <span className="font-medium text-blue-700 dark:text-blue-300">
-                          {path.name}:
-                        </span>
+                        <span className="font-medium">{path.name}:</span>
                       </div>
                       {path.conditions.length > 0 ? (
-                        <div className="ml-4 text-xs text-blue-600 dark:text-blue-400">
+                        <div className="ml-4 text-xs">
                           {t('panels.conditional.summary.conditionsCount', {
                             count: path.conditions.length,
                             operator: path.logicalOperator,
                           })}
                         </div>
                       ) : (
-                        <div className="ml-4 text-xs text-gray-500">
+                        <div className="ml-4 text-xs text-muted-foreground">
                           {t('panels.conditional.summary.noConditionsConfigured')}
                         </div>
                       )}
                     </div>
                   );
                 })}
-                <div className="text-sm mt-2 pt-2 border-t border-blue-200 dark:border-blue-700">
-                  <span className="text-red-600 dark:text-red-400 font-medium">
+                <div className="text-sm mt-2 pt-2 border-t border-flow-feedback-info-border">
+                  <span className="text-flow-feedback-error-fg font-medium">
                     {t('panels.conditional.otherwiseCase')}:
                   </span>
-                  <span className="text-xs text-gray-600 dark:text-gray-400 ml-2">
+                  <span className="text-xs text-muted-foreground ml-2">
                     {t('panels.conditional.summary.otherwiseAlwaysAvailable')}
                   </span>
                 </div>
               </div>
-            </div>
+            </FlowFeedbackBanner>
           </>
         ) : (
-          <div className="p-6 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
-            <GitBranch className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-            <p className="text-gray-500">{t('panels.conditional.emptyState.noPathsConfigured')}</p>
-            <p className="text-xs text-gray-400 mt-1">
+          <div className="p-6 rounded-lg border-2 border-dashed border-border bg-muted/40 text-center">
+            <GitBranch className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+            <p className="text-muted-foreground">
+              {t('panels.conditional.emptyState.noPathsConfigured')}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
               {t('panels.conditional.emptyState.clickToCreateFirst')}
             </p>
           </div>
         )}
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10">
-          {t('actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/defer-conversation/DeferConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/defer-conversation/DeferConversationPanel.tsx
@@ -1,6 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Input,
   Select,
@@ -12,7 +11,8 @@ import {
 import { Clock } from 'lucide-react';
 import { DeferConversationNodeData } from './DeferConversationNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface DeferConversationPanelProps {
@@ -37,11 +37,15 @@ export function DeferConversationPanel({
     if (data.snooze_until) {
       return new Date(data.snooze_until).toISOString().slice(0, 16);
     }
-    // Default to 1 hour from now
     const defaultDate = new Date();
     defaultDate.setHours(defaultDate.getHours() + 1);
     return defaultDate.toISOString().slice(0, 16);
   });
+  const [originalSnapshot] = useState(() => ({
+    snoozeType: data.snooze_type || 'duration',
+    snoozeDuration: data.snooze_duration || 1,
+    snoozeUntil: data.snooze_until ? new Date(data.snooze_until).toISOString().slice(0, 16) : '',
+  }));
   const [formDataOptions, setFormDataOptions] = useState<{
     agents: any[];
     teams: any[];
@@ -51,7 +55,6 @@ export function DeferConversationPanel({
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -78,7 +81,6 @@ export function DeferConversationPanel({
       snooze_duration: snoozeType === 'duration' ? snoozeDuration : undefined,
       snooze_until: snoozeType === 'until_date' ? new Date(snoozeUntil).toISOString() : undefined,
       formDataOptions,
-      // Backend compatibility - snooze needs no parameters
       action_params: [],
     };
 
@@ -86,7 +88,6 @@ export function DeferConversationPanel({
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.agents.length > 0 || formDataOptions.teams.length > 0) {
       const updatedData: DeferConversationNodeData = {
@@ -102,87 +103,101 @@ export function DeferConversationPanel({
     return date > new Date();
   };
 
+  const isValid =
+    !(snoozeType === 'duration' && snoozeDuration < 1) &&
+    !(snoozeType === 'until_date' && (!snoozeUntil || !isValidDateTime(snoozeUntil)));
+
+  const dirty = useMemo(
+    () =>
+      snoozeType !== originalSnapshot.snoozeType ||
+      snoozeDuration !== originalSnapshot.snoozeDuration ||
+      snoozeUntil !== originalSnapshot.snoozeUntil,
+    [snoozeType, snoozeDuration, snoozeUntil, originalSnapshot],
+  );
+
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.deferConversation.title')}
-      icon={<Clock className="w-5 h-5 text-yellow-500" />}
-      onClose={onClose}
-      width="w-[420px]"
+      icon={<Clock className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('actions.save')}
+      cancelLabel={t('actions.cancel')}
     >
-      {/* Tipo de adiamento */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.deferConversation.defermentType')}
-        </Label>
-        <Select
-          value={snoozeType}
-          onValueChange={(value: 'duration' | 'until_date') => setSnoozeType(value)}
-          disabled={loading}
-        >
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent className="bg-sidebar border-sidebar-border">
-            <SelectItem value="duration" className="text-sidebar-foreground">
-              {t('panels.deferConversation.types.duration')}
-            </SelectItem>
-            <SelectItem value="until_date" className="text-sidebar-foreground">
-              {t('panels.deferConversation.types.until_date')}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-
-      {/* Configuração por duração */}
-      {snoozeType === 'duration' && (
+      <div className="space-y-4">
         <div className="space-y-2">
           <Label className="text-sidebar-foreground font-medium">
-            {t('panels.deferConversation.duration.label')}
+            {t('panels.deferConversation.defermentType')}
           </Label>
-          <Input
-            type="number"
-            value={snoozeDuration}
-            onChange={e => setSnoozeDuration(Math.max(1, parseInt(e.target.value) || 1))}
-            min="1"
-            max="8760"
-            className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+          <Select
+            value={snoozeType}
+            onValueChange={(value: 'duration' | 'until_date') => setSnoozeType(value)}
             disabled={loading}
-          />
-          <p className="text-xs text-sidebar-foreground/60">
-            {t('panels.deferConversation.duration.min')}
-          </p>
+          >
+            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              <SelectItem value="duration" className="text-sidebar-foreground">
+                {t('panels.deferConversation.types.duration')}
+              </SelectItem>
+              <SelectItem value="until_date" className="text-sidebar-foreground">
+                {t('panels.deferConversation.types.until_date')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </div>
-      )}
 
-      {/* Configuração por data */}
-      {snoozeType === 'until_date' && (
-        <div className="space-y-2">
-          <Label className="text-sidebar-foreground font-medium">
-            {t('panels.deferConversation.dateTime.label')}
-          </Label>
-          <Input
-            type="datetime-local"
-            value={snoozeUntil}
-            onChange={e => setSnoozeUntil(e.target.value)}
-            className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-            disabled={loading}
-          />
-          {snoozeUntil && !isValidDateTime(snoozeUntil) && (
-            <p className="text-xs text-red-600">
-              {t('panels.deferConversation.dateTime.futureError')}
+        {snoozeType === 'duration' && (
+          <div className="space-y-2">
+            <Label className="text-sidebar-foreground font-medium">
+              {t('panels.deferConversation.duration.label')}
+            </Label>
+            <Input
+              type="number"
+              value={snoozeDuration}
+              onChange={e => setSnoozeDuration(Math.max(1, parseInt(e.target.value) || 1))}
+              min="1"
+              max="8760"
+              className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+              disabled={loading}
+            />
+            <p className="text-xs text-sidebar-foreground/60">
+              {t('panels.deferConversation.duration.min')}
             </p>
-          )}
-          <p className="text-xs text-sidebar-foreground/60">
-            {t('panels.deferConversation.dateTime.description')}
-          </p>
-        </div>
-      )}
+          </div>
+        )}
 
-      {/* Preview da configuração */}
-      {(snoozeType === 'duration' && snoozeDuration > 0) ||
-      (snoozeType === 'until_date' && snoozeUntil && isValidDateTime(snoozeUntil)) ? (
-        <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-          <div className="text-sm text-yellow-800 dark:text-yellow-200">
+        {snoozeType === 'until_date' && (
+          <div className="space-y-2">
+            <Label className="text-sidebar-foreground font-medium">
+              {t('panels.deferConversation.dateTime.label')}
+            </Label>
+            <Input
+              type="datetime-local"
+              value={snoozeUntil}
+              onChange={e => setSnoozeUntil(e.target.value)}
+              className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+              disabled={loading}
+            />
+            {snoozeUntil && !isValidDateTime(snoozeUntil) && (
+              <FlowFeedbackBanner variant="error">
+                <p className="text-xs">{t('panels.deferConversation.dateTime.futureError')}</p>
+              </FlowFeedbackBanner>
+            )}
+            <p className="text-xs text-sidebar-foreground/60">
+              {t('panels.deferConversation.dateTime.description')}
+            </p>
+          </div>
+        )}
+
+        {((snoozeType === 'duration' && snoozeDuration > 0) ||
+          (snoozeType === 'until_date' && snoozeUntil && isValidDateTime(snoozeUntil))) && (
+          <FlowFeedbackBanner variant="warn">
             <div className="font-medium mb-1">{t('panels.deferConversation.preview.title')}</div>
             <div className="text-xs">
               {snoozeType === 'duration' ? (
@@ -208,40 +223,19 @@ export function DeferConversationPanel({
                 />
               )}
             </div>
-          </div>
-        </div>
-      ) : null}
+          </FlowFeedbackBanner>
+        )}
 
-      {/* Informações sobre adiamento */}
-      <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-        <div className="text-xs text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="info">
           <div className="font-medium mb-1">{t('panels.deferConversation.info.title')}</div>
-          <div className="space-y-1">
+          <div className="space-y-1 text-xs">
             <div>{t('panels.deferConversation.info.point1')}</div>
             <div>{t('panels.deferConversation.info.point2')}</div>
             <div>{t('panels.deferConversation.info.point3')}</div>
             <div>{t('panels.deferConversation.info.point4')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('actions.cancel')}
-        </Button>
-        <Button
-          onClick={handleSave}
-          className="flex-1 h-10"
-          disabled={
-            loading ||
-            (snoozeType === 'duration' && snoozeDuration < 1) ||
-            (snoozeType === 'until_date' && (!snoozeUntil || !isValidDateTime(snoozeUntil)))
-          }
-        >
-          {t('actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
-import { Button } from '@evoapi/design-system';
+import { useEffect, useState } from 'react';
 import { VolumeX } from 'lucide-react';
 import { MuteConversationNodeData } from './MuteConversationNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface MuteConversationPanelProps {
@@ -29,7 +29,6 @@ export function MuteConversationPanel({
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -53,7 +52,6 @@ export function MuteConversationPanel({
     const updatedData: MuteConversationNodeData = {
       ...data,
       formDataOptions,
-      // Backend compatibility - mute needs no parameters
       action_params: [],
     };
 
@@ -61,7 +59,6 @@ export function MuteConversationPanel({
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.agents.length > 0 || formDataOptions.teams.length > 0) {
       const updatedData: MuteConversationNodeData = {
@@ -73,61 +70,48 @@ export function MuteConversationPanel({
   }, [formDataOptions, data, nodeId, onUpdate]);
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.muteConversation.title')}
-      icon={<VolumeX className="w-5 h-5 text-orange-500" />}
-      onClose={onClose}
-      width="w-[400px]"
+      icon={<VolumeX className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={!loading}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      {/* Explicação da ação */}
       <div className="space-y-4">
-        <div className="p-3 rounded-lg bg-orange-50 dark:bg-orange-950/20 border border-orange-200 dark:border-orange-800/30">
-          <div className="text-sm text-orange-800 dark:text-orange-200">
-            <div className="font-medium mb-2">🔇 {t('panels.muteConversation.whatHappens')}</div>
-            <div className="space-y-2 text-xs">
-              <div>• {t('panels.muteConversation.noNotifications')}</div>
-              <div>• {t('panels.muteConversation.messagesKeepComing')}</div>
-              <div>• {t('panels.muteConversation.mutedStatus')}</div>
-              <div>• {t('panels.muteConversation.agentsCanUnmute')}</div>
-            </div>
+        <FlowFeedbackBanner variant="warn">
+          <div className="font-medium mb-2">🔇 {t('panels.muteConversation.whatHappens')}</div>
+          <div className="space-y-1 text-xs">
+            <div>• {t('panels.muteConversation.noNotifications')}</div>
+            <div>• {t('panels.muteConversation.messagesKeepComing')}</div>
+            <div>• {t('panels.muteConversation.mutedStatus')}</div>
+            <div>• {t('panels.muteConversation.agentsCanUnmute')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
 
-        {/* Informações técnicas */}
-        <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <div className="text-xs text-blue-800 dark:text-blue-200">
-            <div className="font-medium mb-1">💡 {t('panels.muteConversation.whenToUse')}</div>
-            <div className="space-y-1">
-              <div>• {t('panels.muteConversation.automatedConversations')}</div>
-              <div>• {t('panels.muteConversation.reduceNoise')}</div>
-              <div>• {t('panels.muteConversation.fullAutomation')}</div>
-              <div>• {t('panels.muteConversation.testing')}</div>
-            </div>
+        <FlowFeedbackBanner variant="info">
+          <div className="font-medium mb-1">💡 {t('panels.muteConversation.whenToUse')}</div>
+          <div className="space-y-1 text-xs">
+            <div>• {t('panels.muteConversation.automatedConversations')}</div>
+            <div>• {t('panels.muteConversation.reduceNoise')}</div>
+            <div>• {t('panels.muteConversation.fullAutomation')}</div>
+            <div>• {t('panels.muteConversation.testing')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
 
-        {/* Aviso importante */}
-        <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/30">
-          <div className="text-xs text-amber-800 dark:text-amber-200">
-            <div className="font-medium mb-1">⚠️ {t('panels.muteConversation.important')}</div>
-            <div className="space-y-1">
-              <div>• {t('panels.muteConversation.cannotUndo')}</div>
-              <div>• {t('panels.muteConversation.agentsNeedManualUnmute')}</div>
-              <div>• {t('panels.muteConversation.useWithCare')}</div>
-            </div>
+        <FlowFeedbackBanner variant="warn">
+          <div className="font-medium mb-1">⚠️ {t('panels.muteConversation.important')}</div>
+          <div className="space-y-1 text-xs">
+            <div>• {t('panels.muteConversation.cannotUndo')}</div>
+            <div>• {t('panels.muteConversation.agentsNeedManualUnmute')}</div>
+            <div>• {t('panels.muteConversation.useWithCare')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={loading}>
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/remove-label/RemoveLabelPanel.tsx
+++ b/src/components/journey/nodes/actions/remove-label/RemoveLabelPanel.tsx
@@ -1,17 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
 } from '@evoapi/design-system';
 import { Tag, X } from 'lucide-react';
 import { RemoveLabelNodeData } from './RemoveLabelNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { labelsService } from '@/services/contacts/labelsService';
 import type { Label as LabelType } from '@/types/settings';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -25,9 +24,8 @@ interface RemoveLabelPanelProps {
 
 export function RemoveLabelPanel({ nodeId, data, onUpdate, onClose }: RemoveLabelPanelProps) {
   const { t } = useLanguage('journey');
-  const [formData, setFormData] = useState<RemoveLabelNodeData>({
-    ...data,
-  });
+  const [originalData] = useState<RemoveLabelNodeData>(() => ({ ...data }));
+  const [formData, setFormData] = useState<RemoveLabelNodeData>({ ...data });
   const [labels, setLabels] = useState<LabelType[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,12 +54,6 @@ export function RemoveLabelPanel({ nodeId, data, onUpdate, onClose }: RemoveLabe
   };
 
   const handleSave = () => {
-    // Validação básica
-    if (!formData.labelId) {
-      alert(t('panels.removeLabel.selectLabelAlert'));
-      return;
-    }
-
     onUpdate(nodeId, formData);
     onClose();
   };
@@ -77,36 +69,39 @@ export function RemoveLabelPanel({ nodeId, data, onUpdate, onClose }: RemoveLabe
     }));
   };
 
-  const isValid = formData.labelId && formData.labelName;
+  const isValid = Boolean(formData.labelId && formData.labelName);
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.removeLabel.title')}
       icon={
         <div className="relative">
-          <Tag className="w-5 h-5 text-red-500" />
-          <X className="w-3 h-3 text-red-500 absolute -top-1 -right-1" />
+          <Tag className="h-5 w-5 text-flow-node-action-label-fg" />
+          <X className="h-3 w-3 text-flow-node-action-label-fg absolute -top-1 -right-1" />
         </div>
       }
-      onClose={onClose}
-      width="w-[600px]"
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.removeLabel.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.removeLabel.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               <li>{t('panels.removeLabel.selectLabel')}</li>
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Seleção da etiqueta */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.removeLabel.labelToRemove')}</Label>
           <Select
@@ -144,17 +139,15 @@ export function RemoveLabelPanel({ nodeId, data, onUpdate, onClose }: RemoveLabe
           </Select>
         </div>
 
-        {/* Erro ao carregar */}
         {error && (
-          <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
-            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-          </div>
+          <FlowFeedbackBanner variant="error">
+            <p>{error}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Preview da etiqueta selecionada */}
         {formData.labelId && formData.labelName && (
-          <div className="p-4 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
-            <p className="text-sm text-red-800 dark:text-red-200 mb-2">
+          <FlowFeedbackBanner variant="error">
+            <p className="mb-2">
               <strong>{t('panels.removeLabel.selectedLabel')}:</strong>
             </p>
             <div className="flex items-center gap-2">
@@ -164,30 +157,17 @@ export function RemoveLabelPanel({ nodeId, data, onUpdate, onClose }: RemoveLabe
               />
               <span className="font-medium">{formData.labelName}</span>
             </div>
-            <p className="text-xs text-red-600 dark:text-red-400 mt-2">
-              {t('panels.removeLabel.description')}
-            </p>
-          </div>
+            <p className="text-xs mt-2">{t('panels.removeLabel.description')}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Ajuda */}
-        <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="warn">
+          <p>
             <strong>⚠️ {t('panels.removeLabel.warning')}:</strong>{' '}
             {t('panels.removeLabel.warningDescription')}
           </p>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid ? t('panels.actions.save') : t('panels.removeLabel.selectLabelButton')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
-import { Button } from '@evoapi/design-system';
+import { useEffect, useState } from 'react';
 import { CheckCircle } from 'lucide-react';
 import { ResolveConversationNodeData } from './ResolveConversationNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface ResolveConversationPanelProps {
@@ -29,7 +29,6 @@ export function ResolveConversationPanel({
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -53,7 +52,6 @@ export function ResolveConversationPanel({
     const updatedData: ResolveConversationNodeData = {
       ...data,
       formDataOptions,
-      // Backend compatibility - resolve needs no parameters
       action_params: [],
     };
 
@@ -61,7 +59,6 @@ export function ResolveConversationPanel({
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.agents.length > 0 || formDataOptions.teams.length > 0) {
       const updatedData: ResolveConversationNodeData = {
@@ -73,62 +70,49 @@ export function ResolveConversationPanel({
   }, [formDataOptions, data, nodeId, onUpdate]);
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.resolveConversation.title')}
-      icon={<CheckCircle className="w-5 h-5 text-green-500" />}
-      onClose={onClose}
-      width="w-[400px]"
+      icon={<CheckCircle className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={!loading}
+      loading={loading}
+      saveLabel={t('actions.save')}
+      cancelLabel={t('actions.cancel')}
     >
-      {/* Explicação da ação */}
       <div className="space-y-4">
-        <div className="p-3 rounded-lg bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-800/30">
-          <div className="text-sm text-green-800 dark:text-green-200">
-            <div className="font-medium mb-2">✅ {t('panels.resolveConversation.whatHappens')}</div>
-            <div className="space-y-2 text-xs">
-              <div>• {t('panels.resolveConversation.conversationMarked')}</div>
-              <div>• {t('panels.resolveConversation.automaticallyArchived')}</div>
-              <div>• {t('panels.resolveConversation.stopsNotifications')}</div>
-              <div>• {t('panels.resolveConversation.availableInHistory')}</div>
-              <div>• {t('panels.resolveConversation.newMessagesReopen')}</div>
-            </div>
+        <FlowFeedbackBanner variant="success">
+          <div className="font-medium mb-2">✅ {t('panels.resolveConversation.whatHappens')}</div>
+          <div className="space-y-1 text-xs">
+            <div>• {t('panels.resolveConversation.conversationMarked')}</div>
+            <div>• {t('panels.resolveConversation.automaticallyArchived')}</div>
+            <div>• {t('panels.resolveConversation.stopsNotifications')}</div>
+            <div>• {t('panels.resolveConversation.availableInHistory')}</div>
+            <div>• {t('panels.resolveConversation.newMessagesReopen')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
 
-        {/* Informações técnicas */}
-        <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <div className="text-xs text-blue-800 dark:text-blue-200">
-            <div className="font-medium mb-1">💡 {t('panels.resolveConversation.whenToUse')}</div>
-            <div className="space-y-1">
-              <div>• {t('panels.resolveConversation.endOfSuccessfulFlows')}</div>
-              <div>• {t('panels.resolveConversation.problemSolved')}</div>
-              <div>• {t('panels.resolveConversation.noFollowUpNeeded')}</div>
-              <div>• {t('panels.resolveConversation.organizationProcesses')}</div>
-            </div>
+        <FlowFeedbackBanner variant="info">
+          <div className="font-medium mb-1">💡 {t('panels.resolveConversation.whenToUse')}</div>
+          <div className="space-y-1 text-xs">
+            <div>• {t('panels.resolveConversation.endOfSuccessfulFlows')}</div>
+            <div>• {t('panels.resolveConversation.problemSolved')}</div>
+            <div>• {t('panels.resolveConversation.noFollowUpNeeded')}</div>
+            <div>• {t('panels.resolveConversation.organizationProcesses')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
 
-        {/* Aviso importante */}
-        <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/30">
-          <div className="text-xs text-amber-800 dark:text-amber-200">
-            <div className="font-medium mb-1">⚠️ {t('panels.resolveConversation.important')}</div>
-            <div className="space-y-1">
-              <div>• {t('panels.resolveConversation.actionPermanent')}</div>
-              <div>• {t('panels.resolveConversation.useWhenSure')}</div>
-              <div>• {t('panels.resolveConversation.clientCanMessage')}</div>
-            </div>
+        <FlowFeedbackBanner variant="warn">
+          <div className="font-medium mb-1">⚠️ {t('panels.resolveConversation.important')}</div>
+          <div className="space-y-1 text-xs">
+            <div>• {t('panels.resolveConversation.actionPermanent')}</div>
+            <div>• {t('panels.resolveConversation.useWhenSure')}</div>
+            <div>• {t('panels.resolveConversation.clientCanMessage')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={loading}>
-          {t('actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/scheduled-action/ScheduledActionPanel.tsx
+++ b/src/components/journey/nodes/actions/scheduled-action/ScheduledActionPanel.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from 'react';
-import { Clock, AlertCircle } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Clock } from 'lucide-react';
 import {
-  Button,
   Label,
   Separator,
   Input,
@@ -11,7 +10,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@evoapi/design-system';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 import { journeyService } from '@/services/journeys';
 import InboxesService from '@/services/channels/inboxesService';
@@ -26,7 +26,6 @@ interface ScheduledActionPanelProps {
   onClose: () => void;
 }
 
-// Map backend channel types to simple identifiers
 const CHANNEL_TYPE_MAP: Record<string, string> = {
   'Channel::WhatsappCloud': 'whatsapp',
   'Channel::Sms': 'sms',
@@ -34,7 +33,6 @@ const CHANNEL_TYPE_MAP: Record<string, string> = {
   'Channel::Telegram': 'telegram',
 };
 
-// Helper function to get channel display name
 const getChannelDisplayName = (channelType: string): string => {
   const simpleType = CHANNEL_TYPE_MAP[channelType];
   switch (simpleType) {
@@ -51,15 +49,6 @@ const getChannelDisplayName = (channelType: string): string => {
   }
 };
 
-/**
- * Configuration panel for Scheduled Action node in journey builder.
- *
- * Action types supported (from EVO-195 - See docs/scheduled-actions-types.md):
- * - send_message: Send a message with channel selector (WhatsApp, SMS, Email)
- * - execute_webhook: Call an external webhook
- * - trigger_journey: Start another journey
- * - create_task: Create a task/reminder
- */
 export function ScheduledActionPanel({
   nodeId,
   data,
@@ -67,7 +56,7 @@ export function ScheduledActionPanel({
   onClose,
 }: ScheduledActionPanelProps) {
   const { t } = useLanguage('journey');
-  const [formData, setFormData] = useState<ScheduledActionNodeData>({
+  const initialFormData: ScheduledActionNodeData = {
     label: data.label || 'Schedule Action',
     delayDuration: data.delayDuration || 1,
     delayUnit: data.delayUnit || 'hours',
@@ -76,7 +65,9 @@ export function ScheduledActionPanel({
     retryPolicy: data.retryPolicy || { maxRetries: 0, backoffMultiplier: 1 },
     createScheduledAction: data.createScheduledAction || true,
     notifyUserId: data.notifyUserId,
-  });
+  };
+  const [originalData] = useState<ScheduledActionNodeData>(() => initialFormData);
+  const [formData, setFormData] = useState<ScheduledActionNodeData>(initialFormData);
   const [error] = useState<string | null>(null);
   const [journeys, setJourneys] = useState<Journey[]>([]);
   const [loadingJourneys, setLoadingJourneys] = useState(false);
@@ -96,7 +87,6 @@ export function ScheduledActionPanel({
     });
   }, [data]);
 
-  // Fetch journeys when component mounts
   useEffect(() => {
     const loadJourneys = async () => {
       try {
@@ -113,7 +103,6 @@ export function ScheduledActionPanel({
     loadJourneys();
   }, []);
 
-  // Fetch available inboxes when component mounts
   useEffect(() => {
     const fetchInboxes = async () => {
       setLoadingInboxes(true);
@@ -121,7 +110,6 @@ export function ScheduledActionPanel({
         const response = await InboxesService.list();
         const inboxes = response.data || [];
 
-        // Filter inboxes that support sending messages
         const messagingInboxes = inboxes.filter(inbox => {
           const channelType = inbox.channel_type;
           return Object.keys(CHANNEL_TYPE_MAP).includes(channelType);
@@ -138,7 +126,7 @@ export function ScheduledActionPanel({
     fetchInboxes();
   }, []);
 
-  const handleUpdate = () => {
+  const handleSave = () => {
     onUpdate(nodeId, formData);
     onClose();
   };
@@ -209,7 +197,6 @@ export function ScheduledActionPanel({
     });
   };
 
-  // Check if configuration is complete
   const isDelayConfigured = formData.delayDuration && formData.delayUnit;
   const isActionConfigured = () => {
     if (!formData.actionType) return false;
@@ -238,22 +225,31 @@ export function ScheduledActionPanel({
     }
   };
 
-  const isConfigured = isDelayConfigured && isActionConfigured();
+  const isConfigured = Boolean(isDelayConfigured && isActionConfigured());
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.scheduledAction.title')}
-      onClose={onClose}
-      icon={<Clock className="w-5 h-5 text-orange-500" />}
+      icon={<Clock className="h-5 w-5 text-flow-node-action-webhook-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isConfigured}
+      saveLabel="Save"
+      cancelLabel="Close"
     >
       <div className="space-y-4">
         {error && (
-          <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
-            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-          </div>
+          <FlowFeedbackBanner variant="error">
+            <p>{error}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Delay Duration */}
         <div className="space-y-2">
           <Label>{t('panels.scheduledAction.delayDuration')}</Label>
           <div className="flex gap-2">
@@ -269,7 +265,7 @@ export function ScheduledActionPanel({
             <select
               value={formData.delayUnit || 'hours'}
               onChange={handleUnitChange}
-              className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm"
+              className="flex-1 px-3 py-2 border border-input rounded-md bg-background text-foreground text-sm"
             >
               <option value="minutes">{t('panels.scheduledAction.units.minutes')}</option>
               <option value="hours">{t('panels.scheduledAction.units.hours')}</option>
@@ -281,13 +277,12 @@ export function ScheduledActionPanel({
 
         <Separator />
 
-        {/* Action Type */}
         <div className="space-y-2">
           <Label>{t('panels.scheduledAction.actionType')}</Label>
           <select
             value={formData.actionType || ''}
             onChange={handleActionTypeChange}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm"
+            className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground text-sm"
           >
             <option value="">Select an action</option>
             <option value="send_message">{t('panels.scheduledAction.actions.send_message')}</option>
@@ -301,7 +296,6 @@ export function ScheduledActionPanel({
           </select>
         </div>
 
-        {/* CONDITIONAL: Send Message */}
         {formData.actionType === 'send_message' && (
           <>
             <Separator />
@@ -317,14 +311,12 @@ export function ScheduledActionPanel({
                 >
                   <SelectTrigger>
                     <SelectValue
-                      placeholder={
-                        loadingInboxes ? 'Loading channels...' : 'Select a channel'
-                      }
+                      placeholder={loadingInboxes ? 'Loading channels...' : 'Select a channel'}
                     />
                   </SelectTrigger>
                   <SelectContent>
                     {availableInboxes.length === 0 && !loadingInboxes && (
-                      <div className="px-2 py-1.5 text-sm text-gray-500">
+                      <div className="px-2 py-1.5 text-sm text-muted-foreground">
                         No channels configured
                       </div>
                     )}
@@ -341,9 +333,11 @@ export function ScheduledActionPanel({
                   </SelectContent>
                 </Select>
                 {availableInboxes.length === 0 && !loadingInboxes && (
-                  <p className="text-sm text-amber-600 dark:text-amber-400">
-                    {t('panels.scheduledAction.messages.noChannelsConfigured')}
-                  </p>
+                  <FlowFeedbackBanner variant="warn">
+                    <p className="text-sm">
+                      {t('panels.scheduledAction.messages.noChannelsConfigured')}
+                    </p>
+                  </FlowFeedbackBanner>
                 )}
               </div>
               <div className="space-y-2">
@@ -355,9 +349,9 @@ export function ScheduledActionPanel({
                   }
                   placeholder={t('panels.scheduledAction.placeholders.message')}
                   rows={3}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm font-mono"
+                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground text-sm font-mono"
                 />
-                <p className="text-xs text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-muted-foreground">
                   {formData.actionConfig?.message?.length || 0} characters
                 </p>
               </div>
@@ -365,7 +359,6 @@ export function ScheduledActionPanel({
           </>
         )}
 
-        {/* CONDITIONAL: Execute Webhook */}
         {formData.actionType === 'execute_webhook' && (
           <>
             <Separator />
@@ -391,7 +384,7 @@ export function ScheduledActionPanel({
                   onChange={e =>
                     handleWebhookChange(formData.actionConfig?.webhook_url || '', e.target.value)
                   }
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm"
+                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground text-sm"
                 >
                   <option value="GET">GET</option>
                   <option value="POST">POST</option>
@@ -403,7 +396,6 @@ export function ScheduledActionPanel({
           </>
         )}
 
-        {/* CONDITIONAL: Trigger Journey */}
         {formData.actionType === 'trigger_journey' && (
           <>
             <Separator />
@@ -412,7 +404,7 @@ export function ScheduledActionPanel({
               <select
                 value={formData.actionConfig?.journey_id || ''}
                 onChange={e => handleTriggerJourneyChange(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm"
+                className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground text-sm"
                 disabled={loadingJourneys}
               >
                 <option value="">
@@ -424,14 +416,13 @@ export function ScheduledActionPanel({
                   </option>
                 ))}
               </select>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 {t('panels.scheduledAction.hints.journeyId')}
               </p>
             </div>
           </>
         )}
 
-        {/* CONDITIONAL: Create Task */}
         {formData.actionType === 'create_task' && (
           <>
             <Separator />
@@ -459,35 +450,19 @@ export function ScheduledActionPanel({
                   }
                   placeholder={t('panels.scheduledAction.placeholders.taskDescription')}
                   rows={3}
-                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-sm"
+                  className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground text-sm"
                 />
               </div>
             </div>
           </>
         )}
 
-        {/* Configuration Status */}
         {!isConfigured && formData.actionType && (
-          <div className="bg-orange-50 dark:bg-orange-950/20 border border-orange-200 dark:border-orange-800/30 rounded-md p-3 flex gap-2">
-            <AlertCircle className="w-4 h-4 text-orange-600 dark:text-orange-400 flex-shrink-0 mt-0.5" />
-            <p className="text-xs text-orange-800 dark:text-orange-200">
-              {t('panels.scheduledAction.configure')}
-            </p>
-          </div>
+          <FlowFeedbackBanner variant="warn">
+            <p className="text-xs">{t('panels.scheduledAction.configure')}</p>
+          </FlowFeedbackBanner>
         )}
-
-        <Separator />
-
-        {/* Action Buttons */}
-        <div className="flex gap-2 pt-2">
-          <Button onClick={handleUpdate} disabled={!isConfigured} className="flex-1">
-            Save
-          </Button>
-          <Button onClick={onClose} variant="outline" className="flex-1">
-            Close
-          </Button>
-        </div>
       </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/send-email-team/SendEmailTeamPanel.tsx
+++ b/src/components/journey/nodes/actions/send-email-team/SendEmailTeamPanel.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
-import { Button, Label, Textarea, Checkbox } from '@evoapi/design-system';
+import { useEffect, useMemo, useState } from 'react';
+import { Label, Textarea, Checkbox } from '@evoapi/design-system';
 import { Mail } from 'lucide-react';
 import { SendEmailTeamNodeData } from './SendEmailTeamNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface SendEmailTeamPanelProps {
@@ -19,6 +20,10 @@ export function SendEmailTeamPanel({ nodeId, data, onUpdate, onClose }: SendEmai
     data.team_ids?.map(id => id.toString()) || [],
   );
   const [message, setMessage] = useState<string>(data.message || '');
+  const [originalSnapshot] = useState(() => ({
+    selectedTeams: (data.team_ids?.map(id => id.toString()) || []).slice().sort().join(','),
+    message: data.message || '',
+  }));
   const [formDataOptions, setFormDataOptions] = useState<{
     teams: any[];
   }>({
@@ -26,7 +31,6 @@ export function SendEmailTeamPanel({ nodeId, data, onUpdate, onClose }: SendEmai
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -72,7 +76,6 @@ export function SendEmailTeamPanel({ nodeId, data, onUpdate, onClose }: SendEmai
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.teams.length > 0) {
       const updatedData: SendEmailTeamNodeData = {
@@ -83,97 +86,103 @@ export function SendEmailTeamPanel({ nodeId, data, onUpdate, onClose }: SendEmai
     }
   }, [formDataOptions, data, nodeId, onUpdate]);
 
-  const getCharacterCount = () => {
-    return message.length;
-  };
+  const getCharacterCount = () => message.length;
 
   const getCharacterCountColor = () => {
     const count = getCharacterCount();
-    if (count > 500) return 'text-red-600';
-    if (count > 400) return 'text-orange-600';
+    if (count > 500) return 'text-flow-feedback-error-fg';
+    if (count > 400) return 'text-flow-feedback-warn-fg';
     return 'text-sidebar-foreground/60';
   };
 
-  return (
-    <BaseFlowPanel
-      title={t('panels.sendEmailTeam.title')}
-      icon={<Mail className="w-5 h-5 text-purple-500" />}
-      onClose={onClose}
-      width="w-[420px]"
-    >
-      {/* Seleção de Equipes */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.sendEmailTeam.teams')}
-        </Label>
+  const isValid = selectedTeams.length > 0 && message.trim().length > 0 && getCharacterCount() <= 500;
+  const dirty = useMemo(() => {
+    const currentTeamsKey = selectedTeams.slice().sort().join(',');
+    return currentTeamsKey !== originalSnapshot.selectedTeams || message !== originalSnapshot.message;
+  }, [selectedTeams, message, originalSnapshot]);
 
-        {loading ? (
-          <div className="text-sm text-sidebar-foreground/60">
-            {t('panels.sendEmailTeam.loadingTeams')}
-          </div>
-        ) : (
-          <div className="space-y-2 max-h-48 overflow-y-auto">
-            {formDataOptions.teams.length === 0 ? (
-              <p className="text-sm text-sidebar-foreground/60">
-                {t('panels.sendEmailTeam.noTeamsFound')}
-              </p>
-            ) : (
-              formDataOptions.teams.map(team => (
-                <div
-                  key={team.id}
-                  className="flex items-center space-x-3 p-2 rounded-md hover:bg-sidebar-accent cursor-pointer"
-                  onClick={() => handleTeamToggle(team.id.toString())}
-                >
-                  <Checkbox
-                    checked={selectedTeams.includes(team.id.toString())}
-                    onCheckedChange={() => handleTeamToggle(team.id.toString())}
-                  />
-                  <div className="flex items-center gap-2 flex-1">
-                    <div className="w-8 h-8 rounded-full bg-purple-500 flex items-center justify-center text-white text-xs font-medium">
-                      <Mail className="w-4 h-4" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-sidebar-foreground">{team.name}</div>
-                      <div className="text-xs text-sidebar-foreground/60">
-                        {team.description || t('panels.sendEmailTeam.node.defaultTeamDescription')}
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.sendEmailTeam.title')}
+      icon={<Mail className="h-5 w-5 text-flow-node-action-message-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('actions.save')}
+      cancelLabel={t('actions.cancel')}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.sendEmailTeam.teams')}
+          </Label>
+
+          {loading ? (
+            <div className="text-sm text-sidebar-foreground/60">
+              {t('panels.sendEmailTeam.loadingTeams')}
+            </div>
+          ) : (
+            <div className="space-y-2 max-h-48 overflow-y-auto">
+              {formDataOptions.teams.length === 0 ? (
+                <p className="text-sm text-sidebar-foreground/60">
+                  {t('panels.sendEmailTeam.noTeamsFound')}
+                </p>
+              ) : (
+                formDataOptions.teams.map(team => (
+                  <div
+                    key={team.id}
+                    className="flex items-center space-x-3 p-2 rounded-md hover:bg-sidebar-accent cursor-pointer"
+                    onClick={() => handleTeamToggle(team.id.toString())}
+                  >
+                    <Checkbox
+                      checked={selectedTeams.includes(team.id.toString())}
+                      onCheckedChange={() => handleTeamToggle(team.id.toString())}
+                    />
+                    <div className="flex items-center gap-2 flex-1">
+                      <div className="w-8 h-8 rounded-full bg-flow-node-action-message-bg text-flow-node-action-message-fg flex items-center justify-center text-xs font-medium">
+                        <Mail className="w-4 h-4" />
+                      </div>
+                      <div>
+                        <div className="font-medium text-sidebar-foreground">{team.name}</div>
+                        <div className="text-xs text-sidebar-foreground/60">
+                          {team.description || t('panels.sendEmailTeam.node.defaultTeamDescription')}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-              ))
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Campo de Mensagem */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.sendEmailTeam.messageLabel')}
-        </Label>
-        <Textarea
-          value={message}
-          onChange={e => setMessage(e.target.value)}
-          placeholder={t('panels.sendEmailTeam.messagePlaceholder')}
-          className="min-h-[100px] resize-none bg-sidebar border-sidebar-border text-sidebar-foreground placeholder:text-sidebar-foreground/50"
-          disabled={loading}
-        />
-
-        {/* Contador de caracteres */}
-        <div className="flex justify-between items-center text-xs">
-          <span className="text-sidebar-foreground/50">
-            {t('panels.sendEmailTeam.messageHelp')}
-          </span>
-          <span className={getCharacterCountColor()}>
-            {t('panels.sendEmailTeam.characterCount', { count: getCharacterCount() })}
-          </span>
+                ))
+              )}
+            </div>
+          )}
         </div>
-      </div>
 
-      {/* Preview das equipes selecionadas */}
-      {selectedTeams.length > 0 && (
-        <div className="p-3 rounded-lg bg-purple-50 dark:bg-purple-950/20 border border-purple-200 dark:border-purple-800/30">
-          <div className="text-sm text-purple-800 dark:text-purple-200">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.sendEmailTeam.messageLabel')}
+          </Label>
+          <Textarea
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            placeholder={t('panels.sendEmailTeam.messagePlaceholder')}
+            className="min-h-[100px] resize-none bg-sidebar border-sidebar-border text-sidebar-foreground placeholder:text-sidebar-foreground/50"
+            disabled={loading}
+          />
+
+          <div className="flex justify-between items-center text-xs">
+            <span className="text-sidebar-foreground/50">
+              {t('panels.sendEmailTeam.messageHelp')}
+            </span>
+            <span className={getCharacterCountColor()}>
+              {t('panels.sendEmailTeam.characterCount', { count: getCharacterCount() })}
+            </span>
+          </div>
+        </div>
+
+        {selectedTeams.length > 0 && (
+          <FlowFeedbackBanner variant="info">
             <div className="font-medium mb-1">
               {t('panels.sendEmailTeam.preview.title')}{' '}
               {selectedTeams.length === 1
@@ -181,52 +190,31 @@ export function SendEmailTeamPanel({ nodeId, data, onUpdate, onClose }: SendEmai
                 : t('panels.sendEmailTeam.preview.multipleTeams', { count: selectedTeams.length })}
               :
             </div>
-            <div className="space-y-1">
+            <div className="space-y-1 text-xs">
               {selectedTeams.slice(0, 3).map(teamId => {
-                const team = formDataOptions.teams.find(t => t.id.toString() === teamId);
+                const team = formDataOptions.teams.find(team => team.id.toString() === teamId);
                 return (
-                  <div key={teamId} className="text-xs">
-                    📧 {team?.name || `Equipe #${teamId}`}
-                  </div>
+                  <div key={teamId}>📧 {team?.name || `Equipe #${teamId}`}</div>
                 );
               })}
               {selectedTeams.length > 3 && (
-                <div className="text-xs text-purple-600 dark:text-purple-400">
+                <div className="text-xs">
                   {t('panels.sendEmailTeam.preview.moreTeams', { count: selectedTeams.length - 3 })}
                 </div>
               )}
             </div>
-          </div>
-        </div>
-      )}
+          </FlowFeedbackBanner>
+        )}
 
-      {/* Informações sobre o email */}
-      <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-        <div className="text-xs text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="info">
           <div className="font-medium mb-1">{t('panels.sendEmailTeam.info.title')}</div>
-          <div className="space-y-1">
+          <div className="space-y-1 text-xs">
             <div>{t('panels.sendEmailTeam.info.point1')}</div>
             <div>{t('panels.sendEmailTeam.info.point2')}</div>
             <div>{t('panels.sendEmailTeam.info.point3')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('actions.cancel')}
-        </Button>
-        <Button
-          onClick={handleSave}
-          className="flex-1 h-10"
-          disabled={
-            selectedTeams.length === 0 || !message.trim() || loading || getCharacterCount() > 500
-          }
-        >
-          {t('actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
   Select,
@@ -6,7 +6,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
   Badge,
   Card,
   Label,
@@ -26,7 +25,8 @@ import {
   Send,
 } from 'lucide-react';
 import { SendMessageNodeData } from './SendMessageNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { automationService } from '@/services/automation/automationService';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -48,7 +48,6 @@ interface AttachmentFile {
   uploadProgress?: number;
 }
 
-// Tipos de inbox permitidos
 const ALLOWED_INBOX_TYPES = [
   'Channel::Email',
   'Channel::Whatsapp',
@@ -63,7 +62,6 @@ const ALLOWED_INBOX_TYPES = [
   'Channel::Twilio',
 ];
 
-// Ícones para cada tipo de inbox
 const getInboxIcon = (channelType: string) => {
   switch (channelType) {
     case 'Channel::Email':
@@ -123,7 +121,7 @@ const getChannelTypeName = (channelType: string) => {
 export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessagePanelProps) {
   const { t } = useLanguage('journey');
 
-  const [formData, setFormData] = useState<SendMessageNodeData>({
+  const initialFormData: SendMessageNodeData = {
     ...data,
     message: data.message || '',
     inboxId: data.inboxId || '',
@@ -133,7 +131,9 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
     attachment_ids: data.attachment_ids || [],
     attachment_names: data.attachment_names || [],
     attachment_count: data.attachment_count || 0,
-  });
+  };
+  const [originalData] = useState<SendMessageNodeData>(() => initialFormData);
+  const [formData, setFormData] = useState<SendMessageNodeData>(initialFormData);
 
   const [attachments, setAttachments] = useState<AttachmentFile[]>([]);
   const [formDataOptions, setFormDataOptions] = useState<{
@@ -144,7 +144,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
   const [isDragOver, setIsDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -152,7 +151,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
         const formDataResponse = await automationService.getFormData();
         setFormDataOptions(formDataResponse);
 
-        // Filtrar apenas inboxes dos tipos permitidos
         if (formDataResponse.inboxes) {
           const filtered = formDataResponse.inboxes.filter((inbox: any) =>
             ALLOWED_INBOX_TYPES.includes(inbox.channel_type),
@@ -160,7 +158,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           setFilteredInboxes(filtered);
         }
 
-        // Load existing attachments if any
         if (data.attachment_ids && data.attachment_names) {
           const existingAttachments = data.attachment_ids.map((id, index) => ({
             id: id.toString(),
@@ -184,7 +181,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
 
   const handleFileSelect = (files: FileList) => {
     Array.from(files).forEach(file => {
-      // Check file size (max 10MB)
       if (file.size > 10 * 1024 * 1024) {
         toast.error(t('panels.sendMessage.fileTooLarge', { fileName: file.name }));
         return;
@@ -207,7 +203,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
 
   const uploadFile = async (_file: File, tempId: string) => {
     try {
-      // Simulate upload progress
       for (let progress = 0; progress <= 100; progress += 10) {
         setAttachments(prev =>
           prev.map(att => (att.id === tempId ? { ...att, uploadProgress: progress } : att)),
@@ -215,7 +210,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
         await new Promise(resolve => setTimeout(resolve, 100));
       }
 
-      // Simulate successful upload
       const uploadedId = `uploaded-${Date.now()}`;
       setAttachments(prev =>
         prev.map(att => (att.id === tempId ? { ...att, id: uploadedId, status: 'uploaded' } : att)),
@@ -266,27 +260,12 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
   };
 
   const handleSave = () => {
-    if (!formData.message?.trim()) {
-      toast.error(t('panels.sendMessage.enterMessage'));
-      return;
-    }
-
-    if (!formData.useEventChannel && !formData.inboxId) {
-      toast.error(t('panels.sendMessage.selectChannelOrEvent'));
-      return;
-    }
-
-    if (formData.message.length > 1000) {
-      toast.error(t('panels.sendMessage.messageTooLong'));
-      return;
-    }
-
     const uploadedAttachments = attachments.filter(att => att.status === 'uploaded');
     const hasAttachments = uploadedAttachments.length > 0;
 
     const updatedData: SendMessageNodeData = {
       ...formData,
-      message: formData.message.trim(),
+      message: formData.message!.trim(),
       hasAttachment: hasAttachments,
       attachment_ids: hasAttachments ? uploadedAttachments.map(att => att.id) : [],
       attachment_names: hasAttachments ? uploadedAttachments.map(att => att.name) : [],
@@ -310,8 +289,8 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
   const getCharacterCount = () => formData.message?.length || 0;
   const getCharacterCountColor = () => {
     const count = getCharacterCount();
-    if (count > 1000) return 'text-red-600';
-    if (count > 800) return 'text-orange-600';
+    if (count > 1000) return 'text-flow-feedback-error-fg';
+    if (count > 800) return 'text-flow-feedback-warn-fg';
     return 'text-muted-foreground';
   };
 
@@ -323,24 +302,31 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
     getCharacterCount() <= 1000 &&
     !hasUploading
   );
+  const dirty = useMemo(
+    () =>
+      JSON.stringify(formData) !== JSON.stringify(originalData) ||
+      attachments.some(att => att.id.startsWith('uploaded-') || att.id.startsWith('temp-')),
+    [formData, originalData, attachments],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.sendMessage.title')}
-      icon={<MessageSquare className="w-5 h-5 text-blue-500" />}
-      onClose={onClose}
-      width="w-[500px]"
+      icon={<MessageSquare className="h-5 w-5 text-flow-node-action-message-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+      contentClassName="max-w-3xl"
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.sendMessage.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.sendMessage.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               {!formData.message?.trim() && <li>{t('panels.sendMessage.enterMessage')}</li>}
               {!formData.useEventChannel && !formData.inboxId && (
                 <li>{t('panels.sendMessage.selectChannelOrEvent')}</li>
@@ -348,10 +334,9 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
               {getCharacterCount() > 1000 && <li>{t('panels.sendMessage.messageTooLong')}</li>}
               {hasUploading && <li>{t('panels.sendMessage.waitingUpload')}</li>}
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Opção de usar canal do evento */}
         <div className="space-y-3">
           <div className="flex items-center space-x-2">
             <Checkbox
@@ -361,7 +346,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
                 setFormData(prev => ({
                   ...prev,
                   useEventChannel: !!checked,
-                  // Limpar seleção manual quando marcar para usar evento
                   inboxId: checked ? '' : prev.inboxId,
                   inboxName: checked ? '' : prev.inboxName,
                 }));
@@ -376,14 +360,13 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           </p>
         </div>
 
-        {/* Seleção do Canal */}
         {!formData.useEventChannel && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">{t('panels.sendMessage.sendChannel')}</Label>
 
             {loading ? (
-              <div className="flex items-center justify-center p-8 border-2 border-dashed rounded-lg">
-                <div className="animate-spin w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full mr-2" />
+              <div className="flex items-center justify-center p-8 border-2 border-dashed border-border rounded-lg">
+                <div className="animate-spin w-6 h-6 border-2 border-flow-node-action-message-fg border-t-transparent rounded-full mr-2" />
                 <span className="text-sm text-muted-foreground">
                   {t('panels.sendMessage.loadingChannels')}
                 </span>
@@ -426,7 +409,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           </div>
         )}
 
-        {/* Campo da Mensagem */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.sendMessage.message')}</Label>
           <VariableTextarea
@@ -436,7 +418,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
             className="min-h-[120px] resize-none"
             disabled={loading}
             onVariableInsert={variable => {
-              // A variável já foi inserida pelo componente, apenas logamos para debug se necessário
               console.log('Variable inserted:', variable);
             }}
           />
@@ -447,19 +428,15 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           </div>
         </div>
 
-        {/* Seção de Anexos */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.sendMessage.attachments')}</Label>
 
           <div
-            className={`
-              border-2 border-dashed rounded-lg p-4 text-center transition-colors
-              ${
-                isDragOver
-                  ? 'border-blue-500 bg-blue-50 dark:bg-blue-950/20'
-                  : 'border-border hover:border-blue-400'
-              }
-            `}
+            className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${
+              isDragOver
+                ? 'border-flow-node-action-message-fg bg-flow-node-action-message-bg'
+                : 'border-border hover:border-flow-node-action-message-border'
+            }`}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
@@ -489,7 +466,6 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           </div>
         </div>
 
-        {/* Lista de Anexos */}
         {attachments.length > 0 && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">
@@ -499,17 +475,17 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
               {attachments.map(attachment => (
                 <div
                   key={attachment.id}
-                  className="flex items-center gap-3 p-2 rounded-md bg-muted/30 border"
+                  className="flex items-center gap-3 p-2 rounded-md bg-muted/30 border border-border"
                 >
                   <div className="flex-shrink-0">
                     {attachment.status === 'uploading' && (
-                      <div className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                      <div className="w-4 h-4 border-2 border-flow-node-action-message-fg border-t-transparent rounded-full animate-spin" />
                     )}
                     {attachment.status === 'uploaded' && (
-                      <CheckCircle className="w-4 h-4 text-green-500" />
+                      <CheckCircle className="w-4 h-4 text-flow-feedback-success-fg" />
                     )}
                     {attachment.status === 'error' && (
-                      <AlertCircle className="w-4 h-4 text-red-500" />
+                      <AlertCircle className="w-4 h-4 text-flow-feedback-error-fg" />
                     )}
                   </div>
 
@@ -527,78 +503,51 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
                     </div>
                   </div>
 
-                  {/* eslint-disable-next-line no-restricted-syntax -- pre-EVO-1253 raw <button>; migration to <Button> tracked by EVO-1274 [10.4] modal refactor. */}
-                  <button
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     onClick={() => removeAttachment(attachment.id)}
-                    className="flex-shrink-0 p-1 rounded-md hover:bg-red-100 dark:hover:bg-red-900/20 text-red-500"
+                    className="flex-shrink-0 h-7 w-7 text-flow-feedback-error-fg hover:text-flow-feedback-error-fg"
+                    aria-label={t('panels.sendMessage.removeAttachmentLabel') || 'Remove attachment'}
                   >
                     <X className="w-3 h-3" />
-                  </button>
+                  </Button>
                 </div>
               ))}
             </div>
           </div>
         )}
 
-        {/* Preview da Configuração */}
         {formData.message?.trim() && (
-          <>
-            <Separator />
-            <div className="space-y-4">
-              <div className="flex items-center gap-2">
-                <MessageSquare className="w-4 h-4 text-blue-500" />
-                <h4 className="text-sm font-medium">{t('panels.sendMessage.previewTitle')}</h4>
-              </div>
+          <FlowFeedbackBanner variant="info">
+            <div className="flex items-start gap-3">
+              <MessageSquare className="w-4 h-4 mt-1 shrink-0" />
+              <div className="flex-1">
+                <p className="font-medium">{t('panels.sendMessage.messageConfigured')}</p>
+                <p className="text-sm mt-1">"{formData.message.trim()}"</p>
 
-              <Card className="p-4 bg-blue-50 dark:bg-blue-950/10 border-blue-200 dark:border-blue-800">
-                <div className="space-y-3">
-                  <div className="flex items-start gap-3">
-                    <div className="w-8 h-8 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center flex-shrink-0">
-                      <MessageSquare className="w-4 h-4 text-blue-600" />
-                    </div>
-                    <div className="flex-1">
-                      <p className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                        {t('panels.sendMessage.messageConfigured')}
-                      </p>
-                      <p className="text-sm text-blue-800 dark:text-blue-200 mt-1">
-                        "{formData.message.trim()}"
-                      </p>
+                {(formData.useEventChannel || formData.inboxName) && (
+                  <Badge variant="outline" className="mt-2">
+                    {t('panels.sendMessage.channel')}:{' '}
+                    {formData.useEventChannel
+                      ? t('panels.sendMessage.eventChannel')
+                      : formData.inboxName}
+                  </Badge>
+                )}
 
-                      {(formData.useEventChannel || formData.inboxName) && (
-                        <Badge variant="outline" className="mt-2">
-                          {t('panels.sendMessage.channel')}:{' '}
-                          {formData.useEventChannel
-                            ? t('panels.sendMessage.eventChannel')
-                            : formData.inboxName}
-                        </Badge>
-                      )}
-
-                      {uploadedCount > 0 && (
-                        <div className="mt-2 flex items-center gap-1 text-xs text-blue-700 dark:text-blue-300">
-                          <Paperclip className="w-3 h-3" />
-                          {uploadedCount === 1
-                            ? t('panels.sendMessage.oneAttachment')
-                            : t('panels.sendMessage.multipleAttachments', { count: uploadedCount })}
-                        </div>
-                      )}
-                    </div>
+                {uploadedCount > 0 && (
+                  <div className="mt-2 flex items-center gap-1 text-xs">
+                    <Paperclip className="w-3 h-3" />
+                    {uploadedCount === 1
+                      ? t('panels.sendMessage.oneAttachment')
+                      : t('panels.sendMessage.multipleAttachments', { count: uploadedCount })}
                   </div>
-                </div>
-              </Card>
+                )}
+              </div>
             </div>
-          </>
+          </FlowFeedbackBanner>
         )}
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid ? t('panels.actions.save') : t('panels.sendMessage.completeConfig')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/send-transcript/SendTranscriptPanel.tsx
+++ b/src/components/journey/nodes/actions/send-transcript/SendTranscriptPanel.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
-import { Button, Label, Input } from '@evoapi/design-system';
+import { useEffect, useMemo, useState } from 'react';
+import { Label, Input } from '@evoapi/design-system';
 import { FileText } from 'lucide-react';
 import { SendTranscriptNodeData } from './SendTranscriptNode';
 import { automationService } from '@/services/automation/automationService';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface SendTranscriptPanelProps {
@@ -17,6 +18,10 @@ export function SendTranscriptPanel({ nodeId, data, onUpdate, onClose }: SendTra
   const { t } = useLanguage('journey');
   const [email, setEmail] = useState<string>(data.email || '');
   const [subject, setSubject] = useState<string>(data.subject || '');
+  const [originalSnapshot] = useState(() => ({
+    email: data.email || '',
+    subject: data.subject || '',
+  }));
   const [formDataOptions, setFormDataOptions] = useState<{
     teams: any[];
     agents: any[];
@@ -26,7 +31,6 @@ export function SendTranscriptPanel({ nodeId, data, onUpdate, onClose }: SendTra
   });
   const [loading, setLoading] = useState(true);
 
-  // Load form data options on mount
   useEffect(() => {
     const loadFormData = async () => {
       try {
@@ -52,7 +56,6 @@ export function SendTranscriptPanel({ nodeId, data, onUpdate, onClose }: SendTra
       email: email.trim(),
       subject: subject.trim(),
       formDataOptions,
-      // Backend compatibility - save email as params array like Vue
       action_params: [email.trim()],
     };
 
@@ -60,7 +63,6 @@ export function SendTranscriptPanel({ nodeId, data, onUpdate, onClose }: SendTra
     onClose();
   };
 
-  // Update node with form data when available
   useEffect(() => {
     if (formDataOptions.teams.length > 0 || formDataOptions.agents.length > 0) {
       const updatedData: SendTranscriptNodeData = {
@@ -71,124 +73,110 @@ export function SendTranscriptPanel({ nodeId, data, onUpdate, onClose }: SendTra
     }
   }, [formDataOptions, data, nodeId, onUpdate]);
 
-  const getCharacterCount = (text: string) => {
-    return text.length;
-  };
+  const getCharacterCount = (text: string) => text.length;
 
   const getCharacterCountColor = (text: string, max: number) => {
     const count = getCharacterCount(text);
-    if (count > max) return 'text-red-600';
-    if (count > max * 0.8) return 'text-orange-600';
+    if (count > max) return 'text-flow-feedback-error-fg';
+    if (count > max * 0.8) return 'text-flow-feedback-warn-fg';
     return 'text-sidebar-foreground/60';
   };
 
-  const isValidEmail = (email: string) => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-  };
+  const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+  const isValid =
+    email.trim().length > 0 && isValidEmail(email) && getCharacterCount(subject) <= 100;
+  const dirty = useMemo(
+    () => email !== originalSnapshot.email || subject !== originalSnapshot.subject,
+    [email, subject, originalSnapshot],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.sendTranscript.title')}
-      icon={<FileText className="w-5 h-5 text-teal-500" />}
-      onClose={onClose}
-      width="w-[420px]"
+      icon={<FileText className="h-5 w-5 text-flow-node-action-message-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      {/* Campo de Email */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.sendTranscript.destinationEmail')}
-        </Label>
-        <Input
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-          placeholder={t('panels.sendTranscript.emailPlaceholder')}
-          className="bg-sidebar border-sidebar-border text-sidebar-foreground placeholder:text-sidebar-foreground/50"
-          disabled={loading}
-          type="email"
-        />
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.sendTranscript.destinationEmail')}
+          </Label>
+          <Input
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            placeholder={t('panels.sendTranscript.emailPlaceholder')}
+            className="bg-sidebar border-sidebar-border text-sidebar-foreground placeholder:text-sidebar-foreground/50"
+            disabled={loading}
+            type="email"
+          />
 
-        {email && !isValidEmail(email) && (
-          <p className="text-xs text-red-600">{t('panels.sendTranscript.invalidEmail')}</p>
-        )}
+          {email && !isValidEmail(email) && (
+            <FlowFeedbackBanner variant="error">
+              <p className="text-xs">{t('panels.sendTranscript.invalidEmail')}</p>
+            </FlowFeedbackBanner>
+          )}
 
-        <p className="text-xs text-sidebar-foreground/60">
-          {t('panels.sendTranscript.emailDescription')}
-        </p>
-      </div>
-
-      {/* Campo de Assunto */}
-      <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('panels.sendTranscript.emailSubject')}
-        </Label>
-        <Input
-          value={subject}
-          onChange={e => setSubject(e.target.value)}
-          placeholder={t('panels.sendTranscript.subjectPlaceholder')}
-          className="bg-sidebar border-sidebar-border text-sidebar-foreground placeholder:text-sidebar-foreground/50"
-          disabled={loading}
-        />
-
-        {/* Contador de caracteres */}
-        <div className="flex justify-between items-center text-xs">
-          <span className="text-sidebar-foreground/50">
-            {t('panels.sendTranscript.variablesHint')}
-          </span>
-          <span className={getCharacterCountColor(subject, 100)}>
-            {t('panels.sendTranscript.characterCount', { count: getCharacterCount(subject) })}
-          </span>
+          <p className="text-xs text-sidebar-foreground/60">
+            {t('panels.sendTranscript.emailDescription')}
+          </p>
         </div>
-      </div>
 
-      {/* Preview da configuração */}
-      {email && isValidEmail(email) && (
-        <div className="p-3 rounded-lg bg-teal-50 dark:bg-teal-950/20 border border-teal-200 dark:border-teal-800/30">
-          <div className="text-sm text-teal-800 dark:text-teal-200">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.sendTranscript.emailSubject')}
+          </Label>
+          <Input
+            value={subject}
+            onChange={e => setSubject(e.target.value)}
+            placeholder={t('panels.sendTranscript.subjectPlaceholder')}
+            className="bg-sidebar border-sidebar-border text-sidebar-foreground placeholder:text-sidebar-foreground/50"
+            disabled={loading}
+          />
+
+          <div className="flex justify-between items-center text-xs">
+            <span className="text-sidebar-foreground/50">
+              {t('panels.sendTranscript.variablesHint')}
+            </span>
+            <span className={getCharacterCountColor(subject, 100)}>
+              {t('panels.sendTranscript.characterCount', { count: getCharacterCount(subject) })}
+            </span>
+          </div>
+        </div>
+
+        {email && isValidEmail(email) && (
+          <FlowFeedbackBanner variant="info">
             <div className="font-medium mb-1">{t('panels.sendTranscript.previewTitle')}</div>
-            <div className="space-y-1">
-              <div className="text-xs">
+            <div className="space-y-1 text-xs">
+              <div>
                 <strong>{t('panels.sendTranscript.previewToLabel')}</strong> {email}
               </div>
               {subject && (
-                <div className="text-xs">
+                <div>
                   <strong>{t('panels.sendTranscript.previewSubjectLabel')}</strong>{' '}
                   {subject || t('panels.sendTranscript.previewDefaultSubject')}
                 </div>
               )}
             </div>
-          </div>
-        </div>
-      )}
+          </FlowFeedbackBanner>
+        )}
 
-      {/* Informações sobre a transcrição */}
-      <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-        <div className="text-xs text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="info">
           <div className="font-medium mb-1">{t('panels.sendTranscript.transcriptInfo.title')}</div>
-          <div className="space-y-1">
+          <div className="space-y-1 text-xs">
             <div>• {t('panels.sendTranscript.transcriptInfo.includesMessages')}</div>
             <div>• {t('panels.sendTranscript.transcriptInfo.includesMetadata')}</div>
             <div>• {t('panels.sendTranscript.transcriptInfo.formatHTML')}</div>
             <div>• {t('panels.sendTranscript.transcriptInfo.processedOnExecution')}</div>
           </div>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de Ação */}
-      <div className="flex gap-3 pt-4">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button
-          onClick={handleSave}
-          className="flex-1 h-10"
-          disabled={
-            !email.trim() || !isValidEmail(email) || loading || getCharacterCount(subject) > 100
-          }
-        >
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/send-webhook/SendWebhookPanel.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/SendWebhookPanel.tsx
@@ -1,16 +1,9 @@
-import { useState, useEffect } from 'react';
-import {
-  Button,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-  Separator,
-  Label,
-} from '@evoapi/design-system';
-import { Send, Globe, Settings, Lock, FileText, Play, ArrowRight } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Label } from '@evoapi/design-system';
+import { Send, Play, ArrowRight } from 'lucide-react';
 import { SendWebhookNodeData, WebhookResponseMapping } from './SendWebhookNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableSelect } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
@@ -49,7 +42,7 @@ export function SendWebhookPanel({
   journeyId,
 }: SendWebhookPanelProps) {
   const { t } = useLanguage('journey');
-  const [formData, setFormData] = useState<SendWebhookNodeData>({
+  const initialFormData: SendWebhookNodeData = {
     ...data,
     method: data.method || 'POST',
     timeout: data.timeout || 30,
@@ -57,14 +50,15 @@ export function SendWebhookPanel({
     bodyType: data.bodyType || 'json',
     authenticationType: data.authenticationType || 'none',
     headers: data.headers || [],
-  });
+  };
+  const [originalData] = useState<SendWebhookNodeData>(() => initialFormData);
+  const [formData, setFormData] = useState<SendWebhookNodeData>(initialFormData);
 
-  const [activeTab, setActiveTab] = useState('basic');
   const [testResponse, setTestResponse] = useState<WebhookResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [testError, setTestError] = useState<string | null>(null);
   const [responseMappings, setResponseMappings] = useState<ResponseMapping[]>([]);
-  const [hasChanges, setHasChanges] = useState(false);
+  const [hasMappingChanges, setHasMappingChanges] = useState(false);
 
   useEffect(() => {
     setFormData({
@@ -77,46 +71,16 @@ export function SendWebhookPanel({
       headers: data.headers || [],
     });
 
-    // Carregar mapeamentos salvos
     if (data.responseMappings) {
       setResponseMappings(data.responseMappings.map(mapping => ({ ...mapping })));
     } else {
       setResponseMappings([]);
     }
 
-    setHasChanges(false);
+    setHasMappingChanges(false);
   }, [data]);
 
   const handleSave = () => {
-    // Validação básica
-    if (!formData.webhookUrl) {
-      alert(t('panels.sendWebhook.urlRequired'));
-      return;
-    }
-
-    // Validação de autenticação
-    if (formData.authenticationType === 'bearer' && !formData.authToken) {
-      alert(t('panels.sendWebhook.bearerTokenRequired'));
-      return;
-    }
-
-    if (
-      formData.authenticationType === 'basic' &&
-      (!formData.authUsername || !formData.authPassword)
-    ) {
-      alert(t('panels.sendWebhook.basicAuthRequired'));
-      return;
-    }
-
-    if (
-      formData.authenticationType === 'api_key' &&
-      (!formData.authApiKey || !formData.authApiKeyHeader)
-    ) {
-      alert(t('panels.sendWebhook.apiKeyRequired'));
-      return;
-    }
-
-    // Salvar com os mapeamentos
     const dataToSave = {
       ...formData,
       responseMappings: responseMappings
@@ -138,10 +102,7 @@ export function SendWebhookPanel({
   };
 
   const handleTestWebhook = async () => {
-    if (!formData.webhookUrl) {
-      alert(t('panels.sendWebhook.configureUrlFirst'));
-      return;
-    }
+    if (!formData.webhookUrl) return;
 
     setIsLoading(true);
     setTestError(null);
@@ -150,7 +111,6 @@ export function SendWebhookPanel({
     const startTime = Date.now();
 
     try {
-      // Preparar headers
       const headers: Record<string, string> = {
         'Content-Type':
           formData.bodyType === 'json'
@@ -162,7 +122,6 @@ export function SendWebhookPanel({
             : 'text/plain',
       };
 
-      // Adicionar headers customizados
       if (formData.headers) {
         formData.headers.forEach(header => {
           if (header.key && header.value) {
@@ -171,7 +130,6 @@ export function SendWebhookPanel({
         });
       }
 
-      // Adicionar autenticação
       if (formData.authenticationType === 'bearer' && formData.authToken) {
         headers['Authorization'] = `Bearer ${formData.authToken}`;
       } else if (
@@ -189,7 +147,6 @@ export function SendWebhookPanel({
         headers[formData.authApiKeyHeader] = formData.authApiKey;
       }
 
-      // Preparar body
       let body = undefined;
       if (formData.method !== 'GET' && formData.body) {
         if (formData.bodyType === 'json') {
@@ -204,7 +161,6 @@ export function SendWebhookPanel({
         }
       }
 
-      // Fazer a requisição
       const response = await fetch(formData.webhookUrl, {
         method: formData.method || 'POST',
         headers,
@@ -283,19 +239,19 @@ export function SendWebhookPanel({
       description: '',
     };
     setResponseMappings(prev => [...prev, newMapping]);
-    setHasChanges(true);
+    setHasMappingChanges(true);
   };
 
   const updateResponseMapping = (id: string, updates: Partial<ResponseMapping>) => {
     setResponseMappings(prev =>
       prev.map(mapping => (mapping.id === id ? { ...mapping, ...updates } : mapping)),
     );
-    setHasChanges(true);
+    setHasMappingChanges(true);
   };
 
   const removeResponseMapping = (id: string) => {
     setResponseMappings(prev => prev.filter(mapping => mapping.id !== id));
-    setHasChanges(true);
+    setHasMappingChanges(true);
   };
 
   const getValidationStatus = () => {
@@ -326,351 +282,319 @@ export function SendWebhookPanel({
 
   const validationIssues = getValidationStatus();
   const isValid = validationIssues.length === 0;
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData) || hasMappingChanges,
+    [formData, originalData, hasMappingChanges],
+  );
 
-  return (
-    <BaseFlowPanel
-      title={t('panels.sendWebhook.title')}
-      icon={<Send className="w-5 h-5 text-purple-500" />}
-      onClose={onClose}
-      width="w-[800px]"
-    >
-      <Separator />
+  const validationBanner =
+    !isValid && (
+      <FlowFeedbackBanner variant="warn">
+        <p className="font-medium">{t('panels.sendWebhook.incompleteConfig')}:</p>
+        <ul className="text-xs mt-1 list-disc list-inside">
+          {validationIssues.map((issue, index) => (
+            <li key={index}>{issue}</li>
+          ))}
+        </ul>
+      </FlowFeedbackBanner>
+    );
 
-      <div className="space-y-4">
-        {/* Status de validação */}
-        {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.sendWebhook.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
-              {validationIssues.map((issue, index) => (
-                <li key={index}>{issue}</li>
-              ))}
-            </ul>
+  const basicTab = (
+    <div className="space-y-4">
+      {validationBanner}
+      <WebhookBasicConfig
+        data={formData}
+        onChange={handleFormDataChange}
+        journeyId={journeyId}
+      />
+    </div>
+  );
+
+  const headersTab = (
+    <div className="space-y-4">
+      {validationBanner}
+      <WebhookHeadersConfig
+        data={formData}
+        onChange={handleFormDataChange}
+        journeyId={journeyId}
+      />
+    </div>
+  );
+
+  const bodyTab = (
+    <div className="space-y-4">
+      {validationBanner}
+      <WebhookBodyConfig data={formData} onChange={handleFormDataChange} journeyId={journeyId} />
+    </div>
+  );
+
+  const authTab = (
+    <div className="space-y-4">
+      {validationBanner}
+      <WebhookAuthConfig data={formData} onChange={handleFormDataChange} journeyId={journeyId} />
+    </div>
+  );
+
+  const testTab = (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-medium">{t('panels.sendWebhook.test.title')}</h3>
+          <p className="text-sm text-muted-foreground">
+            {t('panels.sendWebhook.test.description')}
+          </p>
+        </div>
+        <Button
+          onClick={handleTestWebhook}
+          disabled={!formData.webhookUrl || isLoading}
+          className="flex items-center gap-2"
+        >
+          {isLoading ? (
+            <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+          ) : (
+            <Play className="w-4 h-4" />
+          )}
+          {isLoading
+            ? t('panels.sendWebhook.test.executing')
+            : t('panels.sendWebhook.test.executeTest')}
+        </Button>
+      </div>
+
+      {responseMappings.length > 0 && (
+        <FlowFeedbackBanner variant="info">
+          <div className="flex items-center justify-between mb-3">
+            <h4 className="text-sm font-medium">
+              {t('panels.sendWebhook.test.savedConfigs', { count: responseMappings.length })}
+            </h4>
+            {hasMappingChanges && (
+              <span className="text-xs text-flow-feedback-warn-fg">
+                {t('panels.sendWebhook.test.unsavedChanges')}
+              </span>
+            )}
           </div>
-        )}
-
-        {/* Tabs de configuração */}
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <TabsList className="grid w-full grid-cols-5">
-            <TabsTrigger value="basic" className="flex items-center gap-2">
-              <Globe className="w-4 h-4" />
-              {t('panels.sendWebhook.tabs.basic')}
-            </TabsTrigger>
-            <TabsTrigger value="headers" className="flex items-center gap-2">
-              <Settings className="w-4 h-4" />
-              {t('panels.sendWebhook.tabs.headers')}
-              {formData.headers && formData.headers.length > 0 && (
-                <span className="ml-1 px-1.5 py-0.5 text-xs bg-purple-100 text-purple-700 rounded-full">
-                  {formData.headers.length}
+          <div className="space-y-2">
+            {responseMappings.map(mapping => (
+              <div
+                key={mapping.id}
+                className="flex items-center justify-between text-xs p-2 bg-flow-feedback-info-bg/60 rounded"
+              >
+                <span className="font-mono">
+                  {mapping.jsonPath || t('panels.sendWebhook.test.notConfigured')}
                 </span>
-              )}
-            </TabsTrigger>
-            <TabsTrigger value="body" className="flex items-center gap-2">
-              <FileText className="w-4 h-4" />
-              {t('panels.sendWebhook.tabs.body')}
-            </TabsTrigger>
-            <TabsTrigger value="auth" className="flex items-center gap-2">
-              <Lock className="w-4 h-4" />
-              {t('panels.sendWebhook.tabs.auth')}
-              {formData.authenticationType !== 'none' && (
-                <span className="ml-1 w-2 h-2 bg-green-500 rounded-full"></span>
-              )}
-            </TabsTrigger>
-            <TabsTrigger value="test" className="flex items-center gap-2">
-              <Play className="w-4 h-4" />
-              {t('panels.sendWebhook.tabs.test')}
-              {testResponse && <span className="ml-1 w-2 h-2 bg-green-500 rounded-full"></span>}
-            </TabsTrigger>
-          </TabsList>
+                <ArrowRight className="w-3 h-3" />
+                <span className="font-medium">
+                  {mapping.variableName || t('panels.sendWebhook.test.notConfigured')}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs mt-2">{t('panels.sendWebhook.test.mappingsDescription')}</p>
+        </FlowFeedbackBanner>
+      )}
 
-          <TabsContent value="basic" className="mt-4">
-            <WebhookBasicConfig
-              data={formData}
-              onChange={handleFormDataChange}
-              journeyId={journeyId}
-            />
-          </TabsContent>
+      {testError && (
+        <FlowFeedbackBanner variant="error">
+          <h4 className="text-sm font-medium mb-1">{t('panels.sendWebhook.test.executionError')}</h4>
+          <p className="text-sm">{testError}</p>
+        </FlowFeedbackBanner>
+      )}
 
-          <TabsContent value="headers" className="mt-4">
-            <WebhookHeadersConfig
-              data={formData}
-              onChange={handleFormDataChange}
-              journeyId={journeyId}
-            />
-          </TabsContent>
+      {testResponse && (
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h4 className="text-lg font-medium">{t('panels.sendWebhook.test.webhookResponse')}</h4>
+            <div className="flex items-center gap-2">
+              <span
+                className={`inline-flex items-center px-2 py-1 rounded text-xs font-medium ${
+                  testResponse.status >= 200 && testResponse.status < 300
+                    ? 'bg-flow-feedback-success-bg text-flow-feedback-success-fg'
+                    : testResponse.status >= 400
+                    ? 'bg-flow-feedback-error-bg text-flow-feedback-error-fg'
+                    : 'bg-flow-feedback-warn-bg text-flow-feedback-warn-fg'
+                }`}
+              >
+                {testResponse.status} {testResponse.statusText}
+              </span>
+              <span className="text-xs text-muted-foreground">{testResponse.executionTime}ms</span>
+            </div>
+          </div>
 
-          <TabsContent value="body" className="mt-4">
-            <WebhookBodyConfig
-              data={formData}
-              onChange={handleFormDataChange}
-              journeyId={journeyId}
-            />
-          </TabsContent>
+          <div className="p-3 rounded-lg bg-muted">
+            <h5 className="text-sm font-medium mb-2">
+              {t('panels.sendWebhook.test.responseHeaders')}
+            </h5>
+            <pre className="text-xs overflow-x-auto">
+              {JSON.stringify(testResponse.headers, null, 2)}
+            </pre>
+          </div>
 
-          <TabsContent value="auth" className="mt-4">
-            <WebhookAuthConfig
-              data={formData}
-              onChange={handleFormDataChange}
-              journeyId={journeyId}
-            />
-          </TabsContent>
+          <div className="p-3 rounded-lg bg-muted">
+            <h5 className="text-sm font-medium mb-2">
+              {t('panels.sendWebhook.test.responseBody')}
+            </h5>
+            <pre className="text-xs overflow-x-auto max-h-60">
+              {typeof testResponse.data === 'object' && testResponse.data !== null
+                ? JSON.stringify(testResponse.data, null, 2)
+                : String(testResponse.data)}
+            </pre>
+          </div>
 
-          <TabsContent value="test" className="mt-4">
-            <div className="space-y-6">
-              {/* Botão de teste */}
+          {typeof testResponse.data === 'object' && testResponse.data && (
+            <div className="space-y-4 border-t border-border pt-4">
               <div className="flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                    {t('panels.sendWebhook.test.title')}
-                  </h3>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {t('panels.sendWebhook.test.description')}
+                  <h4 className="text-lg font-medium">
+                    {t('panels.sendWebhook.test.mapToVariables')}
+                  </h4>
+                  <p className="text-sm text-muted-foreground">
+                    {t('panels.sendWebhook.test.mapDescription')}
                   </p>
                 </div>
-                <Button
-                  onClick={handleTestWebhook}
-                  disabled={!formData.webhookUrl || isLoading}
-                  className="flex items-center gap-2"
-                >
-                  {isLoading ? (
-                    <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-                  ) : (
-                    <Play className="w-4 h-4" />
-                  )}
-                  {isLoading
-                    ? t('panels.sendWebhook.test.executing')
-                    : t('panels.sendWebhook.test.executeTest')}
+                <Button onClick={addResponseMapping} size="sm" variant="outline">
+                  {t('panels.sendWebhook.test.addMapping')}
                 </Button>
               </div>
 
-              {/* Mapeamentos salvos (sempre visível) */}
-              {responseMappings.length > 0 && (
-                <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-                  <div className="flex items-center justify-between mb-3">
-                    <h4 className="text-sm font-medium text-blue-800 dark:text-blue-200">
-                      {t('panels.sendWebhook.test.savedConfigs', {
-                        count: responseMappings.length,
-                      })}
-                    </h4>
-                    {hasChanges && (
-                      <span className="text-xs text-orange-600 dark:text-orange-400">
-                        {t('panels.sendWebhook.test.unsavedChanges')}
-                      </span>
-                    )}
-                  </div>
-                  <div className="space-y-2">
-                    {responseMappings.map(mapping => (
-                      <div
-                        key={mapping.id}
-                        className="flex items-center justify-between text-xs p-2 bg-blue-100 dark:bg-blue-900/30 rounded"
-                      >
-                        <span className="font-mono text-blue-700 dark:text-blue-300">
-                          {mapping.jsonPath || t('panels.sendWebhook.test.notConfigured')}
-                        </span>
-                        <ArrowRight className="w-3 h-3 text-blue-600 dark:text-blue-400" />
-                        <span className="font-medium text-blue-800 dark:text-blue-200">
-                          {mapping.variableName || t('panels.sendWebhook.test.notConfigured')}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                  <p className="text-xs text-blue-600 dark:text-blue-400 mt-2">
-                    {t('panels.sendWebhook.test.mappingsDescription')}
-                  </p>
-                </div>
-              )}
+              <div className="space-y-3">
+                {responseMappings.map(mapping => {
+                  const availablePaths = extractJsonPaths(testResponse.data);
+                  const currentValue = mapping.jsonPath
+                    ? getValueFromJsonPath(testResponse.data, mapping.jsonPath)
+                    : null;
 
-              {/* Erro */}
-              {testError && (
-                <div className="p-4 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
-                  <h4 className="text-sm font-medium text-red-800 dark:text-red-200 mb-1">
-                    {t('panels.sendWebhook.test.executionError')}
-                  </h4>
-                  <p className="text-sm text-red-700 dark:text-red-300">{testError}</p>
-                </div>
-              )}
-
-              {/* Resposta */}
-              {testResponse && (
-                <div className="space-y-4">
-                  <div className="flex items-center justify-between">
-                    <h4 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                      {t('panels.sendWebhook.test.webhookResponse')}
-                    </h4>
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={`inline-flex items-center px-2 py-1 rounded text-xs font-medium ${
-                          testResponse.status >= 200 && testResponse.status < 300
-                            ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
-                            : testResponse.status >= 400
-                            ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
-                            : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
-                        }`}
-                      >
-                        {testResponse.status} {testResponse.statusText}
-                      </span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        {testResponse.executionTime}ms
-                      </span>
-                    </div>
-                  </div>
-
-                  {/* Headers da resposta */}
-                  <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900">
-                    <h5 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                      {t('panels.sendWebhook.test.responseHeaders')}
-                    </h5>
-                    <pre className="text-xs text-gray-700 dark:text-gray-300 overflow-x-auto">
-                      {JSON.stringify(testResponse.headers, null, 2)}
-                    </pre>
-                  </div>
-
-                  {/* Corpo da resposta */}
-                  <div className="p-3 rounded-lg bg-gray-50 dark:bg-gray-900">
-                    <h5 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                      {t('panels.sendWebhook.test.responseBody')}
-                    </h5>
-                    <pre className="text-xs text-gray-700 dark:text-gray-300 overflow-x-auto max-h-60">
-                      {typeof testResponse.data === 'object' && testResponse.data !== null
-                        ? JSON.stringify(testResponse.data, null, 2)
-                        : String(testResponse.data)}
-                    </pre>
-                  </div>
-
-                  {/* Mapeamento de resposta para variáveis */}
-                  {typeof testResponse.data === 'object' && testResponse.data && (
-                    <div className="space-y-4 border-t pt-4">
-                      <div className="flex items-center justify-between">
+                  return (
+                    <div key={mapping.id} className="p-3 border border-border rounded-lg space-y-3">
+                      <div className="grid grid-cols-2 gap-3">
                         <div>
-                          <h4 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                            {t('panels.sendWebhook.test.mapToVariables')}
-                          </h4>
-                          <p className="text-sm text-gray-500 dark:text-gray-400">
-                            {t('panels.sendWebhook.test.mapDescription')}
-                          </p>
+                          <label className="block text-sm font-medium mb-1">
+                            {t('panels.sendWebhook.test.responseField')}
+                          </label>
+                          <select
+                            value={mapping.jsonPath}
+                            onChange={e =>
+                              updateResponseMapping(mapping.id, { jsonPath: e.target.value })
+                            }
+                            className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm"
+                          >
+                            <option value="">{t('panels.sendWebhook.test.selectField')}</option>
+                            {availablePaths.map(path => (
+                              <option key={path} value={path}>
+                                {path}
+                              </option>
+                            ))}
+                          </select>
                         </div>
-                        <Button onClick={addResponseMapping} size="sm" variant="outline">
-                          {t('panels.sendWebhook.test.addMapping')}
+                        <div>
+                          <Label className="text-sm font-medium">
+                            {t('panels.sendWebhook.test.variableName')}
+                          </Label>
+                          <VariableSelect
+                            value={mapping.variableName || ''}
+                            onValueChange={variableName => {
+                              updateResponseMapping(mapping.id, { variableName });
+                            }}
+                            placeholder={t('panels.sendWebhook.test.selectVariable')}
+                            journeyId={journeyId}
+                            className="w-full"
+                          />
+                        </div>
+                      </div>
+
+                      <div>
+                        <label className="block text-sm font-medium mb-1">
+                          {t('panels.sendWebhook.test.description')}
+                        </label>
+                        <input
+                          type="text"
+                          value={mapping.description}
+                          onChange={e =>
+                            updateResponseMapping(mapping.id, { description: e.target.value })
+                          }
+                          placeholder={t('panels.sendWebhook.test.variableDescription')}
+                          className="w-full px-3 py-2 bg-background border border-input rounded-md text-sm"
+                        />
+                      </div>
+
+                      {currentValue !== null && currentValue !== undefined && (
+                        <FlowFeedbackBanner variant="info">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs font-medium">
+                              {t('panels.sendWebhook.test.currentValue')}:
+                            </span>
+                            <code className="text-xs bg-flow-feedback-info-bg/60 px-1 py-0.5 rounded">
+                              {typeof currentValue === 'object' && currentValue !== null
+                                ? JSON.stringify(currentValue)
+                                : String(currentValue)}
+                            </code>
+                          </div>
+                        </FlowFeedbackBanner>
+                      )}
+
+                      <div className="flex justify-end">
+                        <Button
+                          onClick={() => removeResponseMapping(mapping.id)}
+                          size="sm"
+                          variant="ghost"
+                          className="text-flow-feedback-error-fg hover:text-flow-feedback-error-fg"
+                        >
+                          {t('panels.sendWebhook.test.remove')}
                         </Button>
                       </div>
-
-                      {/* Lista de mapeamentos */}
-                      <div className="space-y-3">
-                        {responseMappings.map(mapping => {
-                          const availablePaths = extractJsonPaths(testResponse.data);
-                          const currentValue = mapping.jsonPath
-                            ? getValueFromJsonPath(testResponse.data, mapping.jsonPath)
-                            : null;
-
-                          return (
-                            <div key={mapping.id} className="p-3 border rounded-lg space-y-3">
-                              <div className="grid grid-cols-2 gap-3">
-                                <div>
-                                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                    {t('panels.sendWebhook.test.responseField')}
-                                  </label>
-                                  <select
-                                    value={mapping.jsonPath}
-                                    onChange={e =>
-                                      updateResponseMapping(mapping.id, {
-                                        jsonPath: e.target.value,
-                                      })
-                                    }
-                                    className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
-                                  >
-                                    <option value="">
-                                      {t('panels.sendWebhook.test.selectField')}
-                                    </option>
-                                    {availablePaths.map(path => (
-                                      <option key={path} value={path}>
-                                        {path}
-                                      </option>
-                                    ))}
-                                  </select>
-                                </div>
-                                <div>
-                                  <Label className="text-sm font-medium">
-                                    {t('panels.sendWebhook.test.variableName')}
-                                  </Label>
-                                  <VariableSelect
-                                    value={mapping.variableName || ''}
-                                    onValueChange={variableName => {
-                                      updateResponseMapping(mapping.id, { variableName });
-                                    }}
-                                    placeholder={t('panels.sendWebhook.test.selectVariable')}
-                                    journeyId={journeyId}
-                                    className="w-full"
-                                  />
-                                </div>
-                              </div>
-
-                              <div>
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                  {t('panels.sendWebhook.test.description')}
-                                </label>
-                                <input
-                                  type="text"
-                                  value={mapping.description}
-                                  onChange={e =>
-                                    updateResponseMapping(mapping.id, {
-                                      description: e.target.value,
-                                    })
-                                  }
-                                  placeholder={t('panels.sendWebhook.test.variableDescription')}
-                                  className="w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md text-sm"
-                                />
-                              </div>
-
-                              {/* Preview do valor */}
-                              {currentValue !== null && currentValue !== undefined && (
-                                <div className="p-2 bg-blue-50 dark:bg-blue-950/20 rounded border border-blue-200 dark:border-blue-800/30">
-                                  <div className="flex items-center gap-2">
-                                    <span className="text-xs text-blue-700 dark:text-blue-300 font-medium">
-                                      {t('panels.sendWebhook.test.currentValue')}:
-                                    </span>
-                                    <code className="text-xs text-blue-800 dark:text-blue-200 bg-blue-100 dark:bg-blue-900/30 px-1 py-0.5 rounded">
-                                      {typeof currentValue === 'object' && currentValue !== null
-                                        ? JSON.stringify(currentValue)
-                                        : String(currentValue)}
-                                    </code>
-                                  </div>
-                                </div>
-                              )}
-
-                              <div className="flex justify-end">
-                                <Button
-                                  onClick={() => removeResponseMapping(mapping.id)}
-                                  size="sm"
-                                  variant="ghost"
-                                  className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                                >
-                                  {t('panels.sendWebhook.test.remove')}
-                                </Button>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
                     </div>
-                  )}
-                </div>
-              )}
+                  );
+                })}
+              </div>
             </div>
-          </TabsContent>
-        </Tabs>
-      </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
 
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid ? t('panels.actions.save') : t('panels.sendWebhook.fixErrors')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+  return (
+    <NodeConfigModal
+      open
+      variant="tabs"
+      title={t('panels.sendWebhook.title')}
+      icon={<Send className="h-5 w-5 text-flow-node-action-webhook-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+      contentClassName="max-w-4xl"
+      defaultTab="basic"
+      tabs={[
+        {
+          value: 'basic',
+          label: t('panels.sendWebhook.tabs.basic'),
+          content: basicTab,
+        },
+        {
+          value: 'headers',
+          label: `${t('panels.sendWebhook.tabs.headers')}${
+            formData.headers && formData.headers.length > 0 ? ` (${formData.headers.length})` : ''
+          }`,
+          content: headersTab,
+        },
+        {
+          value: 'body',
+          label: t('panels.sendWebhook.tabs.body'),
+          content: bodyTab,
+        },
+        {
+          value: 'auth',
+          label: `${t('panels.sendWebhook.tabs.auth')}${
+            formData.authenticationType !== 'none' ? ' ✓' : ''
+          }`,
+          content: authTab,
+        },
+        {
+          value: 'test',
+          label: `${t('panels.sendWebhook.tabs.test')}${testResponse ? ' ✓' : ''}`,
+          content: testTab,
+        },
+      ]}
+    />
   );
 }

--- a/src/components/journey/nodes/actions/set-variable/SetVariablePanel.tsx
+++ b/src/components/journey/nodes/actions/set-variable/SetVariablePanel.tsx
@@ -1,18 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
 } from '@evoapi/design-system';
 import { Settings, Hash, Calendar } from 'lucide-react';
 import { SetVariableNodeData } from './SetVariableNode';
-import { BaseFlowPanel } from '@/components/base';
-import { VariableInput, VariableSelect} from '@/components/journey/environment-manager';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { VariableInput, VariableSelect } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface SetVariablePanelProps {
@@ -22,7 +21,6 @@ interface SetVariablePanelProps {
   onClose: () => void;
   journeyId: string;
 }
-
 
 export function SetVariablePanel({
   nodeId,
@@ -116,13 +114,15 @@ export function SetVariablePanel({
     { value: 'timestamp', label: t('panels.setVariable.idCategories.timestamp'), description: '' },
   ];
 
-  const [formData, setFormData] = useState<SetVariableNodeData>({
+  const initialFormData: SetVariableNodeData = {
     variableName: '',
     operation: 'set',
     value: '',
     category: '',
     ...data,
-  });
+  };
+  const [originalData] = useState<SetVariableNodeData>(() => initialFormData);
+  const [formData, setFormData] = useState<SetVariableNodeData>(initialFormData);
 
   useEffect(() => {
     setFormData({
@@ -135,33 +135,20 @@ export function SetVariablePanel({
   }, [data]);
 
   const handleSave = () => {
-    const selectedOperation = OPERATIONS.find(op => op.value === formData.operation);
-
-    // Validações
-    if (!formData.variableName?.trim()) {
-      alert(t('panels.setVariable.validation.variableNameRequired'));
-      return;
-    }
-
-    if (selectedOperation?.needsValue && !formData.value?.trim()) {
-      alert(t('panels.setVariable.validation.valueRequired'));
-      return;
-    }
-
-    if (selectedOperation?.needsCategory && !formData.category) {
-      alert(t('panels.setVariable.validation.categoryRequired'));
-      return;
-    }
-
     onUpdate(nodeId, formData);
     onClose();
   };
 
   const selectedOperation = OPERATIONS.find(op => op.value === formData.operation);
-  const isValid =
+  const isValid = Boolean(
     formData.variableName &&
-    (!selectedOperation?.needsValue || formData.value) &&
-    (!selectedOperation?.needsCategory || formData.category);
+      (!selectedOperation?.needsValue || formData.value) &&
+      (!selectedOperation?.needsCategory || formData.category),
+  );
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   const renderValueInput = () => {
     if (!selectedOperation?.needsValue) return null;
@@ -220,32 +207,33 @@ export function SetVariablePanel({
   const categories = getOperationsByCategory();
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.setVariable.title')}
-      icon={<Settings className="w-5 h-5 text-purple-500" />}
-      onClose={onClose}
-      width="w-[600px]"
+      icon={<Settings className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.setVariable.buttons.save')}
+      cancelLabel={t('panels.setVariable.buttons.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.setVariable.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.setVariable.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               {!formData.variableName && <li>{t('panels.setVariable.enterVariableName')}</li>}
-              {selectedOperation?.needsValue && !formData.value && <li>{t('panels.setVariable.configureValue')}</li>}
+              {selectedOperation?.needsValue && !formData.value && (
+                <li>{t('panels.setVariable.configureValue')}</li>
+              )}
               {selectedOperation?.needsCategory && !formData.category && (
                 <li>{t('panels.setVariable.selectCategory')}</li>
               )}
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Nome da variável */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.setVariable.variable')}</Label>
           <VariableSelect
@@ -257,13 +245,12 @@ export function SetVariablePanel({
             showSystemVariables={false}
           />
           {formData.variableName && (
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-muted-foreground">
               {t('panels.setVariable.variable')}: {formData.variableName}
             </p>
           )}
         </div>
 
-        {/* Operação */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.setVariable.operation')}</Label>
           <Select
@@ -279,7 +266,6 @@ export function SetVariablePanel({
               <SelectValue placeholder={t('panels.setVariable.placeholders.selectOperation')} />
             </SelectTrigger>
             <SelectContent className="bg-sidebar border-sidebar-border max-h-[400px]">
-              {/* Personalizado */}
               <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50">
                 <div className="flex items-center gap-2">
                   <Settings className="w-3 h-3" />
@@ -296,13 +282,12 @@ export function SetVariablePanel({
                     <span>{operation.icon}</span>
                     <div className="flex flex-col">
                       <span className="font-medium">{operation.label}</span>
-                      <span className="text-xs text-gray-500">{operation.description}</span>
+                      <span className="text-xs text-muted-foreground">{operation.description}</span>
                     </div>
                   </div>
                 </SelectItem>
               ))}
 
-              {/* Numérico */}
               <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50 mt-2">
                 <div className="flex items-center gap-2">
                   <Hash className="w-3 h-3" />
@@ -319,13 +304,12 @@ export function SetVariablePanel({
                     <span>{operation.icon}</span>
                     <div className="flex flex-col">
                       <span className="font-medium">{operation.label}</span>
-                      <span className="text-xs text-gray-500">{operation.description}</span>
+                      <span className="text-xs text-muted-foreground">{operation.description}</span>
                     </div>
                   </div>
                 </SelectItem>
               ))}
 
-              {/* Data e Hora */}
               <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50 mt-2">
                 <div className="flex items-center gap-2">
                   <Calendar className="w-3 h-3" />
@@ -342,13 +326,12 @@ export function SetVariablePanel({
                     <span>{operation.icon}</span>
                     <div className="flex flex-col">
                       <span className="font-medium">{operation.label}</span>
-                      <span className="text-xs text-gray-500">{operation.description}</span>
+                      <span className="text-xs text-muted-foreground">{operation.description}</span>
                     </div>
                   </div>
                 </SelectItem>
               ))}
 
-              {/* Funções */}
               <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50 mt-2">
                 <div className="flex items-center gap-2">
                   <Hash className="w-3 h-3" />
@@ -365,7 +348,7 @@ export function SetVariablePanel({
                     <span>{operation.icon}</span>
                     <div className="flex flex-col">
                       <span className="font-medium">{operation.label}</span>
-                      <span className="text-xs text-gray-500">{operation.description}</span>
+                      <span className="text-xs text-muted-foreground">{operation.description}</span>
                     </div>
                   </div>
                 </SelectItem>
@@ -374,13 +357,10 @@ export function SetVariablePanel({
           </Select>
 
           {selectedOperation && (
-            <p className="text-xs text-gray-500 dark:text-gray-400">
-              {selectedOperation.description}
-            </p>
+            <p className="text-xs text-muted-foreground">{selectedOperation.description}</p>
           )}
         </div>
 
-        {/* Campo de valor (quando necessário) */}
         {selectedOperation?.needsValue && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">
@@ -389,13 +369,12 @@ export function SetVariablePanel({
                 : t('panels.setVariable.value')}
             </Label>
             {renderValueInput()}
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-muted-foreground">
               {t('panels.setVariable.helperTexts.customValue')}
             </p>
           </div>
         )}
 
-        {/* Categoria para ID aleatório */}
         {selectedOperation?.needsCategory && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">{t('panels.setVariable.idCategory')}</Label>
@@ -426,10 +405,9 @@ export function SetVariablePanel({
           </div>
         )}
 
-        {/* Preview da operação */}
         {isValid && (
-          <div className="p-4 rounded-lg bg-purple-50 dark:bg-purple-950/20 border border-purple-200 dark:border-purple-800/30">
-            <p className="text-sm text-purple-800 dark:text-purple-200 mb-2">
+          <FlowFeedbackBanner variant="info">
+            <p className="mb-2">
               <strong>{t('panels.setVariable.preview.variableConfigured')}:</strong>
             </p>
             <div className="flex items-center gap-2 mb-2">
@@ -437,30 +415,18 @@ export function SetVariablePanel({
               <span className="font-medium">
                 {formData.variableName?.replace(/[{}]/g, '') || formData.variableName}
               </span>
-              <span className="text-purple-600 dark:text-purple-400">←</span>
-              <span className="font-medium text-purple-700 dark:text-purple-300">
+              <span>←</span>
+              <span className="font-medium">
                 {selectedOperation?.label}
                 {formData.value && ` (${formData.value})`}
                 {formData.category &&
                   ` - ${ID_CATEGORIES.find(c => c.value === formData.category)?.label}`}
               </span>
             </div>
-            <p className="text-xs text-purple-600 dark:text-purple-400">
-              {selectedOperation?.description}
-            </p>
-          </div>
+            <p className="text-xs">{selectedOperation?.description}</p>
+          </FlowFeedbackBanner>
         )}
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.setVariable.buttons.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid ? t('panels.setVariable.buttons.save') : t('panels.setVariable.buttons.configureVariable')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/split/SplitPanel.tsx
+++ b/src/components/journey/nodes/actions/split/SplitPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Button,
   Label,
@@ -8,12 +8,12 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
   Badge,
 } from '@evoapi/design-system';
 import { Split, Plus, Trash2 } from 'lucide-react';
 import { SplitNodeData, SplitVariant } from './SplitNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { v4 as uuidv4 } from 'uuid';
 import { useLanguage } from '@/hooks/useLanguage';
 
@@ -35,46 +35,39 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
     { value: 'red', label: t('panels.split.colors.red') },
     { value: 'yellow', label: t('panels.split.colors.yellow') },
   ];
-  const [formData, setFormData] = useState<SplitNodeData>({
+
+  const defaultVariants = (): SplitVariant[] => [
+    {
+      id: uuidv4(),
+      name: t('panels.split.variants.defaultNames.variantA'),
+      percentage: 50,
+      color: 'blue',
+    },
+    {
+      id: uuidv4(),
+      name: t('panels.split.variants.defaultNames.variantB'),
+      percentage: 50,
+      color: 'purple',
+    },
+  ];
+
+  const [originalData] = useState<SplitNodeData>(() => ({
     ...data,
-    variants: data.variants || [
-      {
-        id: uuidv4(),
-        name: t('panels.split.variants.defaultNames.variantA'),
-        percentage: 50,
-        color: 'blue',
-      },
-      {
-        id: uuidv4(),
-        name: t('panels.split.variants.defaultNames.variantB'),
-        percentage: 50,
-        color: 'purple',
-      },
-    ],
-  });
+    variants: data.variants || defaultVariants(),
+  }));
+  const [formData, setFormData] = useState<SplitNodeData>(() => ({
+    ...data,
+    variants: data.variants || defaultVariants(),
+  }));
 
   useEffect(() => {
     setFormData({
       ...data,
-      variants: data.variants || [
-        {
-          id: uuidv4(),
-          name: t('panels.split.variants.defaultNames.variantA'),
-          percentage: 50,
-          color: 'blue',
-        },
-        {
-          id: uuidv4(),
-          name: t('panels.split.variants.defaultNames.variantB'),
-          percentage: 50,
-          color: 'purple',
-        },
-      ],
+      variants: data.variants || defaultVariants(),
     });
   }, [data]);
 
   const handleSave = () => {
-    // Normalizar percentuais para somar 100%
     const totalPercentage = formData.variants.reduce((sum, variant) => sum + variant.percentage, 0);
     const normalizedVariants = formData.variants.map(variant => ({
       ...variant,
@@ -119,7 +112,7 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
   };
 
   const removeVariant = (variantId: string) => {
-    if (formData.variants.length <= 2) return; // Mínimo de 2 variantes
+    if (formData.variants.length <= 2) return;
 
     setFormData(prev => ({
       ...prev,
@@ -142,11 +135,15 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
   };
 
   const totalPercentage = formData.variants.reduce((sum, variant) => sum + variant.percentage, 0);
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
+  const isValid = totalPercentage > 0;
 
   const renderVariant = (variant: SplitVariant) => (
-    <div key={variant.id} className="p-4 border rounded-lg bg-sidebar-accent/10 space-y-3">
+    <div key={variant.id} className="p-4 border border-border rounded-lg bg-sidebar-accent/10 space-y-3">
       <div className="grid grid-cols-12 gap-3 items-end">
-        {/* Nome da Variante */}
         <div className="col-span-4">
           <Label className="text-xs">{t('panels.split.variants.name')}</Label>
           <Input
@@ -157,7 +154,6 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
           />
         </div>
 
-        {/* Cor */}
         <div className="col-span-3">
           <Label className="text-xs">{t('panels.split.variants.color')}</Label>
           <Select
@@ -181,7 +177,6 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
           </Select>
         </div>
 
-        {/* Percentual */}
         <div className="col-span-3">
           <Label className="text-xs">{t('panels.split.variants.percentage')}</Label>
           <Input
@@ -194,14 +189,13 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
           />
         </div>
 
-        {/* Botão remover */}
         <div className="col-span-2">
           <Button
             variant="ghost"
             size="sm"
             onClick={() => removeVariant(variant.id)}
             disabled={formData.variants.length <= 2}
-            className="h-10 w-full p-0 text-red-500 hover:text-red-700 disabled:opacity-50"
+            className="h-10 w-full p-0 text-flow-feedback-error-fg hover:text-flow-feedback-error-fg disabled:opacity-50"
           >
             <Trash2 className="w-4 h-4" />
           </Button>
@@ -211,20 +205,23 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
   );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.split.title')}
-      icon={<Split className="w-5 h-5 text-purple-500" />}
-      onClose={onClose}
-      width="w-[700px]"
+      icon={<Split className="h-5 w-5 text-flow-node-condition-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.split.actions.save')}
+      cancelLabel={t('panels.split.actions.cancel')}
+      contentClassName="max-w-3xl"
     >
-      <Separator />
-
       <div className="space-y-4">
         <Label className="text-sidebar-foreground font-medium">
           {t('panels.split.configuration')}
         </Label>
 
-        {/* Controles */}
         <div className="flex gap-2 mb-4">
           <Button variant="outline" size="sm" onClick={addVariant}>
             <Plus className="w-4 h-4 mr-1" />
@@ -235,38 +232,24 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
           </Button>
         </div>
 
-        {/* Lista de variantes */}
         <div className="space-y-3">
           {formData.variants && formData.variants.length > 0 ? (
             formData.variants.map(variant => renderVariant(variant))
           ) : (
-            <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
-              <Split className="h-8 w-8 text-gray-400 mx-auto mb-2" />
-              <p className="text-gray-500">{t('panels.split.messages.emptyState')}</p>
+            <div className="p-4 rounded-lg border-2 border-dashed border-border bg-muted/40 text-center">
+              <Split className="h-8 w-8 text-muted-foreground mx-auto mb-2" />
+              <p className="text-muted-foreground">{t('panels.split.messages.emptyState')}</p>
             </div>
           )}
         </div>
 
-        {/* Status dos percentuais */}
-        <div
-          className={`p-3 rounded-lg border ${
-            totalPercentage === 100
-              ? 'bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-800/30'
-              : 'bg-yellow-50 dark:bg-yellow-950/20 border-yellow-200 dark:border-yellow-800/30'
-          }`}
-        >
+        <FlowFeedbackBanner variant={totalPercentage === 100 ? 'success' : 'warn'}>
           <div className="flex items-center justify-between">
-            <span
-              className={`text-sm font-medium ${
-                totalPercentage === 100
-                  ? 'text-green-800 dark:text-green-200'
-                  : 'text-yellow-800 dark:text-yellow-200'
-              }`}
-            >
+            <span className="font-medium">
               {t('panels.split.status.total')}: {totalPercentage}%
             </span>
             {totalPercentage !== 100 && (
-              <Badge variant="outline" className="text-yellow-600">
+              <Badge variant="outline">
                 {totalPercentage > 100
                   ? t('panels.split.status.excess')
                   : t('panels.split.status.missing')}{' '}
@@ -275,21 +258,18 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
             )}
           </div>
           {totalPercentage !== 100 && (
-            <p className="text-xs text-yellow-600 dark:text-yellow-400 mt-1">
-              {t('panels.split.messages.normalizePercentages')}
-            </p>
+            <p className="text-xs mt-1">{t('panels.split.messages.normalizePercentages')}</p>
           )}
-        </div>
+        </FlowFeedbackBanner>
 
-        {/* Resumo */}
         {formData.variants && formData.variants.length > 0 && (
-          <div className="p-4 rounded-lg bg-purple-50 dark:bg-purple-950/20 border border-purple-200 dark:border-purple-800/30">
-            <Label className="text-sm font-medium text-purple-800 dark:text-purple-200 mb-2 block">
+          <FlowFeedbackBanner variant="info">
+            <Label className="text-sm font-medium mb-2 block">
               {t('panels.split.status.summary')}:
             </Label>
-            <div className="space-y-1">
+            <div className="space-y-1 text-sm">
               {formData.variants.map(variant => (
-                <div key={variant.id} className="text-sm text-purple-700 dark:text-purple-300">
+                <div key={variant.id}>
                   <Badge variant="outline" className="mr-2">
                     {variant.color}
                   </Badge>
@@ -297,19 +277,9 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
                 </div>
               ))}
             </div>
-          </div>
+          </FlowFeedbackBanner>
         )}
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.split.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={totalPercentage <= 0}>
-          {t('panels.split.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/transfer-journey/TransferJourneyPanel.tsx
+++ b/src/components/journey/nodes/actions/transfer-journey/TransferJourneyPanel.tsx
@@ -1,19 +1,18 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
   Badge,
   Card,
   Label,
 } from '@evoapi/design-system';
 import { ArrowRight, Loader2, AlertCircle } from 'lucide-react';
 import { TransferJourneyNodeData } from './TransferJourneyNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { journeyService } from '@/services';
 import type { Journey } from '@/types/automation';
 import { toast } from 'sonner';
@@ -41,6 +40,7 @@ export function TransferJourneyPanel({
     targetJourneyId: data.targetJourneyId || '',
     targetJourneyName: data.targetJourneyName || '',
   });
+  const [originalTargetId] = useState<string>(() => data.targetJourneyId || '');
 
   const [journeys, setJourneys] = useState<Journey[]>([]);
   const [loading, setLoading] = useState(true);
@@ -53,7 +53,6 @@ export function TransferJourneyPanel({
           limit: 100,
         });
 
-        // Filter out the current journey and only show active journeys
         const availableJourneys = response.data.filter(j => j.id !== journeyId && j.isActive);
         setJourneys(availableJourneys);
       } catch (error) {
@@ -69,21 +68,16 @@ export function TransferJourneyPanel({
   }, [journeyId]);
 
   const handleSave = () => {
-    if (!formData.targetJourneyId) {
-      toast.error(t('panels.transferJourney.messages.selectRequired'));
-      return;
-    }
-
     onUpdate(nodeId, formData);
     toast.success(t('panels.transferJourney.messages.configuredSuccess'));
     onClose();
   };
 
-  const handleJourneyChange = (journeyId: string) => {
-    const selectedJourney = journeys.find(j => j.id === journeyId);
+  const handleJourneyChange = (newJourneyId: string) => {
+    const selectedJourney = journeys.find(j => j.id === newJourneyId);
     setFormData(prev => ({
       ...prev,
-      targetJourneyId: journeyId,
+      targetJourneyId: newJourneyId,
       targetJourneyName: selectedJourney?.name || '',
     }));
   };
@@ -97,37 +91,40 @@ export function TransferJourneyPanel({
   };
 
   const isValid = !!formData.targetJourneyId;
+  const dirty = useMemo(
+    () => formData.targetJourneyId !== originalTargetId,
+    [formData.targetJourneyId, originalTargetId],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.transferJourney.title')}
-      icon={<ArrowRight className="w-5 h-5 text-orange-500" />}
-      onClose={onClose}
-      width="w-[600px]"
+      icon={<ArrowRight className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.transferJourney.actions.save')}
+      cancelLabel={t('panels.transferJourney.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.transferJourney.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.transferJourney.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               <li>{t('panels.transferJourney.selectDestination')}</li>
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Seleção da Jornada */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">
             {t('panels.transferJourney.destinationJourney')}
           </Label>
 
           {loading ? (
-            <div className="flex items-center justify-center p-8 border-2 border-dashed rounded-lg">
+            <div className="flex items-center justify-center p-8 border-2 border-dashed border-border rounded-lg">
               <Loader2 className="w-6 h-6 animate-spin text-muted-foreground mr-2" />
               <span className="text-sm text-muted-foreground">
                 {t('panels.transferJourney.loading')}
@@ -168,67 +165,41 @@ export function TransferJourneyPanel({
           )}
         </div>
 
-        {/* Preview da Configuração */}
-        {formData.targetJourneyId && <Separator />}
-
         {formData.targetJourneyId && (
-          <div className="space-y-4">
-            <div className="flex items-center gap-2">
-              <ArrowRight className="w-4 h-4 text-orange-500" />
-              <h4 className="text-sm font-medium">{t('panels.transferJourney.previewTitle')}</h4>
-            </div>
-
-            <Card className="p-4 bg-orange-50 dark:bg-orange-950/10 border-orange-200 dark:border-orange-800">
-              <div className="space-y-3">
-                <div className="flex items-start gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-orange-100 dark:bg-orange-900/30 flex items-center justify-center flex-shrink-0">
-                    <ArrowRight className="w-4 h-4 text-orange-600" />
-                  </div>
-                  <div className="flex-1">
-                    <p className="text-sm font-medium text-orange-900 dark:text-orange-100">
-                      {t('panels.transferJourney.transferConfigured')}
-                    </p>
-                    <p className="text-sm text-orange-800 dark:text-orange-200 mt-1">
-                      {t('panels.transferJourney.contactWillBeTransferred')}:
-                    </p>
-                    <Badge variant="outline" className="mt-2">
-                      {formData.targetJourneyName}
-                    </Badge>
-                  </div>
+          <FlowFeedbackBanner variant="warn">
+            <div className="space-y-3">
+              <div className="flex items-start gap-3">
+                <ArrowRight className="w-4 h-4 mt-1 shrink-0" />
+                <div className="flex-1">
+                  <p className="font-medium">{t('panels.transferJourney.transferConfigured')}</p>
+                  <p className="text-sm mt-1">
+                    {t('panels.transferJourney.contactWillBeTransferred')}:
+                  </p>
+                  <Badge variant="outline" className="mt-2">
+                    {formData.targetJourneyName}
+                  </Badge>
                 </div>
+              </div>
 
-                <div className="border-t border-orange-200 dark:border-orange-800 pt-3">
-                  <div className="flex items-start gap-2">
-                    <AlertCircle className="w-4 h-4 text-orange-600 mt-0.5" />
-                    <div className="space-y-1">
-                      <p className="text-xs font-medium text-orange-800 dark:text-orange-200">
-                        {t('panels.transferJourney.important')}:
-                      </p>
-                      <ul className="text-xs text-orange-700 dark:text-orange-300 space-y-0.5">
-                        <li>• {t('panels.transferJourney.warnings.exitImmediately')}</li>
-                        <li>• {t('panels.transferJourney.warnings.startFromFirst')}</li>
-                        <li>• {t('panels.transferJourney.warnings.noDataTransfer')}</li>
-                      </ul>
-                    </div>
+              <div className="border-t border-flow-feedback-warn-border pt-3">
+                <div className="flex items-start gap-2">
+                  <AlertCircle className="w-4 h-4 mt-0.5 shrink-0" />
+                  <div className="space-y-1">
+                    <p className="text-xs font-medium">
+                      {t('panels.transferJourney.important')}:
+                    </p>
+                    <ul className="text-xs space-y-0.5">
+                      <li>• {t('panels.transferJourney.warnings.exitImmediately')}</li>
+                      <li>• {t('panels.transferJourney.warnings.startFromFirst')}</li>
+                      <li>• {t('panels.transferJourney.warnings.noDataTransfer')}</li>
+                    </ul>
                   </div>
                 </div>
               </div>
-            </Card>
-          </div>
+            </div>
+          </FlowFeedbackBanner>
         )}
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.transferJourney.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid
-            ? t('panels.transferJourney.actions.save')
-            : t('panels.transferJourney.actions.configureJourney')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/update-contact/UpdateContactPanel.tsx
+++ b/src/components/journey/nodes/actions/update-contact/UpdateContactPanel.tsx
@@ -1,18 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
 } from '@evoapi/design-system';
 import { VariableInput } from '@/components/journey/environment-manager';
 import { UserCog } from 'lucide-react';
 import { UpdateContactNodeData } from './UpdateContactNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface UpdateContactPanelProps {
@@ -54,6 +53,7 @@ export function UpdateContactPanel({
       placeholder: t('panels.updateContact.placeholders.identifier'),
     },
   ] as const;
+  const [originalData] = useState<UpdateContactNodeData>(() => ({ ...data }));
   const [formData, setFormData] = useState<UpdateContactNodeData>({
     ...data,
   });
@@ -63,17 +63,6 @@ export function UpdateContactPanel({
   }, [data]);
 
   const handleSave = () => {
-    // Validação básica
-    if (!formData.fieldToUpdate) {
-      alert(t('panels.updateContact.selectField'));
-      return;
-    }
-
-    if (!formData.newValue || formData.newValue.trim() === '') {
-      alert(t('panels.updateContact.enterValue'));
-      return;
-    }
-
     onUpdate(nodeId, formData);
     onClose();
   };
@@ -85,7 +74,7 @@ export function UpdateContactPanel({
       ...prev,
       fieldToUpdate: fieldId as UpdateContactNodeData['fieldToUpdate'],
       fieldLabel: selectedField?.label || '',
-      newValue: '', // Reset value when changing field
+      newValue: '',
     }));
   };
 
@@ -96,34 +85,39 @@ export function UpdateContactPanel({
     }));
   };
 
-  const isValid = formData.fieldToUpdate && formData.newValue && formData.newValue.trim() !== '';
+  const isValid = Boolean(
+    formData.fieldToUpdate && formData.newValue && formData.newValue.trim() !== '',
+  );
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.updateContact.title')}
-      icon={<UserCog className="w-5 h-5 text-cyan-500" />}
-      onClose={onClose}
-      width="w-[600px]"
+      icon={<UserCog className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.updateContact.actions.save')}
+      cancelLabel={t('panels.updateContact.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.updateContact.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.updateContact.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               {!formData.fieldToUpdate && <li>{t('panels.updateContact.selectField')}</li>}
               {!formData.newValue && formData.fieldToUpdate && (
                 <li>{t('panels.updateContact.enterValue')}</li>
               )}
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Seleção do campo */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.updateContact.fieldToUpdate')}</Label>
           <Select value={formData.fieldToUpdate || ''} onValueChange={handleFieldChange}>
@@ -134,7 +128,7 @@ export function UpdateContactPanel({
               {CONTACT_FIELDS.map(field => (
                 <SelectItem key={field.id} value={field.id} className="text-sidebar-foreground">
                   <div className="flex items-center gap-2">
-                    <UserCog className="w-4 h-4 text-cyan-500" />
+                    <UserCog className="w-4 h-4 text-flow-node-control-fg" />
                     <div>
                       <div className="font-medium">{field.label}</div>
                       <div className="text-xs text-muted-foreground">{field.placeholder}</div>
@@ -146,7 +140,6 @@ export function UpdateContactPanel({
           </Select>
         </div>
 
-        {/* Campo de novo valor */}
         {formData.fieldToUpdate && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">{t('panels.updateContact.newValue')}</Label>
@@ -170,48 +163,32 @@ export function UpdateContactPanel({
           </div>
         )}
 
-        {/* Preview da atualização */}
         {isValid && (
-          <div className="p-4 rounded-lg bg-cyan-50 dark:bg-cyan-950/20 border border-cyan-200 dark:border-cyan-800/30">
-            <p className="text-sm text-cyan-800 dark:text-cyan-200 mb-2">
+          <FlowFeedbackBanner variant="info">
+            <p className="mb-2">
               <strong>{t('panels.updateContact.preview.title')}:</strong>
             </p>
             <div className="flex items-center gap-2">
-              <UserCog className="w-4 h-4 text-cyan-500" />
+              <UserCog className="w-4 h-4" />
               <span className="font-medium">{formData.fieldLabel}</span>
-              <span className="text-cyan-600 dark:text-cyan-400">→</span>
-              <span className="font-medium text-cyan-700 dark:text-cyan-300">
-                {formData.newValue}
-              </span>
+              <span>→</span>
+              <span className="font-medium">{formData.newValue}</span>
             </div>
-            <p className="text-xs text-cyan-600 dark:text-cyan-400 mt-2">
+            <p className="text-xs mt-2">
               {t('panels.updateContact.preview.description', {
                 field: formData.fieldLabel?.toLowerCase(),
               })}
             </p>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Ajuda */}
-        <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="info">
+          <p>
             <strong>{t('panels.updateContact.help.title')}:</strong>{' '}
             {t('panels.updateContact.help.description')}
           </p>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.updateContact.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid
-            ? t('panels.updateContact.actions.save')
-            : t('panels.updateContact.actions.configureFields')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.tsx
@@ -1,18 +1,17 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
   Switch,
 } from '@evoapi/design-system';
 import { Settings as SettingsIcon } from 'lucide-react';
 import { UpdateCustomAttributeNodeData } from './UpdateCustomAttributeNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { customAttributesService } from '@/services/customAttributes/customAttributesService';
 import type { CustomAttributeDefinition } from '@/types/settings';
 import { VariableInput } from '@/components/journey/environment-manager';
@@ -46,6 +45,7 @@ export function UpdateCustomAttributePanel({
   journeyId,
 }: UpdateCustomAttributePanelProps) {
   const { t } = useLanguage('journey');
+  const [originalData] = useState<UpdateCustomAttributeNodeData>(() => ({ ...data }));
   const [formData, setFormData] = useState<UpdateCustomAttributeNodeData>({
     ...data,
   });
@@ -79,20 +79,6 @@ export function UpdateCustomAttributePanel({
   };
 
   const handleSave = () => {
-    // Validação básica
-    if (!formData.attributeId) {
-      alert(t('panels.updateCustomAttribute.validation.selectAttribute'));
-      return;
-    }
-
-    if (
-      !formData.newValue ||
-      (formData.attributeDisplayType !== 'checkbox' && formData.newValue.trim() === '')
-    ) {
-      alert(t('panels.updateCustomAttribute.validation.enterValue'));
-      return;
-    }
-
     onUpdate(nodeId, formData);
     onClose();
   };
@@ -105,7 +91,7 @@ export function UpdateCustomAttributePanel({
       attributeId,
       attributeName: selectedAttribute?.attribute_display_name || '',
       attributeDisplayType: selectedAttribute?.attribute_display_type || '',
-      newValue: '', // Reset value when changing attribute
+      newValue: '',
     }));
   };
 
@@ -124,8 +110,13 @@ export function UpdateCustomAttributePanel({
   };
 
   const selectedAttribute = attributes.find(attr => attr.id === formData.attributeId);
-  const isValid =
-    formData.attributeId && formData.newValue !== undefined && formData.newValue !== '';
+  const isValid = Boolean(
+    formData.attributeId && formData.newValue !== undefined && formData.newValue !== '',
+  );
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   const normalizeDateTimeLocalValue = (dateTimeValue: string) => {
     if (!dateTimeValue) return '';
@@ -242,22 +233,22 @@ export function UpdateCustomAttributePanel({
   };
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.updateCustomAttribute.title')}
-      icon={<SettingsIcon className="w-5 h-5 text-pink-500" />}
-      onClose={onClose}
-      width="w-[600px]"
+      icon={<SettingsIcon className="h-5 w-5 text-flow-node-control-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      saveLabel={t('panels.updateCustomAttribute.actions.save')}
+      cancelLabel={t('panels.updateCustomAttribute.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Status de validação */}
         {!isValid && (
-          <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
-            <p className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-              {t('panels.updateCustomAttribute.incompleteConfig')}:
-            </p>
-            <ul className="text-xs text-yellow-700 dark:text-yellow-300 mt-1 list-disc list-inside">
+          <FlowFeedbackBanner variant="warn">
+            <p className="font-medium">{t('panels.updateCustomAttribute.incompleteConfig')}:</p>
+            <ul className="text-xs mt-1 list-disc list-inside">
               {!formData.attributeId && (
                 <li>{t('panels.updateCustomAttribute.selectAttribute')}</li>
               )}
@@ -265,10 +256,9 @@ export function UpdateCustomAttributePanel({
                 <li>{t('panels.updateCustomAttribute.configureValue')}</li>
               )}
             </ul>
-          </div>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Seleção do atributo */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">
             {t('panels.updateCustomAttribute.customAttribute')}
@@ -313,14 +303,12 @@ export function UpdateCustomAttributePanel({
           </Select>
         </div>
 
-        {/* Erro ao carregar */}
         {error && (
-          <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
-            <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
-          </div>
+          <FlowFeedbackBanner variant="error">
+            <p>{error}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Campo de novo valor */}
         {selectedAttribute && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">
@@ -335,10 +323,9 @@ export function UpdateCustomAttributePanel({
           </div>
         )}
 
-        {/* Preview da atualização */}
         {isValid && (
-          <div className="p-4 rounded-lg bg-pink-50 dark:bg-pink-950/20 border border-pink-200 dark:border-pink-800/30">
-            <p className="text-sm text-pink-800 dark:text-pink-200 mb-2">
+          <FlowFeedbackBanner variant="info">
+            <p className="mb-2">
               <strong>{t('panels.updateCustomAttribute.preview.title')}:</strong>
             </p>
             <div className="flex items-center gap-2">
@@ -346,8 +333,8 @@ export function UpdateCustomAttributePanel({
                 {ATTRIBUTE_TYPE_ICONS[selectedAttribute?.attribute_display_type || ''] || '⚙️'}
               </span>
               <span className="font-medium">{formData.attributeName}</span>
-              <span className="text-pink-600 dark:text-pink-400">→</span>
-              <span className="font-medium text-pink-700 dark:text-pink-300">
+              <span>→</span>
+              <span className="font-medium">
                 {selectedAttribute?.attribute_display_type === 'checkbox'
                   ? formData.newValue === 'true'
                     ? t('panels.updateCustomAttribute.booleanValues.true')
@@ -355,32 +342,17 @@ export function UpdateCustomAttributePanel({
                   : formData.newValue}
               </span>
             </div>
-            <p className="text-xs text-pink-600 dark:text-pink-400 mt-2">
-              {t('panels.updateCustomAttribute.preview.description')}
-            </p>
-          </div>
+            <p className="text-xs mt-2">{t('panels.updateCustomAttribute.preview.description')}</p>
+          </FlowFeedbackBanner>
         )}
 
-        {/* Ajuda */}
-        <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <p className="text-sm text-blue-800 dark:text-blue-200">
+        <FlowFeedbackBanner variant="info">
+          <p>
             <strong>{t('panels.updateCustomAttribute.help.title')}:</strong>{' '}
             {t('panels.updateCustomAttribute.help.description')}
           </p>
-        </div>
+        </FlowFeedbackBanner>
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.updateCustomAttribute.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10" disabled={!isValid}>
-          {isValid
-            ? t('panels.updateCustomAttribute.actions.save')
-            : t('panels.updateCustomAttribute.actions.configureAttribute')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }

--- a/src/components/journey/nodes/actions/wait/WaitPanel.tsx
+++ b/src/components/journey/nodes/actions/wait/WaitPanel.tsx
@@ -1,17 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Button,
   Label,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Separator,
 } from '@evoapi/design-system';
 import { Clock, Zap, GitBranch } from 'lucide-react';
 import { WaitNodeData } from './WaitNode';
-import { BaseFlowPanel } from '@/components/base';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import {
   WaitTimeConfig,
   WaitEventConfig,
@@ -58,10 +56,12 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
     },
   ];
 
-  const [formData, setFormData] = useState<WaitNodeData>({
+  const initialFormData: WaitNodeData = {
     ...data,
     waitType: data.waitType || 'time',
-  });
+  };
+  const [originalData] = useState<WaitNodeData>(() => initialFormData);
+  const [formData, setFormData] = useState<WaitNodeData>(initialFormData);
 
   useEffect(() => {
     setFormData({
@@ -71,7 +71,6 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
   }, [data]);
 
   const handleSave = () => {
-    // Validações baseadas no tipo de wait
     const updatedData = { ...formData };
 
     switch (formData.waitType) {
@@ -80,24 +79,20 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
         updatedData.timeUnit = formData.timeUnit || 'minutes';
         break;
       case 'event':
-        // hasTimeout é opcional para event
         if (updatedData.hasTimeout) {
           updatedData.maxWaitTime = updatedData.maxWaitTime || 1;
           updatedData.maxWaitUnit = updatedData.maxWaitUnit || 'hours';
         }
-        // enableFallback é opcional para event
         if (updatedData.enableFallback) {
           updatedData.fallbackTime = updatedData.fallbackTime || 1;
           updatedData.fallbackUnit = updatedData.fallbackUnit || 'hours';
         }
         break;
       case 'condition':
-        // hasTimeout é opcional para condition
         if (updatedData.hasTimeout) {
           updatedData.maxWaitTime = updatedData.maxWaitTime || 1;
           updatedData.maxWaitUnit = updatedData.maxWaitUnit || 'hours';
         }
-        // enableFallback é opcional para condition
         if (updatedData.enableFallback) {
           updatedData.fallbackTime = updatedData.fallbackTime || 1;
           updatedData.fallbackUnit = updatedData.fallbackUnit || 'hours';
@@ -117,7 +112,6 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
     setFormData(prev => ({
       ...prev,
       waitType: value,
-      // Resetar dados específicos quando muda o tipo
       ...(value !== 'time' && {
         duration: undefined,
         timeUnit: undefined,
@@ -181,18 +175,24 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
 
   const currentOption = getCurrentWaitTypeOption();
   const IconComponent = currentOption.icon;
+  const dirty = useMemo(
+    () => JSON.stringify(formData) !== JSON.stringify(originalData),
+    [formData, originalData],
+  );
 
   return (
-    <BaseFlowPanel
+    <NodeConfigModal
+      open
+      variant="simple"
       title={t('panels.wait.title')}
-      icon={<IconComponent className="w-5 h-5 text-blue-500" />}
-      onClose={onClose}
-      width="w-[600px]"
+      icon={<IconComponent className="h-5 w-5 text-flow-node-action-message-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
     >
-      <Separator />
-
       <div className="space-y-4">
-        {/* Seletor de Tipo de Espera */}
         <div className="space-y-2">
           <Label className="text-sidebar-foreground font-medium">{t('panels.wait.waitType')}</Label>
           <Select value={formData.waitType} onValueChange={handleWaitTypeChange}>
@@ -222,7 +222,6 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
           </Select>
         </div>
 
-        {/* Seção de Configuração Específica */}
         <div className="space-y-4">
           <Label className="text-sidebar-foreground font-medium">
             {t('panels.wait.configuration')} - {currentOption.label}
@@ -230,16 +229,6 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
           {renderConfigurationSection()}
         </div>
       </div>
-
-      {/* Botões de ação */}
-      <div className="flex gap-3 pt-2">
-        <Button variant="outline" onClick={onClose} className="flex-1 h-10">
-          {t('panels.actions.cancel')}
-        </Button>
-        <Button onClick={handleSave} className="flex-1 h-10">
-          {t('panels.actions.save')}
-        </Button>
-      </div>
-    </BaseFlowPanel>
+    </NodeConfigModal>
   );
 }


### PR DESCRIPTION
## Summary

Story [EVO-1274](https://linear.app/evoai/issue/EVO-1274) [10.4] applies the design system from [EVO-1253](https://linear.app/evoai/issue/EVO-1253) and the shared `<NodeConfigModal>` from [EVO-1264](https://linear.app/evoai/issue/EVO-1264) to every node configuration modal in the Flow Builder (except Trigger Event, owned by 10.6, and `exit-journey` which has no panel).

Migration recipe per panel:
- Wrap in `<NodeConfigModal variant="simple|tabs">` from `@/components/journey/shared/NodeConfigModal`.
- Track `dirty` via a `useState(() => data)` snapshot + `useMemo` JSON compare; pass `dirty={dirty && isValid}` so Save stays disabled until a field is actually changed (AC #3).
- Replace inline `bg-yellow-50 / bg-red-50 / bg-blue-50 / bg-green-50 / ...` boxes with `<FlowFeedbackBanner variant="warn|error|info|success">` (AC #4).
- Switch hardcoded icon colors (`text-blue-500`, `text-purple-500`, etc.) to design tokens (`text-flow-node-action-*-fg`, `text-flow-node-control-fg`, `text-flow-node-condition-fg`).
- Drop legacy footer `<Button>` pair and the standalone `<Separator />` at the top of the body (chrome now belongs to `<NodeConfigModal>`).
- Drop `alert()` / dead-code `toast.error()` validations in `handleSave` — covered by the disabled state.

UX semantic shift: floating side card on the canvas → centered Radix Dialog with overlay, focus trap, ESC, click-outside. This is the intent of Pain #5 from discovery 8.1.

### Commits (4 waves)

| Wave | Panels | Variant |
|---|---|---|
| 1 — pilot | wait, add-label, remove-label | simple |
| 2 — simples | mute-conversation, resolve-conversation, defer-conversation, change-priority, assign-agent, assign-bot, assign-team, transfer-journey, update-contact, update-custom-attribute | simple |
| 3 — médios | send-message, send-transcript, send-email-team, set-variable, split, scheduled-action | simple |
| 4 — tabs | conditional (internal `<Tabs>` for per-path switcher, variant=simple), send-webhook (variant=tabs, 5 tabs basic / headers / body / auth / test) | tabs / simple |

## Security

Refactor visual puro — zero new endpoints, zero new auth surfaces, zero new validations. Every `<Button>` is the design-system primitive (passes `no-restricted-syntax`). Raw `<select>` and `<textarea>` elements inside panel bodies are pre-existing pre-EVO-1253 patterns kept out of scope; the `<Button>` migration of the attachment remove control in `SendMessagePanel` is the only inner-body cleanup in this PR.

## Test plan

- [x] `pnpm exec tsc -p tsconfig.app.json --noEmit` — clean
- [x] `pnpm exec eslint src/components/journey/nodes/actions/` — 67 problems, identical to `origin/develop` baseline (zero regressions). All remaining `any` types and `react-hooks/exhaustive-deps` warnings predate this PR and are out of scope per the card.
- [x] `pnpm dev` smoke: at least one panel per wave opened, edited, saved, re-opened, validated dirty/Save-disabled, FlowFeedbackBanner color in light + dark, ESC/click-outside/X/Cancel paths.

For reviewers reproducing locally:
```bash
cd evo-ai-frontend-community
pnpm install
pnpm exec tsc -p tsconfig.app.json --noEmit
pnpm exec eslint src/components/journey/nodes/actions/
pnpm dev
# /journeys → create a journey → drop one of each node type → open each modal
```

## Changed Files

21 panels in `src/components/journey/nodes/actions/<node>/<Node>Panel.tsx`:
- `add-label/AddLabelPanel.tsx`
- `assign-agent/AssignAgentPanel.tsx`
- `assign-bot/AssignBotPanel.tsx`
- `assign-team/AssignTeamPanel.tsx`
- `change-priority/ChangePriorityPanel.tsx`
- `conditional/ConditionalPanel.tsx`
- `defer-conversation/DeferConversationPanel.tsx`
- `mute-conversation/MuteConversationPanel.tsx`
- `remove-label/RemoveLabelPanel.tsx`
- `resolve-conversation/ResolveConversationPanel.tsx`
- `scheduled-action/ScheduledActionPanel.tsx`
- `send-email-team/SendEmailTeamPanel.tsx`
- `send-message/SendMessagePanel.tsx`
- `send-transcript/SendTranscriptPanel.tsx`
- `send-webhook/SendWebhookPanel.tsx`
- `set-variable/SetVariablePanel.tsx`
- `split/SplitPanel.tsx`
- `transfer-journey/TransferJourneyPanel.tsx`
- `update-contact/UpdateContactPanel.tsx`
- `update-custom-attribute/UpdateCustomAttributePanel.tsx`
- `wait/WaitPanel.tsx`

Net diff: **+1398 / −1866 (−468 lines)** despite gaining the dirty-tracking machinery — the shared chrome and feedback banner pay for themselves.

## Linked Issue

- https://linear.app/evoai/issue/EVO-1274

🤖 Generated with [Claude Code](https://claude.com/claude-code)