### PR TITLE
fix(segments): traduz paleta do canvas e completa locales (EVO-1572)

### DIFF
--- a/src/components/segments/canvas/SegmentCanvasBuilder.tsx
+++ b/src/components/segments/canvas/SegmentCanvasBuilder.tsx
@@ -26,27 +26,6 @@ const NODE_TYPES: Record<string, ComponentType<NodeProps>> = (() => {
   return reg;
 })();
 
-const NODE_CATEGORIES: NodeCategory[] = [
-  { value: 'identity', label: 'Identity', icon: User, description: 'Who the contact is' },
-  { value: 'behavior', label: 'Behavior', icon: Activity, description: 'What the contact did' },
-  { value: 'messages', label: 'Messages', icon: MessageSquare, description: 'Channel interactions' },
-];
-
-const PALETTE: Record<string, NodeType[]> = SEGMENT_NODE_META.reduce(
-  (acc, m) => {
-    (acc[m.category] ||= []).push({
-      id: m.type,
-      name: m.label,
-      description: m.description,
-      icon: m.icon,
-      color: m.color,
-      category: m.category,
-    });
-    return acc;
-  },
-  {} as Record<string, NodeType[]>,
-);
-
 export interface SegmentCanvasBuilderProps {
   definitionType: EntryType;
   nodes: SegmentNodeUnion[];
@@ -67,6 +46,37 @@ export function SegmentCanvasBuilder({
   onDefinitionTypeChange,
 }: SegmentCanvasBuilderProps) {
   const { t } = useLanguage('segments');
+
+  // Palette labels/descriptions are translated here (not at module scope) so
+  // they react to the active language. Categories mirror SegmentNodeMeta.category.
+  const nodeCategories = useMemo<NodeCategory[]>(
+    () => [
+      { value: 'identity', label: t('canvas.categories.identity.label'), icon: User, description: t('canvas.categories.identity.description') },
+      { value: 'behavior', label: t('canvas.categories.behavior.label'), icon: Activity, description: t('canvas.categories.behavior.description') },
+      { value: 'messages', label: t('canvas.categories.messages.label'), icon: MessageSquare, description: t('canvas.categories.messages.description') },
+    ],
+    [t],
+  );
+
+  const palette = useMemo<Record<string, NodeType[]>>(
+    () =>
+      SEGMENT_NODE_META.reduce(
+        (acc, m) => {
+          (acc[m.category] ||= []).push({
+            id: m.type,
+            name: t(m.labelKey),
+            description: t(m.descriptionKey),
+            icon: m.icon,
+            color: m.color,
+            category: m.category,
+          });
+          return acc;
+        },
+        {} as Record<string, NodeType[]>,
+      ),
+    [t],
+  );
+
   const [selectedNodeId, setSelectedNodeId] = useState<string | undefined>(undefined);
   // Bumped to force a canvas reseed when structure changes outside the canvas
   // (e.g. the inspector removes a node).
@@ -122,8 +132,8 @@ export function SegmentCanvasBuilder({
           showToolbar={false}
           onFlowDataChange={handleFlowDataChange}
           nodeTypes={NODE_TYPES}
-          nodePanelNodeTypes={PALETTE}
-          nodePanelCategories={NODE_CATEGORIES}
+          nodePanelNodeTypes={palette}
+          nodePanelCategories={nodeCategories}
           nodePanelTitle={t('canvas.panelTitle')}
         />
       </div>

--- a/src/components/segments/canvas/SegmentCanvasNode.tsx
+++ b/src/components/segments/canvas/SegmentCanvasNode.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import type { NodeProps } from '@xyflow/react';
+import { useLanguage } from '@/hooks/useLanguage';
 import { BaseFlowNode } from '@/components/base/BaseFlowNode';
 import { metaForType } from './segmentCanvasMeta';
 
@@ -9,8 +10,12 @@ import { metaForType } from './segmentCanvasMeta';
  * (the existing SegmentConditionEditor) when the node is selected.
  */
 function SegmentCanvasNodeComponent({ type, selected }: NodeProps) {
+  const { t } = useLanguage('segments');
   const meta = metaForType(String(type));
   const Icon = meta.icon;
+  // Unknown types carry no i18n key — fall back to the raw type / empty.
+  const label = meta.labelKey ? t(meta.labelKey) : String(type);
+  const description = meta.descriptionKey ? t(meta.descriptionKey) : '';
   return (
     <BaseFlowNode
       selected={!!selected}
@@ -22,8 +27,8 @@ function SegmentCanvasNodeComponent({ type, selected }: NodeProps) {
       <div className="flex items-start gap-2">
         <Icon className="h-4 w-4 mt-0.5" />
         <div className="min-w-0">
-          <p className="text-sm font-medium text-neutral-100">{meta.label}</p>
-          <p className="truncate text-xs text-neutral-400">{meta.description}</p>
+          <p className="text-sm font-medium text-neutral-100">{label}</p>
+          <p className="truncate text-xs text-neutral-400">{description}</p>
         </div>
       </div>
     </BaseFlowNode>

--- a/src/components/segments/canvas/segmentCanvasMeta.ts
+++ b/src/components/segments/canvas/segmentCanvasMeta.ts
@@ -5,8 +5,10 @@ import type { SegmentNodeUnion } from '@/types/analytics/segments';
 export interface SegmentNodeMeta {
   /** The DSL `type` discriminant emitted onto the canvas / definition. */
   type: string;
-  label: string;
-  description: string;
+  /** i18n key (under the `segments` namespace) for the palette label. */
+  labelKey: string;
+  /** i18n key (under the `segments` namespace) for the palette description. */
+  descriptionKey: string;
   icon: LucideIcon;
   color: NodeBorderColor;
   /** Palette category bucket. */
@@ -15,15 +17,17 @@ export interface SegmentNodeMeta {
 
 // The 8 palette node types (AC6). "Channel" defaults to WhatsApp and can be
 // switched to Web/SMS in the inspector. Everyone is the entry-only marker.
+// label/description are i18n keys (segments namespace) resolved at render time —
+// see canvas.nodes.* in the locale files.
 export const SEGMENT_NODE_META: SegmentNodeMeta[] = [
-  { type: 'Everyone', label: 'Everyone', description: 'All contacts in the account', icon: Users, color: 'emerald', category: 'identity' },
-  { type: 'UserProperty', label: 'User property', description: 'Filter by a contact property', icon: User, color: 'indigo', category: 'identity' },
-  { type: 'CustomAttribute', label: 'Custom attribute', description: 'Filter by a custom attribute', icon: Hash, color: 'cyan', category: 'identity' },
-  { type: 'Label', label: 'Label', description: 'Has / lacks a label', icon: Tag, color: 'purple', category: 'identity' },
-  { type: 'Performed', label: 'Performed event', description: 'Did a tracked event', icon: Activity, color: 'blue', category: 'behavior' },
-  { type: 'RandomBucket', label: 'Random bucket', description: 'A random % of contacts', icon: Percent, color: 'amber', category: 'behavior' },
-  { type: 'Email', label: 'Email', description: 'Email interaction', icon: Mail, color: 'rose', category: 'messages' },
-  { type: 'WhatsApp', label: 'Channel', description: 'Reached on a channel (WhatsApp/Web/SMS)', icon: MessageSquare, color: 'teal', category: 'messages' },
+  { type: 'Everyone', labelKey: 'canvas.nodes.Everyone.label', descriptionKey: 'canvas.nodes.Everyone.description', icon: Users, color: 'emerald', category: 'identity' },
+  { type: 'UserProperty', labelKey: 'canvas.nodes.UserProperty.label', descriptionKey: 'canvas.nodes.UserProperty.description', icon: User, color: 'indigo', category: 'identity' },
+  { type: 'CustomAttribute', labelKey: 'canvas.nodes.CustomAttribute.label', descriptionKey: 'canvas.nodes.CustomAttribute.description', icon: Hash, color: 'cyan', category: 'identity' },
+  { type: 'Label', labelKey: 'canvas.nodes.Label.label', descriptionKey: 'canvas.nodes.Label.description', icon: Tag, color: 'purple', category: 'identity' },
+  { type: 'Performed', labelKey: 'canvas.nodes.Performed.label', descriptionKey: 'canvas.nodes.Performed.description', icon: Activity, color: 'blue', category: 'behavior' },
+  { type: 'RandomBucket', labelKey: 'canvas.nodes.RandomBucket.label', descriptionKey: 'canvas.nodes.RandomBucket.description', icon: Percent, color: 'amber', category: 'behavior' },
+  { type: 'Email', labelKey: 'canvas.nodes.Email.label', descriptionKey: 'canvas.nodes.Email.description', icon: Mail, color: 'rose', category: 'messages' },
+  { type: 'WhatsApp', labelKey: 'canvas.nodes.WhatsApp.label', descriptionKey: 'canvas.nodes.WhatsApp.description', icon: MessageSquare, color: 'teal', category: 'messages' },
 ];
 
 const BY_TYPE: Record<string, SegmentNodeMeta> = SEGMENT_NODE_META.reduce(
@@ -42,8 +46,9 @@ export function metaForType(type: string): SegmentNodeMeta {
   return (
     BY_TYPE[type] ?? {
       type,
-      label: type,
-      description: '',
+      // No i18n key for unknown types — consumers fall back to the raw type.
+      labelKey: '',
+      descriptionKey: '',
       icon: Filter,
       color: 'slate',
       category: 'identity',

--- a/src/i18n/locales/en/segments.json
+++ b/src/i18n/locales/en/segments.json
@@ -65,7 +65,22 @@
     "subtitle": "Drag conditions from the panel; click a node to edit it",
     "panelTitle": "Conditions",
     "combineWith": "Combine with",
-    "selectNode": "Select a node on the canvas to edit it, or drag a new condition from the panel."
+    "selectNode": "Select a node on the canvas to edit it, or drag a new condition from the panel.",
+    "categories": {
+      "identity": { "label": "Identity", "description": "Who the contact is" },
+      "behavior": { "label": "Behavior", "description": "What the contact did" },
+      "messages": { "label": "Messages", "description": "Channel interactions" }
+    },
+    "nodes": {
+      "Everyone": { "label": "Everyone", "description": "All contacts in the account" },
+      "UserProperty": { "label": "User property", "description": "Filter by a contact property" },
+      "CustomAttribute": { "label": "Custom attribute", "description": "Filter by a custom attribute" },
+      "Label": { "label": "Label", "description": "Has / lacks a label" },
+      "Performed": { "label": "Performed event", "description": "Did a tracked event" },
+      "RandomBucket": { "label": "Random bucket", "description": "A random % of contacts" },
+      "Email": { "label": "Email", "description": "Email interaction" },
+      "WhatsApp": { "label": "Channel", "description": "Reached on a channel (WhatsApp/Web/SMS)" }
+    }
   },
   "messages": {
     "permissionDenied": {

--- a/src/i18n/locales/es/segments.json
+++ b/src/i18n/locales/es/segments.json
@@ -50,6 +50,34 @@
     "viewIds": "Ver IDs",
     "pause": "Pausar"
   },
+  "preview": {
+    "result_one": "{{count}} contacto coincide con este segmento.",
+    "result_other": "{{count}} contactos coinciden con este segmento.",
+    "sample": "p. ej. {{ids}}",
+    "error": "No se pudo previsualizar este segmento."
+  },
+  "canvas": {
+    "title": "Lienzo del segmento",
+    "subtitle": "Arrastra condiciones desde el panel; haz clic en un nodo para editarlo",
+    "panelTitle": "Condiciones",
+    "combineWith": "Combinar con",
+    "selectNode": "Selecciona un nodo en el lienzo para editarlo, o arrastra una nueva condición desde el panel.",
+    "categories": {
+      "identity": { "label": "Identidad", "description": "Quién es el contacto" },
+      "behavior": { "label": "Comportamiento", "description": "Qué hizo el contacto" },
+      "messages": { "label": "Mensajes", "description": "Interacciones por canal" }
+    },
+    "nodes": {
+      "Everyone": { "label": "Todos", "description": "Todos los contactos de la cuenta" },
+      "UserProperty": { "label": "Propiedad del usuario", "description": "Filtrar por una propiedad del contacto" },
+      "CustomAttribute": { "label": "Atributo personalizado", "description": "Filtrar por un atributo personalizado" },
+      "Label": { "label": "Etiqueta", "description": "Tiene / no tiene una etiqueta" },
+      "Performed": { "label": "Evento realizado", "description": "Realizó un evento rastreado" },
+      "RandomBucket": { "label": "Muestra aleatoria", "description": "Un % aleatorio de contactos" },
+      "Email": { "label": "Correo", "description": "Interacción por correo" },
+      "WhatsApp": { "label": "Canal", "description": "Alcanzado en un canal (WhatsApp/Web/SMS)" }
+    }
+  },
   "messages": {
     "permissionDenied": {
       "read": "No tiene permiso para visualizar segmentos",

--- a/src/i18n/locales/fr/segments.json
+++ b/src/i18n/locales/fr/segments.json
@@ -50,6 +50,34 @@
     "viewIds": "Voir les IDs",
     "pause": "Mettre en Pause"
   },
+  "preview": {
+    "result_one": "{{count}} contact correspond à ce segment.",
+    "result_other": "{{count}} contacts correspondent à ce segment.",
+    "sample": "p. ex. {{ids}}",
+    "error": "Impossible de prévisualiser ce segment."
+  },
+  "canvas": {
+    "title": "Canevas du segment",
+    "subtitle": "Faites glisser des conditions depuis le panneau ; cliquez sur un nœud pour le modifier",
+    "panelTitle": "Conditions",
+    "combineWith": "Combiner avec",
+    "selectNode": "Sélectionnez un nœud sur le canevas pour le modifier, ou faites glisser une nouvelle condition depuis le panneau.",
+    "categories": {
+      "identity": { "label": "Identité", "description": "Qui est le contact" },
+      "behavior": { "label": "Comportement", "description": "Ce que le contact a fait" },
+      "messages": { "label": "Messages", "description": "Interactions par canal" }
+    },
+    "nodes": {
+      "Everyone": { "label": "Tout le monde", "description": "Tous les contacts du compte" },
+      "UserProperty": { "label": "Propriété de l'utilisateur", "description": "Filtrer par une propriété du contact" },
+      "CustomAttribute": { "label": "Attribut personnalisé", "description": "Filtrer par un attribut personnalisé" },
+      "Label": { "label": "Étiquette", "description": "Possède / ne possède pas une étiquette" },
+      "Performed": { "label": "Événement réalisé", "description": "A déclenché un événement suivi" },
+      "RandomBucket": { "label": "Échantillon aléatoire", "description": "Un % aléatoire de contacts" },
+      "Email": { "label": "E-mail", "description": "Interaction par e-mail" },
+      "WhatsApp": { "label": "Canal", "description": "Atteint sur un canal (WhatsApp/Web/SMS)" }
+    }
+  },
   "messages": {
     "permissionDenied": {
       "read": "Vous n'avez pas la permission de visualiser les segments",

--- a/src/i18n/locales/it/segments.json
+++ b/src/i18n/locales/it/segments.json
@@ -50,6 +50,34 @@
     "viewIds": "Visualizza ID",
     "pause": "Pausa"
   },
+  "preview": {
+    "result_one": "{{count}} contatto corrisponde a questo segmento.",
+    "result_other": "{{count}} contatti corrispondono a questo segmento.",
+    "sample": "es. {{ids}}",
+    "error": "Impossibile visualizzare l'anteprima di questo segmento."
+  },
+  "canvas": {
+    "title": "Tela del segmento",
+    "subtitle": "Trascina le condizioni dal pannello; fai clic su un nodo per modificarlo",
+    "panelTitle": "Condizioni",
+    "combineWith": "Combina con",
+    "selectNode": "Seleziona un nodo sulla tela per modificarlo, oppure trascina una nuova condizione dal pannello.",
+    "categories": {
+      "identity": { "label": "Identità", "description": "Chi è il contatto" },
+      "behavior": { "label": "Comportamento", "description": "Cosa ha fatto il contatto" },
+      "messages": { "label": "Messaggi", "description": "Interazioni sui canali" }
+    },
+    "nodes": {
+      "Everyone": { "label": "Tutti", "description": "Tutti i contatti dell'account" },
+      "UserProperty": { "label": "Proprietà utente", "description": "Filtra per una proprietà del contatto" },
+      "CustomAttribute": { "label": "Attributo personalizzato", "description": "Filtra per un attributo personalizzato" },
+      "Label": { "label": "Etichetta", "description": "Ha / non ha un'etichetta" },
+      "Performed": { "label": "Evento eseguito", "description": "Ha effettuato un evento tracciato" },
+      "RandomBucket": { "label": "Campione casuale", "description": "Una % casuale di contatti" },
+      "Email": { "label": "Email", "description": "Interazione via email" },
+      "WhatsApp": { "label": "Canale", "description": "Raggiunto su un canale (WhatsApp/Web/SMS)" }
+    }
+  },
   "messages": {
     "permissionDenied": {
       "read": "Non hai il permesso di visualizzare i segmenti",

--- a/src/i18n/locales/pt-BR/segments.json
+++ b/src/i18n/locales/pt-BR/segments.json
@@ -65,7 +65,22 @@
     "subtitle": "Arraste condições do painel; clique num nó para editar",
     "panelTitle": "Condições",
     "combineWith": "Combinar com",
-    "selectNode": "Selecione um nó no canvas para editar, ou arraste uma nova condição do painel."
+    "selectNode": "Selecione um nó no canvas para editar, ou arraste uma nova condição do painel.",
+    "categories": {
+      "identity": { "label": "Identidade", "description": "Quem é o contato" },
+      "behavior": { "label": "Comportamento", "description": "O que o contato fez" },
+      "messages": { "label": "Mensagens", "description": "Interações por canal" }
+    },
+    "nodes": {
+      "Everyone": { "label": "Todos", "description": "Todos os contatos da conta" },
+      "UserProperty": { "label": "Propriedade do usuário", "description": "Filtrar por uma propriedade do contato" },
+      "CustomAttribute": { "label": "Atributo personalizado", "description": "Filtrar por um atributo personalizado" },
+      "Label": { "label": "Etiqueta", "description": "Possui / não possui uma etiqueta" },
+      "Performed": { "label": "Evento realizado", "description": "Realizou um evento rastreado" },
+      "RandomBucket": { "label": "Amostra aleatória", "description": "Uma % aleatória de contatos" },
+      "Email": { "label": "E-mail", "description": "Interação por e-mail" },
+      "WhatsApp": { "label": "Canal", "description": "Alcançado em um canal (WhatsApp/Web/SMS)" }
+    }
   },
   "messages": {
     "permissionDenied": {

--- a/src/i18n/locales/pt/segments.json
+++ b/src/i18n/locales/pt/segments.json
@@ -50,6 +50,34 @@
     "viewIds": "Ver IDs",
     "pause": "Pausar"
   },
+  "preview": {
+    "result_one": "{{count}} contacto corresponde a este segmento.",
+    "result_other": "{{count}} contactos correspondem a este segmento.",
+    "sample": "ex.: {{ids}}",
+    "error": "Não foi possível pré-visualizar este segmento."
+  },
+  "canvas": {
+    "title": "Tela do segmento",
+    "subtitle": "Arraste condições do painel; clique num nó para o editar",
+    "panelTitle": "Condições",
+    "combineWith": "Combinar com",
+    "selectNode": "Selecione um nó na tela para o editar, ou arraste uma nova condição do painel.",
+    "categories": {
+      "identity": { "label": "Identidade", "description": "Quem é o contacto" },
+      "behavior": { "label": "Comportamento", "description": "O que o contacto fez" },
+      "messages": { "label": "Mensagens", "description": "Interações por canal" }
+    },
+    "nodes": {
+      "Everyone": { "label": "Todos", "description": "Todos os contactos da conta" },
+      "UserProperty": { "label": "Propriedade do utilizador", "description": "Filtrar por uma propriedade do contacto" },
+      "CustomAttribute": { "label": "Atributo personalizado", "description": "Filtrar por um atributo personalizado" },
+      "Label": { "label": "Etiqueta", "description": "Tem / não tem uma etiqueta" },
+      "Performed": { "label": "Evento realizado", "description": "Realizou um evento monitorizado" },
+      "RandomBucket": { "label": "Amostra aleatória", "description": "Uma % aleatória de contactos" },
+      "Email": { "label": "E-mail", "description": "Interação por e-mail" },
+      "WhatsApp": { "label": "Canal", "description": "Alcançado num canal (WhatsApp/Web/SMS)" }
+    }
+  },
   "messages": {
     "permissionDenied": {
       "read": "Você não tem permissão para visualizar segmentos",


### PR DESCRIPTION
## Summary
Follow-up de polish de i18n da EVO-1247 (Segment Builder). Não bloqueou o merge da story; o contrato dos 3 repos bate ponta-a-ponta. Dois ajustes:

1. **[UX] Paleta do canvas estava hardcoded em inglês.** `SEGMENT_NODE_META` (`segmentCanvasMeta.ts`) e `NODE_CATEGORIES`/`PALETTE` (`SegmentCanvasBuilder.tsx`) usavam strings cruas (`'Everyone'`, `'Identity'`…), destoando do resto da página já traduzido.
2. **[i18n] Chaves novas faltando em 4 locales.** As seções `canvas.*` e `preview.*` (adicionadas na EVO-1247) só existiam em `en` e `pt-BR`. Estavam **ausentes em `es`, `fr`, `it` e `pt`** → usuário via a key crua (ex.: `canvas.title`). A review só apontou `es`, mas a lacuna era nos 4.

## Mudanças
- `segmentCanvasMeta.ts`: `SEGMENT_NODE_META` passa de `label`/`description` literais para `labelKey`/`descriptionKey` (chaves i18n `canvas.nodes.<Type>.*`), resolvidas via `t()` no render. Fallback de tipo desconhecido = chaves vazias → cai no type cru.
- `SegmentCanvasNode.tsx`: usa `useLanguage('segments')` e traduz label/description.
- `SegmentCanvasBuilder.tsx`: `NODE_CATEGORIES` e `PALETTE` saem do module-scope para `useMemo` dentro do componente (dependem de `t`, reagem ao idioma ativo).
- Locales: `canvas.categories.*` + `canvas.nodes.*` adicionados em `en`/`pt-BR`; seções `canvas.*` e `preview.*` completas adicionadas em `es`, `fr`, `it`, `pt`.

## Test plan
- [x] `tsc -b` — 0 erros
- [x] `eslint` nos arquivos alterados — 0
- [x] `vitest run segmentCanvas.spec.ts` — 6/6 (palette ainda expõe os 8 tipos)
- [x] JSON dos 6 locales válido — nodes=8, categories=3, preview=4 em cada
- [ ] Smoke manual: abrir `/segments/new` em cada idioma e confirmar que nenhuma key crua aparece na paleta

## Notas
- A paleta mantém **8** tipos (Email separado de Channel; Web/SMS herdam o tile via `BY_TYPE`). O AC6 da EVO-1247 enumerava 7 — está respaldado pelo `EmailSegmentBuilder` real no evo-flow, mas fica registrado para confirmação.
- Card de rastreio: EVO-1572.