### PR TITLE
feat(trigger): schema-validated Event Properties form in Trigger node (EVO-1275)

### DIFF
--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -51,11 +51,15 @@ export function JourneyTriggerPanel({
     data.triggerType === 'customAttribute',
   );
   const [showWebhookConfig, setShowWebhookConfig] = useState(data.triggerType === 'webhook');
+  // Required-field validity reported by EventConfiguration. True (non-blocking)
+  // whenever the event config isn't shown, so other trigger types can always Save.
+  const [eventPropsValid, setEventPropsValid] = useState(true);
 
   useEffect(() => {
     setFormData(data);
     setEventProperties(data.eventProperties || []);
     setContactFields(data.contactFields || []);
+    if (data.triggerType !== 'event') setEventPropsValid(true);
     setShowEventConfig(data.triggerType === 'event');
     setShowSegmentConfig(data.triggerType === 'segment');
     setShowContactConfig(['contactCreated', 'contactUpdated'].includes(data.triggerType));
@@ -103,6 +107,7 @@ export function JourneyTriggerPanel({
     setShowLabelConfig(value === 'label');
     setShowCustomAttributeConfig(value === 'customAttribute');
     setShowWebhookConfig(value === 'webhook');
+    if (value !== 'event') setEventPropsValid(true);
   };
 
   const handleEventNameChange = (name: string) => {
@@ -166,6 +171,7 @@ export function JourneyTriggerPanel({
       onCancel={onClose}
       onSave={handleSave}
       dirty={dirty}
+      saveDisabled={showEventConfig && !eventPropsValid}
       saveLabel={t('panels.actions.save')}
       cancelLabel={t('panels.actions.cancel')}
       savingAriaLabel={t('modal.actions.saving')}
@@ -184,6 +190,7 @@ export function JourneyTriggerPanel({
           eventProperties={eventProperties}
           onEventNameChange={handleEventNameChange}
           onEventPropertiesChange={setEventProperties}
+          onValidityChange={setEventPropsValid}
           variableMappings={formData.variableMappings || []}
           onVariableMappingsChange={mappings =>
             setFormData(prev => ({ ...prev, variableMappings: mappings }))

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
@@ -16,11 +16,12 @@ import '@/i18n/config';
 // behavior — the executable proof of the "same component reused" conclusion and
 // that the only difference is props.
 //
-// Network seam: `VariableInput`/`VariableMapping` call `useJourneyVariables(journeyId)`,
-// which hits `journeyService.getJourneyVariables`. We mock it AND capture the journeyId
-// it receives, so we can assert the context-aware behaviour: the campaign context (no
-// journey) must call the hook with `undefined` — never a real/sentinel id — so no fetch
-// fires; the flow context passes the real journey id.
+// Network seam: the custom-event-name `VariableInput` calls
+// `useJourneyVariables(journeyId)`, which hits `journeyService.getJourneyVariables`.
+// We mock it AND capture the journeyId it receives, so we can assert the
+// context-aware behaviour: the campaign context (no journey) must call the hook
+// with `undefined` — never a real/sentinel id — so no fetch fires; the flow
+// context passes the real journey id.
 const { useJourneyVariablesSpy } = vi.hoisted(() => ({ useJourneyVariablesSpy: vi.fn() }));
 vi.mock('@/hooks/useJourneyVariables', () => ({
   useJourneyVariables: (journeyId?: string) => {
@@ -84,6 +85,19 @@ function renderInContext(context: Context) {
   return { onEventNameChange, onEventPropertiesChange };
 }
 
+// Pick the canonical "Contact created" entry from the shared EventSelector.
+async function selectContactCreated(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('combobox'));
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(/contact created|contato criado/i));
+}
+
+async function selectCustomEvent(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('combobox'));
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(/custom event|evento personalizado/i));
+}
+
 const CONTEXT_CASES: Context[] = ['flow', 'campaign'];
 
 describe('EventConfiguration — shared across Flow Builder + Campaign contexts', () => {
@@ -92,13 +106,15 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
   });
 
   it.each(CONTEXT_CASES)(
-    'renders the shared EventSelector + properties editor (%s context)',
-    context => {
+    'renders the shared EventSelector + schema-driven properties form (%s context)',
+    async context => {
       renderInContext(context);
+      const user = userEvent.setup();
       // EventSelector (EVO-1271 / 10.6) — the combobox is the primary entry point.
       expect(screen.getByRole('combobox')).toBeTruthy();
-      // Event-properties editor — the "Add property" affordance.
-      expect(screen.getByRole('button', { name: /add|adicionar/i })).toBeTruthy();
+      // After picking a canonical event, the schema-driven form renders its fields.
+      await selectContactCreated(user);
+      expect(screen.getByLabelText(/source/i)).toBeTruthy();
     },
   );
 
@@ -108,9 +124,7 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
       const { onEventNameChange } = renderInContext(context);
       const user = userEvent.setup();
 
-      await user.click(screen.getByRole('combobox'));
-      const listbox = await screen.findByRole('listbox');
-      await user.click(within(listbox).getByText(/contact created|contato criado/i));
+      await selectContactCreated(user);
 
       // Same canonical value resolved regardless of context.
       expect(onEventNameChange).toHaveBeenCalledWith('contact.created');
@@ -118,15 +132,17 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
   );
 
   it.each(CONTEXT_CASES)(
-    'adds an event property identically (%s context)',
+    'emits an Equals filter-condition array when a schema field is filled (%s context)',
     async context => {
       const { onEventPropertiesChange } = renderInContext(context);
       const user = userEvent.setup();
 
-      await user.click(screen.getByRole('button', { name: /add|adicionar/i }));
+      await selectContactCreated(user);
+      await user.type(screen.getByLabelText(/source/i), 'crm');
 
-      expect(onEventPropertiesChange).toHaveBeenCalledTimes(1);
-      expect(onEventPropertiesChange.mock.calls[0][0]).toHaveLength(1);
+      // Option A: the persisted shape stays the {path, operator} array.
+      const last = onEventPropertiesChange.mock.calls.at(-1)?.[0];
+      expect(last).toEqual([{ path: 'source', operator: { type: 'Equals', value: 'crm' } }]);
     },
   );
 
@@ -148,14 +164,14 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
 
   // EVO-1608: context-aware journeyId. The campaign context has no journey, so the
   // optional journeyId is omitted and the variable autocomplete must never fetch a
-  // journey (no sentinel, no 404). Drive a VariableInput to render (a property row)
-  // so the hook is invoked, then assert the journeyId it receives per context.
+  // journey (no sentinel, no 404). Drive the custom-event-name VariableInput to
+  // render (custom mode) so the hook is invoked, then assert the journeyId per context.
   it.each(CONTEXT_CASES)(
     'forwards the context journeyId to useJourneyVariables (%s context)',
     async context => {
       renderInContext(context);
       const user = userEvent.setup();
-      await user.click(screen.getByRole('button', { name: /add|adicionar/i }));
+      await selectCustomEvent(user);
 
       const expected = CONTEXTS[context].journeyId; // 'journey-uuid-123' | undefined
       expect(useJourneyVariablesSpy).toHaveBeenCalledWith(expected);
@@ -167,10 +183,9 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
   it('never asks for a real journey in the Campaign context (no fetch)', async () => {
     renderInContext('campaign');
     const user = userEvent.setup();
-    // Mount a VariableInput (a property row) so the hook is actually exercised —
-    // otherwise no VariableInput/VariableMapping renders and the assertion below
-    // would be vacuously true.
-    await user.click(screen.getByRole('button', { name: /add|adicionar/i }));
+    // Switch to custom mode so the custom-name VariableInput renders and the hook
+    // is actually exercised — otherwise the assertion below would be vacuously true.
+    await selectCustomEvent(user);
 
     expect(useJourneyVariablesSpy).toHaveBeenCalled();
     // Every call must be with undefined → useJourneyVariables skips getJourneyVariables.

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
@@ -5,26 +5,54 @@ import { describe, expect, it, vi } from 'vitest';
 import { EventConfiguration } from './EventConfiguration';
 import '@/i18n/config';
 
-interface HarnessProps {
-  initialEventName?: string;
-  onEventNameChange?: (name: string) => void;
+interface EventProperty {
+  path: string;
+  operator: { type: string; value?: unknown };
 }
 
-function Harness({ initialEventName = '', onEventNameChange }: HarnessProps) {
+interface HarnessProps {
+  initialEventName?: string;
+  initialEventProperties?: EventProperty[];
+  onEventNameChange?: (name: string) => void;
+  onEventPropertiesChange?: (props: EventProperty[]) => void;
+  onValidityChange?: (valid: boolean) => void;
+}
+
+// Stateful over BOTH eventName and eventProperties so event-switch and
+// property-edit round-trips behave like the real consumers.
+function Harness({
+  initialEventName = '',
+  initialEventProperties = [],
+  onEventNameChange,
+  onEventPropertiesChange,
+  onValidityChange,
+}: HarnessProps) {
   const [eventName, setEventName] = useState(initialEventName);
-  const handleChange = (next: string) => {
-    setEventName(next);
-    onEventNameChange?.(next);
-  };
+  const [eventProperties, setEventProperties] = useState<EventProperty[]>(initialEventProperties);
   return (
     <EventConfiguration
       eventName={eventName}
-      eventProperties={[]}
-      onEventNameChange={handleChange}
-      onEventPropertiesChange={() => {}}
+      eventProperties={eventProperties}
+      onEventNameChange={next => {
+        setEventName(next);
+        onEventNameChange?.(next);
+      }}
+      onEventPropertiesChange={next => {
+        setEventProperties(next);
+        onEventPropertiesChange?.(next);
+      }}
+      onValidityChange={onValidityChange}
       journeyId="test-journey-id"
     />
   );
+}
+
+async function selectEvent(user: ReturnType<typeof userEvent.setup>, label: RegExp) {
+  // The EventSelector is the FIRST combobox; the optional-field picker (when an
+  // event is already selected) renders a second one.
+  await user.click(screen.getAllByRole('combobox')[0]);
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(label));
 }
 
 describe('EventConfiguration — event name UI', () => {
@@ -116,5 +144,206 @@ describe('EventConfiguration — event name UI', () => {
     expect(
       screen.getByText(/custom events have no schema validation|não têm validação de schema/i),
     ).toBeTruthy();
+  });
+});
+
+describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)', () => {
+  it('AC1: renders required schema fields with a "*" marker under the Required section', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await selectEvent(user, /message delivered|mensagem entregue/i);
+
+    expect(screen.getByText(/required fields|campos obrigatórios/i)).toBeTruthy();
+    // message.delivered requires message_id; the schema field renders with a "*".
+    const label = screen.getByText('message_id');
+    expect(label).toBeTruthy();
+    expect(within(label).getByText('*')).toBeTruthy();
+  });
+
+  it('AC3: the optional-field autocomplete lists schema optionals and adds a field on select', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await selectEvent(user, /message delivered|mensagem entregue/i);
+
+    // The "+ Add field" picker is the second combobox (the EventSelector is the first).
+    const comboboxes = screen.getAllByRole('combobox');
+    expect(comboboxes.length).toBeGreaterThan(1);
+    await user.click(comboboxes[1]);
+    const option = await screen.findByRole('option', { name: 'status' });
+    expect(option).toBeTruthy();
+    await user.click(option);
+
+    // Selecting it surfaces an input for that optional field.
+    expect(screen.getByText('status')).toBeTruthy();
+  });
+
+  it('AC5: custom event renders a free key/value editor and reports validity = true', async () => {
+    const onValidityChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onValidityChange={onValidityChange} />);
+    await selectEvent(user, /custom event|evento personalizado/i);
+
+    expect(screen.getByText(/custom properties|propriedades personalizadas|propiedades personalizadas|propriétés personnalisées|proprietà personalizzate/i)).toBeTruthy();
+    expect(screen.getAllByPlaceholderText(/key|chave|clave|clé|key/i).length).toBeGreaterThan(0);
+    // Custom mode is never schema-blocked.
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('AC6: filling a required field persists an Equals filter-condition array', async () => {
+    const onEventPropertiesChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onEventPropertiesChange={onEventPropertiesChange} />);
+    await selectEvent(user, /contact created|contato criado/i);
+
+    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
+
+    const last = onEventPropertiesChange.mock.calls.at(-1)?.[0];
+    expect(last).toEqual([{ path: 'source', operator: { type: 'Equals', value: 'crm' } }]);
+  });
+
+  it('AC7: editing a legacy non-Equals field collapses it to Equals while untouched rows keep their operator', async () => {
+    const onEventPropertiesChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          { path: 'message_id', operator: { type: 'Contains', value: 'x' } },
+          { path: 'channel_type', operator: { type: 'Contains', value: 'wa' } },
+        ]}
+        onEventPropertiesChange={onEventPropertiesChange}
+      />,
+    );
+
+    // Edit only message_id; leave channel_type untouched.
+    await user.type(screen.getByLabelText(/^message_id\s*\*?$/i), 'y');
+
+    const last = onEventPropertiesChange.mock.calls.at(-1)?.[0] as EventProperty[];
+    const messageId = last.find(p => p.path === 'message_id');
+    const channelType = last.find(p => p.path === 'channel_type');
+    expect(messageId?.operator.type).toBe('Equals'); // edited → collapsed
+    expect(messageId?.operator.value).toBe('xy');
+    expect(channelType?.operator.type).toBe('Contains'); // untouched → preserved
+    expect(channelType?.operator.value).toBe('wa');
+  });
+
+  it('AC2 (validity): reports invalid while a required field is empty and valid once filled', async () => {
+    const onValidityChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onValidityChange={onValidityChange} />);
+    await selectEvent(user, /contact created|contato criado/i);
+
+    // contact.created requires id + source; both empty → invalid.
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+    await user.type(screen.getByLabelText(/^id\s*\*?$/i), 'id-1');
+    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('AC4: switching canonical events prompts preserve/clear; Preserve keeps compatible values and drops the rest', async () => {
+    const onEventPropertiesChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+          { path: 'conversation_id', operator: { type: 'Equals', value: 'c-1' } },
+          { path: 'channel_type', operator: { type: 'Equals', value: 'wa' } },
+          { path: 'source', operator: { type: 'Equals', value: 'crm' } },
+        ]}
+        onEventPropertiesChange={onEventPropertiesChange}
+      />,
+    );
+
+    await selectEvent(user, /conversation created|conversa criada/i);
+
+    // Confirm dialog appears.
+    expect(
+      await screen.findByText(/preserve compatible values|preservar valores compatíveis/i),
+    ).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: /preserve compatible|preservar compatíveis/i }));
+
+    const last = onEventPropertiesChange.mock.calls.at(-1)?.[0] as EventProperty[];
+    const keys = last.map(p => p.path).sort();
+    // conversation.created shares conversation_id (uuid), source (string), channel_type (string);
+    // message_id is absent from its schema → dropped.
+    expect(keys).toEqual(['channel_type', 'conversation_id', 'source']);
+    expect(keys).not.toContain('message_id');
+  });
+
+  it('AC4: choosing Clear on an event switch resets properties to an empty array', async () => {
+    const onEventPropertiesChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+        ]}
+        onEventPropertiesChange={onEventPropertiesChange}
+      />,
+    );
+
+    await selectEvent(user, /conversation created|conversa criada/i);
+    await user.click(screen.getByRole('button', { name: /clear all|limpar tudo/i }));
+
+    expect(onEventPropertiesChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('M1: dismissing the event-switch dialog (Esc) defaults to Clear, never stranding old values', async () => {
+    const onEventPropertiesChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+        ]}
+        onEventPropertiesChange={onEventPropertiesChange}
+      />,
+    );
+
+    await selectEvent(user, /conversation created|conversa criada/i);
+    expect(
+      await screen.findByText(/preserve compatible values|preservar valores compatíveis/i),
+    ).toBeTruthy();
+
+    await user.keyboard('{Escape}');
+
+    // Dismiss must not leave message.delivered's values under conversation.created.
+    expect(onEventPropertiesChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('M2: an optional field that already holds a value is shown on open (not hidden behind the picker)', () => {
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          // `content` is an OPTIONAL field on message.delivered.
+          { path: 'content', operator: { type: 'Equals', value: 'hello world' } },
+        ]}
+      />,
+    );
+
+    // The field renders immediately with its persisted value — no "+ Add field" click needed.
+    expect(screen.getByText('content')).toBeTruthy();
+    expect(screen.getByDisplayValue('hello world')).toBeTruthy();
+  });
+
+  it('L1: blocks validity until an event is actually selected', async () => {
+    const onValidityChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onValidityChange={onValidityChange} />);
+
+    // No event chosen yet → invalid (Save must not be enabled by an empty config).
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+    // Custom event has no required fields → valid once selected.
+    await selectEvent(user, /custom event|evento personalizado/i);
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
   });
 });

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -1,30 +1,38 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Button,
   Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
   Separator,
 } from '@evoapi/design-system';
-import { Plus, X } from 'lucide-react';
 import { VariableInput, VariableMapping, type DataMapping } from '@/components/journey/environment-manager';
 import { EventSelector } from '@/components/journey/shared/EventSelector';
-import { getEvent, resolveLegacyEventName } from '@/lib/events-manifest';
+import { EventPropertiesForm } from '@/components/journey/shared/EventPropertiesForm';
+import {
+  getEvent,
+  resolveLegacyEventName,
+  propertiesToRecord,
+  recordToProperties,
+  validateEventProperties,
+  preserveCompatibleValues,
+  type EventProperty,
+} from '@/lib/events-manifest';
 import { useLanguage } from '@/hooks/useLanguage';
-
-interface EventProperty {
-  path: string;
-  operator: { type: string; value?: unknown };
-}
 
 interface EventConfigurationProps {
   eventName: string;
   eventProperties: EventProperty[];
   onEventNameChange: (name: string) => void;
   onEventPropertiesChange: (properties: EventProperty[]) => void;
+  // Optional: only the Flow Builder (JourneyTriggerPanel) gates Save on this.
+  // Campaigns/Wait omit it and rely on the inline required-field indicators
+  // <EventPropertiesForm> renders. See EVO-1275.
+  onValidityChange?: (valid: boolean) => void;
   variableMappings?: DataMapping[];
   onVariableMappingsChange?: (mappings: DataMapping[]) => void;
   // Optional: in contexts without a journey (e.g. trigger-type Campaigns) it is
@@ -38,6 +46,7 @@ export function EventConfiguration({
   eventProperties,
   onEventNameChange,
   onEventPropertiesChange,
+  onValidityChange,
   variableMappings = [],
   onVariableMappingsChange,
   journeyId,
@@ -70,15 +79,48 @@ export function EventConfiguration({
     lastPushedRef.current = eventName;
   }, [eventName]);
 
+  const isCustomMode = selectorValue === 'custom';
+  // The event identity the schema form reasons about: 'custom' in custom mode,
+  // otherwise the canonical selector value.
+  const formEventName = isCustomMode ? 'custom' : selectorValue;
+
+  // Option A bridge: the persisted shape stays the filter-condition array;
+  // derive the flat Record the form consumes WITHOUT mutating the source.
+  const record = useMemo(() => propertiesToRecord(eventProperties), [eventProperties]);
+
+  const canonicalDescription =
+    !isCustomMode && selectorValue ? getEvent(selectorValue)?.description : undefined;
+
   const generateEventPaths = () => {
     const basePaths = ['event.id', 'event.name', 'event.timestamp', 'event.user_id'];
-    const propertyPaths = eventProperties
-      .filter(prop => prop.path && prop.path.trim())
-      .map(prop => `event.properties.${prop.path}`);
+    const propertyPaths = Object.keys(record).map((key) => `event.properties.${key}`);
     return [...basePaths, ...propertyPaths];
   };
 
+  // Emit validity to opted-in consumers, but only when it actually flips so we
+  // don't churn the parent's state on every keystroke.
+  const lastValidityRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    // An event trigger with no event chosen yet is not a savable config — treat
+    // the empty selection as invalid (formEventName === selectorValue, which is
+    // '' until something is picked; 'custom' once Custom is selected).
+    const valid =
+      formEventName === '' ? false : validateEventProperties(formEventName, record).valid;
+    if (lastValidityRef.current !== valid) {
+      lastValidityRef.current = valid;
+      onValidityChange?.(valid);
+    }
+  }, [formEventName, record, onValidityChange]);
+
+  // Pending event switch awaiting the user's preserve/clear decision.
+  const [pendingSwitch, setPendingSwitch] = useState<{ from: string; to: string } | null>(null);
+
   const handleSelectorChange = ({ eventName: picked, isCustom }: { eventName: string; isCustom: boolean }) => {
+    const prevFormEvent = formEventName;
+    const nextFormEvent = isCustom ? 'custom' : picked;
+
+    // The event NAME (and selector) updates immediately so the schema reflects
+    // the new event; the properties decision is deferred to the confirm dialog.
     if (isCustom) {
       setSelectorValue('custom');
       lastPushedRef.current = customName;
@@ -89,6 +131,12 @@ export function EventConfiguration({
       lastPushedRef.current = picked;
       onEventNameChange(picked);
     }
+
+    const identityChanged = prevFormEvent !== nextFormEvent;
+    const hasValues = Object.keys(record).length > 0;
+    if (identityChanged && hasValues) {
+      setPendingSwitch({ from: prevFormEvent, to: nextFormEvent });
+    }
   };
 
   const handleCustomNameChange = (next: string) => {
@@ -97,23 +145,21 @@ export function EventConfiguration({
     onEventNameChange(next);
   };
 
-  const isCustomMode = selectorValue === 'custom';
-  const canonicalDescription =
-    !isCustomMode && selectorValue ? getEvent(selectorValue)?.description : undefined;
-
-  const addEventProperty = () => {
-    const newProperty = { path: '', operator: { type: 'Equals', value: '' } };
-    onEventPropertiesChange([...eventProperties, newProperty]);
+  const handlePropertiesRecordChange = (next: Record<string, unknown>) => {
+    onEventPropertiesChange(recordToProperties(next, eventProperties));
   };
 
-  const removeEventProperty = (index: number) => {
-    onEventPropertiesChange(eventProperties.filter((_, i) => i !== index));
+  const handlePreserveValues = () => {
+    if (pendingSwitch) {
+      const kept = preserveCompatibleValues(record, pendingSwitch.from, pendingSwitch.to);
+      onEventPropertiesChange(recordToProperties(kept, eventProperties));
+    }
+    setPendingSwitch(null);
   };
 
-  const updateEventProperty = (index: number, property: EventProperty) => {
-    const updated = [...eventProperties];
-    updated[index] = property;
-    onEventPropertiesChange(updated);
+  const handleClearValues = () => {
+    onEventPropertiesChange([]);
+    setPendingSwitch(null);
   };
 
   return (
@@ -157,110 +203,14 @@ export function EventConfiguration({
 
         {/* Propriedades do evento */}
         <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <Label className="text-sidebar-foreground font-medium text-sm">
-              {t('triggerComponents.event.eventProperties')}
-            </Label>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={addEventProperty}
-              className="h-8 px-3 text-xs"
-            >
-              <Plus className="w-3 h-3 mr-1" />
-              {t('triggerComponents.event.addProperty')}
-            </Button>
-          </div>
-
-          {eventProperties.length === 0 ? (
-            <div className="p-4 rounded-lg bg-sidebar-accent/20 border border-sidebar-border/50">
-              <p className="text-sm text-sidebar-foreground/70 text-center">
-                {t('triggerComponents.event.noPropertiesConfigured')}
-                <br />
-                {t('triggerComponents.event.triggerForAnyOccurrence')}
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-2">
-              {eventProperties.map((property, index) => (
-                <div key={index} className="p-3 rounded-lg bg-sidebar border border-sidebar-border">
-                  <div className="flex items-center gap-2">
-                    <VariableInput
-                      placeholder={t('triggerComponents.event.property')}
-                      value={property.path}
-                      onChange={e =>
-                        updateEventProperty(index, {
-                          ...property,
-                          path: e.target.value,
-                        })
-                      }
-                      className="flex-1 bg-sidebar-accent border-sidebar-border text-sidebar-foreground"
-                      journeyId={journeyId}
-                    />
-                    <Select
-                      value={property.operator.type}
-                      onValueChange={value =>
-                        updateEventProperty(index, {
-                          ...property,
-                          operator: { ...property.operator, type: value },
-                        })
-                      }
-                    >
-                      <SelectTrigger className="w-32 bg-sidebar-accent border-sidebar-border text-sidebar-foreground">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent className="bg-sidebar border-sidebar-border">
-                        <SelectItem value="Equals" className="text-sidebar-foreground">
-                          {t('triggerComponents.operators.equals')}
-                        </SelectItem>
-                        <SelectItem value="NotEquals" className="text-sidebar-foreground">
-                          {t('triggerComponents.operators.not_equals')}
-                        </SelectItem>
-                        <SelectItem value="Contains" className="text-sidebar-foreground">
-                          {t('triggerComponents.operators.contains')}
-                        </SelectItem>
-                        <SelectItem value="GreaterThan" className="text-sidebar-foreground">
-                          {t('triggerComponents.operators.greater_than')}
-                        </SelectItem>
-                        <SelectItem value="LessThan" className="text-sidebar-foreground">
-                          {t('triggerComponents.operators.less_than')}
-                        </SelectItem>
-                        <SelectItem value="Exists" className="text-sidebar-foreground">
-                          {t('triggerComponents.operators.exists')}
-                        </SelectItem>
-                      </SelectContent>
-                    </Select>
-                    {property.operator.type !== 'Exists' && (
-                      <VariableInput
-                        placeholder={t('triggerComponents.event.value')}
-                        value={
-                          property.operator.value == null
-                            ? ''
-                            : String(property.operator.value)
-                        }
-                        onChange={e =>
-                          updateEventProperty(index, {
-                            ...property,
-                            operator: { ...property.operator, value: e.target.value },
-                          })
-                        }
-                        className="flex-1 bg-sidebar-accent border-sidebar-border text-sidebar-foreground"
-                        journeyId={journeyId}
-                      />
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => removeEventProperty(index)}
-                      className="h-7 w-7 p-0 text-sidebar-foreground/60 hover:text-red-500"
-                    >
-                      <X className="w-3 h-3" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
+          <Label className="text-sidebar-foreground font-medium text-sm">
+            {t('triggerComponents.event.eventProperties')}
+          </Label>
+          <EventPropertiesForm
+            eventName={formEventName}
+            value={record}
+            onChange={handlePropertiesRecordChange}
+          />
         </div>
       </div>
 
@@ -282,6 +232,35 @@ export function EventConfiguration({
           </div>
         </>
       )}
+
+      {/* Preserve-compatible-values confirm on event switch */}
+      <AlertDialog
+        open={pendingSwitch !== null}
+        onOpenChange={open => {
+          // Dismissing (Esc) without an explicit choice would otherwise strand
+          // the newly-selected event with the previous event's values (incl.
+          // keys absent from the new schema). Default a dismiss to the safe
+          // Clear. Explicit Preserve/Clear close via state, not onOpenChange.
+          if (!open) handleClearValues();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('triggerComponents.event.eventSwitch.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('triggerComponents.event.eventSwitch.body')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={handleClearValues}>
+              {t('triggerComponents.event.eventSwitch.clear')}
+            </Button>
+            <Button onClick={handlePreserveValues}>
+              {t('triggerComponents.event.eventSwitch.preserve')}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -86,7 +86,12 @@ function SchemaDrivenFields({
   className?: string;
   t: (key: string) => string;
 }) {
-  const [shownOptional, setShownOptional] = useState<string[]>([]);
+  // EVO-1275: seed from any optional fields that already carry a value, so a
+  // reopened node (or values preserved across an event switch) renders them
+  // instead of hiding persisted data behind the "+ Add field" picker.
+  const [shownOptional, setShownOptional] = useState<string[]>(
+    () => Object.keys(value).filter((field) => field in optionalFields),
+  );
 
   // F1 fix: when eventName changes upstream, optionalFields changes synchronously
   // but shownOptional state lingers. Compute the filtered set at render time
@@ -97,9 +102,20 @@ function SchemaDrivenFields({
     [shownOptional, optionalFields],
   );
 
+  // Prune entries that no longer belong to the current schema AND surface any
+  // optional field that has a value (e.g. preserved across an event switch).
+  // Returns the previous array unchanged when nothing differs, so a fresh
+  // `value` object reference with identical content can't cause a render loop.
   useEffect(() => {
-    setShownOptional((prev) => prev.filter((field) => field in optionalFields));
-  }, [optionalFields]);
+    setShownOptional((prev) => {
+      const pruned = prev.filter((field) => field in optionalFields);
+      const withValues = Object.keys(value).filter(
+        (field) => field in optionalFields && !pruned.includes(field),
+      );
+      if (withValues.length === 0 && pruned.length === prev.length) return prev;
+      return [...pruned, ...withValues];
+    });
+  }, [optionalFields, value]);
 
   const optionalKeysAvailable = useMemo(
     () => Object.keys(optionalFields).filter((k) => !visibleOptional.includes(k)),

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
@@ -59,6 +59,23 @@ describe('NodeConfigModal — common chrome', () => {
     expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
   });
 
+  it('keeps Save disabled when saveDisabled is true even if dirty (EVO-1275)', () => {
+    const { rerender } = render(
+      <NodeConfigModal {...baseProps} variant="simple" dirty saveDisabled>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    // Clearing saveDisabled (while still dirty) re-enables Save.
+    rerender(
+      <NodeConfigModal {...baseProps} variant="simple" dirty saveDisabled={false}>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+  });
+
   it('disables both Save and Cancel while loading', () => {
     render(
       <NodeConfigModal {...baseProps} variant="simple" dirty loading>

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
@@ -40,6 +40,8 @@ type CommonProps = {
   description?: string;
   loading?: boolean;
   dirty?: boolean;
+  /** Gate the Save button beyond dirty/loading — e.g. required-field validation. Defaults to false. */
+  saveDisabled?: boolean;
   saveLabel?: string;
   cancelLabel?: string;
   /**
@@ -84,6 +86,7 @@ export function NodeConfigModal(props: NodeConfigModalProps) {
     description,
     loading = false,
     dirty = false,
+    saveDisabled = false,
     saveLabel = 'Save',
     cancelLabel = 'Cancel',
     savingAriaLabel = 'Saving...',
@@ -170,7 +173,7 @@ export function NodeConfigModal(props: NodeConfigModalProps) {
           </Button>
           <Button
             onClick={onSave}
-            disabled={!dirty || loading}
+            disabled={!dirty || loading || saveDisabled}
             className="flex-1 sm:flex-initial h-10"
           >
             {loading ? (

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1728,7 +1728,13 @@
       "value": "Value",
       "captureEventData": "Capture Event Data",
       "customEventNamePlaceholder": "Type the custom event name (e.g. button_clicked)",
-      "customEventWarning": "Custom events have no schema validation. Use only for cases not covered by canonical events."
+      "customEventWarning": "Custom events have no schema validation. Use only for cases not covered by canonical events.",
+      "eventSwitch": {
+        "title": "Preserve compatible values?",
+        "body": "You changed the event. Keep the property values that also exist on the new event (same name and type), or clear them all?",
+        "preserve": "Preserve compatible",
+        "clear": "Clear all"
+      }
     },
     "label": {
       "configuration": "Label Configuration",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -1726,7 +1726,13 @@
       "triggerForAnyOccurrence": "El trigger será ejecutado para cualquier ocurrencia del evento.",
       "property": "Propiedad",
       "value": "Valor",
-      "captureEventData": "Capturar Datos del Evento"
+      "captureEventData": "Capturar Datos del Evento",
+      "eventSwitch": {
+        "title": "¿Preservar valores compatibles?",
+        "body": "Cambiaste el evento. ¿Mantener los valores de propiedad que también existen en el nuevo evento (mismo nombre y tipo) o borrarlos todos?",
+        "preserve": "Preservar compatibles",
+        "clear": "Borrar todo"
+      }
     },
     "label": {
       "configuration": "Configuración de la Etiqueta",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -1726,7 +1726,13 @@
       "triggerForAnyOccurrence": "Le déclencheur sera exécuté pour toute occurrence de l'événement.",
       "property": "Propriété",
       "value": "Valeur",
-      "captureEventData": "Capturer les données de l'événement"
+      "captureEventData": "Capturer les données de l'événement",
+      "eventSwitch": {
+        "title": "Conserver les valeurs compatibles ?",
+        "body": "Vous avez changé d'événement. Conserver les valeurs de propriété qui existent aussi sur le nouvel événement (même nom et type) ou tout effacer ?",
+        "preserve": "Conserver compatibles",
+        "clear": "Tout effacer"
+      }
     },
     "label": {
       "configuration": "Configuration de l'étiquette",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -1738,7 +1738,13 @@
       "triggerForAnyOccurrence": "Il trigger verrà eseguito per qualsiasi occorrenza dell'evento.",
       "property": "Proprietà",
       "value": "Valore",
-      "captureEventData": "Cattura Dati dell'Evento"
+      "captureEventData": "Cattura Dati dell'Evento",
+      "eventSwitch": {
+        "title": "Conservare i valori compatibili?",
+        "body": "Hai cambiato l'evento. Mantenere i valori delle proprietà che esistono anche nel nuovo evento (stesso nome e tipo) o cancellarli tutti?",
+        "preserve": "Conserva compatibili",
+        "clear": "Cancella tutto"
+      }
     },
     "label": {
       "configuration": "Configurazione dell'Etichetta",

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -106,6 +106,32 @@ describe('journey i18n parity (EVO-1260)', () => {
     expect(empties).toEqual([]);
   });
 
+  // EVO-1275: the event-switch confirm-modal keys were added to ALL six
+  // locales (the strict en↔pt-BR mirror would otherwise leave pt/es/fr/it
+  // unguarded against silent drift/removal). Assert presence + non-empty
+  // across every shipped locale, mirroring the EVO-1260 pattern above.
+  const evo1275Keys = [
+    'triggerComponents.event.eventSwitch.title',
+    'triggerComponents.event.eventSwitch.body',
+    'triggerComponents.event.eventSwitch.preserve',
+    'triggerComponents.event.eventSwitch.clear',
+  ];
+
+  it.each([
+    ['en', en],
+    ['pt-BR', ptBR],
+    ['pt', pt],
+    ['es', es],
+    ['fr', fr],
+    ['it', itLocale],
+  ])('%s contains every EVO-1275 event-switch key, non-empty', (_name, locale) => {
+    const offenders = evo1275Keys.filter((k) => {
+      const v = getAtPath(locale, k);
+      return typeof v !== 'string' || v.trim() === '';
+    });
+    expect(offenders).toEqual([]);
+  });
+
   // Generalised non-empty check across EN and pt-BR (the lock-step pair):
   // every string value must be non-empty. Catches an entire-file regression
   // class (e.g. a script writing "" to a key during a future sweep) that

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1728,7 +1728,13 @@
       "value": "Valor",
       "captureEventData": "Capturar Dados do Evento",
       "customEventNamePlaceholder": "Digite o nome do evento custom (ex: button_clicked)",
-      "customEventWarning": "Eventos custom não têm validação de schema. Use apenas para casos não cobertos pelos eventos canônicos."
+      "customEventWarning": "Eventos custom não têm validação de schema. Use apenas para casos não cobertos pelos eventos canônicos.",
+      "eventSwitch": {
+        "title": "Preservar valores compatíveis?",
+        "body": "Você alterou o evento. Manter os valores de propriedade que também existem no novo evento (mesmo nome e tipo) ou limpar todos?",
+        "preserve": "Preservar compatíveis",
+        "clear": "Limpar tudo"
+      }
     },
     "label": {
       "configuration": "Configuração da Etiqueta",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -1726,7 +1726,13 @@
       "triggerForAnyOccurrence": "O trigger será executado para qualquer ocorrência do evento.",
       "property": "Propriedade",
       "value": "Valor",
-      "captureEventData": "Capturar Dados do Evento"
+      "captureEventData": "Capturar Dados do Evento",
+      "eventSwitch": {
+        "title": "Preservar valores compatíveis?",
+        "body": "Você alterou o evento. Manter os valores de propriedade que também existem no novo evento (mesmo nome e tipo) ou limpar todos?",
+        "preserve": "Preservar compatíveis",
+        "clear": "Limpar tudo"
+      }
     },
     "label": {
       "configuration": "Configuração da Etiqueta",

--- a/src/lib/events-manifest/event-properties-bridge.spec.ts
+++ b/src/lib/events-manifest/event-properties-bridge.spec.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  propertiesToRecord,
+  recordToProperties,
+  validateEventProperties,
+  preserveCompatibleValues,
+  type EventProperty,
+} from './event-properties-bridge';
+
+// Unit-test the bridge against a synthetic catalog so the assertions don't drift
+// with the real manifest AND so a genuine type-mismatch pair exists (the real
+// catalog happens to use the same type for every shared key name). The fake
+// keeps the names the spec calls out (`message.delivered` / `message_id`).
+vi.mock('./index', () => {
+  const FAKE: Record<string, { schema: { required: Record<string, { type: string }>; optional: Record<string, { type: string }> } }> = {
+    'message.delivered': {
+      schema: { required: { message_id: { type: 'uuid' } }, optional: { status: { type: 'string' } } },
+    },
+    'message.read': {
+      schema: { required: { message_id: { type: 'uuid' } }, optional: { status: { type: 'string' } } },
+    },
+    // `status` is a number here → type-incompatible with message.delivered's string.
+    'number.event': {
+      schema: { required: {}, optional: { status: { type: 'number' }, count: { type: 'number' } } },
+    },
+    custom: { schema: { required: {}, optional: {} } },
+  };
+  return {
+    getEvent: (name: string) => FAKE[name],
+    isCustomEvent: (name: string) => name === 'custom',
+  };
+});
+
+describe('propertiesToRecord / recordToProperties round-trip', () => {
+  it('round-trips an all-Equals array', () => {
+    const props: EventProperty[] = [
+      { path: 'message_id', operator: { type: 'Equals', value: 'abc' } },
+      { path: 'status', operator: { type: 'Equals', value: 'sent' } },
+    ];
+    const record = propertiesToRecord(props);
+    expect(record).toEqual({ message_id: 'abc', status: 'sent' });
+    expect(recordToProperties(record, props)).toEqual(props);
+  });
+
+  it('surfaces values of non-Equals operators in the record', () => {
+    const props: EventProperty[] = [
+      { path: 'status', operator: { type: 'Contains', value: 'fail' } },
+    ];
+    expect(propertiesToRecord(props)).toEqual({ status: 'fail' });
+  });
+
+  it('skips blank paths and last-write-wins on duplicates', () => {
+    const props: EventProperty[] = [
+      { path: '', operator: { type: 'Equals', value: 'ignored' } },
+      { path: '   ', operator: { type: 'Equals', value: 'ignored' } },
+      { path: 'k', operator: { type: 'Equals', value: 'first' } },
+      { path: 'k', operator: { type: 'Equals', value: 'second' } },
+    ];
+    expect(propertiesToRecord(props)).toEqual({ k: 'second' });
+  });
+
+  it('preserves an untouched non-Equals row but flattens an edited one to Equals', () => {
+    const prev: EventProperty[] = [
+      { path: 'status', operator: { type: 'Contains', value: 'fail' } },
+      { path: 'message_id', operator: { type: 'GreaterThan', value: 5 } },
+    ];
+    // status unchanged (deep-equals prev value) → operator preserved.
+    // message_id edited → collapses to Equals.
+    const next = recordToProperties({ status: 'fail', message_id: 9 }, prev);
+    expect(next).toEqual([
+      { path: 'status', operator: { type: 'Contains', value: 'fail' } },
+      { path: 'message_id', operator: { type: 'Equals', value: 9 } },
+    ]);
+  });
+
+  it('emits Equals rows when there is no prev context', () => {
+    expect(recordToProperties({ a: '1' })).toEqual([
+      { path: 'a', operator: { type: 'Equals', value: '1' } },
+    ]);
+  });
+});
+
+describe('validateEventProperties', () => {
+  it('flags missing required fields', () => {
+    expect(validateEventProperties('message.delivered', {})).toEqual({
+      valid: false,
+      missing: ['message_id'],
+    });
+  });
+
+  it('treats empty-string / null / undefined as missing', () => {
+    expect(validateEventProperties('message.delivered', { message_id: '' }).valid).toBe(false);
+    expect(validateEventProperties('message.delivered', { message_id: null }).valid).toBe(false);
+  });
+
+  it('is valid when all required fields are filled', () => {
+    expect(validateEventProperties('message.delivered', { message_id: 'uuid-1' })).toEqual({
+      valid: true,
+      missing: [],
+    });
+  });
+
+  it('is always valid for custom or unknown events', () => {
+    expect(validateEventProperties('custom', {}).valid).toBe(true);
+    expect(validateEventProperties('does.not.exist', {}).valid).toBe(true);
+  });
+});
+
+describe('preserveCompatibleValues', () => {
+  it('keeps same-name-same-type values across a canonical switch', () => {
+    const result = preserveCompatibleValues(
+      { message_id: 'uuid-1', status: 'sent' },
+      'message.delivered',
+      'message.read',
+    );
+    expect(result).toEqual({ message_id: 'uuid-1', status: 'sent' });
+  });
+
+  it('drops a value whose type differs in the target schema', () => {
+    // `status` is string in message.delivered, number in number.event → dropped.
+    const result = preserveCompatibleValues(
+      { status: 'sent' },
+      'message.delivered',
+      'number.event',
+    );
+    expect(result).toEqual({});
+  });
+
+  it('drops keys absent from the target schema', () => {
+    const result = preserveCompatibleValues(
+      { message_id: 'uuid-1', stray: 'x' },
+      'message.delivered',
+      'message.read',
+    );
+    expect(result).toEqual({ message_id: 'uuid-1' });
+  });
+
+  it('keeps everything when the target event is custom', () => {
+    const record = { anything: 1, free: 'form' };
+    expect(preserveCompatibleValues(record, 'message.delivered', 'custom')).toEqual(record);
+  });
+
+  it('keeps target-schema keys without a type check when the source is custom', () => {
+    const result = preserveCompatibleValues(
+      { message_id: 'uuid-1', stray: 'x' },
+      'custom',
+      'message.read',
+    );
+    expect(result).toEqual({ message_id: 'uuid-1' });
+  });
+
+  it('drops everything when the target event is unknown', () => {
+    expect(
+      preserveCompatibleValues({ message_id: 'uuid-1' }, 'message.delivered', 'nope'),
+    ).toEqual({});
+  });
+});

--- a/src/lib/events-manifest/event-properties-bridge.ts
+++ b/src/lib/events-manifest/event-properties-bridge.ts
@@ -1,0 +1,131 @@
+import { getEvent, isCustomEvent } from './index';
+import type { FieldSpec } from './types';
+
+/**
+ * The persisted Event-Properties row. Mirrors the `evo-flow` `JourneyEventProperty`
+ * shape (`src/modules/journeys/services/triggers/event.trigger.ts`) and the FE
+ * `JourneyTriggerNodeData.eventProperties` item. The trigger backend matches each
+ * `{path, operator}` against the incoming event payload and gates filtering on
+ * `Array.isArray(eventProperties) && length > 0`.
+ *
+ * EVO-1275 (Option A "adapter"): the persisted shape STAYS this array; the
+ * functions below convert it ⇄ the flat `Record<string, unknown>` that
+ * `<EventPropertiesForm>` consumes, so the backend contract and existing
+ * journeys are untouched. The structured form expresses only `Equals`; an
+ * edited field collapses to `Equals` while untouched rows keep their operator.
+ */
+export interface EventProperty {
+  path: string;
+  operator: { type: string; value?: unknown };
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (typeof a !== 'object') return false;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((k) => k in bObj && deepEqual(aObj[k], bObj[k]));
+}
+
+/**
+ * Flatten the persisted filter-condition array into the flat Record the form
+ * consumes. Surfaces `operator.value` regardless of operator type so legacy
+ * non-`Equals` rows are still visible in the form. Last-write-wins on duplicate
+ * paths; blank paths are skipped.
+ */
+export function propertiesToRecord(props: EventProperty[]): Record<string, unknown> {
+  const record: Record<string, unknown> = {};
+  for (const prop of props) {
+    if (!prop?.path || !prop.path.trim()) continue;
+    record[prop.path] = prop.operator?.value;
+  }
+  return record;
+}
+
+/**
+ * Convert the form's flat Record back into the persisted array. For each entry:
+ * if `prev` holds a row with the same `path` whose `operator.value` deep-equals
+ * the value (i.e. the field was NOT edited), KEEP that original row so its
+ * operator (e.g. `Contains`) survives; otherwise emit a fresh `Equals` row.
+ * This preserves untouched legacy operators and only flattens edited fields.
+ */
+export function recordToProperties(
+  record: Record<string, unknown>,
+  prev: EventProperty[] = [],
+): EventProperty[] {
+  return Object.entries(record).map(([key, value]) => {
+    const original = prev.find(
+      (p) => p.path === key && deepEqual(p.operator?.value, value),
+    );
+    if (original) return original;
+    return { path: key, operator: { type: 'Equals', value } };
+  });
+}
+
+/**
+ * Required-field validation for the structured form. Custom or unknown events
+ * have no schema → always valid. For canonical events, every key in the
+ * event's `schema.required` must be present with a non-empty value.
+ */
+export function validateEventProperties(
+  eventName: string,
+  record: Record<string, unknown>,
+): { valid: boolean; missing: string[] } {
+  const entry = getEvent(eventName);
+  if (!entry || isCustomEvent(eventName)) return { valid: true, missing: [] };
+
+  const missing = Object.keys(entry.schema.required).filter((key) => {
+    const value = record[key];
+    return value === undefined || value === null || value === '';
+  });
+  return { valid: missing.length === 0, missing };
+}
+
+function fieldType(eventName: string, key: string): FieldSpec['type'] | undefined {
+  const entry = getEvent(eventName);
+  if (!entry) return undefined;
+  return (entry.schema.required[key] ?? entry.schema.optional[key])?.type;
+}
+
+/**
+ * Decide which property values survive an event switch A→B. A value is kept
+ * when its key exists in the target event's schema (required ∪ optional) AND
+ * its `FieldSpec.type` matches the source field's type ("compatible" = same
+ * name AND same type). Targeting `custom` keeps everything; a `custom`/unknown
+ * source keeps keys present in the target schema without a type check.
+ */
+export function preserveCompatibleValues(
+  record: Record<string, unknown>,
+  fromEventName: string,
+  toEventName: string,
+): Record<string, unknown> {
+  if (isCustomEvent(toEventName)) return { ...record };
+
+  const target = getEvent(toEventName);
+  if (!target) return {};
+
+  const sourceIsSchemaless = isCustomEvent(fromEventName) || !getEvent(fromEventName);
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const targetType = fieldType(toEventName, key);
+    if (targetType === undefined) continue;
+    if (sourceIsSchemaless) {
+      result[key] = value;
+      continue;
+    }
+    if (fieldType(fromEventName, key) === targetType) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/lib/events-manifest/index.ts
+++ b/src/lib/events-manifest/index.ts
@@ -41,3 +41,11 @@ export function isCustomEvent(eventName: string): boolean {
 
 export { resolveLegacyEventName } from './legacy';
 export type { ResolvedLegacyEventName } from './legacy';
+
+export {
+  propertiesToRecord,
+  recordToProperties,
+  validateEventProperties,
+  preserveCompatibleValues,
+} from './event-properties-bridge';
+export type { EventProperty } from './event-properties-bridge';


### PR DESCRIPTION
> ⚠️ **Stacked sobre #122 (EVO-1608).** Base = branch da EVO-1608 para o diff ficar limpo (o `EventConfiguration` com `journeyId` opcional e o spec `both-contexts` vêm de lá). **Após o merge de #122 → develop, retargetar esta PR para `develop`** (o GitHub re-aponta automaticamente quando a base mergeia).

## Summary

Substitui o painel genérico "+ Add" de Event Properties no nó Trigger Event pelo `<EventPropertiesForm>` schema-driven (10.A / EVO-1261), consumindo o schema do evento selecionado do manifesto canônico (10.6 / EVO-1271): campos obrigatórios validados, opcionais via autocomplete, e modo livre key/value só quando o evento é `custom`.

**Decisão de modelo de dados — Opção A "adapter" (Danilo, 2026-06-01):** o shape persistido **continua** o array de filtro do evo-flow `Array<{path, operator:{type,value}}>`. Um bridge util converte array ⇄ `Record` internamente (campos preenchidos viram `Equals`; linhas legadas não-`Equals` não tocadas são preservadas). Assim **não há mudança de backend nem migração de journey-JSON**, e a interface pública do `EventConfiguration` (array in/out) fica igual → os 3 consumidores (Flow Builder, Campanhas, Wait) pegam o form novo automaticamente.

- **bridge util** (`event-properties-bridge.ts`): `propertiesToRecord` / `recordToProperties` / `validateEventProperties` / `preserveCompatibleValues` (+ testes unitários)
- **NodeConfigModal**: nova prop opcional `saveDisabled`; `JourneyTriggerPanel` bloqueia o Save em campo obrigatório vazio via `onValidityChange` (Campanhas/Wait não têm modal → usam os indicadores `*`/"required" inline do form)
- **Troca de evento**: dialog "preservar valores compatíveis?" (mesmo nome **e** tipo de `FieldSpec`); **Esc/dismiss faz Clear** (não deixa valores do evento antigo presos no novo)
- **EventPropertiesForm**: passa a exibir campos opcionais que já possuem valor ao abrir (não esconde dado persistido atrás do "+ Add field")
- **i18n**: `triggerComponents.event.eventSwitch.{title,body,preserve,clear}` nos 6 locales + guard de paridade

## Limitação conhecida (consequência da Opção A)

O form estruturado só expressa `Equals`. Abrir um nó legado com outro operador (`Contains`, `GreaterThan`, `Exists`, …) mostra o **valor** do campo mas, ao **editar e salvar** esse campo, o operador colapsa para `Equals`. Linhas não editadas mantêm o operador original. Filtro avançado por operador fica fora de escopo (candidato a um "advanced toggle" futuro / 10.8).

## Test plan

- [x] `pnpm exec tsc -b --noEmit`
- [x] `pnpm lint` nos arquivos alterados — sem erro novo
- [x] `event-properties-bridge.spec.ts` — round-trip, preservação de operador, validação, preserve-compatible
- [x] `EventConfiguration.spec.tsx` — AC1 (`*`), AC2/L1 (validade), AC3 (autocomplete), AC4 (preserve/clear + Esc→Clear), AC5 (custom), AC6 (shape array `Equals`), AC7 (operador legado), M2 (opcional com valor visível)
- [x] `EventConfiguration.both-contexts.spec.tsx` — guard cross-context (campanha não dispara fetch de jornada) atualizado
- [x] `NodeConfigModal.spec.tsx` — caso `saveDisabled`
- [x] `journey-parity.spec.ts` — paridade i18n + guard EVO-1275
- [x] Suíte tocada: **147 testes verdes**
- [ ] Smoke manual com evo-flow orquestrado (não roda localmente — matching em runtime fora deste smoke)

## Critérios de aceite (EVO-1275)

- [x] AC1 campo obrigatório com `*` · AC2 Save bloqueado com obrigatório vazio · AC3 autocomplete de opcionais
- [x] AC4 troca de evento com preserve/clear · AC5 modo custom · AC6 shape `Array<{path, operator:{type:'Equals'}}>` preservado
- [x] AC7 operador legado preservado quando não editado · AC8 paridade cross-context (sem fetch de jornada em campanha)

Closes EVO-1275.

## Summary by Sourcery

Adopt a schema-driven Event Properties form for Trigger event configuration while preserving the existing filter-condition storage shape, adding validation and event-switch handling to integrate seamlessly with existing journeys.

New Features:
- Introduce a schema-driven Event Properties form in the Trigger event configuration that derives its fields from the canonical event manifest and supports custom events via a free-form key/value editor.
- Add a user prompt on event type changes that lets users preserve only schema-compatible property values or clear all properties, with dismiss defaulting to clearing values.
- Expose event configuration validity to the JourneyTriggerPanel so the node Save action is gated on required fields and a selected event.

Enhancements:
- Implement an adapter layer to convert between the persisted event-properties filter-condition array and the schema form's flat record representation, preserving legacy non-Equals operators for untouched fields.
- Ensure optional schema fields that already have values are shown immediately when reopening a node instead of being hidden behind an add-field control.
- Extend the generic NodeConfigModal to support an explicit saveDisabled gate in addition to dirty/loading state.
- Strengthen parity tests for EventConfiguration across flow and campaign contexts, including journeyId handling for variable autocompletion.
- Add i18n coverage and parity checks for the new event-switch confirmation dialog strings across all supported locales.

Tests:
- Add unit tests for the event-properties bridge adapter covering round-tripping, validation, operator preservation, and compatibility-based value preservation.
- Expand EventConfiguration tests to cover schema-driven required/optional behavior, validity reporting, event switching semantics, custom mode, and legacy operator handling.
- Update NodeConfigModal, EventConfiguration cross-context, and journey i18n parity tests to exercise the new props, behaviors, and translation keys.