### PR TITLE
feat(frontend): add Assign to Pipeline action node to Flow Builder (EVO-1265)

### DIFF
--- a/src/components/journey/nodes/actions/action-nodes.ts
+++ b/src/components/journey/nodes/actions/action-nodes.ts
@@ -37,6 +37,7 @@ export * from './set-variable';
 export * from './assign-agent';
 export * from './assign-team';
 export * from './assign-bot';
+export * from './assign-to-pipeline';
 
 // Conversation Management
 export * from './mute-conversation';

--- a/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelineNode.tsx
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelineNode.tsx
@@ -1,0 +1,95 @@
+import { Workflow, Settings } from 'lucide-react';
+import { BaseFlowNode } from '@/components/base';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface AssignToPipelinePipelineOption {
+  id: string;
+  name: string;
+}
+
+export interface AssignToPipelineNodeData {
+  label: string;
+  description?: string;
+  pipeline_id?: string;
+  pipeline_name?: string;
+  formDataOptions?: {
+    pipelines: AssignToPipelinePipelineOption[];
+  };
+}
+
+export interface AssignToPipelineNodeType {
+  id: string;
+  type: 'assign-to-pipeline-node';
+  position: { x: number; y: number };
+  data: AssignToPipelineNodeData;
+}
+
+interface AssignToPipelineNodeProps {
+  selected: boolean;
+  data: AssignToPipelineNodeData;
+  id: string;
+}
+
+export function AssignToPipelineNode({ selected, data, id }: AssignToPipelineNodeProps) {
+  const { t } = useLanguage('journey');
+
+  const getPipelineName = () => {
+    if (data.pipeline_name) return data.pipeline_name;
+
+    if (data.pipeline_id && data.formDataOptions?.pipelines) {
+      const pipeline = data.formDataOptions.pipelines.find(
+        p => p.id.toString() === data.pipeline_id?.toString(),
+      );
+      return (
+        pipeline?.name ||
+        t('flowEditor.nodes.assignToPipeline.pipelineNumber', { pipelineId: data.pipeline_id })
+      );
+    }
+
+    return t('flowEditor.nodes.assignToPipeline.selectPipeline');
+  };
+
+  const pipelineName = getPipelineName();
+  const hasPipelineSelected = !!data.pipeline_id;
+
+  return (
+    <BaseFlowNode
+      selected={selected}
+      hasTarget={true}
+      borderColor="amber"
+      isExecuting={false}
+      hasSource={true}
+      nodeId={id}
+      sourceHandleId="assign-to-pipeline-output"
+      targetHandleId="assign-to-pipeline-input"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
+            <Workflow className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-medium text-foreground truncate">
+              {t('flowEditor.nodes.assignToPipeline.name')}
+            </h3>
+          </div>
+          <div className="flex-shrink-0">
+            <Settings className="w-3 h-3 text-muted-foreground" />
+          </div>
+        </div>
+
+        <div className="p-2 rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/30">
+          <p className="text-xs text-amber-800 dark:text-amber-200 leading-relaxed">
+            {hasPipelineSelected ? (
+              <>
+                {t('flowEditor.nodes.assignToPipeline.assignTo')} <strong>{pipelineName}</strong>
+              </>
+            ) : (
+              t('flowEditor.nodes.assignToPipeline.noPipelineSelected')
+            )}
+          </p>
+        </div>
+      </div>
+    </BaseFlowNode>
+  );
+}

--- a/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.spec.tsx
@@ -1,0 +1,192 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AssignToPipelinePanel } from './AssignToPipelinePanel';
+import { AssignToPipelineNodeData } from './AssignToPipelineNode';
+import '@/i18n/config';
+
+vi.mock('@/services/pipelines/pipelinesService', () => ({
+  pipelinesService: {
+    getPipelines: vi.fn(),
+  },
+}));
+
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
+
+const PIPELINES = [
+  { id: 'pipe-1', name: 'Sales' },
+  { id: 'pipe-2', name: 'Onboarding' },
+];
+
+function makeData(overrides: Partial<AssignToPipelineNodeData> = {}): AssignToPipelineNodeData {
+  return {
+    label: 'Assign to Pipeline',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AssignToPipelinePanel', () => {
+  it('shows the loading placeholder while pipelines are fetching', async () => {
+    let resolveFn: (value: unknown) => void = () => {};
+    mockGetPipelines.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <AssignToPipelinePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toBeTruthy();
+
+    resolveFn({ data: PIPELINES });
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+  });
+
+  it('renders the pipelines returned by the service inside the select', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    const user = userEvent.setup();
+
+    render(
+      <AssignToPipelinePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    await user.click(screen.getByRole('combobox'));
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('Sales')).toBeTruthy();
+    expect(within(listbox).getByText('Onboarding')).toBeTruthy();
+  });
+
+  it('keeps Save disabled until a pipeline is selected, then enables it', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    const user = userEvent.setup();
+
+    render(
+      <AssignToPipelinePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    const saveBtn = screen.getByRole('button', { name: /save|salvar|guardar|enregistrer|salva/i });
+    expect(saveBtn).toBeDisabled();
+
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Sales'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /save|salvar|guardar|enregistrer|salva/i }),
+      ).not.toBeDisabled(),
+    );
+  });
+
+  it('emits onUpdate with pipeline_id + pipeline_name on save (AC1 contract)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <AssignToPipelinePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={onUpdate}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Onboarding'));
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /save|salvar|guardar|enregistrer|salva/i,
+    });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    const saveCall = onUpdate.mock.calls.find(
+      ([, payload]) => payload?.pipeline_id === 'pipe-2',
+    );
+    expect(saveCall).toBeTruthy();
+    expect(saveCall?.[0]).toBe('n1');
+    expect(saveCall?.[1]).toMatchObject({
+      pipeline_id: 'pipe-2',
+      pipeline_name: 'Onboarding',
+      formDataOptions: { pipelines: PIPELINES },
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the empty-state message when zero pipelines are returned', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: [] });
+
+    render(
+      <AssignToPipelinePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText(
+        /no pipelines found|nenhuma pipeline|sin pipelines|aucune pipeline|nessuna pipeline/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('swallows fetch errors and renders an empty list', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetPipelines.mockRejectedValueOnce(new Error('boom'));
+
+    render(
+      <AssignToPipelinePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText(
+        /no pipelines found|nenhuma pipeline|sin pipelines|aucune pipeline|nessuna pipeline/i,
+      ),
+    ).toBeTruthy();
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.spec.tsx
@@ -166,7 +166,7 @@ describe('AssignToPipelinePanel', () => {
     ).toBeTruthy();
   });
 
-  it('swallows fetch errors and renders an empty list', async () => {
+  it('renders an error banner when the fetch fails', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockGetPipelines.mockRejectedValueOnce(new Error('boom'));
 
@@ -183,7 +183,7 @@ describe('AssignToPipelinePanel', () => {
 
     expect(
       await screen.findByText(
-        /no pipelines found|nenhuma pipeline|sin pipelines|aucune pipeline|nessuna pipeline/i,
+        /could not load pipelines|n[ãa]o foi poss[íi]vel carregar|no se pudieron cargar|impossible de charger|impossibile caricare/i,
       ),
     ).toBeTruthy();
 

--- a/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx
@@ -7,7 +7,7 @@ import {
   SelectValue,
   Label,
 } from '@evoapi/design-system';
-import { Workflow } from 'lucide-react';
+import { AlertCircle, Workflow } from 'lucide-react';
 import { AssignToPipelineNodeData, AssignToPipelinePipelineOption } from './AssignToPipelineNode';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
@@ -32,11 +32,13 @@ export function AssignToPipelinePanel({
   const [originalPipelineId] = useState<string>(() => data.pipeline_id?.toString() || '');
   const [pipelines, setPipelines] = useState<AssignToPipelinePipelineOption[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     const loadPipelines = async () => {
       try {
         setLoading(true);
+        setLoadError(false);
         const response = await pipelinesService.getPipelines();
         const list = (response?.data || []).map(p => ({
           id: p.id.toString(),
@@ -45,6 +47,7 @@ export function AssignToPipelinePanel({
         setPipelines(list);
       } catch (error) {
         console.error(t('panels.assignToPipeline.loadDataError'), error);
+        setLoadError(true);
       } finally {
         setLoading(false);
       }
@@ -84,6 +87,14 @@ export function AssignToPipelinePanel({
       cancelLabel={t('panels.actions.cancel')}
     >
       <div className="space-y-4">
+        {loadError && (
+          <FlowFeedbackBanner variant="error">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" />
+              <span>{t('panels.assignToPipeline.loadErrorBanner')}</span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
         <div className="space-y-2">
           <Label className="text-sidebar-foreground font-medium">
             {t('panels.assignToPipeline.pipeline')}

--- a/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx
@@ -67,16 +67,6 @@ export function AssignToPipelinePanel({
     onClose();
   };
 
-  useEffect(() => {
-    if (pipelines.length > 0) {
-      const updatedData: AssignToPipelineNodeData = {
-        ...data,
-        formDataOptions: { pipelines },
-      };
-      onUpdate(nodeId, updatedData);
-    }
-  }, [pipelines, data, nodeId, onUpdate]);
-
   const dirty = useMemo(() => pipelineId !== originalPipelineId, [pipelineId, originalPipelineId]);
   const isValid = Boolean(pipelineId);
 

--- a/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Label,
+} from '@evoapi/design-system';
+import { Workflow } from 'lucide-react';
+import { AssignToPipelineNodeData, AssignToPipelinePipelineOption } from './AssignToPipelineNode';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { useLanguage } from '@/hooks/useLanguage';
+
+interface AssignToPipelinePanelProps {
+  nodeId: string;
+  data: AssignToPipelineNodeData;
+  onUpdate: (nodeId: string, newData: AssignToPipelineNodeData) => void;
+  onClose: () => void;
+}
+
+export function AssignToPipelinePanel({
+  nodeId,
+  data,
+  onUpdate,
+  onClose,
+}: AssignToPipelinePanelProps) {
+  const { t } = useLanguage('journey');
+  const [pipelineId, setPipelineId] = useState<string>(data.pipeline_id?.toString() || '');
+  const [originalPipelineId] = useState<string>(() => data.pipeline_id?.toString() || '');
+  const [pipelines, setPipelines] = useState<AssignToPipelinePipelineOption[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadPipelines = async () => {
+      try {
+        setLoading(true);
+        const response = await pipelinesService.getPipelines();
+        const list = (response?.data || []).map(p => ({
+          id: p.id.toString(),
+          name: p.name,
+        }));
+        setPipelines(list);
+      } catch (error) {
+        console.error(t('panels.assignToPipeline.loadDataError'), error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPipelines();
+  }, []);
+
+  const handleSave = () => {
+    const selectedPipeline = pipelines.find(p => p.id === pipelineId);
+
+    const updatedData: AssignToPipelineNodeData = {
+      ...data,
+      pipeline_id: pipelineId || '',
+      pipeline_name: selectedPipeline?.name || '',
+      formDataOptions: { pipelines },
+    };
+
+    onUpdate(nodeId, updatedData);
+    onClose();
+  };
+
+  useEffect(() => {
+    if (pipelines.length > 0) {
+      const updatedData: AssignToPipelineNodeData = {
+        ...data,
+        formDataOptions: { pipelines },
+      };
+      onUpdate(nodeId, updatedData);
+    }
+  }, [pipelines, data, nodeId, onUpdate]);
+
+  const dirty = useMemo(() => pipelineId !== originalPipelineId, [pipelineId, originalPipelineId]);
+  const isValid = Boolean(pipelineId);
+
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.assignToPipeline.title')}
+      icon={<Workflow className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.assignToPipeline.pipeline')}
+          </Label>
+          <Select value={pipelineId} onValueChange={setPipelineId} disabled={loading}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.assignToPipeline.pipeline')}
+            >
+              <SelectValue
+                placeholder={
+                  loading
+                    ? t('panels.assignToPipeline.loadingPipelines')
+                    : t('panels.assignToPipeline.selectPipeline')
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {pipelines.map(pipeline => (
+                <SelectItem
+                  key={pipeline.id}
+                  value={pipeline.id}
+                  className="text-sidebar-foreground"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-md bg-flow-node-action-pipeline-bg text-flow-node-action-pipeline-fg flex items-center justify-center">
+                      <Workflow className="w-4 h-4" />
+                    </div>
+                    <div className="font-medium">{pipeline.name}</div>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {!loading && pipelines.length === 0 && (
+            <p className="text-sm text-sidebar-foreground/60">
+              {t('panels.assignToPipeline.noPipelinesFound')}
+            </p>
+          )}
+        </div>
+
+        {pipelineId && (
+          <FlowFeedbackBanner variant="info">
+            <div className="flex items-center gap-2">
+              <Workflow className="w-4 h-4" />
+              <span>
+                {t('panels.assignToPipeline.conversationWillBeAssigned')}{' '}
+                <strong>
+                  {pipelines.find(p => p.id === pipelineId)?.name ||
+                    `${t('panels.assignToPipeline.pipeline')} #${pipelineId}`}
+                </strong>
+                {' — '}
+                {t('panels.assignToPipeline.replacesAnyPrevious')}
+              </span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
+      </div>
+    </NodeConfigModal>
+  );
+}

--- a/src/components/journey/nodes/actions/assign-to-pipeline/index.ts
+++ b/src/components/journey/nodes/actions/assign-to-pipeline/index.ts
@@ -1,0 +1,2 @@
+export * from './AssignToPipelineNode';
+export * from './AssignToPipelinePanel';

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -314,6 +314,14 @@
         "name": "Assign Bot",
         "description": "Connects a specific bot to an inbox to automate responses"
       },
+      "assignToPipeline": {
+        "name": "Assign to Pipeline",
+        "description": "Adds the conversation to a sales pipeline",
+        "selectPipeline": "Select pipeline",
+        "pipelineNumber": "Pipeline #{{pipelineId}}",
+        "assignTo": "Assign conversation to",
+        "noPipelineSelected": "No pipeline selected"
+      },
       "muteConversation": {
         "name": "Mute Conversation",
         "description": "The conversation will be muted and will not generate notifications for Agents"
@@ -858,6 +866,16 @@
       "selectBotNode": "Select bot",
       "selectInboxNode": "Select inbox",
       "assignBotAction": "Assign bot"
+    },
+    "assignToPipeline": {
+      "title": "Configure Assign to Pipeline",
+      "loadDataError": "Error loading pipelines:",
+      "pipeline": "Pipeline",
+      "loadingPipelines": "Loading pipelines...",
+      "selectPipeline": "Select a pipeline",
+      "noPipelinesFound": "No pipelines found in the account.",
+      "conversationWillBeAssigned": "The conversation will be assigned to the pipeline",
+      "replacesAnyPrevious": "this replaces any previous pipeline assignment"
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -875,7 +875,8 @@
       "selectPipeline": "Select a pipeline",
       "noPipelinesFound": "No pipelines found in the account.",
       "conversationWillBeAssigned": "The conversation will be assigned to the pipeline",
-      "replacesAnyPrevious": "this replaces any previous pipeline assignment"
+      "replacesAnyPrevious": "this replaces any previous pipeline assignment",
+      "loadErrorBanner": "Could not load pipelines. Check your connection and try reopening this node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -875,7 +875,8 @@
       "selectPipeline": "Selecciona un pipeline",
       "noPipelinesFound": "Sin pipelines encontrados en la cuenta.",
       "conversationWillBeAssigned": "La conversación será asignada al pipeline",
-      "replacesAnyPrevious": "esto reemplaza cualquier asignación previa de pipeline"
+      "replacesAnyPrevious": "esto reemplaza cualquier asignación previa de pipeline",
+      "loadErrorBanner": "No se pudieron cargar los pipelines. Verifica tu conexión y reabre este node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -314,6 +314,14 @@
         "name": "Asignar Bot",
         "description": "Conecta un bot específico a una bandeja de entrada para automatizar respuestas"
       },
+      "assignToPipeline": {
+        "name": "Asignar al Pipeline",
+        "description": "Agrega la conversación a un pipeline de ventas",
+        "selectPipeline": "Seleccionar pipeline",
+        "pipelineNumber": "Pipeline #{{pipelineId}}",
+        "assignTo": "Asignar conversación al",
+        "noPipelineSelected": "Ningún pipeline seleccionado"
+      },
       "muteConversation": {
         "name": "Silenciar Conversación",
         "description": "La conversación será silenciada y no generará más notificaciones para los agentes"
@@ -858,6 +866,16 @@
       "selectBotNode": "Select bot",
       "selectInboxNode": "Select inbox",
       "assignBotAction": "Assign bot"
+    },
+    "assignToPipeline": {
+      "title": "Configurar Asignar al Pipeline",
+      "loadDataError": "Error al cargar los pipelines:",
+      "pipeline": "Pipeline",
+      "loadingPipelines": "Cargando pipelines...",
+      "selectPipeline": "Selecciona un pipeline",
+      "noPipelinesFound": "Sin pipelines encontrados en la cuenta.",
+      "conversationWillBeAssigned": "La conversación será asignada al pipeline",
+      "replacesAnyPrevious": "esto reemplaza cualquier asignación previa de pipeline"
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -875,7 +875,8 @@
       "selectPipeline": "Sélectionnez un pipeline",
       "noPipelinesFound": "Aucune pipeline trouvée dans le compte.",
       "conversationWillBeAssigned": "La conversation sera attribuée au pipeline",
-      "replacesAnyPrevious": "cela remplace toute attribution de pipeline précédente"
+      "replacesAnyPrevious": "cela remplace toute attribution de pipeline précédente",
+      "loadErrorBanner": "Impossible de charger les pipelines. Vérifiez votre connexion et rouvrez ce node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -314,6 +314,14 @@
         "name": "Attribuer un Bot",
         "description": "Connecte un bot spécifique à une boîte de réception pour automatiser les réponses"
       },
+      "assignToPipeline": {
+        "name": "Attribuer au Pipeline",
+        "description": "Ajoute la conversation à un pipeline de ventes",
+        "selectPipeline": "Sélectionner un pipeline",
+        "pipelineNumber": "Pipeline #{{pipelineId}}",
+        "assignTo": "Attribuer la conversation au",
+        "noPipelineSelected": "Aucune pipeline sélectionnée"
+      },
       "muteConversation": {
         "name": "Mettre en sourdine la conversation",
         "description": "La conversation sera mise en sourdine et ne générera plus de notifications pour les Agents"
@@ -858,6 +866,16 @@
       "selectBotNode": "Select bot",
       "selectInboxNode": "Select inbox",
       "assignBotAction": "Assign bot"
+    },
+    "assignToPipeline": {
+      "title": "Configurer Attribuer au Pipeline",
+      "loadDataError": "Erreur de chargement des pipelines:",
+      "pipeline": "Pipeline",
+      "loadingPipelines": "Chargement des pipelines...",
+      "selectPipeline": "Sélectionnez un pipeline",
+      "noPipelinesFound": "Aucune pipeline trouvée dans le compte.",
+      "conversationWillBeAssigned": "La conversation sera attribuée au pipeline",
+      "replacesAnyPrevious": "cela remplace toute attribution de pipeline précédente"
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -887,7 +887,8 @@
       "selectPipeline": "Seleziona una pipeline",
       "noPipelinesFound": "Nessuna pipeline trovata nell'account.",
       "conversationWillBeAssigned": "La conversazione sarà assegnata alla pipeline",
-      "replacesAnyPrevious": "questo sostituisce qualsiasi assegnazione precedente di pipeline"
+      "replacesAnyPrevious": "questo sostituisce qualsiasi assegnazione precedente di pipeline",
+      "loadErrorBanner": "Impossibile caricare le pipeline. Controlla la connessione e riapri questo node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -326,6 +326,14 @@
         "name": "Assegna Bot",
         "description": "Connette un bot specifico a una casella di posta per automatizzare le risposte"
       },
+      "assignToPipeline": {
+        "name": "Assegna alla Pipeline",
+        "description": "Aggiunge la conversazione a una pipeline di vendita",
+        "selectPipeline": "Seleziona pipeline",
+        "pipelineNumber": "Pipeline #{{pipelineId}}",
+        "assignTo": "Assegna conversazione alla",
+        "noPipelineSelected": "Nessuna pipeline selezionata"
+      },
       "muteConversation": {
         "name": "Silenzia Conversazione",
         "description": "La conversazione verrà silenziata e non genererà più notifiche per gli Agenti"
@@ -870,6 +878,16 @@
       "selectBotNode": "Select bot",
       "selectInboxNode": "Select inbox",
       "assignBotAction": "Assign bot"
+    },
+    "assignToPipeline": {
+      "title": "Configura Assegna alla Pipeline",
+      "loadDataError": "Errore caricamento pipeline:",
+      "pipeline": "Pipeline",
+      "loadingPipelines": "Caricamento pipeline...",
+      "selectPipeline": "Seleziona una pipeline",
+      "noPipelinesFound": "Nessuna pipeline trovata nell'account.",
+      "conversationWillBeAssigned": "La conversazione sarà assegnata alla pipeline",
+      "replacesAnyPrevious": "questo sostituisce qualsiasi assegnazione precedente di pipeline"
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -140,7 +140,7 @@ describe('journey i18n parity (EVO-1260)', () => {
       'Bearer', 'Token', 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'UUID',
       'UTC', 'SLA', 'CRM', 'ID', 'Trigger', 'Triggers', 'Tag', 'Status',
       'Timeout', 'Headers', 'Header', 'Timestamp', 'XML', 'Total', 'Logs',
-      'Form Data',
+      'Form Data', 'Pipeline', 'Pipeline #{{pipelineId}}',
       // time units
       'min', 'h', 'd', 's', 'ms',
       // symbol-only operators (unicode notequal is the literal char)

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -314,6 +314,14 @@
         "name": "Atribuir Bot",
         "description": "Conecta um bot específico a uma caixa de entrada para automatizar respostas"
       },
+      "assignToPipeline": {
+        "name": "Atribuir ao Pipeline",
+        "description": "Adiciona a conversa a um pipeline de vendas",
+        "selectPipeline": "Selecionar pipeline",
+        "pipelineNumber": "Pipeline #{{pipelineId}}",
+        "assignTo": "Atribuir conversa ao",
+        "noPipelineSelected": "Nenhum pipeline selecionado"
+      },
       "muteConversation": {
         "name": "Silenciar Conversa",
         "description": "A conversa será silenciada e não gerará mais notificações para os atendentes"
@@ -858,6 +866,16 @@
       "selectBotNode": "Selecionar bot",
       "selectInboxNode": "Selecionar caixa de entrada",
       "assignBotAction": "Atribuir bot"
+    },
+    "assignToPipeline": {
+      "title": "Configurar Atribuir ao Pipeline",
+      "loadDataError": "Erro ao carregar pipelines:",
+      "pipeline": "Pipeline",
+      "loadingPipelines": "Carregando pipelines...",
+      "selectPipeline": "Selecione um pipeline",
+      "noPipelinesFound": "Nenhum pipeline encontrado na conta.",
+      "conversationWillBeAssigned": "A conversa será atribuída ao pipeline",
+      "replacesAnyPrevious": "isso substitui qualquer atribuição anterior de pipeline"
     },
     "changePriority": {
       "title": "Configurar Prioridade",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -875,7 +875,8 @@
       "selectPipeline": "Selecione um pipeline",
       "noPipelinesFound": "Nenhum pipeline encontrado na conta.",
       "conversationWillBeAssigned": "A conversa será atribuída ao pipeline",
-      "replacesAnyPrevious": "isso substitui qualquer atribuição anterior de pipeline"
+      "replacesAnyPrevious": "isso substitui qualquer atribuição anterior de pipeline",
+      "loadErrorBanner": "Não foi possível carregar os pipelines. Verifique sua conexão e reabra este node."
     },
     "changePriority": {
       "title": "Configurar Prioridade",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -314,6 +314,14 @@
         "name": "Atribuir Bot",
         "description": "Conecta um bot específico a uma caixa de entrada para automatizar respostas"
       },
+      "assignToPipeline": {
+        "name": "Atribuir a Pipeline",
+        "description": "Adiciona a conversa a uma pipeline de vendas",
+        "selectPipeline": "Selecionar pipeline",
+        "pipelineNumber": "Pipeline #{{pipelineId}}",
+        "assignTo": "Atribuir conversa à",
+        "noPipelineSelected": "Nenhuma pipeline selecionada"
+      },
       "muteConversation": {
         "name": "Silenciar Conversa",
         "description": "A conversa será silenciada e não gerará mais notificações para os atendentes"
@@ -858,6 +866,16 @@
       "selectBotNode": "Select bot",
       "selectInboxNode": "Select inbox",
       "assignBotAction": "Assign bot"
+    },
+    "assignToPipeline": {
+      "title": "Configurar Atribuir a Pipeline",
+      "loadDataError": "Erro ao carregar pipelines:",
+      "pipeline": "Pipeline",
+      "loadingPipelines": "A carregar pipelines...",
+      "selectPipeline": "Selecione uma pipeline",
+      "noPipelinesFound": "Nenhuma pipeline encontrada na conta.",
+      "conversationWillBeAssigned": "A conversa será atribuída à pipeline",
+      "replacesAnyPrevious": "isto substitui qualquer atribuição anterior de pipeline"
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -875,7 +875,8 @@
       "selectPipeline": "Selecione uma pipeline",
       "noPipelinesFound": "Nenhuma pipeline encontrada na conta.",
       "conversationWillBeAssigned": "A conversa será atribuída à pipeline",
-      "replacesAnyPrevious": "isto substitui qualquer atribuição anterior de pipeline"
+      "replacesAnyPrevious": "isto substitui qualquer atribuição anterior de pipeline",
+      "loadErrorBanner": "Não foi possível carregar as pipelines. Verifique a sua ligação e reabra este node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -52,6 +52,7 @@ import {
   AssignAgentNode,
   AssignTeamNode,
   AssignBotNode,
+  AssignToPipelineNode,
   SendEmailTeamNode,
   SendTranscriptNode,
   MuteConversationNode,
@@ -78,6 +79,7 @@ import {
   AssignAgentPanel,
   AssignTeamPanel,
   AssignBotPanel,
+  AssignToPipelinePanel,
   SendEmailTeamPanel,
   SendTranscriptPanel,
   MuteConversationPanel,
@@ -109,6 +111,7 @@ import {
   AlertTriangle,
   Clock,
   Bot,
+  Workflow,
 } from 'lucide-react';
 
 /**
@@ -171,6 +174,7 @@ function JourneyFlowEditor() {
       'assign-agent-node': AssignAgentNode,
       'assign-team-node': AssignTeamNode,
       'assign-bot-node': AssignBotNode,
+      'assign-to-pipeline-node': AssignToPipelineNode,
       'send-email-team-node': SendEmailTeamNode,
       'send-transcript-node': SendTranscriptNode,
       'mute-conversation-node': MuteConversationNode,
@@ -398,6 +402,15 @@ function JourneyFlowEditor() {
         description: t('flowEditor.nodes.assignBot.description'),
         searchKeywords: ['bot', 'automation', 'ai', 'assistant', 'automate'],
       },
+      {
+        id: 'assign-to-pipeline-node',
+        name: t('flowEditor.nodes.assignToPipeline.name'),
+        icon: Workflow,
+        color: 'text-amber-400',
+        category: 'contact',
+        description: t('flowEditor.nodes.assignToPipeline.description'),
+        searchKeywords: ['pipeline', 'funnel', 'sales', 'stage', 'crm', 'deal'],
+      },
     ],
     conversation: [
       {
@@ -465,6 +478,7 @@ function JourneyFlowEditor() {
       'assign-agent-node': flowTokens.node.action.pipeline.border,
       'assign-team-node': flowTokens.node.action.pipeline.border,
       'assign-bot-node': flowTokens.node.action.pipeline.border,
+      'assign-to-pipeline-node': flowTokens.node.action.pipeline.border,
       'change-priority-node': flowTokens.node.action.pipeline.border,
       'mute-conversation-node': flowTokens.node.action.pipeline.border,
       'defer-conversation-node': flowTokens.node.action.pipeline.border,
@@ -526,6 +540,8 @@ function JourneyFlowEditor() {
           return <AssignTeamPanel {...commonProps} />;
         case 'assign-bot-node':
           return <AssignBotPanel {...commonProps} />;
+        case 'assign-to-pipeline-node':
+          return <AssignToPipelinePanel {...commonProps} />;
         case 'send-email-team-node':
           return <SendEmailTeamPanel {...commonProps} />;
         case 'send-transcript-node':

--- a/src/services/automation/automationService.ts
+++ b/src/services/automation/automationService.ts
@@ -390,6 +390,7 @@ class AutomationService {
       'resolve-conversation-node',
       'change-priority-node',
       'change-status-node',
+      'assign-to-pipeline-node',
     ];
 
     return actionNodeTypes.includes(nodeType);
@@ -513,6 +514,12 @@ class AutomationService {
           return {
             action_name: 'change_status',
             action_params: [nodeData.status || null],
+          };
+
+        case 'assign-to-pipeline-node':
+          return {
+            action_name: 'assign_to_pipeline',
+            action_params: [nodeData.pipeline_id || null],
           };
 
         default:


### PR DESCRIPTION
## Summary

Adds the **Assign to Pipeline** action node to the Customer Journey / Flow Builder canvas. Backend handler (FlowExecutionService dispatch + `PipelineActionHandlers#assign_to_pipeline`) was shipped with EVO-1262 (PR #96 on `evo-ai-crm-community`); this PR is the frontend wiring only, plus an AC3-logging fix that lives in a sibling CRM PR.

- New `AssignToPipelineNode` + `AssignToPipelinePanel` under `src/components/journey/nodes/actions/assign-to-pipeline/`
- Registered in the action-nodes barrel, `JourneyFlowEditor` palette (`contact` category), `nodeTypes` map, `renderConfigPanel` switch and `miniMapNodeColors`
- `automationService` recognises `'assign-to-pipeline-node'` and emits `{ action_name: 'assign_to_pipeline', action_params: [pipeline_id] }` for the legacy modal `ActionService` path. The handler in `PipelineActionHandlers` accepts both bare ID and `{id: x}` shapes; bare ID matches the convention of the sibling `assign_agent` node
- i18n: `flowEditor.nodes.assignToPipeline.*` and `panels.assignToPipeline.*` keys added across all 6 locales (en, pt-BR, pt, es, fr, it). `"Pipeline"` (CRM term, used identically across the codebase) whitelisted in the journey-parity leakage spec
- Render-loop fix during smoke (commit `f2c1468`): removed the eager `useEffect` that pushed `formDataOptions` back to the parent on every `data` change. The same pattern existed on `AssignAgentPanel` but only fired on empty-list envs; with real pipelines populated, the parent re-renders fed back into the effect indefinitely. `handleSave` already cascades all needed data on save
- Error banner (`FlowFeedbackBanner variant="error"`) shows when the `pipelinesService.getPipelines` fetch fails, with an actionable i18n message instead of swallowed `console.error` + empty-state misdirection

## Security

- Pipelines API client is the existing `pipelinesService.getPipelines()` (account-scoped via `Current.user.accessible_by` in Rails). No new attack surface.
- No `dangerouslySetInnerHTML`; all pipeline names rendered via JSX text nodes.
- No new `any` types in the new files.

## Test plan

- `pnpm exec tsc -b --noEmit` — exit 0
- `pnpm exec vitest run src/components/journey/nodes/actions/assign-to-pipeline` — 6/6 passing (load, render, dirty/Save gating, save payload, empty state, fetch error banner)
- `pnpm exec vitest run src/i18n/locales/journey-parity.spec.ts` — 14/14 passing (i18n parity + no-EN-leakage in pt-BR)
- Wider journey/automation suite — 111/111 passing (1 pre-existing failure unrelated: `tokens.contrast.spec.ts` is missing the `colorjs.io` dep on `develop`)
- Manual smoke confirmed by reporter on `/journey/:id/flow`: drag → configure → save → node persists with `pipeline_id`

## Changed Files

- `src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelineNode.tsx` (new)
- `src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.tsx` (new)
- `src/components/journey/nodes/actions/assign-to-pipeline/AssignToPipelinePanel.spec.tsx` (new)
- `src/components/journey/nodes/actions/assign-to-pipeline/index.ts` (new)
- `src/components/journey/nodes/actions/action-nodes.ts` (+1 export)
- `src/pages/Customer/Journey/JourneyFlowEditor.tsx` (4 registration sites + import)
- `src/services/automation/automationService.ts` (`isActionNode` + `convertNodeToAction` switch)
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/journey.json` (added `assignToPipeline` keys under `flowEditor.nodes` and `panels`)
- `src/i18n/locales/journey-parity.spec.ts` (whitelisted `"Pipeline"` and `"Pipeline #{{pipelineId}}"` as identical-across-locales)

## Known limitations / out of scope

- The Customer Journey runtime (evo-flow Temporal worker) does not yet have an action runner for `assign-to-pipeline-node`; it currently no-ops the node in the default branch of `journey-execution.workflow.ts`. The shipped backend handler (`PipelineActionHandlers#assign_to_pipeline`) only runs via `AutomationRules::FlowExecutionService`, which is exercised by `AutomationRule.mode='flow'`. The `AutomationFlowEditor` route is currently commented out (`src/routes/index.tsx:501-512`) so end-to-end execution from the live UI awaits a future card. AC2/AC3/AC4 are covered by the Rails rspec; AC1 was smoked on the live Journey canvas.
- During smoke a pre-existing canvas bug was noticed: `BaseFlowCanvas.handleConnect` (`ecadb81`, original OSS release) does not call `onFlowDataChange`, so a freshly-drawn edge is only persisted when the next subsequent node-change carries the updated `edges` array. Affects all node types (not specific to this PR). EVO-1258 refactored the autosave/dirty state but did not patch this code path. A separate bug card will be filed via `/bugs-to-linear-routine`.

## Linked Issue

- EVO-1265 — https://linear.app/evoai/issue/EVO-1265

## Related PRs

- `evo-ai-crm-community` PR #108 — AC3 warn log + spec for invalid pipeline_id: https://github.com/evolution-foundation/evo-ai-crm-community/pull/108