### PR TITLE
fix(frontend): bump ConditionalNode empty-state hint to text-yellow-700 for WCAG AA (EVO-1454)

### DIFF
--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -292,7 +292,7 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
         ) : (
           <div className="p-3 rounded-lg border-2 border-dashed border-yellow-300 bg-yellow-50 dark:bg-yellow-950/20 text-center">
             <GitBranch className="h-6 w-6 text-yellow-400 mx-auto mb-2" />
-            <p className="text-xs text-yellow-600 dark:text-yellow-300">{t('panels.conditional.configurePaths')}</p>
+            <p className="text-xs text-yellow-700 dark:text-yellow-300">{t('panels.conditional.configurePaths')}</p>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

`ConditionalNode.tsx` empty-state hint used `text-yellow-600` on `bg-yellow-50` (~2.8:1, failing WCAG AA). Bumped to `text-yellow-700` (~5.4:1, AA passing) to match the adjacent legacy-fallback block that already used that token.

## Context

Follow-up of the EVO-1270 / PR #105 light-mode pass. The two blocks (legacy fallback at line ~288 and empty-state at line ~295) share the same `bg-yellow-50` container; PR #105 fixed the fallback but left the empty-state with the lower-contrast `text-yellow-600`. This aligns the two.

## Security

- N/A — single-token Tailwind class swap, no logic / endpoint / payload change.

## Test plan

- [ ] `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` (run locally — passing)
- [ ] Drag a new ConditionalNode onto the canvas in light mode → hint text "Configurar caminhos" reads with AA contrast (use Axe DevTools to confirm no contrast violation on the hint paragraph)
- [ ] Confirm dark mode unchanged (token `dark:text-yellow-300` preserved)
- [ ] Confirm the adjacent legacy-fallback block still renders identically

## Changed Files

- `src/components/journey/nodes/actions/conditional/ConditionalNode.tsx` (1 char: `yellow-600` → `yellow-700` on the empty-state hint)

## Linked Issue

- EVO-1454 (https://linear.app/evoai/issue/EVO-1454/10211-contraste-aa-empty-state-do-conditionalnode-usa-text-yellow-600)
- Original review surface: EVO-1270 (PR #105)

## Summary by Sourcery

Bug Fixes:
- Increase the ConditionalNode empty-state hint text color contrast on light mode by switching to a higher-contrast yellow token.