### PR TITLE
fix(contacts): mostrar traits na timeline de eventos + CSP localhost (EVO-1571)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,7 @@ APP_ENV="${VITE_APP_ENV:-development}"
 
 if [ "$APP_ENV" = "development" ]; then
   # Development: Allow localhost connections and permissive frame-ancestors for widget
-  sed -i "s|connect-src 'self' https: wss: ws:|connect-src 'self' https: wss: ws: http://localhost:*|g" /etc/nginx/conf.d/default.conf
+  sed -i "s|connect-src 'self' blob: https: wss: ws:|connect-src 'self' blob: https: wss: ws: http://localhost:*|g" /etc/nginx/conf.d/default.conf
   sed -i "s|frame-ancestors 'self'|frame-ancestors *|g" /etc/nginx/conf.d/default.conf
 fi
 

--- a/src/components/contacts/ContactEventCard.tsx
+++ b/src/components/contacts/ContactEventCard.tsx
@@ -55,6 +55,14 @@ function ContactEventCardImpl({ event }: ContactEventCardProps) {
 
   const enriched = event.enriched;
 
+  // Identify events (e.g. contact.updated) carry their payload in `traits`,
+  // not `properties` (which is `{}`). Track/page events use `properties`.
+  // Render whichever has data so no event shows up empty.
+  const hasKeys = (o?: Record<string, unknown>): boolean =>
+    !!o && typeof o === 'object' && Object.keys(o).length > 0;
+  const hasProps = hasKeys(event.properties);
+  const hasTraits = hasKeys(event.traits);
+
   return (
     <Card className="border border-border bg-card transition-colors hover:bg-accent/30">
       <CardContent className="p-4">
@@ -108,12 +116,35 @@ function ContactEventCardImpl({ event }: ContactEventCardProps) {
             </Button>
 
             {expanded && (
-              <pre
-                id={propertiesId}
-                className="mt-2 max-h-64 overflow-auto rounded-md bg-muted/40 p-3 text-xs"
-              >
-                {JSON.stringify(event.properties, redactReplacer, 2)}
-              </pre>
+              <div id={propertiesId} className="mt-2 space-y-2">
+                {hasProps && (
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">
+                      {t('events.card.properties', { defaultValue: 'Properties' })}
+                    </p>
+                    <pre className="max-h-64 overflow-auto rounded-md bg-muted/40 p-3 text-xs">
+                      {JSON.stringify(event.properties, redactReplacer, 2)}
+                    </pre>
+                  </div>
+                )}
+                {hasTraits && (
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">
+                      {t('events.card.traits', { defaultValue: 'Traits' })}
+                    </p>
+                    <pre className="max-h-64 overflow-auto rounded-md bg-muted/40 p-3 text-xs">
+                      {JSON.stringify(event.traits, redactReplacer, 2)}
+                    </pre>
+                  </div>
+                )}
+                {!hasProps && !hasTraits && (
+                  <p className="rounded-md bg-muted/40 p-3 text-xs text-muted-foreground">
+                    {t('events.card.noData', {
+                      defaultValue: 'No additional data for this event',
+                    })}
+                  </p>
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/src/components/contacts/__tests__/ContactEventCard.spec.tsx
+++ b/src/components/contacts/__tests__/ContactEventCard.spec.tsx
@@ -124,7 +124,7 @@ describe('ContactEventCard', () => {
     expect(text).not.toContain('t1');
   });
 
-  it('exposes aria-controls linking the button to the properties pre element', async () => {
+  it('exposes aria-controls linking the button to the expanded properties region', async () => {
     const user = userEvent.setup();
     render(<ContactEventCard event={makeEvent({ properties: { foo: 'bar' } })} />);
     const button = screen.getByRole('button', { name: /events\.card\.expand/ });
@@ -132,8 +132,12 @@ describe('ContactEventCard', () => {
     expect(controls).toBeTruthy();
 
     await user.click(button);
+    // The id lives on the wrapper region (it can hold properties, traits and the
+    // empty-state message), with the <pre> nested inside it.
+    const region = document.getElementById(controls!);
+    expect(region).not.toBeNull();
     const pre = await screen.findByText((_, node) => node?.tagName.toLowerCase() === 'pre');
-    expect(pre.id).toBe(controls);
-    expect(within(pre.parentElement!).getByText(/foo/)).toBeInTheDocument();
+    expect(region!.contains(pre)).toBe(true);
+    expect(within(region!).getByText(/foo/)).toBeInTheDocument();
   });
 });

--- a/src/i18n/locales/contacts-parity.spec.ts
+++ b/src/i18n/locales/contacts-parity.spec.ts
@@ -111,6 +111,8 @@ describe('contacts i18n parity (EVO-1244)', () => {
     'events.card.expand',
     'events.card.collapse',
     'events.card.properties',
+    'events.card.traits',
+    'events.card.noData',
     'events.card.justNow',
     'events.card.enriched.campaign',
     'events.card.enriched.channel',

--- a/src/i18n/locales/en/contacts.json
+++ b/src/i18n/locales/en/contacts.json
@@ -685,6 +685,8 @@
       "expand": "Show details",
       "collapse": "Hide details",
       "properties": "Event properties",
+      "traits": "Event traits",
+      "noData": "No additional data for this event",
       "justNow": "just now",
       "enriched": {
         "campaign": "Campaign: {{name}}",

--- a/src/i18n/locales/es/contacts.json
+++ b/src/i18n/locales/es/contacts.json
@@ -677,6 +677,8 @@
       "expand": "Ver detalles",
       "collapse": "Ocultar detalles",
       "properties": "Propiedades del evento",
+      "traits": "Atributos del evento",
+      "noData": "Sin datos adicionales para este evento",
       "justNow": "ahora",
       "enriched": {
         "campaign": "Campaña: {{name}}",

--- a/src/i18n/locales/fr/contacts.json
+++ b/src/i18n/locales/fr/contacts.json
@@ -677,6 +677,8 @@
       "expand": "Voir les détails",
       "collapse": "Masquer les détails",
       "properties": "Propriétés de l'événement",
+      "traits": "Attributs de l'événement",
+      "noData": "Aucune donnée supplémentaire pour cet événement",
       "justNow": "à l'instant",
       "enriched": {
         "campaign": "Campagne : {{name}}",

--- a/src/i18n/locales/it/contacts.json
+++ b/src/i18n/locales/it/contacts.json
@@ -677,6 +677,8 @@
       "expand": "Mostra dettagli",
       "collapse": "Nascondi dettagli",
       "properties": "Proprietà dell'evento",
+      "traits": "Attributi dell'evento",
+      "noData": "Nessun dato aggiuntivo per questo evento",
       "justNow": "adesso",
       "enriched": {
         "campaign": "Campagna: {{name}}",

--- a/src/i18n/locales/pt-BR/contacts.json
+++ b/src/i18n/locales/pt-BR/contacts.json
@@ -685,6 +685,8 @@
       "expand": "Ver detalhes",
       "collapse": "Ocultar detalhes",
       "properties": "Propriedades do evento",
+      "traits": "Atributos do evento",
+      "noData": "Sem dados adicionais para este evento",
       "justNow": "agora",
       "enriched": {
         "campaign": "Campanha: {{name}}",

--- a/src/i18n/locales/pt/contacts.json
+++ b/src/i18n/locales/pt/contacts.json
@@ -685,6 +685,8 @@
       "expand": "Ver detalhes",
       "collapse": "Ocultar detalhes",
       "properties": "Propriedades do evento",
+      "traits": "Atributos do evento",
+      "noData": "Sem dados adicionais para este evento",
       "justNow": "agora",
       "enriched": {
         "campaign": "Campanha: {{name}}",


### PR DESCRIPTION
## Summary
Dois fixes da feature de Histórico/Tracking (aba "Eventos" do contato):

1. **`fix(contacts)`** — `ContactEventCard` agora renderiza `traits` além de `properties`. Eventos `identify` (`contact.updated`, `contact.custom_attribute.changed`) têm `properties: {}` e os dados reais (nome, `customAttributes`, `changes`) em `traits`; antes o card mostrava `{}` e o evento ficava sem nenhuma informação útil. Fallback "no additional data" só quando ambos vazios.
2. **`fix(docker)`** — corrige o `connect-src` do CSP no `docker-entrypoint.sh`: o `sed` que libera `http://localhost:*` em dev não casava com o CSP real do `nginx.conf` (faltava `blob:`), bloqueando login (`:3001`) e chamadas ao CRM/evo-flow no browser.

## Test plan
- `npm run build` (tsc + vite)
- E2E: editar um contato → aba Eventos → expandir o `contact.updated` → ver os dados (traits: nome, changes, custom attributes).
- Login e chamadas a `http://localhost:*` não são mais bloqueados pelo CSP.

Relacionado: EVO-1571

## Summary by Sourcery

Fix contact event timeline data visibility and align CSP configuration for localhost in development.

Bug Fixes:
- Ensure contact event cards display traits as well as properties so identify-style events show their payload instead of appearing empty.
- Show a clear fallback message when an event has neither properties nor traits data to render.
- Correct the development Content Security Policy connect-src directive so localhost HTTP calls are allowed alongside existing sources.