### PR TITLE
feat(journey): rewire Trigger Event UX to consume shared EventSelector + custom fallback (EVO-1271)

### DIFF
--- a/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { EventConfiguration } from './EventConfiguration';
+import '@/i18n/config';
+
+interface HarnessProps {
+  initialEventName?: string;
+  onEventNameChange?: (name: string) => void;
+}
+
+function Harness({ initialEventName = '', onEventNameChange }: HarnessProps) {
+  const [eventName, setEventName] = useState(initialEventName);
+  const handleChange = (next: string) => {
+    setEventName(next);
+    onEventNameChange?.(next);
+  };
+  return (
+    <EventConfiguration
+      eventName={eventName}
+      eventProperties={[]}
+      onEventNameChange={handleChange}
+      onEventPropertiesChange={() => {}}
+      journeyId="test-journey-id"
+    />
+  );
+}
+
+describe('EventConfiguration — event name UI', () => {
+  it('AC1: renders the shared EventSelector as the primary entry point', () => {
+    render(<Harness />);
+    expect(screen.getByRole('combobox')).toBeTruthy();
+  });
+
+  it('AC2: when a canonical event is selected, persists its name and shows the contextual description', async () => {
+    const onEventNameChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onEventNameChange={onEventNameChange} />);
+
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText(/contact created|contato criado/i));
+
+    expect(onEventNameChange).toHaveBeenCalledWith('contact.created');
+    // Description from the manifest entry appears under the selector.
+    expect(
+      await screen.findByText(/a new contact was created/i),
+    ).toBeTruthy();
+  });
+
+  it('AC3: when "Custom" is picked, exposes a free-text input + warning and persists the typed name', async () => {
+    const onEventNameChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onEventNameChange={onEventNameChange} />);
+
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText(/custom event|evento personalizado/i));
+
+    const customInput = screen.getByPlaceholderText(/custom event name|nome do evento custom/i);
+    expect(customInput).toBeTruthy();
+    expect(
+      screen.getByText(/custom events have no schema validation|não têm validação de schema/i),
+    ).toBeTruthy();
+
+    await user.type(customInput, 'button_clicked');
+    expect(onEventNameChange).toHaveBeenLastCalledWith('button_clicked');
+  });
+
+  it('AC4: a legacy node with a non-canonical event name opens in custom mode with the value preserved', () => {
+    render(<Harness initialEventName="button_click" />);
+
+    const customInput = screen.getByPlaceholderText(
+      /custom event name|nome do evento custom/i,
+    ) as HTMLInputElement;
+    expect(customInput.value).toBe('button_click');
+    expect(
+      screen.getByText(/custom events have no schema validation|não têm validação de schema/i),
+    ).toBeTruthy();
+  });
+
+  it('migration: a legacy snake_case node upgrades to the canonical dot.notation on display', () => {
+    render(<Harness initialEventName="contact_created" />);
+    // Custom-mode UI is NOT rendered because the legacy name resolves to a canonical event.
+    expect(
+      screen.queryByPlaceholderText(/custom event name|nome do evento custom/i),
+    ).toBeNull();
+    // The canonical description is surfaced.
+    expect(
+      screen.getByText(/a new contact was created/i),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
@@ -91,4 +91,30 @@ describe('EventConfiguration — event name UI', () => {
       screen.getByText(/a new contact was created/i),
     ).toBeTruthy();
   });
+
+  it('typing a canonical-looking name into the custom input does NOT switch out of custom mode', async () => {
+    const user = userEvent.setup();
+    render(<Harness initialEventName="button_click" />);
+
+    // Sanity: starts in custom mode with the legacy value preserved.
+    const customInput = screen.getByPlaceholderText(
+      /custom event name|nome do evento custom/i,
+    ) as HTMLInputElement;
+    expect(customInput.value).toBe('button_click');
+
+    // Clear and type a name that would resolve as canonical if re-derived.
+    await user.clear(customInput);
+    await user.type(customInput, 'contact.created');
+
+    // Custom input MUST still be visible (no premature exit from custom mode).
+    expect(
+      screen.queryByPlaceholderText(/custom event name|nome do evento custom/i),
+    ).not.toBeNull();
+    // The canonical description must NOT be rendered (we're still in custom mode).
+    expect(screen.queryByText(/a new contact was created/i)).toBeNull();
+    // And the warning is still visible.
+    expect(
+      screen.getByText(/custom events have no schema validation|não têm validação de schema/i),
+    ).toBeTruthy();
+  });
 });

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import {
   Button,
   Label,
@@ -10,11 +11,13 @@ import {
 } from '@evoapi/design-system';
 import { Plus, X } from 'lucide-react';
 import { VariableInput, VariableMapping, type DataMapping } from '@/components/journey/environment-manager';
+import { EventSelector } from '@/components/journey/shared/EventSelector';
+import { getEvent, resolveLegacyEventName } from '@/lib/events-manifest';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface EventProperty {
   path: string;
-  operator: { type: string; value?: any };
+  operator: { type: string; value?: unknown };
 }
 
 interface EventConfigurationProps {
@@ -27,58 +30,6 @@ interface EventConfigurationProps {
   journeyId: string;
 }
 
-const eventTemplates = {
-  contact_created: {
-    event: 'contact_created',
-    properties: [
-      { path: 'source', operator: { type: 'Equals', value: '' } },
-      { path: 'contact_type', operator: { type: 'Equals', value: 'lead' } },
-    ],
-  },
-  contact_updated: {
-    event: 'contact_updated',
-    properties: [
-      { path: 'changeCount', operator: { type: 'GreaterThanOrEqual', value: '1' } },
-      { path: 'changedFields', operator: { type: 'Contains', value: '' } },
-    ],
-  },
-  message_created: {
-    event: 'message_created',
-    properties: [
-      { path: 'message_type', operator: { type: 'Equals', value: 'incoming' } },
-      { path: 'content_type', operator: { type: 'Equals', value: 'text' } },
-    ],
-  },
-  button_clicked: {
-    event: 'button_clicked',
-    properties: [
-      { path: 'button_id', operator: { type: 'Equals', value: '' } },
-      { path: 'page_url', operator: { type: 'Contains', value: '' } },
-    ],
-  },
-  page_viewed: {
-    event: 'page_viewed',
-    properties: [
-      { path: 'page_url', operator: { type: 'Equals', value: '' } },
-      { path: 'page_title', operator: { type: 'Contains', value: '' } },
-    ],
-  },
-  form_submitted: {
-    event: 'form_submitted',
-    properties: [
-      { path: 'form_id', operator: { type: 'Equals', value: '' } },
-      { path: 'form_name', operator: { type: 'Equals', value: '' } },
-    ],
-  },
-  product_purchased: {
-    event: 'product_purchased',
-    properties: [
-      { path: 'product_id', operator: { type: 'Equals', value: '' } },
-      { path: 'price', operator: { type: 'GreaterThan', value: '0' } },
-    ],
-  },
-};
-
 export function EventConfiguration({
   eventName,
   eventProperties,
@@ -88,25 +39,49 @@ export function EventConfiguration({
   onVariableMappingsChange,
   journeyId,
 }: EventConfigurationProps) {
-  const { t } = useLanguage('journey');
-  // Gerar paths dinamicamente baseado nas propriedades configuradas
+  const { t, currentLanguage } = useLanguage('journey');
+
+  // selectorValue tracks which dropdown entry is rendered as selected
+  // (canonical event name OR the literal 'custom' placeholder); customName
+  // holds the free-text typed value when the user is in custom mode. The
+  // persisted `eventName` prop stays as the canonical name OR the custom
+  // string the user typed — never the literal 'custom'.
+  const [selectorValue, setSelectorValue] = useState<string>('');
+  const [customName, setCustomName] = useState<string>('');
+
+  useEffect(() => {
+    const resolved = resolveLegacyEventName(eventName);
+    setSelectorValue(resolved.selectorValue);
+    setCustomName(resolved.customName ?? '');
+  }, [eventName]);
+
   const generateEventPaths = () => {
     const basePaths = ['event.id', 'event.name', 'event.timestamp', 'event.user_id'];
-
-    // Adicionar propriedades configuradas
     const propertyPaths = eventProperties
       .filter(prop => prop.path && prop.path.trim())
       .map(prop => `event.properties.${prop.path}`);
-
     return [...basePaths, ...propertyPaths];
   };
-  const applyEventTemplate = (templateKey: string) => {
-    const template = eventTemplates[templateKey as keyof typeof eventTemplates];
-    if (template) {
-      onEventNameChange(template.event);
-      onEventPropertiesChange(template.properties);
+
+  const handleSelectorChange = ({ eventName: picked, isCustom }: { eventName: string; isCustom: boolean }) => {
+    if (isCustom) {
+      setSelectorValue('custom');
+      onEventNameChange(customName);
+    } else {
+      setSelectorValue(picked);
+      setCustomName('');
+      onEventNameChange(picked);
     }
   };
+
+  const handleCustomNameChange = (next: string) => {
+    setCustomName(next);
+    onEventNameChange(next);
+  };
+
+  const isCustomMode = selectorValue === 'custom';
+  const canonicalDescription =
+    !isCustomMode && selectorValue ? getEvent(selectorValue)?.description : undefined;
 
   const addEventProperty = () => {
     const newProperty = { path: '', operator: { type: 'Equals', value: '' } };
@@ -134,64 +109,29 @@ export function EventConfiguration({
         {/* Nome do evento */}
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('triggerComponents.event.eventName')}</Label>
-          <div className="flex gap-2">
-            <VariableInput
-              value={eventName || ''}
-              onChange={e => onEventNameChange(e.target.value)}
-              placeholder={t('triggerComponents.event.eventNamePlaceholder')}
-              className="flex-1 bg-sidebar border-sidebar-border text-sidebar-foreground"
-              journeyId={journeyId}
-              onVariableInsert={variable => {
-                console.log('Variable inserted in event name:', variable);
-              }}
-            />
-            <Select
-              value=""
-              onValueChange={templateKey => {
-                if (templateKey) {
-                  applyEventTemplate(templateKey);
-                }
-              }}
-            >
-              <SelectTrigger className="w-48 bg-sidebar border-sidebar-border text-sidebar-foreground">
-                <SelectValue placeholder={t('triggerComponents.event.templates')} />
-              </SelectTrigger>
-              <SelectContent className="bg-sidebar border-sidebar-border">
-                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50">
-                  {t('triggerComponents.event.contactEvents')}
-                </div>
-                <SelectItem value="contact_created" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.contactCreated')}
-                </SelectItem>
-                <SelectItem value="contact_updated" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.contactUpdated')}
-                </SelectItem>
-
-                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50">
-                  {t('triggerComponents.event.messageEvents')}
-                </div>
-                <SelectItem value="message_created" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.messageCreated')}
-                </SelectItem>
-
-                <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground bg-muted/50">
-                  {t('triggerComponents.event.customEvents')}
-                </div>
-                <SelectItem value="button_clicked" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.buttonClicked')}
-                </SelectItem>
-                <SelectItem value="page_viewed" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.pageViewed')}
-                </SelectItem>
-                <SelectItem value="form_submitted" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.formSubmitted')}
-                </SelectItem>
-                <SelectItem value="product_purchased" className="text-sidebar-foreground">
-                  {t('triggerComponents.event.productPurchased')}
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          <EventSelector
+            value={selectorValue || undefined}
+            onChange={handleSelectorChange}
+            className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+            key={currentLanguage}
+          />
+          {canonicalDescription && (
+            <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
+          )}
+          {isCustomMode && (
+            <div className="space-y-2 pt-1">
+              <VariableInput
+                value={customName}
+                onChange={e => handleCustomNameChange(e.target.value)}
+                placeholder={t('triggerComponents.event.customEventNamePlaceholder')}
+                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                journeyId={journeyId}
+              />
+              <p className="text-xs text-amber-700 dark:text-amber-300">
+                {t('triggerComponents.event.customEventWarning')}
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Propriedades do evento */}
@@ -235,9 +175,6 @@ export function EventConfiguration({
                       }
                       className="flex-1 bg-sidebar-accent border-sidebar-border text-sidebar-foreground"
                       journeyId={journeyId}
-                      onVariableInsert={variable => {
-                        console.log('Variable inserted in property path:', variable);
-                      }}
                     />
                     <Select
                       value={property.operator.type}
@@ -275,7 +212,11 @@ export function EventConfiguration({
                     {property.operator.type !== 'Exists' && (
                       <VariableInput
                         placeholder={t('triggerComponents.event.value')}
-                        value={property.operator.value || ''}
+                        value={
+                          property.operator.value == null
+                            ? ''
+                            : String(property.operator.value)
+                        }
                         onChange={e =>
                           updateEventProperty(index, {
                             ...property,
@@ -284,9 +225,6 @@ export function EventConfiguration({
                         }
                         className="flex-1 bg-sidebar-accent border-sidebar-border text-sidebar-foreground"
                         journeyId={journeyId}
-                        onVariableInsert={variable => {
-                          console.log('Variable inserted in property value:', variable);
-                        }}
                       />
                     )}
                     <Button

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   Label,
@@ -39,20 +39,32 @@ export function EventConfiguration({
   onVariableMappingsChange,
   journeyId,
 }: EventConfigurationProps) {
-  const { t, currentLanguage } = useLanguage('journey');
+  const { t } = useLanguage('journey');
 
   // selectorValue tracks which dropdown entry is rendered as selected
   // (canonical event name OR the literal 'custom' placeholder); customName
   // holds the free-text typed value when the user is in custom mode. The
   // persisted `eventName` prop stays as the canonical name OR the custom
   // string the user typed — never the literal 'custom'.
-  const [selectorValue, setSelectorValue] = useState<string>('');
-  const [customName, setCustomName] = useState<string>('');
+  const [selectorValue, setSelectorValue] = useState<string>(
+    () => resolveLegacyEventName(eventName).selectorValue,
+  );
+  const [customName, setCustomName] = useState<string>(
+    () => resolveLegacyEventName(eventName).customName ?? '',
+  );
+
+  // Skip the re-derive effect when the prop is just echoing back our own
+  // onEventNameChange call. Without this, typing a name in the custom
+  // input that happens to be canonical would yank the user out of custom
+  // mode mid-keystroke.
+  const lastPushedRef = useRef<string>(eventName);
 
   useEffect(() => {
+    if (lastPushedRef.current === eventName) return;
     const resolved = resolveLegacyEventName(eventName);
     setSelectorValue(resolved.selectorValue);
     setCustomName(resolved.customName ?? '');
+    lastPushedRef.current = eventName;
   }, [eventName]);
 
   const generateEventPaths = () => {
@@ -66,16 +78,19 @@ export function EventConfiguration({
   const handleSelectorChange = ({ eventName: picked, isCustom }: { eventName: string; isCustom: boolean }) => {
     if (isCustom) {
       setSelectorValue('custom');
+      lastPushedRef.current = customName;
       onEventNameChange(customName);
     } else {
       setSelectorValue(picked);
       setCustomName('');
+      lastPushedRef.current = picked;
       onEventNameChange(picked);
     }
   };
 
   const handleCustomNameChange = (next: string) => {
     setCustomName(next);
+    lastPushedRef.current = next;
     onEventNameChange(next);
   };
 
@@ -113,14 +128,17 @@ export function EventConfiguration({
             value={selectorValue || undefined}
             onChange={handleSelectorChange}
             className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-            key={currentLanguage}
           />
           {canonicalDescription && (
             <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
           )}
           {isCustomMode && (
             <div className="space-y-2 pt-1">
+              <Label htmlFor="custom-event-name" className="text-sm font-medium">
+                {t('triggerComponents.event.eventName')}
+              </Label>
               <VariableInput
+                id="custom-event-name"
                 value={customName}
                 onChange={e => handleCustomNameChange(e.target.value)}
                 placeholder={t('triggerComponents.event.customEventNamePlaceholder')}

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1707,7 +1707,9 @@
       "triggerForAnyOccurrence": "The trigger will be executed for any occurrence of the event.",
       "property": "Property",
       "value": "Value",
-      "captureEventData": "Capture Event Data"
+      "captureEventData": "Capture Event Data",
+      "customEventNamePlaceholder": "Type the custom event name (e.g. button_clicked)",
+      "customEventWarning": "Custom events have no schema validation. Use only for cases not covered by canonical events."
     },
     "label": {
       "configuration": "Label Configuration",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1707,7 +1707,9 @@
       "triggerForAnyOccurrence": "O trigger será executado para qualquer ocorrência do evento.",
       "property": "Propriedade",
       "value": "Valor",
-      "captureEventData": "Capturar Dados do Evento"
+      "captureEventData": "Capturar Dados do Evento",
+      "customEventNamePlaceholder": "Digite o nome do evento custom (ex: button_clicked)",
+      "customEventWarning": "Eventos custom não têm validação de schema. Use apenas para casos não cobertos pelos eventos canônicos."
     },
     "label": {
       "configuration": "Configuração da Etiqueta",

--- a/src/lib/events-manifest/index.ts
+++ b/src/lib/events-manifest/index.ts
@@ -38,3 +38,6 @@ export function getEventLabel(eventName: string, locale: Locale | string): strin
 export function isCustomEvent(eventName: string): boolean {
   return eventName === 'custom';
 }
+
+export { resolveLegacyEventName } from './legacy';
+export type { ResolvedLegacyEventName } from './legacy';

--- a/src/lib/events-manifest/legacy.spec.ts
+++ b/src/lib/events-manifest/legacy.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLegacyEventName } from './legacy';
+
+describe('resolveLegacyEventName', () => {
+  it('returns unconfigured for empty / null / undefined input', () => {
+    expect(resolveLegacyEventName('')).toEqual({ selectorValue: '', customName: null });
+    expect(resolveLegacyEventName(null)).toEqual({ selectorValue: '', customName: null });
+    expect(resolveLegacyEventName(undefined)).toEqual({ selectorValue: '', customName: null });
+  });
+
+  it('passes through canonical dot.notation event names unchanged', () => {
+    expect(resolveLegacyEventName('contact.created')).toEqual({
+      selectorValue: 'contact.created',
+      customName: null,
+    });
+    expect(resolveLegacyEventName('message.delivered')).toEqual({
+      selectorValue: 'message.delivered',
+      customName: null,
+    });
+    expect(resolveLegacyEventName('campaign.message.clicked')).toEqual({
+      selectorValue: 'campaign.message.clicked',
+      customName: null,
+    });
+  });
+
+  it('passes through the canonical custom placeholder without a custom name', () => {
+    expect(resolveLegacyEventName('custom')).toEqual({
+      selectorValue: 'custom',
+      customName: null,
+    });
+  });
+
+  it('upgrades known snake_case names to their canonical dot.notation equivalent', () => {
+    expect(resolveLegacyEventName('contact_created')).toEqual({
+      selectorValue: 'contact.created',
+      customName: null,
+    });
+    expect(resolveLegacyEventName('contact_updated')).toEqual({
+      selectorValue: 'contact.updated',
+      customName: null,
+    });
+    expect(resolveLegacyEventName('conversation_created')).toEqual({
+      selectorValue: 'conversation.created',
+      customName: null,
+    });
+    expect(resolveLegacyEventName('message_created')).toEqual({
+      selectorValue: 'message.created',
+      customName: null,
+    });
+  });
+
+  it('marks unknown event names as custom with the original value preserved', () => {
+    expect(resolveLegacyEventName('button_click')).toEqual({
+      selectorValue: 'custom',
+      customName: 'button_click',
+    });
+    expect(resolveLegacyEventName('page_viewed')).toEqual({
+      selectorValue: 'custom',
+      customName: 'page_viewed',
+    });
+    expect(resolveLegacyEventName('product_purchased')).toEqual({
+      selectorValue: 'custom',
+      customName: 'product_purchased',
+    });
+  });
+
+  it('preserves names that are not in the manifest even if they look canonical (no false positives)', () => {
+    expect(resolveLegacyEventName('pipeline.stage.updated')).toEqual({
+      selectorValue: 'custom',
+      customName: 'pipeline.stage.updated',
+    });
+  });
+});

--- a/src/lib/events-manifest/legacy.ts
+++ b/src/lib/events-manifest/legacy.ts
@@ -1,0 +1,42 @@
+import { isCanonicalEvent } from './index';
+
+/**
+ * Maps legacy snake_case event names (used by older Journey/Campaign nodes
+ * and the Automation Rules path) to the canonical dot.notation names from
+ * the event manifest. Entries here are conservative — only names that have
+ * an unambiguous canonical equivalent are mapped; everything else falls
+ * through to the custom-event path so the user's original value is preserved.
+ */
+const SNAKE_CASE_TO_CANONICAL: Record<string, string> = {
+  contact_created: 'contact.created',
+  contact_updated: 'contact.updated',
+  conversation_created: 'conversation.created',
+  message_created: 'message.created',
+};
+
+export interface ResolvedLegacyEventName {
+  selectorValue: string;
+  customName: string | null;
+}
+
+/**
+ * Decides how a persisted `event_name` should be displayed in the EventSelector
+ * + custom-input UI of the trigger config modal.
+ *
+ * - Canonical match → preselect that event, no custom input shown.
+ * - Legacy snake_case with known canonical equivalent → preselect the
+ *   canonical name (the user's value is upgraded on next Save).
+ * - Anything else non-empty → mark as custom and surface the original value
+ *   in the free-text input so the user can keep or edit it.
+ * - Empty/undefined → unconfigured (empty selector, no custom input).
+ */
+export function resolveLegacyEventName(value: string | undefined | null): ResolvedLegacyEventName {
+  if (!value) return { selectorValue: '', customName: null };
+  if (value === 'custom') return { selectorValue: 'custom', customName: null };
+  if (isCanonicalEvent(value)) return { selectorValue: value, customName: null };
+
+  const mapped = SNAKE_CASE_TO_CANONICAL[value];
+  if (mapped && isCanonicalEvent(mapped)) return { selectorValue: mapped, customName: null };
+
+  return { selectorValue: 'custom', customName: value };
+}


### PR DESCRIPTION
## Summary

Pain #4 (a, b) of discovery 8.1: the journey Trigger Event modal's event-name section used a free-text input as the primary entry point with a hardcoded "Templates" dropdown as a secondary path. This PR inverts the UX per the 10.6 spec:

- Primary entry is now the shared `<EventSelector>` from `src/components/journey/shared/EventSelector` (delivered by EVO-1261 / 10.A), which renders the full canonical event catalog grouped by category with search and per-event icons.
- When the user picks "Custom event" from the catalog, a free-text input + warning surface below the selector. The persisted `event_name` continues to hold the user's typed value verbatim — the literal `'custom'` placeholder is never persisted.
- When a canonical event is selected, its description from the manifest is rendered as contextual help below the selector.
- Legacy nodes are migrated on display via the `resolveLegacyEventName` utility: known snake_case names upgrade to dot.notation (overwritten on next Save); unknown names pre-populate custom mode with the original value preserved.
- Local state survives prop echoes from our own `onEventNameChange` calls via a `lastPushedRef`, so typing a canonical-looking name in the custom input does NOT yank the user out of custom mode mid-keystroke.

Because `EventConfiguration` is the shared sub-component used by `JourneyTriggerPanel`, `CampaignTriggerConfig`, and `WaitEventConfig`, the new UX propagates automatically to all three surfaces — exactly the outcome that story 10.9 (EVO-1277) expects to verify. Automation Rules stays unchanged: the architectural decision recorded in 10.A keeps each domain free to evolve its own UX around the shared manifest.

## Security

- No new endpoints, no auth changes, no `dangerouslySetInnerHTML`.
- Custom event input goes through the existing `<VariableInput>` (controlled text input).
- Persisted shape is unchanged — `event_name` stays a flat string. Legacy values are migrated on display only; the underlying value is only rewritten when the user explicitly saves.

## Test plan

- [x] `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` (clean)
- [x] `evo-ai-frontend-community: pnpm exec eslint <touched files>` (clean)
- [x] `evo-ai-frontend-community: pnpm test src/lib/events-manifest/ src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx` — 26 specs pass (6 legacy helper + 6 EventConfiguration covering AC1-AC4 + migration + H1 echo-loop guard, plus existing manifest specs)
- [x] Local smoke against `feat/EVO-1561` (`evo-flow` boot fix below) + `evo-ai-crm-community` running:
  - AC1: dropdown is primary, search filters, categories grouped — verified
  - AC2: selecting "Contact created" persists `contact.created` + description appears — verified
  - AC3: selecting "Custom event" exposes free-text input + warning; typed value persists — verified
  - Cross-surface: Campaign Trigger and Wait for Event nodes show the same new UX — verified
  - AC4: covered by unit test; manual DB-edit verification deferred

## AC literal check

| # | AC text | Evidence | Status |
|---|---|---|---|
| 1 | "...vê o seletor, então é um dropdown principal usando `<EventSelector>` da 10.A" | `EventConfiguration.tsx` renders `<EventSelector value={...} onChange={handleSelectorChange} />` as the primary control. Spec `EventConfiguration.spec.tsx` AC1 asserts combobox visible. Smoke verified. | ✓ fully satisfied |
| 2 | "...seleciona 'Contact Created'...`event_name=contact.created` e descrição contextual aparece" | Spec `EventConfiguration.spec.tsx` AC2 asserts `onEventNameChange('contact.created')` + description rendered via `getEvent(value)?.description`. Smoke verified. | ✓ fully satisfied |
| 3 | "...seleciona 'Custom event'...pode digitar qualquer event_name com warning" | Spec `EventConfiguration.spec.tsx` AC3 asserts custom input + warning + `onEventNameChange` with typed value. Smoke verified. | ✓ fully satisfied |
| 4 | "...node legado com `event_name=\"button_click\"`...mostra 'Custom event' selecionado com valor preservado" | Spec `EventConfiguration.spec.tsx` AC4 asserts the legacy `button_click` value pre-populates custom mode with the value preserved. `resolveLegacyEventName` covered by `legacy.spec.ts`. Manual DB-edit verification deferred. | ✓ fully satisfied (test-only for legacy DB rows; new flow verified manually) |

## Changed Files

- `src/lib/events-manifest/legacy.ts` (new — `resolveLegacyEventName` utility)
- `src/lib/events-manifest/legacy.spec.ts` (new — 6 specs)
- `src/lib/events-manifest/index.ts` (re-export)
- `src/components/journey/nodes/trigger/components/EventConfiguration.tsx` (rewire event-name section)
- `src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx` (new — 6 specs)
- `src/i18n/locales/pt-BR/journey.json` (2 new keys: `customEventNamePlaceholder`, `customEventWarning`)
- `src/i18n/locales/en/journey.json` (2 new keys)

## Related PRs / dependencies

- Depends on **EVO-1561 / evo-flow#13** for local-dev boot. `evo-flow` `develop` crashes on boot until that catalog fix lands; this PR's smoke test required `feat/EVO-1561` checked out locally on `evo-flow`. CI / reviewer should pull EVO-1561 first OR wait until it merges before smoke-testing this PR.

## Not in scope (deferred to downstream stories)

- `EventProperty` array refactor → `<EventPropertiesForm>` (10.7, EVO-1275)
- Separar config básica vs avançada do Trigger (10.8, EVO-1276)
- Cross-surface validation E2E that Campaign Trigger and Journey Trigger share the same component (10.9, EVO-1277 — propagation already happens via shared `EventConfiguration`, this story documents the assumption)
- Automation Rules' EventSelector (architectural decision in 10.A: each domain keeps its own UX around the shared manifest)
- Filtering `<EventSelector>` categories per surface (e.g. hide `campaign.message.*` from Journey Trigger) — out of scope; let users see the full catalog
- Edge case: `eventName='custom'` literally persisted from a buggy old state shows custom mode with empty input — known limitation, very rare in practice; placeholder still guides user input

## Linked Issue

- https://linear.app/evoai/issue/EVO-1271/106-refazer-ux-do-node-trigger-event-consumindo-manifesto

## Summary by Sourcery

Rework the journey trigger event configuration UI to use the shared event catalog selector with custom-event fallback and legacy-name migration.

New Features:
- Introduce an event-name UX where the shared EventSelector is the primary control with contextual descriptions for canonical events and a dedicated custom-event input with warnings.

Enhancements:
- Add a resolveLegacyEventName helper to migrate legacy snake_case event names to canonical dot notation or route them into custom mode while preserving original values.
- Refine event property handling by normalizing operator value types and removing unused variable insertion logging in trigger configuration.

Tests:
- Add unit tests for the new EventConfiguration event-name UX, covering canonical selection, custom mode, legacy migration, and custom-mode stability.
- Add unit tests for the legacy event-name resolution helper to validate mapping behavior.