### PR TITLE
test(trigger): guard shared EventConfiguration across flow + campaign contexts (EVO-1277)

### DIFF
--- a/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { EventConfiguration } from './EventConfiguration';
+import '@/i18n/config';
+
+// Cross-context regression guard.
+//
+// Both consumers render THIS SAME `EventConfiguration` from the same barrel
+// (`@/components/journey/nodes/trigger/components`):
+//   - Flow Builder  → JourneyTriggerPanel.tsx (real journeyId + variable-mapping callback)
+//   - Campaigns     → CampaignTriggerConfig.tsx (sentinel journeyId='campaign-trigger', no callback)
+// The only intended difference is the props each context passes. This spec mounts
+// the component with each context's EXACT prop shape and locks in equivalent
+// behavior — the executable proof of the "same component reused" conclusion and
+// of AC #3 ("the only difference is the props").
+//
+// Network seam: `VariableInput`/`VariableMapping` call `useJourneyVariables(journeyId)`,
+// which hits `journeyService.getJourneyVariables`. Mock it so the campaign sentinel
+// journeyId does not fire a (404-ing) request during the test.
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+type Context = 'flow' | 'campaign';
+
+interface EventProperty {
+  path: string;
+  operator: { type: string; value?: unknown };
+}
+
+// The exact prop shapes the two consumers pass (see JourneyTriggerPanel.tsx:181-193
+// and CampaignTriggerConfig.tsx:193-206). The only differences are journeyId and
+// whether onVariableMappingsChange is provided.
+const CONTEXTS: Record<Context, { journeyId: string; hasMappingCallback: boolean }> = {
+  flow: { journeyId: 'journey-uuid-123', hasMappingCallback: true },
+  campaign: { journeyId: 'campaign-trigger', hasMappingCallback: false },
+};
+
+function renderInContext(context: Context) {
+  const onEventNameChange = vi.fn();
+  const onEventPropertiesChange = vi.fn();
+  const { journeyId, hasMappingCallback } = CONTEXTS[context];
+
+  function Harness() {
+    const [eventName, setEventName] = useState('');
+    const [eventProperties, setEventProperties] = useState<EventProperty[]>([]);
+    return (
+      <EventConfiguration
+        eventName={eventName}
+        eventProperties={eventProperties}
+        onEventNameChange={next => {
+          setEventName(next);
+          onEventNameChange(next);
+        }}
+        onEventPropertiesChange={next => {
+          setEventProperties(next);
+          onEventPropertiesChange(next);
+        }}
+        variableMappings={[]}
+        onVariableMappingsChange={hasMappingCallback ? vi.fn() : undefined}
+        journeyId={journeyId}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return { onEventNameChange, onEventPropertiesChange };
+}
+
+const CONTEXT_CASES: Context[] = ['flow', 'campaign'];
+
+describe('EventConfiguration — shared across Flow Builder + Campaign contexts', () => {
+  it.each(CONTEXT_CASES)(
+    'renders the shared EventSelector + properties editor (%s context)',
+    context => {
+      renderInContext(context);
+      // EventSelector (EVO-1271 / 10.6) — the combobox is the primary entry point.
+      expect(screen.getByRole('combobox')).toBeTruthy();
+      // Event-properties editor — the "Add property" affordance.
+      expect(screen.getByRole('button', { name: /add|adicionar/i })).toBeTruthy();
+    },
+  );
+
+  it.each(CONTEXT_CASES)(
+    'persists a canonical event name identically (%s context)',
+    async context => {
+      const { onEventNameChange } = renderInContext(context);
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('combobox'));
+      const listbox = await screen.findByRole('listbox');
+      await user.click(within(listbox).getByText(/contact created|contato criado/i));
+
+      // Same canonical value resolved regardless of context.
+      expect(onEventNameChange).toHaveBeenCalledWith('contact.created');
+    },
+  );
+
+  it.each(CONTEXT_CASES)(
+    'adds an event property identically (%s context)',
+    async context => {
+      const { onEventPropertiesChange } = renderInContext(context);
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: /add|adicionar/i }));
+
+      expect(onEventPropertiesChange).toHaveBeenCalledTimes(1);
+      expect(onEventPropertiesChange.mock.calls[0][0]).toHaveLength(1);
+    },
+  );
+
+  it('renders the VariableMapping (capture-event-data) UI in the Flow Builder context', () => {
+    renderInContext('flow');
+    // Gated by `onVariableMappingsChange &&` (EventConfiguration.tsx:265-280).
+    expect(
+      screen.getByText(/capture event data|capturar dados do evento|cattura dati|capturer les données/i),
+    ).toBeTruthy();
+  });
+
+  it('omits the VariableMapping UI in the Campaign context (no mapping callback)', () => {
+    renderInContext('campaign');
+    // Campaign passes onVariableMappingsChange={undefined}, so the block must not render.
+    expect(
+      screen.queryByText(/capture event data|capturar dados do evento|cattura dati|capturer les données/i),
+    ).toBeNull();
+  });
+
+  it('renders without crashing in the Campaign context despite the sentinel journeyId', () => {
+    // journeyId='campaign-trigger' is a non-journey sentinel; the mocked hook keeps it
+    // inert here, proving the component degrades cleanly rather than throwing.
+    expect(() => renderInContext('campaign')).not.toThrow();
+    expect(screen.getByRole('combobox')).toBeTruthy();
+  });
+});

--- a/src/pages/Customer/Campaigns/NewCampaign/components/CampaignTriggerConfig.tsx
+++ b/src/pages/Customer/Campaigns/NewCampaign/components/CampaignTriggerConfig.tsx
@@ -169,7 +169,13 @@ export function CampaignTriggerConfig({ config, onChange }: CampaignTriggerConfi
     updateFormData({ expectedHeaders: headers });
   };
 
-  // Single-account: usar identificador estável para componentes de jornada que esperam journeyId
+  // O <EventConfiguration> abaixo é INTENCIONALMENTE o MESMO componente
+  // compartilhado renderizado pelo Flow Builder (JourneyTriggerPanel) — importado do
+  // mesmo barrel `@/components/journey/nodes/trigger/components`. A única diferença é
+  // o contexto via props (aqui: sem onVariableMappingsChange + journeyId sentinel).
+  // O sentinel só alimenta o autocomplete de variáveis de jornada (useJourneyVariables);
+  // em campanha não há jornada, então o fetch degrada graciosamente (sem variáveis de
+  // jornada, só as de sistema). Tornar `journeyId` opcional/context-aware é um follow-up.
   const journeyId = 'campaign-trigger';
 
   return (


### PR DESCRIPTION
## Summary

EVO-1277 (Pain #4): confirma em código que o node **Trigger Event** do Flow Builder e a config de **Campanhas tipo trigger** consomem o **mesmo** `EventConfiguration` (mesmo barrel `@/components/journey/nodes/trigger/components`) — **reuso, não duplicação**. Adiciona um guard de regressão cross-context e documenta o caveat do `journeyId`.

- **Novo teste** `EventConfiguration.both-contexts.spec.tsx` (Vitest + RTL): renderiza o mesmo `EventConfiguration` com o shape de props exato de cada contexto e prova:
  - seleção de evento + propriedades idênticas nos 2 contextos;
  - a UI de `VariableMapping` (capturar dados do evento) aparece no Flow Builder e **não** em Campanhas (gated por `onVariableMappingsChange &&`);
  - Campanha renderiza sem crashar apesar do `journeyId` sentinel. Mocka `useJourneyVariables` para manter o sentinel inerte.
- **Comentário** no call site da campanha (`CampaignTriggerConfig.tsx`) documentando o reuso intencional e a degradação do `journeyId` sentinel (`'campaign-trigger'`).

### Propagação 10.6 / 10.7 / 10.8
Por ser um único componente compartilhado, fixes propagam aos 2 contextos por construção. Hoje: **10.6 (EVO-1271)** ✅ ativo (EventSelector em ambos); **10.7 (EVO-1275)** / **10.8 (EVO-1276)** ⏳ Todo — o guard cobrirá automaticamente quando entrarem.

## Test plan

- [x] `pnpm exec tsc -b --noEmit`
- [x] Novo spec `EventConfiguration.both-contexts.spec.tsx` — 9/9
- [x] Lint do arquivo novo limpo
- [ ] CI: suíte completa (`pnpm test`)

## Notas

- Sem mudança de comportamento de trigger; sem refactor de campanhas (escopo do ticket).
- AC #3: a coupling de nome `journeyId` (sentinel em campanha → fetch 404/degrada autocomplete) fica **documentada**, não corrigida aqui. Follow-up: **EVO-1608**.
- Os `@typescript-eslint/no-explicit-any` em `CampaignTriggerConfig.tsx:30,40` são pré-existentes em `develop` (fora de escopo).

Closes EVO-1277.

## Summary by Sourcery

Add a regression guard to ensure Flow Builder and Campaign triggers share the same EventConfiguration component across contexts.

Documentation:
- Document the intentional reuse of the shared EventConfiguration component in CampaignTriggerConfig and the current journeyId sentinel behavior.

Tests:
- Add a cross-context integration-style spec to verify EventConfiguration behaves identically for flow and campaign consumers, including event selection and properties editing, and that variable mapping UI only appears in the flow context.