### PR TITLE
feat(segments): route direct segment calls through CRM proxy (EVO-1569)

### DIFF
--- a/src/services/segments/segmentsService.spec.ts
+++ b/src/services/segments/segmentsService.spec.ts
@@ -1,46 +1,212 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { segmentsService } from './segmentsService';
-import api from '@/services/core/api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SegmentDefinition } from '@/types/analytics/segments';
 
+// CRM proxy axios instance — every segment method must route through this.
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
 vi.mock('@/services/core/api', () => ({
-  default: { post: vi.fn() },
+  default: {
+    get: (...args: unknown[]) => mockApi.get(...args),
+    post: (...args: unknown[]) => mockApi.post(...args),
+    put: (...args: unknown[]) => mockApi.put(...args),
+    delete: (...args: unknown[]) => mockApi.delete(...args),
+  },
 }));
 
+// The direct evo-flow instance must receive ZERO calls after the migration
+// (EVO-1569 AC1). It is still mocked in case any stale reference remains, so
+// the assertions below fail loudly rather than hitting the network.
+const mockEvoFlow = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
 vi.mock('@/services/core/apiEvoFlow', () => ({
-  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  default: {
+    get: (...args: unknown[]) => mockEvoFlow.get(...args),
+    post: (...args: unknown[]) => mockEvoFlow.post(...args),
+    put: (...args: unknown[]) => mockEvoFlow.put(...args),
+    delete: (...args: unknown[]) => mockEvoFlow.delete(...args),
+  },
 }));
 
-const definition: SegmentDefinition = {
-  entryNode: { id: 'entry', type: 'Everyone' },
-  nodes: [],
+import { segmentsService } from './segmentsService';
+
+const expectNoEvoFlowCalls = () => {
+  expect(mockEvoFlow.get).not.toHaveBeenCalled();
+  expect(mockEvoFlow.post).not.toHaveBeenCalled();
+  expect(mockEvoFlow.put).not.toHaveBeenCalled();
+  expect(mockEvoFlow.delete).not.toHaveBeenCalled();
+};
+
+const resetMocks = () => {
+  Object.values(mockApi).forEach((fn) => fn.mockReset());
+  Object.values(mockEvoFlow).forEach((fn) => fn.mockReset());
 };
 
 describe('segmentsService.previewSegment', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+  const definition: SegmentDefinition = {
+    entryNode: { id: 'entry', type: 'Everyone' },
+    nodes: [],
+  };
+
+  beforeEach(resetMocks);
+  afterEach(() => vi.clearAllMocks());
 
   it('posts the definition to the CRM proxy and returns count + sample', async () => {
-    vi.mocked(api.post).mockResolvedValue({
+    mockApi.post.mockResolvedValueOnce({
       data: { count: 7, sample: [{ id: 'c1' }, { id: 'c2' }] },
-    } as never);
+    });
 
     const result = await segmentsService.previewSegment(definition);
 
-    expect(api.post).toHaveBeenCalledWith('/segments/preview', { definition });
+    expect(mockApi.post).toHaveBeenCalledWith('/segments/preview', { definition });
     expect(result.count).toBe(7);
     expect(result.sample).toEqual([{ id: 'c1' }, { id: 'c2' }]);
+    expectNoEvoFlowCalls();
   });
 
   it('unwraps a { success, data } envelope when present', async () => {
-    vi.mocked(api.post).mockResolvedValue({
+    mockApi.post.mockResolvedValueOnce({
       data: { success: true, data: { count: 3, sample: [] } },
-    } as never);
+    });
 
     const result = await segmentsService.previewSegment(definition);
 
     expect(result.count).toBe(3);
     expect(result.sample).toEqual([]);
+  });
+});
+
+describe('segmentsService — EVO-1569 proxy migration', () => {
+  beforeEach(resetMocks);
+  afterEach(() => vi.clearAllMocks());
+
+  it('deleteSegment → api.delete /segments/:id (not apiEvoFlow)', async () => {
+    mockApi.delete.mockResolvedValueOnce({ data: { id: 'seg-1', deleted: true } });
+
+    const result = await segmentsService.deleteSegment('seg-1');
+
+    expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    expect(mockApi.delete).toHaveBeenCalledWith('/segments/seg-1');
+    expect(result).toEqual({ id: 'seg-1', deleted: true });
+    expectNoEvoFlowCalls();
+  });
+
+  it('deleteSegment resolves on an empty/204 body (AC6)', async () => {
+    mockApi.delete.mockResolvedValueOnce({ data: null });
+
+    await expect(segmentsService.deleteSegment('seg-1')).resolves.toBeNull();
+    expectNoEvoFlowCalls();
+  });
+
+  it('recomputeSegment → api.post /segments/:id/recompute (not apiEvoFlow)', async () => {
+    mockApi.post.mockResolvedValueOnce({ data: {} });
+
+    await segmentsService.recomputeSegment('seg-1');
+
+    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockApi.post).toHaveBeenCalledWith('/segments/seg-1/recompute', {});
+    expectNoEvoFlowCalls();
+  });
+
+  it('recomputeAllSegments → api.post /segments/recompute-all (not apiEvoFlow)', async () => {
+    mockApi.post.mockResolvedValueOnce({
+      data: { results: [], totalProcessingTimeMs: 5 },
+    });
+
+    const result = await segmentsService.recomputeAllSegments();
+
+    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockApi.post).toHaveBeenCalledWith('/segments/recompute-all', {});
+    expect(result).toEqual({ results: [], totalProcessingTimeMs: 5 });
+    expectNoEvoFlowCalls();
+  });
+
+  it('getSegmentContactIds → api.get /segments/:id/contact-ids (not apiEvoFlow)', async () => {
+    mockApi.get.mockResolvedValueOnce({
+      data: { contactIds: ['c1'], total: 1, limit: 50, offset: 0 },
+    });
+
+    const result = await segmentsService.getSegmentContactIds('seg-1', { limit: 50, offset: 0 });
+
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(mockApi.get).toHaveBeenCalledWith('/segments/seg-1/contact-ids', {
+      params: { limit: 50, offset: 0 },
+    });
+    expect(result).toEqual({ contactIds: ['c1'], total: 1, limit: 50, offset: 0 });
+    expectNoEvoFlowCalls();
+  });
+
+  it('getContactSegments uses api.get with snake_case event_type=segment (AC4)', async () => {
+    // 1st api.get = getSegments (limit 100); 2nd api.get = contact events.
+    mockApi.get
+      .mockResolvedValueOnce({ data: { segments: [], total: 0, page: 1, limit: 100 } })
+      .mockResolvedValueOnce({ data: { events: [] } });
+
+    await segmentsService.getContactSegments('contact-1');
+
+    const eventsCall = mockApi.get.mock.calls.find(
+      ([url]) => url === '/contacts/contact-1/events',
+    );
+    expect(eventsCall).toBeDefined();
+    expect(eventsCall?.[1]).toEqual({ params: { event_type: 'segment', limit: 100 } });
+    expectNoEvoFlowCalls();
+  });
+
+  it('getContactSegments derives active segments from segment_entered events', async () => {
+    const segments = [{ id: 'seg-active' }, { id: 'seg-left' }];
+    mockApi.get
+      .mockResolvedValueOnce({ data: { segments, total: 2, page: 1, limit: 100 } })
+      .mockResolvedValueOnce({
+        data: {
+          events: [
+            {
+              eventName: 'segment_entered',
+              occurredAt: '2026-05-02T00:00:00Z',
+              properties: { segmentId: 'seg-active' },
+            },
+            {
+              eventName: 'segment_exited',
+              occurredAt: '2026-05-02T00:00:00Z',
+              properties: { segmentId: 'seg-left' },
+            },
+          ],
+        },
+      });
+
+    const result = await segmentsService.getContactSegments('contact-1');
+
+    expect(result.segmentIds).toEqual(['seg-active']);
+    expect(result.total).toBe(1);
+    expectNoEvoFlowCalls();
+  });
+
+  it('getContactSegments rethrows auth failures (401/403) instead of masking them', async () => {
+    // getSegments succeeds, the events call 403s — must NOT resolve to empty.
+    mockApi.get
+      .mockResolvedValueOnce({ data: { segments: [], total: 0, page: 1, limit: 100 } })
+      .mockRejectedValueOnce({ response: { status: 403 } });
+
+    await expect(segmentsService.getContactSegments('contact-1')).rejects.toEqual({
+      response: { status: 403 },
+    });
+  });
+
+  it('getContactSegments still degrades to empty on a non-auth error', async () => {
+    mockApi.get
+      .mockResolvedValueOnce({ data: { segments: [], total: 0, page: 1, limit: 100 } })
+      .mockRejectedValueOnce({ response: { status: 500 } });
+
+    await expect(segmentsService.getContactSegments('contact-1')).resolves.toEqual({
+      segmentIds: [],
+      segments: [],
+      total: 0,
+    });
   });
 });

--- a/src/services/segments/segmentsService.ts
+++ b/src/services/segments/segmentsService.ts
@@ -1,4 +1,3 @@
-import apiEvoFlow from '@/services/core/apiEvoFlow';
 import api from '@/services/core/api';
 import { extractData } from '@/utils/apiHelpers';
 import { SegmentsResponse, SegmentResponse, SegmentDeleteResponse, SegmentFormData, Segment } from '@/types/analytics';
@@ -22,7 +21,7 @@ class SegmentsService {
       status?: string;
     },
   ): Promise<SegmentsResponse> {
-    // Routed through the CRM proxy (api → /api/v1/segments), not apiEvoFlow.
+    // Routed through the CRM proxy (api → /api/v1/segments).
     const response = await api.get(this.getBaseUrl(), {
       params,
     });
@@ -60,7 +59,8 @@ class SegmentsService {
   }
 
   async deleteSegment(segmentId: string): Promise<SegmentDeleteResponse> {
-    const response = await apiEvoFlow.delete(`${this.getBaseUrl()}/${segmentId}`);
+    // Via CRM proxy (DELETE /api/v1/segments/:id → evo-flow).
+    const response = await api.delete(`${this.getBaseUrl()}/${segmentId}`);
     return extractData<SegmentDeleteResponse>(response);
   }
 
@@ -82,7 +82,8 @@ class SegmentsService {
   }
 
   async recomputeSegment(segmentId: string): Promise<void> {
-    await apiEvoFlow.post(`${this.getBaseUrl()}/${segmentId}/recompute`, {});
+    // Via CRM proxy (POST /api/v1/segments/:id/recompute → evo-flow).
+    await api.post(`${this.getBaseUrl()}/${segmentId}/recompute`, {});
   }
 
   async recomputeAllSegments(): Promise<{
@@ -95,7 +96,8 @@ class SegmentsService {
     }>;
     totalProcessingTimeMs: number;
   }> {
-    const response = await apiEvoFlow.post(`${this.getBaseUrl()}/recompute-all`, {});
+    // Via CRM proxy (POST /api/v1/segments/recompute-all → evo-flow).
+    const response = await api.post(`${this.getBaseUrl()}/recompute-all`, {});
     return extractData<{
       results: Array<{
         segmentId: string;
@@ -120,7 +122,8 @@ class SegmentsService {
     limit: number;
     offset: number;
   }> {
-    const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${segmentId}/contact-ids`, {
+    // Via CRM proxy (GET /api/v1/segments/:id/contact-ids → evo-flow).
+    const response = await api.get(`${this.getBaseUrl()}/${segmentId}/contact-ids`, {
       params,
     });
     return extractData<{
@@ -142,10 +145,12 @@ class SegmentsService {
 
       const allSegments = segmentsResponse.data || [];
 
-      // Buscar eventos do tipo 'segment' do contato
-      const eventsResponse = await apiEvoFlow.get(`/contacts/${contactId}/events`, {
+      // Buscar eventos do tipo 'segment' do contato.
+      // O proxy permite somente chaves snake_case (event_type); camelCase é
+      // silenciosamente descartado, o que retornaria eventos não filtrados.
+      const eventsResponse = await api.get(`/contacts/${contactId}/events`, {
         params: {
-          eventType: 'segment',
+          event_type: 'segment',
           limit: 100,
         },
       });
@@ -186,6 +191,13 @@ class SegmentsService {
         total: activeSegments.length,
       };
     } catch (error) {
+      // Now that this flows through the auth-gated CRM proxy, an auth failure
+      // must NOT be masked as "contact is in no segments" — rethrow it so the
+      // api interceptor (401 refresh / 403 handling) and callers can react.
+      const status = (error as { response?: { status?: number } })?.response?.status;
+      if (status === 401 || status === 403) {
+        throw error;
+      }
       console.error('Error fetching contact segments:', error);
       return {
         segmentIds: [],


### PR DESCRIPTION
## Summary
Follow-up da 7.11 (EVO-1247). Migra as 5 chamadas restantes do `segmentsService.ts` de `apiEvoFlow` (que carrega o `X-Integration-API-Key` de serviço no browser) para o proxy CRM autenticado (`api`).

- `deleteSegment`, `recomputeSegment`, `recomputeAllSegments`, `getSegmentContactIds` → agora via `api` (rotas novas do proxy CRM, PR irmão no `evo-ai-crm-community`).
- `getContactSegments` passa a usar o proxy de eventos da 7.7 e o param **snake_case** `event_type` (camelCase é silenciosamente descartado pelo proxy).
- `getContactSegments` agora **relança 401/403** em vez de mascarar falha de auth como "contato sem segmentos" — deixa o interceptor do `api` (refresh 401 / handling 403) e os callers reagirem.
- Remove o import de `apiEvoFlow`; o spec garante zero chamadas diretas ao evo-flow (AC1).

## Test plan
- `npm test -- segmentsService` → 11 testes verdes (preview + migração das 5 + rethrow 401/403 + degrade em erro não-auth; helper afirma zero chamadas em `apiEvoFlow`).
- `npx tsc --noEmit` limpo nos arquivos alterados.
- AC1: `grep apiEvoFlow src/services/segments/segmentsService.ts` → 0 ocorrências.

## Notas
- AC5 ("browser não precisa de `VITE_EVOFLOW_API_URL`") fica satisfeito estruturalmente: o service não referencia mais `apiEvoFlow` para essas chamadas.
- Par no backend: 4 ações novas no `Api::V1::EvoFlow::SegmentsController` (PR no `evo-ai-crm-community`). Mergear o backend antes para o fluxo funcionar e2e.
- Linear: EVO-1569.