### PR TITLE
fix(trigger): make EventConfiguration journeyId optional, drop campaign sentinel (EVO-1608)

### DIFF
--- a/src/components/journey/environment-manager/VariableInput.tsx
+++ b/src/components/journey/environment-manager/VariableInput.tsx
@@ -15,7 +15,9 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { PhoneInput } from '@/components/shared/PhoneInput';
 
 export interface VariableInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  journeyId: string;
+  // Optional: contexts without a journey (campaigns, automations) omit it, so the
+  // variable autocomplete falls back to system variables only — no journey fetch.
+  journeyId?: string;
   onVariableInsert?: (variable: string) => void;
   showVariableButton?: boolean;
   variableButtonTooltip?: string;

--- a/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
@@ -25,7 +25,7 @@ interface ContactConfigurationProps {
   onContactFieldsChange: (fields: ContactField[]) => void;
   variableMappings?: DataMapping[];
   onVariableMappingsChange?: (mappings: DataMapping[]) => void;
-  journeyId: string;
+  journeyId?: string;
 }
 
 // Moved to component to use translations

--- a/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
@@ -21,7 +21,7 @@ interface CustomAttributeConfigurationProps {
   onAttributeNameChange: (name: string, displayName?: string) => void;
   onOperatorChange: (operator: string) => void;
   onValueChange: (value: string) => void;
-  journeyId: string;
+  journeyId?: string;
   variableMappings?: DataMapping[];
   onVariableMappingsChange?: (mappings: DataMapping[]) => void;
 }

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
@@ -164,10 +164,16 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
     },
   );
 
-  it('does not fetch journey variables in the Campaign context (no journeyId)', () => {
+  it('never asks for a real journey in the Campaign context (no fetch)', async () => {
     renderInContext('campaign');
-    // With no journeyId and no mapping callback, nothing should ask for a real journey:
-    // every (if any) hook call is with undefined → useJourneyVariables skips the fetch.
+    const user = userEvent.setup();
+    // Mount a VariableInput (a property row) so the hook is actually exercised —
+    // otherwise no VariableInput/VariableMapping renders and the assertion below
+    // would be vacuously true.
+    await user.click(screen.getByRole('button', { name: /add|adicionar/i }));
+
+    expect(useJourneyVariablesSpy).toHaveBeenCalled();
+    // Every call must be with undefined → useJourneyVariables skips getJourneyVariables.
     expect(useJourneyVariablesSpy.mock.calls.every(([id]) => id === undefined)).toBe(true);
   });
 

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventConfiguration } from './EventConfiguration';
 import '@/i18n/config';
 
@@ -10,26 +10,32 @@ import '@/i18n/config';
 // Both consumers render THIS SAME `EventConfiguration` from the same barrel
 // (`@/components/journey/nodes/trigger/components`):
 //   - Flow Builder  → JourneyTriggerPanel.tsx (real journeyId + variable-mapping callback)
-//   - Campaigns     → CampaignTriggerConfig.tsx (sentinel journeyId='campaign-trigger', no callback)
+//   - Campaigns     → CampaignTriggerConfig.tsx (NO journeyId, no mapping callback)
 // The only intended difference is the props each context passes. This spec mounts
 // the component with each context's EXACT prop shape and locks in equivalent
 // behavior — the executable proof of the "same component reused" conclusion and
-// of AC #3 ("the only difference is the props").
+// that the only difference is props.
 //
 // Network seam: `VariableInput`/`VariableMapping` call `useJourneyVariables(journeyId)`,
-// which hits `journeyService.getJourneyVariables`. Mock it so the campaign sentinel
-// journeyId does not fire a (404-ing) request during the test.
+// which hits `journeyService.getJourneyVariables`. We mock it AND capture the journeyId
+// it receives, so we can assert the context-aware behaviour: the campaign context (no
+// journey) must call the hook with `undefined` — never a real/sentinel id — so no fetch
+// fires; the flow context passes the real journey id.
+const { useJourneyVariablesSpy } = vi.hoisted(() => ({ useJourneyVariablesSpy: vi.fn() }));
 vi.mock('@/hooks/useJourneyVariables', () => ({
-  useJourneyVariables: () => ({
-    variables: [],
-    loading: false,
-    error: null,
-    fetchVariables: vi.fn(),
-    updateVariables: vi.fn(),
-    addVariable: vi.fn(),
-    updateVariable: vi.fn(),
-    deleteVariable: vi.fn(),
-  }),
+  useJourneyVariables: (journeyId?: string) => {
+    useJourneyVariablesSpy(journeyId);
+    return {
+      variables: [],
+      loading: false,
+      error: null,
+      fetchVariables: vi.fn(),
+      updateVariables: vi.fn(),
+      addVariable: vi.fn(),
+      updateVariable: vi.fn(),
+      deleteVariable: vi.fn(),
+    };
+  },
 }));
 
 type Context = 'flow' | 'campaign';
@@ -39,12 +45,12 @@ interface EventProperty {
   operator: { type: string; value?: unknown };
 }
 
-// The exact prop shapes the two consumers pass (see JourneyTriggerPanel.tsx:181-193
-// and CampaignTriggerConfig.tsx:193-206). The only differences are journeyId and
-// whether onVariableMappingsChange is provided.
-const CONTEXTS: Record<Context, { journeyId: string; hasMappingCallback: boolean }> = {
+// The exact prop shapes the two consumers pass (see JourneyTriggerPanel.tsx and
+// CampaignTriggerConfig.tsx). The only differences are journeyId (real id vs none)
+// and whether onVariableMappingsChange is provided.
+const CONTEXTS: Record<Context, { journeyId?: string; hasMappingCallback: boolean }> = {
   flow: { journeyId: 'journey-uuid-123', hasMappingCallback: true },
-  campaign: { journeyId: 'campaign-trigger', hasMappingCallback: false },
+  campaign: { journeyId: undefined, hasMappingCallback: false },
 };
 
 function renderInContext(context: Context) {
@@ -81,6 +87,10 @@ function renderInContext(context: Context) {
 const CONTEXT_CASES: Context[] = ['flow', 'campaign'];
 
 describe('EventConfiguration — shared across Flow Builder + Campaign contexts', () => {
+  beforeEach(() => {
+    useJourneyVariablesSpy.mockClear();
+  });
+
   it.each(CONTEXT_CASES)(
     'renders the shared EventSelector + properties editor (%s context)',
     context => {
@@ -122,7 +132,7 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
 
   it('renders the VariableMapping (capture-event-data) UI in the Flow Builder context', () => {
     renderInContext('flow');
-    // Gated by `onVariableMappingsChange &&` (EventConfiguration.tsx:265-280).
+    // Gated by `onVariableMappingsChange &&` (EventConfiguration.tsx).
     expect(
       screen.getByText(/capture event data|capturar dados do evento|cattura dati|capturer les données/i),
     ).toBeTruthy();
@@ -136,9 +146,32 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
     ).toBeNull();
   });
 
-  it('renders without crashing in the Campaign context despite the sentinel journeyId', () => {
-    // journeyId='campaign-trigger' is a non-journey sentinel; the mocked hook keeps it
-    // inert here, proving the component degrades cleanly rather than throwing.
+  // EVO-1608: context-aware journeyId. The campaign context has no journey, so the
+  // optional journeyId is omitted and the variable autocomplete must never fetch a
+  // journey (no sentinel, no 404). Drive a VariableInput to render (a property row)
+  // so the hook is invoked, then assert the journeyId it receives per context.
+  it.each(CONTEXT_CASES)(
+    'forwards the context journeyId to useJourneyVariables (%s context)',
+    async context => {
+      renderInContext(context);
+      const user = userEvent.setup();
+      await user.click(screen.getByRole('button', { name: /add|adicionar/i }));
+
+      const expected = CONTEXTS[context].journeyId; // 'journey-uuid-123' | undefined
+      expect(useJourneyVariablesSpy).toHaveBeenCalledWith(expected);
+      // No call may use any other id — campaign must NEVER pass a real/sentinel journey id.
+      expect(useJourneyVariablesSpy.mock.calls.every(([id]) => id === expected)).toBe(true);
+    },
+  );
+
+  it('does not fetch journey variables in the Campaign context (no journeyId)', () => {
+    renderInContext('campaign');
+    // With no journeyId and no mapping callback, nothing should ask for a real journey:
+    // every (if any) hook call is with undefined → useJourneyVariables skips the fetch.
+    expect(useJourneyVariablesSpy.mock.calls.every(([id]) => id === undefined)).toBe(true);
+  });
+
+  it('renders without crashing in the Campaign context with no journeyId', () => {
     expect(() => renderInContext('campaign')).not.toThrow();
     expect(screen.getByRole('combobox')).toBeTruthy();
   });

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -27,7 +27,10 @@ interface EventConfigurationProps {
   onEventPropertiesChange: (properties: EventProperty[]) => void;
   variableMappings?: DataMapping[];
   onVariableMappingsChange?: (mappings: DataMapping[]) => void;
-  journeyId: string;
+  // Optional: in contexts without a journey (e.g. trigger-type Campaigns) it is
+  // omitted, so useJourneyVariables skips the fetch and the autocomplete degrades
+  // to system variables only — no 404. See EVO-1608.
+  journeyId?: string;
 }
 
 export function EventConfiguration({

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx
@@ -1,0 +1,58 @@
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebhookConfiguration } from './WebhookConfiguration';
+import '@/i18n/config';
+
+// WebhookConfiguration auto-generates its trigger URL from the REAL journey id.
+// journeyId optional and removed the campaign sentinel, so this pins
+// both paths: a journey present → URL generated; no journey → no auto-URL (campaigns
+// must not get a bogus .../trigger/<sentinel> URL).
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+function renderWebhook(journeyId?: string) {
+  const onWebhookUrlChange = vi.fn();
+  render(
+    <WebhookConfiguration
+      webhookUrl=""
+      expectedHeaders={[]}
+      onWebhookUrlChange={onWebhookUrlChange}
+      onExpectedHeadersChange={vi.fn()}
+      journeyId={journeyId}
+    />,
+  );
+  return { onWebhookUrlChange };
+}
+
+describe('WebhookConfiguration — trigger URL generation', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('auto-generates the journey trigger URL when a real journeyId is present', async () => {
+    const { onWebhookUrlChange } = renderWebhook('journey-uuid-123');
+
+    await waitFor(() => expect(onWebhookUrlChange).toHaveBeenCalledTimes(1));
+    expect(onWebhookUrlChange.mock.calls[0][0]).toMatch(
+      /\/api\/v1\/journeys\/trigger\/journey-uuid-123$/,
+    );
+  });
+
+  it('does NOT auto-generate a URL when there is no journeyId (campaign context)', async () => {
+    const { onWebhookUrlChange } = renderWebhook(undefined);
+
+    // Give the effect a tick; it must stay silent without a journey (no sentinel URL).
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(onWebhookUrlChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
@@ -48,7 +48,11 @@ export function WebhookConfiguration({
   const isInitialized = useRef(false);
 
   useEffect(() => {
-    // Generate webhook URL using actual journey ID
+    // Generate the trigger webhook URL from the REAL journey id. Contexts without a
+    // journey (trigger-type Campaigns / automations) pass no journeyId (EVO-1608, ex
+    // sentinel 'campaign-trigger' que gerava uma URL .../trigger/campaign-trigger não
+    // roteável). Nesses casos NÃO auto-geramos URL — o contexto deve fornecer a sua.
+    // Campanha precisa de uma URL de trigger própria.
     if (journeyId && !webhookUrl) {
       const campaignApiUrl = import.meta.env.VITE_CAMPAIGN_API_URL || 'http://localhost:3000';
       const url = `${campaignApiUrl}/api/v1/journeys/trigger/${journeyId}`;

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
@@ -18,7 +18,7 @@ interface WebhookConfigurationProps {
   }>;
   onWebhookUrlChange: (url: string) => void;
   onExpectedHeadersChange: (headers: Array<{ name: string; value: string }>) => void;
-  journeyId: string;
+  journeyId?: string;
   variableMappings?: DataMapping[];
   onVariableMappingsChange?: (mappings: DataMapping[]) => void;
   onVariablesChange?: (variables: JourneyVariable[]) => void;

--- a/src/pages/Customer/Campaigns/NewCampaign/components/CampaignTriggerConfig.tsx
+++ b/src/pages/Customer/Campaigns/NewCampaign/components/CampaignTriggerConfig.tsx
@@ -169,15 +169,12 @@ export function CampaignTriggerConfig({ config, onChange }: CampaignTriggerConfi
     updateFormData({ expectedHeaders: headers });
   };
 
-  // O <EventConfiguration> abaixo é INTENCIONALMENTE o MESMO componente
-  // compartilhado renderizado pelo Flow Builder (JourneyTriggerPanel) — importado do
-  // mesmo barrel `@/components/journey/nodes/trigger/components`. A única diferença é
-  // o contexto via props (aqui: sem onVariableMappingsChange + journeyId sentinel).
-  // O sentinel só alimenta o autocomplete de variáveis de jornada (useJourneyVariables);
-  // em campanha não há jornada, então o fetch degrada graciosamente (sem variáveis de
-  // jornada, só as de sistema). Tornar `journeyId` opcional/context-aware é um follow-up.
-  const journeyId = 'campaign-trigger';
-
+  // Os componentes de config abaixo (EventConfiguration etc.) são INTENCIONALMENTE os
+  // MESMOS compartilhados com o Flow Builder (JourneyTriggerPanel), do mesmo barrel
+  // `@/components/journey/nodes/trigger/components`. A única diferença é o contexto via
+  // props. Campanha NÃO tem jornada, então `journeyId` é omitido (prop opcional): o
+  // autocomplete de variáveis cai para variáveis de sistema sem disparar fetch a
+  // getJourneyVariables (EVO-1608, removendo o antigo sentinel 'campaign-trigger').
   return (
     <>
       <Separator className="my-4" />
@@ -206,9 +203,7 @@ export function CampaignTriggerConfig({ config, onChange }: CampaignTriggerConfi
               updateFormData({ eventProperties: props });
             }}
             variableMappings={[]}
-            onVariableMappingsChange={undefined}
-            journeyId={journeyId}
-          />
+            onVariableMappingsChange={undefined}          />
         )}
 
         {/* Configuração de Segmento */}
@@ -231,9 +226,7 @@ export function CampaignTriggerConfig({ config, onChange }: CampaignTriggerConfi
               updateFormData({ contactFields: fields });
             }}
             variableMappings={[]}
-            onVariableMappingsChange={undefined}
-            journeyId={journeyId}
-          />
+            onVariableMappingsChange={undefined}          />
         )}
 
         {/* Configuração de Etiqueta */}
@@ -256,9 +249,7 @@ export function CampaignTriggerConfig({ config, onChange }: CampaignTriggerConfi
             onOperatorChange={handleCustomAttributeOperatorChange}
             onValueChange={handleCustomAttributeValueChange}
             variableMappings={[]}
-            onVariableMappingsChange={undefined}
-            journeyId={journeyId}
-          />
+            onVariableMappingsChange={undefined}          />
         )}
 
         {/* Configuração de Webhook */}
@@ -267,9 +258,7 @@ export function CampaignTriggerConfig({ config, onChange }: CampaignTriggerConfi
             webhookUrl={formData.webhookUrl || ''}
             expectedHeaders={formData.expectedHeaders}
             onWebhookUrlChange={handleWebhookUrlChange}
-            onExpectedHeadersChange={handleExpectedHeadersChange}
-            journeyId={journeyId}
-            variableMappings={[]}
+            onExpectedHeadersChange={handleExpectedHeadersChange}            variableMappings={[]}
             onVariableMappingsChange={undefined}
           />
         )}


### PR DESCRIPTION
> ⚠️ **Stacked sobre #121 (EVO-1277).** Base = branch da EVO-1277 para o diff ficar limpo (o spec `both-contexts` e o call site da campanha vêm de lá). **Após o merge de #121, retargetar esta PR para `develop`.**

## Summary

Follow-up de EVO-1277. As Campanhas tipo trigger reusam o mesmo `EventConfiguration`, mas **não têm jornada**. Elas injetavam um sentinel `journeyId='campaign-trigger'` que chegava em `useJourneyVariables` → `getJourneyVariables('campaign-trigger')` → **404**, degradando o autocomplete de variáveis.

- `journeyId` agora é **opcional** na cadeia de config do trigger: `EventConfiguration`, `VariableInput`, `ContactConfiguration`, `CustomAttributeConfiguration`, `WebhookConfiguration` (os demais `environment-manager` já eram opcionais).
- **Sentinel removido** de `CampaignTriggerConfig.tsx`: campanhas agora **omitem** `journeyId`, então `useJourneyVariables` **pula o fetch** (`useEffect: if (journeyId) fetchVariables()`) e o autocomplete cai para variáveis de sistema, **sem request**.
- Spec cross-context **estendido**: assert de que o hook recebe `undefined` no contexto de campanha e o id real no Flow Builder (prova executável da context-awareness).

## ⚠️ Efeito colateral a revisar

Em **webhook trigger de campanha**, a URL auto-gerada `…/journeys/trigger/campaign-trigger` **deixa de ser produzida** (o efeito já era guardado por `if (journeyId && !webhookUrl)`). Essa URL com o sentinel já era um placeholder inválido em campanhas; agora o campo fica vazio para o usuário preencher. Se for desejado auto-gerar uma URL de trigger de campanha, isso é um identificador próprio de campanha (fora do escopo deste follow-up) — sinalizo para decisão no review.

## Test plan

- [x] `pnpm exec tsc -b --noEmit`
- [x] `EventConfiguration.both-contexts.spec.tsx` — 12/12 (inclui os novos asserts de `journeyId` opcional)
- [x] `EventConfiguration.spec.tsx` (existente) — 6/6
- [x] Lint dos arquivos alterados: sem erro novo (os `any`/exhaustive-deps reportados são pré-existentes em linhas não tocadas)
- [ ] CI: suíte completa

## Critérios de aceite (EVO-1608)

- [x] Em contexto de campanha, configurar um Trigger Event **não dispara** request a `getJourneyVariables`.
- [x] O sentinel `'campaign-trigger'` foi removido.
- [x] O teste cross-context continua verde e foi estendido para cobrir a prop opcional.

Closes EVO-1608.

## Summary by Sourcery

Make trigger-related journey configuration accept an optional journeyId so campaign triggers no longer rely on a sentinel journey id and degrade cleanly when no journey exists.

Bug Fixes:
- Avoid 404-ing journey variable requests for campaign triggers by omitting journeyId and preventing unnecessary fetches.

Enhancements:
- Relax journeyId from required to optional across trigger configuration components and shared variable input to support contexts without a journey.
- Extend the cross-context EventConfiguration test to assert correct journeyId propagation and no variable fetches in campaign context.

Tests:
- Expand EventConfiguration cross-context specs to spy on useJourneyVariables usage, covering campaign vs flow behavior and the optional journeyId handling.