### PR TITLE
feat(frontend): make Flow Builder respect the CRM light/dark theme (EVO-1270)

### DIFF
--- a/src/components/base/BaseFlow.css
+++ b/src/components/base/BaseFlow.css
@@ -29,13 +29,18 @@
   padding: 5px;
 }
 
+/*
+ * Controls chrome — keep the structural rules (sizing, radius, blur)
+ * but defer all colour decisions to React Flow's own --xy-* defaults,
+ * which are remapped to shadcn semantic tokens in globals.css. The
+ * previous block hardcoded dark rgba(...) values with !important and
+ * stomped on the light theme (EVO-1270).
+ */
 .react-flow__controls {
-  background-color: rgba(30, 30, 30, 0.8);
   backdrop-filter: blur(4px);
   border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(70, 70, 70, 0.5);
+  box-shadow: 0 4px 15px color-mix(in srgb, var(--color-foreground) 18%, transparent);
   padding: 4px;
 }
 
@@ -44,10 +49,7 @@
   width: 32px;
   height: 32px;
   margin: 4px 0;
-  border: none !important;
-  background-color: rgba(40, 40, 40, 0.8) !important;
-  color: #a0a0a0 !important;
-  border-radius: 6px !important;
+  border-radius: 6px;
   transition: all 0.2s ease;
   display: flex;
   align-items: center;
@@ -55,24 +57,14 @@
 }
 
 .react-flow__controls-button:hover {
-  background-color: rgba(60, 60, 60, 0.9) !important;
-  color: #ffffff !important;
   transform: translateY(-1px);
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 2px 5px color-mix(in srgb, var(--color-foreground) 12%, transparent);
 }
 
 .react-flow__controls-button svg {
   fill: currentColor;
   width: 16px;
   height: 16px;
-}
-
-.react-flow__controls-button[data-action="zoom-in"] {
-  border-bottom: 1px solid rgba(70, 70, 70, 0.5) !important;
-}
-
-.react-flow__controls-button[data-action="zoom-out"] {
-  border-bottom: 1px solid rgba(70, 70, 70, 0.5) !important;
 }
 
 /* Hide scrollbar for all browsers while maintaining scroll functionality */
@@ -310,20 +302,10 @@
   }
 }
 
-/* Dark theme adjustments */
-@media (prefers-color-scheme: dark) {
-  .react-flow__controls {
-    background-color: rgba(20, 20, 20, 0.9);
-    border-color: rgba(60, 60, 60, 0.5);
-  }
-
-  .react-flow__controls-button {
-    background-color: rgba(30, 30, 30, 0.8) !important;
-    color: #b0b0b0 !important;
-  }
-
-  .react-flow__controls-button:hover {
-    background-color: rgba(50, 50, 50, 0.9) !important;
-    color: #ffffff !important;
-  }
-}
+/*
+ * Removed: legacy @media (prefers-color-scheme: dark) block that
+ * duplicated the hardcoded dark control styles. The CRM theme toggle is
+ * the canonical switch (not the OS preference), and React Flow's own
+ * `.react-flow.dark { ... }` defaults — driven by the colorMode prop
+ * (EVO-1270 C7) — handle the dark variant correctly.
+ */

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -18,7 +18,6 @@ import {
   type Edge,
   ConnectionLineType,
 } from '@xyflow/react';
-import '@xyflow/react/dist/style.css';
 import './BaseFlow.css';
 
 import { Button } from '@evoapi/design-system';

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -536,9 +536,9 @@ export function BaseFlowCanvas({
         {/* MiniMap */}
         {showMiniMap && (
           <MiniMap
-            className="bg-flow-palette-bg border border-flow-palette-divider rounded-lg shadow-lg"
+            className="bg-flow-palette-bg/85 border border-flow-palette-divider rounded-lg shadow-lg backdrop-blur-sm"
             nodeColor={node => defaultMiniMapColors[node.type || 'default'] || 'var(--color-muted-foreground)'}
-            maskColor="color-mix(in srgb, var(--color-foreground) 30%, transparent)"
+            maskColor="color-mix(in srgb, var(--color-foreground) 12%, transparent)"
           />
         )}
 

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -27,6 +27,7 @@ import { BaseFlowContextMenu } from './BaseFlowContextMenu';
 import { BaseFlowHelperLines } from './BaseFlowHelperLines';
 import BaseDefaultEdge from './BaseDefaultEdge';
 import { cn, getHelperLines, createMiniMapNodeColors } from '@/lib/utils';
+import { useDarkMode } from '@/hooks/useDarkMode';
 
 // Edge types padrão
 const defaultEdgeTypes = {
@@ -169,6 +170,7 @@ export function BaseFlowCanvas({
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { screenToFlowPosition } = useReactFlow();
   const { type, setPointerEvents, setType } = useDnD();
+  const { theme } = useDarkMode();
 
   // Estados do canvas
   const [nodes, setNodes, onNodesChangeInternal] = useNodesState(initialNodes);
@@ -476,7 +478,7 @@ export function BaseFlowCanvas({
         snapToGrid={snapToGrid}
         snapGrid={snapGrid}
         proOptions={proOptions}
-        colorMode="dark"
+        colorMode={theme === 'dark' ? 'dark' : 'light'}
         deleteKeyCode={['Backspace', 'Delete']}
         multiSelectionKeyCode={['Meta', 'Ctrl']}
         panOnDrag={true}

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -516,6 +516,7 @@ export function BaseFlowCanvas({
             variant={backgroundVariant as any}
             gap={24}
             size={1.5}
+            color="var(--color-flow-canvas-grid)"
             className="bg-sidebar"
           />
         )}
@@ -535,9 +536,9 @@ export function BaseFlowCanvas({
         {/* MiniMap */}
         {showMiniMap && (
           <MiniMap
-            className="bg-neutral-800/80 border border-neutral-700 rounded-lg shadow-lg"
-            nodeColor={node => defaultMiniMapColors[node.type || 'default'] || '#64748b'}
-            maskColor="rgba(21, 21, 21, 0.6)"
+            className="bg-flow-palette-bg border border-flow-palette-divider rounded-lg shadow-lg"
+            nodeColor={node => defaultMiniMapColors[node.type || 'default'] || 'var(--color-muted-foreground)'}
+            maskColor="color-mix(in srgb, var(--color-foreground) 30%, transparent)"
           />
         )}
 

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -28,6 +28,7 @@ import { BaseFlowHelperLines } from './BaseFlowHelperLines';
 import BaseDefaultEdge from './BaseDefaultEdge';
 import { cn, getHelperLines, createMiniMapNodeColors } from '@/lib/utils';
 import { useDarkMode } from '@/hooks/useDarkMode';
+import { flowTokens } from '@/components/journey/_ui/tokens';
 
 // Edge types padrão
 const defaultEdgeTypes = {
@@ -517,7 +518,7 @@ export function BaseFlowCanvas({
             variant={backgroundVariant as any}
             gap={24}
             size={1.5}
-            color="var(--color-flow-canvas-grid)"
+            color={flowTokens.canvas.grid}
             className="bg-sidebar"
           />
         )}

--- a/src/components/base/BaseFlowNode.tsx
+++ b/src/components/base/BaseFlowNode.tsx
@@ -45,63 +45,63 @@ export type NodeBorderColor =
 const colorStyles = {
   blue: {
     border: "border-blue-300 hover:border-blue-500 dark:border-blue-700/70 dark:hover:border-blue-500",
-    gradient: "bg-gradient-to-br from-blue-50 to-card dark:from-blue-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-blue-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(59,130,246,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(59,130,246,0.3)]",
     handle: "bg-yellow-500 border-yellow-400" // Mantém o padrão atual de handles amarelos
   },
   orange: {
     border: "border-orange-300 hover:border-orange-500 dark:border-orange-700/70 dark:hover:border-orange-500",
-    gradient: "bg-gradient-to-br from-orange-50 to-card dark:from-orange-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-orange-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(249,115,22,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(249,115,22,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   green: {
     border: "border-green-300 hover:border-green-500 dark:border-green-700/70 dark:hover:border-green-500",
-    gradient: "bg-gradient-to-br from-green-50 to-card dark:from-green-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-green-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(34,197,94,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(34,197,94,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   red: {
     border: "border-red-300 hover:border-red-500 dark:border-red-700/70 dark:hover:border-red-500",
-    gradient: "bg-gradient-to-br from-red-50 to-card dark:from-red-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-red-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(239,68,68,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(239,68,68,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   yellow: {
     border: "border-yellow-300 hover:border-yellow-500 dark:border-yellow-700/70 dark:hover:border-yellow-500",
-    gradient: "bg-gradient-to-br from-yellow-50 to-card dark:from-yellow-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-yellow-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(234,179,8,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(234,179,8,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   purple: {
     border: "border-purple-300 hover:border-purple-500 dark:border-purple-700/70 dark:hover:border-purple-500",
-    gradient: "bg-gradient-to-br from-purple-50 to-card dark:from-purple-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-purple-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(168,85,247,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(168,85,247,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   indigo: {
     border: "border-indigo-300 hover:border-indigo-500 dark:border-indigo-700/70 dark:hover:border-indigo-500",
-    gradient: "bg-gradient-to-br from-indigo-50 to-card dark:from-indigo-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-indigo-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(99,102,241,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(99,102,241,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   pink: {
     border: "border-pink-300 hover:border-pink-500 dark:border-pink-700/70 dark:hover:border-pink-500",
-    gradient: "bg-gradient-to-br from-pink-50 to-card dark:from-pink-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-pink-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(236,72,153,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(236,72,153,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   emerald: {
     border: "border-emerald-300 hover:border-emerald-500 dark:border-emerald-700/70 dark:hover:border-emerald-500",
-    gradient: "bg-gradient-to-br from-emerald-50 to-card dark:from-emerald-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-emerald-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(16,185,129,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(16,185,129,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
@@ -116,42 +116,42 @@ const colorStyles = {
   // Cores extras mantendo compatibilidade
   cyan: {
     border: "border-cyan-300 hover:border-cyan-500 dark:border-cyan-700/70 dark:hover:border-cyan-500",
-    gradient: "bg-gradient-to-br from-cyan-50 to-card dark:from-cyan-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-cyan-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(6,182,212,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(6,182,212,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   teal: {
     border: "border-teal-300 hover:border-teal-500 dark:border-teal-700/70 dark:hover:border-teal-500",
-    gradient: "bg-gradient-to-br from-teal-50 to-card dark:from-teal-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-teal-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(20,184,166,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(20,184,166,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   lime: {
     border: "border-lime-300 hover:border-lime-500 dark:border-lime-700/70 dark:hover:border-lime-500",
-    gradient: "bg-gradient-to-br from-lime-50 to-card dark:from-lime-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-lime-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(132,204,22,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(132,204,22,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   amber: {
     border: "border-amber-300 hover:border-amber-500 dark:border-amber-700/70 dark:hover:border-amber-500",
-    gradient: "bg-gradient-to-br from-amber-50 to-card dark:from-amber-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-amber-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(245,158,11,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(245,158,11,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   rose: {
     border: "border-rose-300 hover:border-rose-500 dark:border-rose-700/70 dark:hover:border-rose-500",
-    gradient: "bg-gradient-to-br from-rose-50 to-card dark:from-rose-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-rose-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(244,63,94,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(244,63,94,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   violet: {
     border: "border-violet-300 hover:border-violet-500 dark:border-violet-700/70 dark:hover:border-violet-500",
-    gradient: "bg-gradient-to-br from-violet-50 to-card dark:from-violet-950/40 dark:to-neutral-900/90",
+    gradient: "bg-card dark:bg-gradient-to-br dark:from-violet-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(139,92,246,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(139,92,246,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"

--- a/src/components/base/BaseFlowNode.tsx
+++ b/src/components/base/BaseFlowNode.tsx
@@ -38,116 +38,120 @@ export type NodeBorderColor =
   | 'cyan' | 'teal' | 'lime' | 'amber' | 'rose';
 
 // Mapeamento de cores - COMPATÍVEL COM BaseNode ATUAL
+// Cada gradient mantém o feel dark-only original e ganha uma variante
+// light (`dark:` prefix vira a regra dark; default é light) usando
+// tints -50/-100 sobre o token semântico `bg-card`. Light variant
+// resolve EVO-1270 AC#2 sem redesenhar visualmente o node.
 const colorStyles = {
   blue: {
-    border: "border-blue-700/70 hover:border-blue-500",
-    gradient: "bg-gradient-to-br from-blue-950/40 to-neutral-900/90",
+    border: "border-blue-300 hover:border-blue-500 dark:border-blue-700/70 dark:hover:border-blue-500",
+    gradient: "bg-gradient-to-br from-blue-50 to-card dark:from-blue-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(59,130,246,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(59,130,246,0.3)]",
     handle: "bg-yellow-500 border-yellow-400" // Mantém o padrão atual de handles amarelos
   },
   orange: {
-    border: "border-orange-700/70 hover:border-orange-500",
-    gradient: "bg-gradient-to-br from-orange-950/40 to-neutral-900/90",
+    border: "border-orange-300 hover:border-orange-500 dark:border-orange-700/70 dark:hover:border-orange-500",
+    gradient: "bg-gradient-to-br from-orange-50 to-card dark:from-orange-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(249,115,22,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(249,115,22,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   green: {
-    border: "border-green-700/70 hover:border-green-500",
-    gradient: "bg-gradient-to-br from-green-950/40 to-neutral-900/90",
+    border: "border-green-300 hover:border-green-500 dark:border-green-700/70 dark:hover:border-green-500",
+    gradient: "bg-gradient-to-br from-green-50 to-card dark:from-green-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(34,197,94,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(34,197,94,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   red: {
-    border: "border-red-700/70 hover:border-red-500",
-    gradient: "bg-gradient-to-br from-red-950/40 to-neutral-900/90",
+    border: "border-red-300 hover:border-red-500 dark:border-red-700/70 dark:hover:border-red-500",
+    gradient: "bg-gradient-to-br from-red-50 to-card dark:from-red-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(239,68,68,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(239,68,68,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   yellow: {
-    border: "border-yellow-700/70 hover:border-yellow-500",
-    gradient: "bg-gradient-to-br from-yellow-950/40 to-neutral-900/90",
+    border: "border-yellow-300 hover:border-yellow-500 dark:border-yellow-700/70 dark:hover:border-yellow-500",
+    gradient: "bg-gradient-to-br from-yellow-50 to-card dark:from-yellow-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(234,179,8,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(234,179,8,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   purple: {
-    border: "border-purple-700/70 hover:border-purple-500",
-    gradient: "bg-gradient-to-br from-purple-950/40 to-neutral-900/90",
+    border: "border-purple-300 hover:border-purple-500 dark:border-purple-700/70 dark:hover:border-purple-500",
+    gradient: "bg-gradient-to-br from-purple-50 to-card dark:from-purple-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(168,85,247,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(168,85,247,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   indigo: {
-    border: "border-indigo-700/70 hover:border-indigo-500",
-    gradient: "bg-gradient-to-br from-indigo-950/40 to-neutral-900/90",
+    border: "border-indigo-300 hover:border-indigo-500 dark:border-indigo-700/70 dark:hover:border-indigo-500",
+    gradient: "bg-gradient-to-br from-indigo-50 to-card dark:from-indigo-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(99,102,241,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(99,102,241,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   pink: {
-    border: "border-pink-700/70 hover:border-pink-500",
-    gradient: "bg-gradient-to-br from-pink-950/40 to-neutral-900/90",
+    border: "border-pink-300 hover:border-pink-500 dark:border-pink-700/70 dark:hover:border-pink-500",
+    gradient: "bg-gradient-to-br from-pink-50 to-card dark:from-pink-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(236,72,153,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(236,72,153,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   emerald: {
-    border: "border-emerald-700/70 hover:border-emerald-500",
-    gradient: "bg-gradient-to-br from-emerald-950/40 to-neutral-900/90",
+    border: "border-emerald-300 hover:border-emerald-500 dark:border-emerald-700/70 dark:hover:border-emerald-500",
+    gradient: "bg-gradient-to-br from-emerald-50 to-card dark:from-emerald-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(16,185,129,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(16,185,129,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   slate: {
-    border: "border-slate-700/70 hover:border-slate-500",
-    gradient: "bg-gradient-to-br from-slate-800/40 to-neutral-900/90",
+    border: "border-slate-300 hover:border-slate-500 dark:border-slate-700/70 dark:hover:border-slate-500",
+    gradient: "bg-gradient-to-br from-slate-50 to-card dark:from-slate-800/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(100,116,139,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(100,116,139,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   // Cores extras mantendo compatibilidade
   cyan: {
-    border: "border-cyan-700/70 hover:border-cyan-500",
-    gradient: "bg-gradient-to-br from-cyan-950/40 to-neutral-900/90",
+    border: "border-cyan-300 hover:border-cyan-500 dark:border-cyan-700/70 dark:hover:border-cyan-500",
+    gradient: "bg-gradient-to-br from-cyan-50 to-card dark:from-cyan-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(6,182,212,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(6,182,212,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   teal: {
-    border: "border-teal-700/70 hover:border-teal-500",
-    gradient: "bg-gradient-to-br from-teal-950/40 to-neutral-900/90",
+    border: "border-teal-300 hover:border-teal-500 dark:border-teal-700/70 dark:hover:border-teal-500",
+    gradient: "bg-gradient-to-br from-teal-50 to-card dark:from-teal-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(20,184,166,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(20,184,166,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   lime: {
-    border: "border-lime-700/70 hover:border-lime-500",
-    gradient: "bg-gradient-to-br from-lime-950/40 to-neutral-900/90",
+    border: "border-lime-300 hover:border-lime-500 dark:border-lime-700/70 dark:hover:border-lime-500",
+    gradient: "bg-gradient-to-br from-lime-50 to-card dark:from-lime-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(132,204,22,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(132,204,22,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   amber: {
-    border: "border-amber-700/70 hover:border-amber-500",
-    gradient: "bg-gradient-to-br from-amber-950/40 to-neutral-900/90",
+    border: "border-amber-300 hover:border-amber-500 dark:border-amber-700/70 dark:hover:border-amber-500",
+    gradient: "bg-gradient-to-br from-amber-50 to-card dark:from-amber-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(245,158,11,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(245,158,11,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   rose: {
-    border: "border-rose-700/70 hover:border-rose-500",
-    gradient: "bg-gradient-to-br from-rose-950/40 to-neutral-900/90",
+    border: "border-rose-300 hover:border-rose-500 dark:border-rose-700/70 dark:hover:border-rose-500",
+    gradient: "bg-gradient-to-br from-rose-50 to-card dark:from-rose-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(244,63,94,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(244,63,94,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
   },
   violet: {
-    border: "border-violet-700/70 hover:border-violet-500",
-    gradient: "bg-gradient-to-br from-violet-950/40 to-neutral-900/90",
+    border: "border-violet-300 hover:border-violet-500 dark:border-violet-700/70 dark:hover:border-violet-500",
+    gradient: "bg-gradient-to-br from-violet-50 to-card dark:from-violet-950/40 dark:to-neutral-900/90",
     glow: "shadow-[0_0_15px_rgba(139,92,246,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(139,92,246,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
@@ -239,7 +243,7 @@ export function BaseFlowNode({
 
       {/* Source Handle - mantém comportamento exato do BaseNode atual */}
       {hasSource && (
-        <div className="mt-2 flex items-center justify-end text-sm text-neutral-400 transition-colors">
+        <div className="mt-2 flex items-center justify-end text-sm text-muted-foreground transition-colors">
           {showSourceArrow && (
             <div className="flex items-center space-x-1 rounded-md py-1 px-2">
               <span>{t('base.flow.node.nextStep')}</span>
@@ -299,11 +303,11 @@ export function NodeHeader({
         </div>
       </div>
       <div className="flex-1 min-w-0">
-        <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+        <h3 className="text-sm font-medium text-foreground truncate">
           {title}
         </h3>
         {subtitle && (
-          <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
+          <p className="text-xs text-muted-foreground truncate">
             {subtitle}
           </p>
         )}

--- a/src/components/journey/nodes/actions/add-label/AddLabelNode.tsx
+++ b/src/components/journey/nodes/actions/add-label/AddLabelNode.tsx
@@ -52,12 +52,12 @@ export function AddLabelNode({ selected, data, id }: AddLabelNodeProps) {
             <Tag className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               Adicionar Etiqueta
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/assign-agent/AssignAgentNode.tsx
+++ b/src/components/journey/nodes/actions/assign-agent/AssignAgentNode.tsx
@@ -64,12 +64,12 @@ export function AssignAgentNode({ selected, data, id }: AssignAgentNodeProps) {
             <User className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('flowEditor.nodes.assignAgent.name')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/assign-team/AssignTeamNode.tsx
+++ b/src/components/journey/nodes/actions/assign-team/AssignTeamNode.tsx
@@ -64,12 +64,12 @@ export function AssignTeamNode({ selected, data, id }: AssignTeamNodeProps) {
             <Users className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('flowEditor.nodes.assignTeam.name')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/change-priority/ChangePriorityNode.tsx
+++ b/src/components/journey/nodes/actions/change-priority/ChangePriorityNode.tsx
@@ -72,12 +72,12 @@ export function ChangePriorityNode({ selected, data, id }: ChangePriorityNodePro
             <AlertTriangle className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.changePriority.alterPriority')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -144,7 +144,7 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
               <p className={`text-xs font-medium ${colors.text}`}>
                 {path.name || t('panels.conditional.pathNumber', { number: index + 1 })}
               </p>
-              <p className="text-xs text-gray-400 mt-1">{t('panels.conditional.noConditionsConfigured')}</p>
+              <p className="text-xs text-muted-foreground mt-1">{t('panels.conditional.noConditionsConfigured')}</p>
             </div>
             <Handle
               className={cn(
@@ -189,7 +189,7 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
                     </span>
                   )}
                   <span className="text-gray-300">{getFieldLabel(condition.field)}</span>{' '}
-                  <span className="text-gray-400">{getOperatorLabel(condition.operator)}</span>
+                  <span className="text-muted-foreground">{getOperatorLabel(condition.operator)}</span>
                   {needsValue(condition.operator) && condition.value && (
                     <>
                       {' '}
@@ -245,12 +245,12 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
             <GitBranch className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.conditional.nodeTitle')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 
@@ -275,10 +275,10 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
         <div className="cursor-pointer rounded-lg border border-red-700/40 bg-red-950/10 p-3 text-left transition-all duration-200 hover:border-red-600/50 hover:bg-red-900/10">
           <div className="flex items-center justify-between">
             <div className="flex-1">
-              <p className="font-medium text-neutral-300">
+              <p className="font-medium text-foreground">
                 <span className="font-semibold text-red-400">{t('panels.conditional.otherwiseCase')}</span>
               </p>
-              <p className="text-xs text-gray-400 mt-1">
+              <p className="text-xs text-muted-foreground mt-1">
                 {t('panels.conditional.otherwiseDescription')}
               </p>
             </div>

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -98,31 +98,44 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
   };
 
   const getPathColor = (color?: string) => {
-    const colors: Record<string, { border: string; bg: string; text: string }> = {
+    const colors: Record<
+      string,
+      { border: string; bg: string; text: string; hoverBorder: string; hoverBg: string }
+    > = {
       green: {
-        border: 'border-green-700/40',
-        bg: 'bg-green-950/10',
-        text: 'text-green-400',
+        border: 'border-green-300 dark:border-green-700/40',
+        bg: 'bg-green-50 dark:bg-green-950/10',
+        text: 'text-green-700 dark:text-green-400',
+        hoverBorder: 'hover:border-green-400 dark:hover:border-green-600/50',
+        hoverBg: 'hover:bg-green-100 dark:hover:bg-green-900/20',
       },
       blue: {
-        border: 'border-blue-700/40',
-        bg: 'bg-blue-950/10',
-        text: 'text-blue-400',
+        border: 'border-blue-300 dark:border-blue-700/40',
+        bg: 'bg-blue-50 dark:bg-blue-950/10',
+        text: 'text-blue-700 dark:text-blue-400',
+        hoverBorder: 'hover:border-blue-400 dark:hover:border-blue-600/50',
+        hoverBg: 'hover:bg-blue-100 dark:hover:bg-blue-900/20',
       },
       purple: {
-        border: 'border-purple-700/40',
-        bg: 'bg-purple-950/10',
-        text: 'text-purple-400',
+        border: 'border-purple-300 dark:border-purple-700/40',
+        bg: 'bg-purple-50 dark:bg-purple-950/10',
+        text: 'text-purple-700 dark:text-purple-400',
+        hoverBorder: 'hover:border-purple-400 dark:hover:border-purple-600/50',
+        hoverBg: 'hover:bg-purple-100 dark:hover:bg-purple-900/20',
       },
       orange: {
-        border: 'border-orange-700/40',
-        bg: 'bg-orange-950/10',
-        text: 'text-orange-400',
+        border: 'border-orange-300 dark:border-orange-700/40',
+        bg: 'bg-orange-50 dark:bg-orange-950/10',
+        text: 'text-orange-700 dark:text-orange-400',
+        hoverBorder: 'hover:border-orange-400 dark:hover:border-orange-600/50',
+        hoverBg: 'hover:bg-orange-100 dark:hover:bg-orange-900/20',
       },
       yellow: {
-        border: 'border-yellow-700/40',
-        bg: 'bg-yellow-950/10',
-        text: 'text-yellow-400',
+        border: 'border-yellow-300 dark:border-yellow-700/40',
+        bg: 'bg-yellow-50 dark:bg-yellow-950/10',
+        text: 'text-yellow-700 dark:text-yellow-400',
+        hoverBorder: 'hover:border-yellow-400 dark:hover:border-yellow-600/50',
+        hoverBg: 'hover:bg-yellow-100 dark:hover:bg-yellow-900/20',
       },
     };
     return colors[color || 'yellow'] || colors.yellow;
@@ -137,11 +150,17 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
       return (
         <div
           key={path.id}
-          className={`mb-3 cursor-pointer rounded-lg border border-dashed ${colors.border} ${colors.bg} p-3 text-left transition-all duration-200 hover:border-opacity-70`}
+          className={cn(
+            'mb-3 cursor-pointer rounded-lg border border-dashed p-3 text-left transition-all duration-200',
+            colors.border,
+            colors.bg,
+            colors.hoverBorder,
+            colors.hoverBg,
+          )}
         >
           <div className="flex items-center justify-between">
             <div className="flex-1">
-              <p className={`text-xs font-medium ${colors.text}`}>
+              <p className={cn('text-xs font-medium', colors.text)}>
                 {path.name || t('panels.conditional.pathNumber', { number: index + 1 })}
               </p>
               <p className="text-xs text-muted-foreground mt-1">{t('panels.conditional.noConditionsConfigured')}</p>
@@ -173,27 +192,33 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
     return (
       <div
         key={path.id}
-        className={`mb-3 cursor-pointer rounded-lg border ${colors.border} ${colors.bg} p-3 text-left transition-all duration-200 hover:border-opacity-70`}
+        className={cn(
+          'mb-3 cursor-pointer rounded-lg border p-3 text-left transition-all duration-200',
+          colors.border,
+          colors.bg,
+          colors.hoverBorder,
+          colors.hoverBg,
+        )}
       >
         <div className="flex items-center justify-between">
           <div className="flex-1">
-            <p className={`text-xs font-bold ${colors.text} mb-2`}>
+            <p className={cn('text-xs font-bold mb-2', colors.text)}>
               {path.name || t('panels.conditional.pathNumber', { number: index + 1 })}
             </p>
             <div className="space-y-1">
               {path.conditions.map((condition, idx) => (
                 <div key={condition.id} className="text-xs">
                   {idx > 0 && (
-                    <span className="text-gray-500 font-medium mr-1">
+                    <span className="text-muted-foreground font-medium mr-1">
                       {path.logicalOperator === 'AND' ? t('panels.conditional.logicalOperators.and') : t('panels.conditional.logicalOperators.or')}
                     </span>
                   )}
-                  <span className="text-gray-300">{getFieldLabel(condition.field)}</span>{' '}
+                  <span className="text-foreground">{getFieldLabel(condition.field)}</span>{' '}
                   <span className="text-muted-foreground">{getOperatorLabel(condition.operator)}</span>
                   {needsValue(condition.operator) && condition.value && (
                     <>
                       {' '}
-                      <span className="text-green-400 font-medium">"{condition.value}"</span>
+                      <span className="text-green-700 dark:text-green-400 font-medium">"{condition.value}"</span>
                     </>
                   )}
                 </div>
@@ -259,8 +284,8 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
           <div className="space-y-2">{paths.map((path, index) => renderPath(path, index))}</div>
         ) : hasLegacyRules ? (
           // Fallback para estrutura antiga
-          <div className="p-3 rounded-lg border border-yellow-700/40 bg-yellow-950/10">
-            <p className="text-xs text-yellow-600 dark:text-yellow-300 mb-2">
+          <div className="p-3 rounded-lg border border-yellow-300 bg-yellow-50 dark:border-yellow-700/40 dark:bg-yellow-950/10">
+            <p className="text-xs text-yellow-700 dark:text-yellow-300 mb-2">
               {t('panels.conditional.oldStructureDetected')}
             </p>
           </div>
@@ -272,11 +297,11 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
         )}
 
         {/* Handle para "caso contrário" - sempre presente */}
-        <div className="cursor-pointer rounded-lg border border-red-700/40 bg-red-950/10 p-3 text-left transition-all duration-200 hover:border-red-600/50 hover:bg-red-900/10">
+        <div className="cursor-pointer rounded-lg border border-red-300 bg-red-50 hover:border-red-400 hover:bg-red-100 dark:border-red-700/40 dark:bg-red-950/10 dark:hover:border-red-600/50 dark:hover:bg-red-900/10 p-3 text-left transition-all duration-200">
           <div className="flex items-center justify-between">
             <div className="flex-1">
               <p className="font-medium text-foreground">
-                <span className="font-semibold text-red-400">{t('panels.conditional.otherwiseCase')}</span>
+                <span className="font-semibold text-red-700 dark:text-red-400">{t('panels.conditional.otherwiseCase')}</span>
               </p>
               <p className="text-xs text-muted-foreground mt-1">
                 {t('panels.conditional.otherwiseDescription')}

--- a/src/components/journey/nodes/actions/defer-conversation/DeferConversationNode.tsx
+++ b/src/components/journey/nodes/actions/defer-conversation/DeferConversationNode.tsx
@@ -116,12 +116,12 @@ export function DeferConversationNode({ selected, data, id }: DeferConversationN
             <Clock className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.deferConversation.node.title')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/exit-journey/ExitJourneyNode.tsx
+++ b/src/components/journey/nodes/actions/exit-journey/ExitJourneyNode.tsx
@@ -40,7 +40,7 @@ export function ExitJourneyNode({ selected, id }: ExitJourneyNodeProps) {
             <LogOut className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.exitJourney.title')}
             </h3>
           </div>

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationNode.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationNode.tsx
@@ -48,12 +48,12 @@ export function MuteConversationNode({ selected, id }: MuteConversationNodeProps
             <VolumeX className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+          <h3 className="text-sm font-medium text-foreground truncate">
             {t('flowEditor.nodes.muteConversation.name')}
           </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/remove-label/RemoveLabelNode.tsx
+++ b/src/components/journey/nodes/actions/remove-label/RemoveLabelNode.tsx
@@ -55,12 +55,12 @@ export function RemoveLabelNode({ selected, data, id }: RemoveLabelNodeProps) {
             </div>
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('flowEditor.nodes.removeLabel.name')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationNode.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationNode.tsx
@@ -48,12 +48,12 @@ export function ResolveConversationNode({ selected, id }: ResolveConversationNod
             <CheckCircle className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+          <h3 className="text-sm font-medium text-foreground truncate">
             {t('flowEditor.nodes.resolveConversation.name')}
           </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/scheduled-action/ScheduledActionNode.tsx
+++ b/src/components/journey/nodes/actions/scheduled-action/ScheduledActionNode.tsx
@@ -72,12 +72,12 @@ export function ScheduledActionNode({ selected, data, id }: ScheduledActionNodeP
             <Clock className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('flowEditor.nodes.scheduledAction.title')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/send-email-team/SendEmailTeamNode.tsx
+++ b/src/components/journey/nodes/actions/send-email-team/SendEmailTeamNode.tsx
@@ -99,12 +99,12 @@ export function SendEmailTeamNode({ selected, data, id }: SendEmailTeamNodeProps
             <Mail className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.sendEmailTeam.node.title')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/send-message/SendMessageNode.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessageNode.tsx
@@ -111,12 +111,12 @@ export function SendMessageNode({ selected, data, id }: SendMessageNodeProps) {
             <MessageSquare className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               Enviar Mensagem
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/send-transcript/SendTranscriptNode.tsx
+++ b/src/components/journey/nodes/actions/send-transcript/SendTranscriptNode.tsx
@@ -77,12 +77,12 @@ export function SendTranscriptNode({ selected, data, id }: SendTranscriptNodePro
             <FileText className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.sendTranscript.node.title')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/send-webhook/SendWebhookNode.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/SendWebhookNode.tsx
@@ -109,12 +109,12 @@ export function SendWebhookNode({ selected, data, id }: SendWebhookNodeProps) {
             <Send className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('flowEditor.nodes.sendWebhook.name')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/set-variable/SetVariableNode.tsx
+++ b/src/components/journey/nodes/actions/set-variable/SetVariableNode.tsx
@@ -103,7 +103,7 @@ export function SetVariableNode({ selected, data, id }: SetVariableNodeProps) {
             {t('flowEditor.nodes.setVariable.name')}
           </h3>
           {data.variableName && (
-            <p className="text-xs text-gray-600 dark:text-muted-foreground mt-1">
+            <p className="text-xs text-muted-foreground mt-1">
               {data.variableName}
             </p>
           )}
@@ -125,7 +125,7 @@ export function SetVariableNode({ selected, data, id }: SetVariableNodeProps) {
               <div className={`text-xs font-medium ${getOperationColor()}`}>
                 {getOperationLabel()}
               </div>
-              <div className="text-xs text-gray-600 dark:text-muted-foreground mt-1">
+              <div className="text-xs text-muted-foreground mt-1">
                 {getPreviewValue()}
               </div>
             </div>

--- a/src/components/journey/nodes/actions/set-variable/SetVariableNode.tsx
+++ b/src/components/journey/nodes/actions/set-variable/SetVariableNode.tsx
@@ -99,17 +99,17 @@ export function SetVariableNode({ selected, data, id }: SetVariableNodeProps) {
           <Variable className="w-4 h-4 text-white" />
         </div>
         <div className="flex-1 min-w-0">
-          <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+          <h3 className="text-sm font-medium text-foreground truncate">
             {t('flowEditor.nodes.setVariable.name')}
           </h3>
           {data.variableName && (
-            <p className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+            <p className="text-xs text-gray-600 dark:text-muted-foreground mt-1">
               {data.variableName}
             </p>
           )}
         </div>
         <div className="flex-shrink-0">
-          <Settings className="w-3 h-3 text-gray-400" />
+          <Settings className="w-3 h-3 text-muted-foreground" />
         </div>
       </div>
 
@@ -125,7 +125,7 @@ export function SetVariableNode({ selected, data, id }: SetVariableNodeProps) {
               <div className={`text-xs font-medium ${getOperationColor()}`}>
                 {getOperationLabel()}
               </div>
-              <div className="text-xs text-gray-600 dark:text-gray-400 mt-1">
+              <div className="text-xs text-gray-600 dark:text-muted-foreground mt-1">
                 {getPreviewValue()}
               </div>
             </div>

--- a/src/components/journey/nodes/actions/split/SplitNode.tsx
+++ b/src/components/journey/nodes/actions/split/SplitNode.tsx
@@ -47,13 +47,52 @@ export function SplitNode({ selected, data, id }: SplitNodeProps) {
   const variants = data.variants && data.variants.length > 0 ? data.variants : defaultVariants;
 
   const getVariantColorClasses = (color: string) => {
-    const colorMap: Record<string, { bg: string; border: string; text: string }> = {
-      blue: { bg: 'bg-blue-950/10', border: 'border-blue-700/40', text: 'text-blue-400' },
-      purple: { bg: 'bg-purple-950/10', border: 'border-purple-700/40', text: 'text-purple-400' },
-      green: { bg: 'bg-green-950/10', border: 'border-green-700/40', text: 'text-green-400' },
-      orange: { bg: 'bg-orange-950/10', border: 'border-orange-700/40', text: 'text-orange-400' },
-      red: { bg: 'bg-red-950/10', border: 'border-red-700/40', text: 'text-red-400' },
-      yellow: { bg: 'bg-yellow-950/10', border: 'border-yellow-700/40', text: 'text-yellow-400' },
+    const colorMap: Record<
+      string,
+      { bg: string; border: string; text: string; hoverBg: string; hoverBorder: string }
+    > = {
+      blue: {
+        bg: 'bg-blue-50 dark:bg-blue-950/10',
+        border: 'border-blue-300 dark:border-blue-700/40',
+        text: 'text-blue-700 dark:text-blue-400',
+        hoverBg: 'hover:bg-blue-100 dark:hover:bg-blue-900/20',
+        hoverBorder: 'hover:border-blue-400 dark:hover:border-blue-600/50',
+      },
+      purple: {
+        bg: 'bg-purple-50 dark:bg-purple-950/10',
+        border: 'border-purple-300 dark:border-purple-700/40',
+        text: 'text-purple-700 dark:text-purple-400',
+        hoverBg: 'hover:bg-purple-100 dark:hover:bg-purple-900/20',
+        hoverBorder: 'hover:border-purple-400 dark:hover:border-purple-600/50',
+      },
+      green: {
+        bg: 'bg-green-50 dark:bg-green-950/10',
+        border: 'border-green-300 dark:border-green-700/40',
+        text: 'text-green-700 dark:text-green-400',
+        hoverBg: 'hover:bg-green-100 dark:hover:bg-green-900/20',
+        hoverBorder: 'hover:border-green-400 dark:hover:border-green-600/50',
+      },
+      orange: {
+        bg: 'bg-orange-50 dark:bg-orange-950/10',
+        border: 'border-orange-300 dark:border-orange-700/40',
+        text: 'text-orange-700 dark:text-orange-400',
+        hoverBg: 'hover:bg-orange-100 dark:hover:bg-orange-900/20',
+        hoverBorder: 'hover:border-orange-400 dark:hover:border-orange-600/50',
+      },
+      red: {
+        bg: 'bg-red-50 dark:bg-red-950/10',
+        border: 'border-red-300 dark:border-red-700/40',
+        text: 'text-red-700 dark:text-red-400',
+        hoverBg: 'hover:bg-red-100 dark:hover:bg-red-900/20',
+        hoverBorder: 'hover:border-red-400 dark:hover:border-red-600/50',
+      },
+      yellow: {
+        bg: 'bg-yellow-50 dark:bg-yellow-950/10',
+        border: 'border-yellow-300 dark:border-yellow-700/40',
+        text: 'text-yellow-700 dark:text-yellow-400',
+        hoverBg: 'hover:bg-yellow-100 dark:hover:bg-yellow-900/20',
+        hoverBorder: 'hover:border-yellow-400 dark:hover:border-yellow-600/50',
+      },
     };
     return colorMap[color] || colorMap.blue;
   };
@@ -70,10 +109,8 @@ export function SplitNode({ selected, data, id }: SplitNodeProps) {
           'mb-3 cursor-pointer rounded-lg border p-3 text-left transition-all duration-200',
           colorClasses.bg,
           colorClasses.border,
-          `hover:${colorClasses.border.replace('/40', '/50')} hover:${colorClasses.bg.replace(
-            '/10',
-            '/20',
-          )}`,
+          colorClasses.hoverBg,
+          colorClasses.hoverBorder,
         )}
       >
         <div className="flex items-center justify-between">

--- a/src/components/journey/nodes/actions/split/SplitNode.tsx
+++ b/src/components/journey/nodes/actions/split/SplitNode.tsx
@@ -78,9 +78,9 @@ export function SplitNode({ selected, data, id }: SplitNodeProps) {
       >
         <div className="flex items-center justify-between">
           <div className="flex-1">
-            <p className="font-medium text-neutral-300">
+            <p className="font-medium text-foreground">
               <span className={cn('font-semibold', colorClasses.text)}>{variant.name}</span>{' '}
-              <span className="text-neutral-400">({variant.percentage}%)</span>
+              <span className="text-muted-foreground">({variant.percentage}%)</span>
             </p>
           </div>
           <Handle
@@ -124,10 +124,10 @@ export function SplitNode({ selected, data, id }: SplitNodeProps) {
             <Split className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">{t('panels.split.nodeTitle')}</h3>
+            <h3 className="text-sm font-medium text-foreground truncate">{t('panels.split.nodeTitle')}</h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/transfer-journey/TransferJourneyNode.tsx
+++ b/src/components/journey/nodes/actions/transfer-journey/TransferJourneyNode.tsx
@@ -51,12 +51,12 @@ export function TransferJourneyNode({ selected, data, id }: TransferJourneyNodeP
             <ArrowRight className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.transferJourney.nodeTitle')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/update-contact/UpdateContactNode.tsx
+++ b/src/components/journey/nodes/actions/update-contact/UpdateContactNode.tsx
@@ -60,12 +60,12 @@ export function UpdateContactNode({ selected, data, id }: UpdateContactNodeProps
             <UserCog className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.updateContact.nodeTitle')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributeNode.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributeNode.tsx
@@ -73,12 +73,12 @@ export function UpdateCustomAttributeNode({ selected, data, id }: UpdateCustomAt
             <SettingsIcon className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {t('panels.updateCustomAttribute.nodeTitle')}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/nodes/actions/wait/WaitNode.tsx
+++ b/src/components/journey/nodes/actions/wait/WaitNode.tsx
@@ -316,11 +316,11 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
         {needsMultipleOutputs && (
           <div className="space-y-2">
             {/* Handle principal (condição/evento atendido) */}
-            <div className="mb-3 cursor-pointer rounded-lg border border-green-700/40 bg-green-950/10 p-3 text-left transition-all duration-200 hover:border-green-600/50 hover:bg-green-900/10">
+            <div className="mb-3 cursor-pointer rounded-lg border border-green-300 bg-green-50 hover:border-green-400 hover:bg-green-100 dark:border-green-700/40 dark:bg-green-950/10 dark:hover:border-green-600/50 dark:hover:bg-green-900/10 p-3 text-left transition-all duration-200">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
                   <p className="font-medium text-foreground">
-                    <span className="font-semibold text-green-400">
+                    <span className="font-semibold text-green-700 dark:text-green-400">
                       {data.waitType === 'event'
                         ? t('flowEditor.nodes.wait.outputs.eventOccurred')
                         : data.waitType === 'condition'
@@ -352,17 +352,17 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
             </div>
 
             {/* Handle para fallback/timeout */}
-            <div className="mb-3 cursor-pointer rounded-lg border border-red-700/40 bg-red-950/10 p-3 text-left transition-all duration-200 hover:border-red-600/50 hover:bg-red-900/10">
+            <div className="mb-3 cursor-pointer rounded-lg border border-red-300 bg-red-50 hover:border-red-400 hover:bg-red-100 dark:border-red-700/40 dark:bg-red-950/10 dark:hover:border-red-600/50 dark:hover:bg-red-900/10 p-3 text-left transition-all duration-200">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
                   <p className="font-medium text-foreground">
-                    <span className="font-semibold text-red-400">
+                    <span className="font-semibold text-red-700 dark:text-red-400">
                       {data.waitType === 'time_or_condition'
                         ? t('flowEditor.nodes.wait.outputs.timeout')
                         : t('flowEditor.nodes.wait.outputs.otherwise')}
                     </span>
                     {data.enableFallback && data.fallbackTime && data.fallbackUnit && (
-                      <span className="text-xs text-red-300 block mt-1">
+                      <span className="text-xs text-red-700 dark:text-red-300 block mt-1">
                         {t('flowEditor.nodes.wait.descriptions.after', {
                           time: data.fallbackTime,
                           unit: t(`units.${data.fallbackUnit}.short`),

--- a/src/components/journey/nodes/actions/wait/WaitNode.tsx
+++ b/src/components/journey/nodes/actions/wait/WaitNode.tsx
@@ -282,12 +282,12 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
             <IconComponent className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {typeConfig.title}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 
@@ -319,7 +319,7 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
             <div className="mb-3 cursor-pointer rounded-lg border border-green-700/40 bg-green-950/10 p-3 text-left transition-all duration-200 hover:border-green-600/50 hover:bg-green-900/10">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
-                  <p className="font-medium text-neutral-300">
+                  <p className="font-medium text-foreground">
                     <span className="font-semibold text-green-400">
                       {data.waitType === 'event'
                         ? t('flowEditor.nodes.wait.outputs.eventOccurred')
@@ -355,7 +355,7 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
             <div className="mb-3 cursor-pointer rounded-lg border border-red-700/40 bg-red-950/10 p-3 text-left transition-all duration-200 hover:border-red-600/50 hover:bg-red-900/10">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
-                  <p className="font-medium text-neutral-300">
+                  <p className="font-medium text-foreground">
                     <span className="font-semibold text-red-400">
                       {data.waitType === 'time_or_condition'
                         ? t('flowEditor.nodes.wait.outputs.timeout')

--- a/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
@@ -206,12 +206,12 @@ export function JourneyTriggerNode({ selected, data, id }: JourneyTriggerNodePro
             <Play className="w-4 h-4 text-white" />
           </div>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+            <h3 className="text-sm font-medium text-foreground truncate">
               {getTriggerLabel()}
             </h3>
           </div>
           <div className="flex-shrink-0">
-            <Settings className="w-3 h-3 text-gray-400" />
+            <Settings className="w-3 h-3 text-muted-foreground" />
           </div>
         </div>
 

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
@@ -149,13 +149,13 @@ describe('NodeConfigModal — common chrome', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
-  it('announces "Saving…" to assistive tech while loading', () => {
+  it('announces the saving label to assistive tech while loading', () => {
     render(
       <NodeConfigModal {...baseProps} variant="simple" dirty loading>
         body
       </NodeConfigModal>,
     );
-    expect(screen.getByText('Saving…')).toBeTruthy();
+    expect(screen.getByText('Saving...')).toBeTruthy();
   });
 });
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client';
 import "@evoapi/design-system/styles";
+// React Flow CSS imported here so it is processed BEFORE globals.css and
+// our theming overrides in globals.css can win the cascade (EVO-1270).
+import '@xyflow/react/dist/style.css';
 import './styles/globals.css';
 import './i18n/config'; // Importar configuração do i18n
 import App from './App.tsx';

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -438,33 +438,36 @@ function JourneyFlowEditor() {
     ],
   };
 
-  // Cores para o MiniMap
+  // Maps each node type to a flow-* design-system token (declared in
+  // globals.css with light/dark variants by EVO-1253). Nodes without a
+  // direct subtype match in the current taxonomy fall back to
+  // action-pipeline (see EVO-1259 audit §G3 for the taxonomy gap).
   const miniMapNodeColors = useMemo(
     () => ({
-      'journey-trigger-node': '#10b981', // verde para trigger
-      'wait-node': '#3b82f6', // azul para wait
-      'scheduled-action-node': '#fb923c', // orange para scheduled action
-      'conditional-node': '#eab308', // amarelo para condicional
-      'split-node': '#6366f1', // indigo para split
-      'exit-journey-node': '#ef4444', // vermelho para sair da jornada
-      'send-webhook-node': '#a855f7', // purple para webhook
-      'add-label-node': '#10b981', // verde para adicionar etiqueta
-      'remove-label-node': '#ef4444', // vermelho para remover etiqueta
-      'update-contact-node': '#06b6d4', // cyan para atualizar contato
-      'update-custom-attribute-node': '#ec4899', // pink para atributo personalizado
-      'transfer-journey-node': '#fb923c', // orange para transferir jornada
-      'send-message-node': '#3b82f6', // blue para enviar mensagem
-      'set-variable-node': '#a855f7', // purple para definir variável
-      'assign-agent-node': '#8b5cf6', // violet para atribuir agente
-      'assign-team-node': '#0ea5e9', // sky para atribuir equipe
-      'assign-bot-node': '#a855f7', // purple, matches AssignBotNode borderColor — converted to the flow token in the EVO-1270 sweep alongside the other 22 entries
-      'send-email-team-node': '#10b981', // emerald para enviar email equipe
-      'send-transcript-node': '#14b8a6', // teal para enviar transcrição
-      'mute-conversation-node': '#64748b', // gray para silenciar conversa
-      'defer-conversation-node': '#eab308', // yellow para adiar conversa
-      'resolve-conversation-node': '#10b981', // green para resolver conversa
-      'change-priority-node': '#6366f1', // indigo para alterar prioridade
-      default: '#64748b', // cinza para outros
+      'journey-trigger-node': 'var(--color-flow-node-trigger-border)',
+      'conditional-node': 'var(--color-flow-node-condition-border)',
+      'wait-node': 'var(--color-flow-node-control-border)',
+      'split-node': 'var(--color-flow-node-control-border)',
+      'scheduled-action-node': 'var(--color-flow-node-control-border)',
+      'set-variable-node': 'var(--color-flow-node-control-border)',
+      'exit-journey-node': 'var(--color-flow-node-exit-border)',
+      'transfer-journey-node': 'var(--color-flow-node-exit-border)',
+      'send-message-node': 'var(--color-flow-node-action-message-border)',
+      'send-transcript-node': 'var(--color-flow-node-action-message-border)',
+      'send-email-team-node': 'var(--color-flow-node-action-message-border)',
+      'send-webhook-node': 'var(--color-flow-node-action-webhook-border)',
+      'add-label-node': 'var(--color-flow-node-action-label-border)',
+      'remove-label-node': 'var(--color-flow-node-action-label-border)',
+      'update-contact-node': 'var(--color-flow-node-action-pipeline-border)',
+      'update-custom-attribute-node': 'var(--color-flow-node-action-pipeline-border)',
+      'assign-agent-node': 'var(--color-flow-node-action-pipeline-border)',
+      'assign-team-node': 'var(--color-flow-node-action-pipeline-border)',
+      'assign-bot-node': 'var(--color-flow-node-action-pipeline-border)',
+      'change-priority-node': 'var(--color-flow-node-action-pipeline-border)',
+      'mute-conversation-node': 'var(--color-flow-node-action-pipeline-border)',
+      'defer-conversation-node': 'var(--color-flow-node-action-pipeline-border)',
+      'resolve-conversation-node': 'var(--color-flow-node-action-pipeline-border)',
+      default: 'var(--color-muted-foreground)',
     }),
     [],
   );

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -31,6 +31,7 @@ import {
 import { loadSnapshot } from '@/store/flowEditor/idbSnapshot';
 import { loadLastSavedAt } from '@/store/flowEditor/lastSavedMark';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { flowTokens } from '@/components/journey/_ui/tokens';
 
 // Importar todos os nodes da jornada por categoria
 import { JourneyTriggerNode } from '@/components/journey/nodes/trigger/JourneyTriggerNode';
@@ -438,35 +439,36 @@ function JourneyFlowEditor() {
     ],
   };
 
-  // Maps each node type to a flow-* design-system token (declared in
-  // globals.css with light/dark variants by EVO-1253). Nodes without a
-  // direct subtype match in the current taxonomy fall back to
-  // action-pipeline (see EVO-1259 audit §G3 for the taxonomy gap).
+  // Maps each node type to a flow-* design-system token via the
+  // typed `flowTokens` object from `@/components/journey/_ui/tokens`
+  // (EVO-1253 contract for consumers outside Tailwind className). Nodes
+  // without a direct subtype match in the current taxonomy fall back to
+  // action-pipeline (see EVO-1259 audit §G3).
   const miniMapNodeColors = useMemo(
     () => ({
-      'journey-trigger-node': 'var(--color-flow-node-trigger-border)',
-      'conditional-node': 'var(--color-flow-node-condition-border)',
-      'wait-node': 'var(--color-flow-node-control-border)',
-      'split-node': 'var(--color-flow-node-control-border)',
-      'scheduled-action-node': 'var(--color-flow-node-control-border)',
-      'set-variable-node': 'var(--color-flow-node-control-border)',
-      'exit-journey-node': 'var(--color-flow-node-exit-border)',
-      'transfer-journey-node': 'var(--color-flow-node-exit-border)',
-      'send-message-node': 'var(--color-flow-node-action-message-border)',
-      'send-transcript-node': 'var(--color-flow-node-action-message-border)',
-      'send-email-team-node': 'var(--color-flow-node-action-message-border)',
-      'send-webhook-node': 'var(--color-flow-node-action-webhook-border)',
-      'add-label-node': 'var(--color-flow-node-action-label-border)',
-      'remove-label-node': 'var(--color-flow-node-action-label-border)',
-      'update-contact-node': 'var(--color-flow-node-action-pipeline-border)',
-      'update-custom-attribute-node': 'var(--color-flow-node-action-pipeline-border)',
-      'assign-agent-node': 'var(--color-flow-node-action-pipeline-border)',
-      'assign-team-node': 'var(--color-flow-node-action-pipeline-border)',
-      'assign-bot-node': 'var(--color-flow-node-action-pipeline-border)',
-      'change-priority-node': 'var(--color-flow-node-action-pipeline-border)',
-      'mute-conversation-node': 'var(--color-flow-node-action-pipeline-border)',
-      'defer-conversation-node': 'var(--color-flow-node-action-pipeline-border)',
-      'resolve-conversation-node': 'var(--color-flow-node-action-pipeline-border)',
+      'journey-trigger-node': flowTokens.node.trigger.border,
+      'conditional-node': flowTokens.node.condition.border,
+      'wait-node': flowTokens.node.control.border,
+      'split-node': flowTokens.node.control.border,
+      'scheduled-action-node': flowTokens.node.control.border,
+      'set-variable-node': flowTokens.node.control.border,
+      'exit-journey-node': flowTokens.node.exit.border,
+      'transfer-journey-node': flowTokens.node.exit.border,
+      'send-message-node': flowTokens.node.action.message.border,
+      'send-transcript-node': flowTokens.node.action.message.border,
+      'send-email-team-node': flowTokens.node.action.message.border,
+      'send-webhook-node': flowTokens.node.action.webhook.border,
+      'add-label-node': flowTokens.node.action.label.border,
+      'remove-label-node': flowTokens.node.action.label.border,
+      'update-contact-node': flowTokens.node.action.pipeline.border,
+      'update-custom-attribute-node': flowTokens.node.action.pipeline.border,
+      'assign-agent-node': flowTokens.node.action.pipeline.border,
+      'assign-team-node': flowTokens.node.action.pipeline.border,
+      'assign-bot-node': flowTokens.node.action.pipeline.border,
+      'change-priority-node': flowTokens.node.action.pipeline.border,
+      'mute-conversation-node': flowTokens.node.action.pipeline.border,
+      'defer-conversation-node': flowTokens.node.action.pipeline.border,
+      'resolve-conversation-node': flowTokens.node.action.pipeline.border,
       default: 'var(--color-muted-foreground)',
     }),
     [],

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -414,14 +414,25 @@
 /*
  * React Flow theming bridge (EVO-1270).
  *
- * React Flow ships its own `--xy-*` design tokens with light defaults at
- * `.react-flow` and dark defaults at `.react-flow.dark`. Our CRM toggles
- * `.dark` on the html root (shadcn pattern) instead of on the React Flow
- * wrapper, so React Flow's own dark variant never activates and the
- * canvas chrome (Controls, MiniMap internals, edges) stays stuck on
- * one default per build. Override the relevant `--xy-*` defaults with
- * shadcn semantic tokens so the Flow Builder chrome tracks the global
- * light/dark toggle.
+ * React Flow ships its own `--xy-*` design tokens with light defaults
+ * scoped to `.react-flow {}` and dark defaults scoped to
+ * `.react-flow.dark {}`. The CRM theme toggle drives that `.dark` class
+ * on the React Flow wrapper via the `colorMode` prop on <ReactFlow>
+ * (set in BaseFlowCanvas from the `useDarkMode()` hook), so the
+ * package's own dark switching now works correctly out of the box.
+ *
+ * We still want the chrome (Controls, MiniMap internals, edges,
+ * attribution, handle) to look like the rest of the CRM, so this block
+ * remaps the relevant `--xy-*-default` tokens onto the shadcn semantic
+ * tokens (--color-card, --color-foreground, --color-border, etc.).
+ * Each shadcn token has its own light/dark resolution in @evoapi/
+ * design-system/styles, so the chrome tracks the global theme via the
+ * shadcn cascade.
+ *
+ * Specificity is bumped to `.react-flow.react-flow` so this block beats
+ * the package's `.react-flow.dark {}` selector when both load (the
+ * package CSS is imported in main.tsx before globals.css so cascade
+ * order also favours this file).
  */
 .react-flow.react-flow {
   --xy-controls-button-background-color-default: var(--color-card);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -423,7 +423,7 @@
  * shadcn semantic tokens so the Flow Builder chrome tracks the global
  * light/dark toggle.
  */
-.react-flow {
+.react-flow.react-flow {
   --xy-controls-button-background-color-default: var(--color-card);
   --xy-controls-button-background-color-hover-default: var(--color-accent);
   --xy-controls-button-color-default: var(--color-foreground);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -410,3 +410,30 @@
     color: #000000 !important;
   }
 }
+
+/*
+ * React Flow theming bridge (EVO-1270).
+ *
+ * React Flow ships its own `--xy-*` design tokens with light defaults at
+ * `.react-flow` and dark defaults at `.react-flow.dark`. Our CRM toggles
+ * `.dark` on the html root (shadcn pattern) instead of on the React Flow
+ * wrapper, so React Flow's own dark variant never activates and the
+ * canvas chrome (Controls, MiniMap internals, edges) stays stuck on
+ * one default per build. Override the relevant `--xy-*` defaults with
+ * shadcn semantic tokens so the Flow Builder chrome tracks the global
+ * light/dark toggle.
+ */
+.react-flow {
+  --xy-controls-button-background-color-default: var(--color-card);
+  --xy-controls-button-background-color-hover-default: var(--color-accent);
+  --xy-controls-button-color-default: var(--color-foreground);
+  --xy-controls-button-color-hover-default: var(--color-foreground);
+  --xy-controls-button-border-color-default: var(--color-border);
+  --xy-minimap-background-color-default: var(--color-flow-palette-bg);
+  --xy-edge-stroke-default: var(--color-flow-edge-default);
+  --xy-edge-stroke-selected-default: var(--color-flow-edge-active);
+  --xy-connectionline-stroke-default: var(--color-flow-edge-active);
+  --xy-attribution-background-color-default: color-mix(in srgb, var(--color-card) 50%, transparent);
+  --xy-handle-background-color-default: var(--color-muted-foreground);
+  --xy-handle-border-color-default: var(--color-foreground);
+}


### PR DESCRIPTION
## Summary

Light mode of the Flow Builder rendered with dark-only chrome, dark gradients on node cards, and dark React Flow Controls regardless of the CRM theme. EVO-1253 had landed the design tokens with both light and dark values, but the Flow Builder code never consumed them in a theme-aware way and React Flow's `colorMode` prop was hardcoded `dark`.

This PR wires the Flow Builder into the existing CRM theme toggle without redesigning anything visually:

- `<ReactFlow colorMode={...}>` now reads from the CRM theme (`useDarkMode()`), so React Flow's own `.react-flow.dark {}` block fires correctly and its native chrome (Controls, edges, attribution, minimap internals) follows the toggle.
- Hardcoded dark `rgba(...)` styles with `!important` were removed from `BaseFlow.css` (`.react-flow__controls`, `.react-flow__controls-button`, plus a dead `@media (prefers-color-scheme: dark)` block). React Flow's own token cascade now handles the chrome.
- `globals.css` remaps the relevant `--xy-*-default` tokens onto shadcn semantic tokens (`--color-card`, `--color-foreground`, `--color-border`, etc.) so the canvas chrome looks like the rest of the CRM in both modes. React Flow CSS is imported in `main.tsx` before `globals.css` so this remap wins the cascade. Selector specificity bumped to `.react-flow.react-flow` as defensive insurance.
- `BaseFlowNode` colorStyles get paired `border-{color}-300 dark:border-{color}-700/70` borders so category identity stays legible in light. The node body uses solid `bg-card` in light (no gradient — the white-to-gray look was reported as ugly during smoke test) and keeps the existing colored gradient in dark.
- `JourneyFlowEditor`'s `miniMapNodeColors` swap 22 hex literals for `var(--color-flow-node-*-border)` so the minimap dots track the theme too. 9 nodes share the `action-pipeline` token because the EVO-1253 taxonomy has no 1:1 subtype for them (documented in EVO-1259 audit §G3).
- A C3 sweep across the 22 active `*Node.tsx` files replaces single-class dark-only `text-gray-400` / `text-neutral-300` / `text-neutral-400` / `text-gray-900 dark:text-gray-100` with semantic shadcn equivalents (`text-foreground`, `text-muted-foreground`). assign-bot ghost intentionally excluded (EVO-1259 G1).

Includes a tiny EVO-1260 follow-up fix: `NodeConfigModal.spec.tsx` was asserting `'Saving…'` (ellipsis char) while the EN locale value resolved by `t('modal.actions.saving')` is `'Saving...'` (three dots). The test was failing on develop prior to this branch — fixed inline to keep CI green.

## Security

n/a — pure presentation / theming change. No new routes, no data paths touched.

## Test plan

- `pnpm exec tsc -p tsconfig.app.json --noEmit` — clean (only pre-existing unrelated error in `EvolutionHubConfig.tsx` survives, same as develop)
- `pnpm test src/components/journey` — 125/125 passing
- Manual smoke (validated by reporter): toggle CRM theme dark ↔ light on `/journey/:id/flow`:
  - MiniMap container + internal canvas + node dots track the theme ✓
  - React Flow Controls (zoom, fit, lock) track the theme ✓
  - Edge stroke colour tracks the theme ✓
  - Journey Components toggle button + opened panel track the theme ✓
  - Node card backgrounds: solid card-bg in light, coloured gradient in dark ✓
  - Node borders carry category colour in both themes ✓
  - Toggle preserves flow state (no node loss) ✓

## Changed Files

- `src/components/base/BaseFlowCanvas.tsx` — dynamic `colorMode` prop, miniMap chrome
- `src/components/base/BaseFlowNode.tsx` — paired light/dark borders, solid card bg in light + gradient in dark
- `src/components/base/BaseFlow.css` — strip hardcoded dark `.react-flow__controls*` rules and dead `@media (prefers-color-scheme: dark)` block
- `src/components/journey/nodes/**/*Node.tsx` (22 files + trigger) — single-class dark-only colours → shadcn semantic tokens
- `src/pages/Customer/Journey/JourneyFlowEditor.tsx` — miniMapNodeColors → flow tokens
- `src/styles/globals.css` — `.react-flow.react-flow {}` overrides remapping `--xy-*-default` to shadcn semantic tokens
- `src/main.tsx` — move `@xyflow/react/dist/style.css` import before `globals.css` so the override block wins the cascade
- `src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx` — align "Saving..." assertion with EVO-1260 EN locale (drive-by fix for a develop-breaking test)

## Known limitations / deferred follow-ups

- `BaseFlowNode.colorStyle.handle` field is an orphan (never consumed) across the 17 colour entries. Pre-existing, not introduced by this PR. Worth a cleanup card.
- `BaseFlow.css` still declares `.base-flow-panel`, `.base-node-panel`, `.base-flow-context-menu` with `hsl(var(--sidebar))` which is the wrong colour-space syntax for an `oklch()` token. No consumers found in the current codebase. Pre-existing dead CSS. Worth a separate cleanup card.
- No automated test for theme-toggle regression (AC#4). The change was validated by manual smoke. Worth a follow-up to add a basic Playwright check.
- Existing nodes do not consume the `<FlowNode>` bridge from `src/components/journey/_ui/`; that broader refactor belongs to EVO-1268 / EVO-1274.

## Linked Issue

- https://linear.app/evoai/issue/EVO-1270