### PR TITLE
feat(frontend): add Pipeline Stage Changed trigger variant to Customer Journey (EVO-1266)

### DIFF
--- a/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
@@ -14,13 +14,21 @@ export interface JourneyTriggerNodeData {
     | 'contactCreated'
     | 'contactUpdated'
     | 'label'
-    | 'customAttribute';
+    | 'customAttribute'
+    | 'pipelineStageChanged';
   // Configurações de evento
   eventName?: string;
   eventProperties?: Array<{
     path: string;
     operator: { type: string; value?: unknown };
   }>;
+  // Configurações de pipeline stage changed (EVO-1266)
+  pipelineId?: string;
+  pipelineName?: string;
+  fromStageId?: string;
+  fromStageName?: string;
+  toStageId?: string;
+  toStageName?: string;
   // Configurações de segmento
   segmentId?: string;
   segmentName?: string;
@@ -94,6 +102,8 @@ export function JourneyTriggerNode({ selected, data, id }: JourneyTriggerNodePro
         return t('flowEditor.nodes.trigger.types.label');
       case 'customAttribute':
         return t('flowEditor.nodes.trigger.types.customAttribute');
+      case 'pipelineStageChanged':
+        return t('flowEditor.nodes.trigger.types.pipelineStageChanged');
       default:
         return t('flowEditor.nodes.trigger.label');
     }
@@ -183,6 +193,25 @@ export function JourneyTriggerNode({ selected, data, id }: JourneyTriggerNodePro
           });
         }
         return t('flowEditor.nodes.trigger.descriptions.configureWebhook');
+
+      case 'pipelineStageChanged': {
+        const pipelineLabel = data.pipelineName || data.pipelineId;
+        if (!pipelineLabel) {
+          return t('flowEditor.nodes.trigger.descriptions.anyStageTransition');
+        }
+        const fromLabel = data.fromStageName || data.fromStageId;
+        const toLabel = data.toStageName || data.toStageId;
+        if (fromLabel && toLabel) {
+          return `${pipelineLabel}: ${fromLabel} → ${toLabel}`;
+        }
+        if (toLabel) {
+          return `${pipelineLabel} → ${toLabel}`;
+        }
+        if (fromLabel) {
+          return `${pipelineLabel}: ${fromLabel} →`;
+        }
+        return pipelineLabel;
+      }
 
       default:
         return t('flowEditor.nodes.trigger.descriptions.configureTrigger');

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -15,6 +15,8 @@ import {
   LabelConfiguration,
   CustomAttributeConfiguration,
   WebhookConfiguration,
+  PipelineStageChangedConfiguration,
+  type PipelineStageChangedSelection,
 } from './components';
 
 interface JourneyTriggerPanelProps {
@@ -53,6 +55,9 @@ export function JourneyTriggerPanel({
     data.triggerType === 'customAttribute',
   );
   const [showWebhookConfig, setShowWebhookConfig] = useState(data.triggerType === 'webhook');
+  const [showPipelineStageChangedConfig, setShowPipelineStageChangedConfig] = useState(
+    data.triggerType === 'pipelineStageChanged',
+  );
   // Required-field validity reported by EventBasicConfig. True (non-blocking)
   // whenever the event config isn't shown, so other trigger types can always Save.
   const [eventPropsValid, setEventPropsValid] = useState(true);
@@ -71,6 +76,7 @@ export function JourneyTriggerPanel({
     setShowLabelConfig(data.triggerType === 'label');
     setShowCustomAttributeConfig(data.triggerType === 'customAttribute');
     setShowWebhookConfig(data.triggerType === 'webhook');
+    setShowPipelineStageChangedConfig(data.triggerType === 'pipelineStageChanged');
   }, [data]);
 
   const handleSave = () => {
@@ -103,6 +109,13 @@ export function JourneyTriggerPanel({
       webhookSecret: showWebhookConfig ? formData.webhookSecret : undefined,
       webhookMethod: showWebhookConfig ? formData.webhookMethod : undefined,
       expectedHeaders: showWebhookConfig ? formData.expectedHeaders : undefined,
+      pipelineId: showPipelineStageChangedConfig ? formData.pipelineId : undefined,
+      pipelineName: showPipelineStageChangedConfig ? formData.pipelineName : undefined,
+      fromStageId: showPipelineStageChangedConfig ? formData.fromStageId : undefined,
+      fromStageName: showPipelineStageChangedConfig ? formData.fromStageName : undefined,
+      toStageId: showPipelineStageChangedConfig ? formData.toStageId : undefined,
+      toStageName: showPipelineStageChangedConfig ? formData.toStageName : undefined,
+      eventName: showPipelineStageChangedConfig ? 'pipeline.stage_changed' : formData.eventName,
     };
     onUpdate(nodeId, updatedData);
     onClose();
@@ -119,8 +132,21 @@ export function JourneyTriggerPanel({
     setShowLabelConfig(value === 'label');
     setShowCustomAttributeConfig(value === 'customAttribute');
     setShowWebhookConfig(value === 'webhook');
+    setShowPipelineStageChangedConfig(value === 'pipelineStageChanged');
     if (value !== 'event') setEventPropsValid(true);
     setActiveTab('basico');
+  };
+
+  const handlePipelineStageChangedChange = (next: PipelineStageChangedSelection) => {
+    setFormData(prev => ({
+      ...prev,
+      pipelineId: next.pipelineId,
+      pipelineName: next.pipelineName,
+      fromStageId: next.fromStageId,
+      fromStageName: next.fromStageName,
+      toStageId: next.toStageId,
+      toStageName: next.toStageName,
+    }));
   };
 
   const handleEventNameChange = (name: string) => {
@@ -338,6 +364,21 @@ export function JourneyTriggerPanel({
             setFormData(prev => ({ ...prev, variableMappings: mappings }))
           }
           onVariablesChange={onVariablesChange}
+        />
+      )}
+
+      {/* Configuração de Pipeline Stage Changed (EVO-1266) */}
+      {showPipelineStageChangedConfig && (
+        <PipelineStageChangedConfiguration
+          selection={{
+            pipelineId: formData.pipelineId,
+            pipelineName: formData.pipelineName,
+            fromStageId: formData.fromStageId,
+            fromStageName: formData.fromStageName,
+            toStageId: formData.toStageId,
+            toStageName: formData.toStageName,
+          }}
+          onChange={handlePipelineStageChangedChange}
         />
       )}
     </NodeConfigModal>

--- a/src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.spec.tsx
@@ -1,0 +1,186 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  PipelineStageChangedConfiguration,
+  type PipelineStageChangedSelection,
+} from './PipelineStageChangedConfiguration';
+import '@/i18n/config';
+
+vi.mock('@/services/pipelines/pipelinesService', () => ({
+  pipelinesService: {
+    getPipelines: vi.fn(),
+    getPipelineStages: vi.fn(),
+  },
+}));
+
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
+const mockGetStages = pipelinesService.getPipelineStages as unknown as ReturnType<typeof vi.fn>;
+
+const PIPELINES = [
+  { id: 'pipe-sales', name: 'Sales' },
+  { id: 'pipe-onboarding', name: 'Onboarding' },
+];
+const SALES_STAGES = [
+  { id: 'stage-lead', name: 'Lead' },
+  { id: 'stage-qualified', name: 'Qualified' },
+];
+
+function Harness({ initial }: { initial?: PipelineStageChangedSelection }) {
+  const [selection, setSelection] = useState<PipelineStageChangedSelection>(initial ?? {});
+  return (
+    <>
+      <PipelineStageChangedConfiguration selection={selection} onChange={setSelection} />
+      <div data-testid="state">{JSON.stringify(selection)}</div>
+    </>
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PipelineStageChangedConfiguration', () => {
+  it('loads pipelines on mount and renders them in the pipeline select (AC1 prep)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    const user = userEvent.setup();
+
+    render(<Harness />);
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    const pipelineCombo = screen.getByRole('combobox', { name: /pipeline/i });
+    await user.click(pipelineCombo);
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('Sales')).toBeTruthy();
+    expect(within(listbox).getByText('Onboarding')).toBeTruthy();
+  });
+
+  it('shows the empty-state info banner when no filters are configured (AC1)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+
+    render(<Harness />);
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText(
+        /any pipeline stage transition|qualquer transi[çc][ãa]o|cualquier transici[óo]n|toute transition|qualsiasi transizione/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('fetches stages when a pipeline is selected and lists them in From/To selects (AC1, AC2)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: SALES_STAGES });
+    const user = userEvent.setup();
+
+    render(<Harness />);
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    await user.click(screen.getByRole('combobox', { name: /pipeline/i }));
+    const pipelineList = await screen.findByRole('listbox');
+    await user.click(within(pipelineList).getByText('Sales'));
+
+    await waitFor(() => expect(mockGetStages).toHaveBeenCalledWith('pipe-sales'));
+
+    await user.click(screen.getByRole('combobox', { name: /from stage|stage de origem|etapa de origen|étape d'origine|stage di origine/i }));
+    const fromList = await screen.findByRole('listbox');
+    expect(within(fromList).getByText('Lead')).toBeTruthy();
+    expect(within(fromList).getByText('Qualified')).toBeTruthy();
+  });
+
+  it('emits onChange with pipelineId + pipelineName when pipeline is picked (AC1 contract)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: SALES_STAGES });
+    const user = userEvent.setup();
+
+    render(<Harness />);
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    await user.click(screen.getByRole('combobox', { name: /pipeline/i }));
+    const list = await screen.findByRole('listbox');
+    await user.click(within(list).getByText('Sales'));
+
+    await waitFor(() => {
+      const state = JSON.parse(screen.getByTestId('state').textContent || '{}');
+      expect(state.pipelineId).toBe('pipe-sales');
+      expect(state.pipelineName).toBe('Sales');
+    });
+  });
+
+  it('emits onChange with fromStageId + fromStageName when a from-stage is picked', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: SALES_STAGES });
+    const user = userEvent.setup();
+
+    render(
+      <Harness
+        initial={{ pipelineId: 'pipe-sales', pipelineName: 'Sales' }}
+      />,
+    );
+    await waitFor(() => expect(mockGetStages).toHaveBeenCalledWith('pipe-sales'));
+
+    await user.click(screen.getByRole('combobox', { name: /from stage|stage de origem|etapa de origen|étape d'origine|stage di origine/i }));
+    const list = await screen.findByRole('listbox');
+    await user.click(within(list).getByText('Lead'));
+
+    await waitFor(() => {
+      const state = JSON.parse(screen.getByTestId('state').textContent || '{}');
+      expect(state.fromStageId).toBe('stage-lead');
+      expect(state.fromStageName).toBe('Lead');
+      expect(state.pipelineId).toBe('pipe-sales');
+    });
+  });
+
+  it('resets stage filters when the user switches pipelines (AC2 — no leakage)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: SALES_STAGES });
+    mockGetStages.mockResolvedValueOnce({ data: [] });
+    const user = userEvent.setup();
+
+    render(
+      <Harness
+        initial={{
+          pipelineId: 'pipe-sales',
+          pipelineName: 'Sales',
+          fromStageId: 'stage-lead',
+          fromStageName: 'Lead',
+        }}
+      />,
+    );
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    await user.click(screen.getByRole('combobox', { name: /pipeline/i }));
+    const list = await screen.findByRole('listbox');
+    await user.click(within(list).getByText('Onboarding'));
+
+    await waitFor(() => {
+      const state = JSON.parse(screen.getByTestId('state').textContent || '{}');
+      expect(state.pipelineId).toBe('pipe-onboarding');
+      expect(state.fromStageId).toBeUndefined();
+      expect(state.fromStageName).toBeUndefined();
+    });
+  });
+
+  it('renders the error banner when getPipelines fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetPipelines.mockRejectedValueOnce(new Error('network down'));
+
+    render(<Harness />);
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText(
+        /could not load pipelines|n[ãa]o foi poss[íi]vel carregar|no se pudieron cargar|impossible de charger|impossibile caricare/i,
+      ),
+    ).toBeTruthy();
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.tsx
@@ -1,0 +1,273 @@
+import { useEffect, useState } from 'react';
+import {
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { Workflow } from 'lucide-react';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface PipelineStageChangedSelection {
+  pipelineId?: string;
+  pipelineName?: string;
+  fromStageId?: string;
+  fromStageName?: string;
+  toStageId?: string;
+  toStageName?: string;
+}
+
+interface PipelineOption {
+  id: string;
+  name: string;
+}
+
+interface StageOption {
+  id: string;
+  name: string;
+}
+
+interface PipelineStageChangedConfigurationProps {
+  selection: PipelineStageChangedSelection;
+  onChange: (next: PipelineStageChangedSelection) => void;
+}
+
+const ANY_STAGE_VALUE = '__any__';
+
+export function PipelineStageChangedConfiguration({
+  selection,
+  onChange,
+}: PipelineStageChangedConfigurationProps) {
+  const { t } = useLanguage('journey');
+  const [pipelines, setPipelines] = useState<PipelineOption[]>([]);
+  const [stages, setStages] = useState<StageOption[]>([]);
+  const [loadingPipelines, setLoadingPipelines] = useState(true);
+  const [loadingStages, setLoadingStages] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+
+  useEffect(() => {
+    const loadPipelines = async () => {
+      try {
+        setLoadingPipelines(true);
+        setLoadError(false);
+        const response = await pipelinesService.getPipelines();
+        const list = (response?.data || []).map(p => ({
+          id: p.id.toString(),
+          name: p.name,
+        }));
+        setPipelines(list);
+      } catch (error) {
+        console.error(t('triggerComponents.pipelineStageChanged.loadError'), error);
+        setLoadError(true);
+      } finally {
+        setLoadingPipelines(false);
+      }
+    };
+
+    loadPipelines();
+  }, []);
+
+  useEffect(() => {
+    if (!selection.pipelineId) {
+      setStages([]);
+      return;
+    }
+
+    let cancelled = false;
+    const loadStages = async () => {
+      try {
+        setLoadingStages(true);
+        const response = await pipelinesService.getPipelineStages(selection.pipelineId!);
+        if (cancelled) return;
+        const list = (response?.data || []).map(s => ({
+          id: s.id.toString(),
+          name: s.name,
+        }));
+        setStages(list);
+      } catch (error) {
+        if (cancelled) return;
+        console.error(t('triggerComponents.pipelineStageChanged.loadError'), error);
+        setStages([]);
+      } finally {
+        if (!cancelled) setLoadingStages(false);
+      }
+    };
+
+    loadStages();
+    return () => {
+      cancelled = true;
+    };
+  }, [selection.pipelineId]);
+
+  const handlePipelineChange = (value: string) => {
+    const pipeline = pipelines.find(p => p.id === value);
+    onChange({
+      pipelineId: value || undefined,
+      pipelineName: pipeline?.name,
+      fromStageId: undefined,
+      fromStageName: undefined,
+      toStageId: undefined,
+      toStageName: undefined,
+    });
+  };
+
+  const handleFromStageChange = (value: string) => {
+    if (value === ANY_STAGE_VALUE) {
+      onChange({ ...selection, fromStageId: undefined, fromStageName: undefined });
+      return;
+    }
+    const stage = stages.find(s => s.id === value);
+    onChange({ ...selection, fromStageId: value || undefined, fromStageName: stage?.name });
+  };
+
+  const handleToStageChange = (value: string) => {
+    if (value === ANY_STAGE_VALUE) {
+      onChange({ ...selection, toStageId: undefined, toStageName: undefined });
+      return;
+    }
+    const stage = stages.find(s => s.id === value);
+    onChange({ ...selection, toStageId: value || undefined, toStageName: stage?.name });
+  };
+
+  const noFilters = !selection.pipelineId && !selection.fromStageId && !selection.toStageId;
+
+  return (
+    <div className="space-y-4">
+      {loadError && (
+        <FlowFeedbackBanner variant="error">
+          <span>{t('triggerComponents.pipelineStageChanged.loadErrorBanner')}</span>
+        </FlowFeedbackBanner>
+      )}
+
+      <div className="space-y-2">
+        <Label className="text-sidebar-foreground font-medium">
+          {t('triggerComponents.pipelineStageChanged.pipeline')}
+        </Label>
+        <Select
+          value={selection.pipelineId || ''}
+          onValueChange={handlePipelineChange}
+          disabled={loadingPipelines}
+        >
+          <SelectTrigger
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            aria-label={t('triggerComponents.pipelineStageChanged.pipeline')}
+          >
+            <SelectValue
+              placeholder={
+                loadingPipelines
+                  ? t('triggerComponents.pipelineStageChanged.loadingPipelines')
+                  : t('triggerComponents.pipelineStageChanged.selectPipeline')
+              }
+            />
+          </SelectTrigger>
+          <SelectContent className="bg-sidebar border-sidebar-border">
+            {pipelines.map(p => (
+              <SelectItem key={p.id} value={p.id} className="text-sidebar-foreground">
+                {p.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {!loadingPipelines && pipelines.length === 0 && !loadError && (
+          <p className="text-sm text-sidebar-foreground/60">
+            {t('triggerComponents.pipelineStageChanged.noPipelinesFound')}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sidebar-foreground font-medium">
+          {t('triggerComponents.pipelineStageChanged.fromStage')}
+        </Label>
+        <Select
+          value={selection.fromStageId || ANY_STAGE_VALUE}
+          onValueChange={handleFromStageChange}
+          disabled={!selection.pipelineId || loadingStages}
+        >
+          <SelectTrigger
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            aria-label={t('triggerComponents.pipelineStageChanged.fromStage')}
+          >
+            <SelectValue
+              placeholder={
+                loadingStages
+                  ? t('triggerComponents.pipelineStageChanged.loadingStages')
+                  : t('triggerComponents.pipelineStageChanged.anyStage')
+              }
+            />
+          </SelectTrigger>
+          <SelectContent className="bg-sidebar border-sidebar-border">
+            <SelectItem value={ANY_STAGE_VALUE} className="text-sidebar-foreground">
+              {t('triggerComponents.pipelineStageChanged.anyStage')}
+            </SelectItem>
+            {stages.map(s => (
+              <SelectItem key={s.id} value={s.id} className="text-sidebar-foreground">
+                {s.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sidebar-foreground font-medium">
+          {t('triggerComponents.pipelineStageChanged.toStage')}
+        </Label>
+        <Select
+          value={selection.toStageId || ANY_STAGE_VALUE}
+          onValueChange={handleToStageChange}
+          disabled={!selection.pipelineId || loadingStages}
+        >
+          <SelectTrigger
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            aria-label={t('triggerComponents.pipelineStageChanged.toStage')}
+          >
+            <SelectValue
+              placeholder={
+                loadingStages
+                  ? t('triggerComponents.pipelineStageChanged.loadingStages')
+                  : t('triggerComponents.pipelineStageChanged.anyStage')
+              }
+            />
+          </SelectTrigger>
+          <SelectContent className="bg-sidebar border-sidebar-border">
+            <SelectItem value={ANY_STAGE_VALUE} className="text-sidebar-foreground">
+              {t('triggerComponents.pipelineStageChanged.anyStage')}
+            </SelectItem>
+            {stages.map(s => (
+              <SelectItem key={s.id} value={s.id} className="text-sidebar-foreground">
+                {s.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {noFilters ? (
+        <FlowFeedbackBanner variant="info">
+          <div className="flex items-center gap-2">
+            <Workflow className="w-4 h-4" />
+            <span>{t('triggerComponents.pipelineStageChanged.anyStageTransition')}</span>
+          </div>
+        </FlowFeedbackBanner>
+      ) : (
+        <FlowFeedbackBanner variant="info">
+          <div className="flex items-center gap-2">
+            <Workflow className="w-4 h-4" />
+            <span>
+              {t('triggerComponents.pipelineStageChanged.summary', {
+                pipeline: selection.pipelineName || t('triggerComponents.pipelineStageChanged.anyPipeline'),
+                from: selection.fromStageName || t('triggerComponents.pipelineStageChanged.anyStage'),
+                to: selection.toStageName || t('triggerComponents.pipelineStageChanged.anyStage'),
+              })}
+            </span>
+          </div>
+        </FlowFeedbackBanner>
+      )}
+    </div>
+  );
+}

--- a/src/components/journey/nodes/trigger/components/TriggerDescription.tsx
+++ b/src/components/journey/nodes/trigger/components/TriggerDescription.tsx
@@ -24,6 +24,8 @@ export function TriggerDescription({ triggerType }: TriggerDescriptionProps) {
         return t('triggerComponents.descriptions.label');
       case 'customAttribute':
         return t('triggerComponents.descriptions.customAttribute');
+      case 'pipelineStageChanged':
+        return t('triggerComponents.descriptions.pipelineStageChanged');
       default:
         return t('triggerComponents.descriptions.selectType');
     }

--- a/src/components/journey/nodes/trigger/components/TriggerTypeSelector.tsx
+++ b/src/components/journey/nodes/trigger/components/TriggerTypeSelector.tsx
@@ -50,6 +50,9 @@ export function TriggerTypeSelector({ value, onChange }: TriggerTypeSelectorProp
           <SelectItem value="customAttribute" className="text-sidebar-foreground">
             {t('triggerComponents.types.customAttribute')}
           </SelectItem>
+          <SelectItem value="pipelineStageChanged" className="text-sidebar-foreground">
+            {t('triggerComponents.types.pipelineStageChanged')}
+          </SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/src/components/journey/nodes/trigger/components/index.ts
+++ b/src/components/journey/nodes/trigger/components/index.ts
@@ -4,6 +4,7 @@ export * from './EventBasicConfig';
 export * from './EventAdvancedConfig';
 export * from './EventConfiguration';
 export * from './LabelConfiguration';
+export * from './PipelineStageChangedConfiguration';
 export * from './SegmentConfiguration';
 export * from './TriggerDescription';
 export * from './TriggerTypeSelector';

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -108,7 +108,8 @@
           "contactCreated": "Contact Created",
           "contactUpdated": "Contact Updated",
           "label": "Label",
-          "customAttribute": "Custom Attribute"
+          "customAttribute": "Custom Attribute",
+          "pipelineStageChanged": "Pipeline Stage Changed"
         },
         "descriptions": {
           "manual": "Manual trigger",
@@ -147,7 +148,8 @@
           "daysWeek": "{{count}} day/week",
           "daysWeekPlural": "{{count}} days/week",
           "daysWeekAt": "{{count}} day/week at {{time}}",
-          "daysWeekPluralAt": "{{count}} days/week at {{time}}"
+          "daysWeekPluralAt": "{{count}} days/week at {{time}}",
+          "anyStageTransition": "Triggered on any stage transition"
         }
       },
       "wait": {
@@ -1626,7 +1628,8 @@
       "contactCreated": "Contact Created",
       "contactUpdated": "Contact Updated",
       "label": "Label",
-      "customAttribute": "Custom Attribute"
+      "customAttribute": "Custom Attribute",
+      "pipelineStageChanged": "Pipeline Stage Changed"
     },
     "descriptions": {
       "manual": "Contacts will be added manually to the journey.",
@@ -1637,6 +1640,7 @@
       "contactUpdated": "The journey will be triggered when a contact is updated. You can configure specific fields to change.",
       "label": "The journey will be triggered when a label is applied to a contact.",
       "customAttribute": "The journey will be triggered based on custom attributes of the contact.",
+      "pipelineStageChanged": "The journey will be triggered when a contact moves between pipeline stages.",
       "selectType": "Select a trigger type to see its description."
     },
     "operators": {
@@ -1688,6 +1692,21 @@
         "criado": "Created",
         "atualizado": "Updated"
       }
+    },
+    "pipelineStageChanged": {
+      "pipeline": "Pipeline",
+      "fromStage": "From stage",
+      "toStage": "To stage",
+      "selectPipeline": "Select a pipeline (optional)",
+      "loadingPipelines": "Loading pipelines...",
+      "loadingStages": "Loading stages...",
+      "noPipelinesFound": "No pipelines found in the account.",
+      "anyStage": "Any stage",
+      "anyPipeline": "any pipeline",
+      "anyStageTransition": "The journey will be triggered on any pipeline stage transition.",
+      "summary": "Triggered when a contact moves in {{pipeline}}, from {{from}} to {{to}}.",
+      "loadError": "Error loading pipelines:",
+      "loadErrorBanner": "Could not load pipelines. Check your connection and try reopening this node."
     },
     "customAttribute": {
       "configuration": "Custom Attribute Configuration",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -108,7 +108,8 @@
           "contactCreated": "Contacto Creado",
           "contactUpdated": "Contacto Actualizado",
           "label": "Etiqueta",
-          "customAttribute": "Atributo Personalizado"
+          "customAttribute": "Atributo Personalizado",
+          "pipelineStageChanged": "Etapa del Pipeline Cambiada"
         },
         "descriptions": {
           "manual": "Disparo manual",
@@ -147,7 +148,8 @@
           "daysWeek": "{{count}} día/sem",
           "daysWeekPlural": "{{count}} días/sem",
           "daysWeekAt": "{{count}} día/sem a las {{time}}",
-          "daysWeekPluralAt": "{{count}} días/sem a las {{time}}"
+          "daysWeekPluralAt": "{{count}} días/sem a las {{time}}",
+          "anyStageTransition": "Activado en cualquier transición de etapa"
         }
       },
       "wait": {
@@ -1619,7 +1621,8 @@
       "contactCreated": "Contacto Creado",
       "contactUpdated": "Contacto Actualizado",
       "label": "Etiqueta",
-      "customAttribute": "Atributo Personalizado"
+      "customAttribute": "Atributo Personalizado",
+      "pipelineStageChanged": "Etapa del Pipeline Cambiada"
     },
     "descriptions": {
       "manual": "Los contactos serán añadidos manualmente a la jornada.",
@@ -1630,6 +1633,7 @@
       "contactUpdated": "La jornada será disparada cuando un contacto sea actualizado. Puede configurar cuáles campos deben ser alterados.",
       "label": "La jornada será disparada cuando una etiqueta sea aplicada al contacto.",
       "customAttribute": "La jornada será disparada basándose en atributos personalizados del contacto.",
+      "pipelineStageChanged": "La jornada será disparada cuando un contacto cambie de etapa en el pipeline.",
       "selectType": "Seleccione un tipo de trigger para ver su descripción."
     },
     "operators": {
@@ -1681,6 +1685,21 @@
         "criado": "Creado",
         "atualizado": "Actualizado"
       }
+    },
+    "pipelineStageChanged": {
+      "pipeline": "Pipeline",
+      "fromStage": "Etapa de origen",
+      "toStage": "Etapa de destino",
+      "selectPipeline": "Selecciona un pipeline (opcional)",
+      "loadingPipelines": "Cargando pipelines...",
+      "loadingStages": "Cargando etapas...",
+      "noPipelinesFound": "Sin pipelines encontrados en la cuenta.",
+      "anyStage": "Cualquier etapa",
+      "anyPipeline": "cualquier pipeline",
+      "anyStageTransition": "La jornada se activará en cualquier transición de etapa del pipeline.",
+      "summary": "Activado cuando un contacto cambia en {{pipeline}}, de {{from}} a {{to}}.",
+      "loadError": "Error al cargar los pipelines:",
+      "loadErrorBanner": "No se pudieron cargar los pipelines. Verifica tu conexión y reabre este node."
     },
     "customAttribute": {
       "configuration": "Configuración del Atributo Personalizado",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -108,7 +108,8 @@
           "contactCreated": "Contact créé",
           "contactUpdated": "Contact mis à jour",
           "label": "Étiquette",
-          "customAttribute": "Attribut personnalisé"
+          "customAttribute": "Attribut personnalisé",
+          "pipelineStageChanged": "Étape du Pipeline Modifiée"
         },
         "descriptions": {
           "manual": "Déclenchement manuel",
@@ -147,7 +148,8 @@
           "daysWeek": "{{count}} jour/sem",
           "daysWeekPlural": "{{count}} jours/sem",
           "daysWeekAt": "{{count}} jour/sem à {{time}}",
-          "daysWeekPluralAt": "{{count}} jours/sem à {{time}}"
+          "daysWeekPluralAt": "{{count}} jours/sem à {{time}}",
+          "anyStageTransition": "Déclenché sur toute transition d'étape"
         }
       },
       "wait": {
@@ -1619,7 +1621,8 @@
       "contactCreated": "Contact créé",
       "contactUpdated": "Contact mis à jour",
       "label": "Étiquette",
-      "customAttribute": "Attribut personnalisé"
+      "customAttribute": "Attribut personnalisé",
+      "pipelineStageChanged": "Étape du Pipeline Modifiée"
     },
     "descriptions": {
       "manual": "Les contacts seront ajoutés manuellement au parcours.",
@@ -1630,6 +1633,7 @@
       "contactUpdated": "Le parcours sera déclenché lorsqu'un contact est mis à jour. Vous pouvez configurer quels champs doivent être modifiés.",
       "label": "Le parcours sera déclenché lorsqu'une étiquette est appliquée au contact.",
       "customAttribute": "Le parcours sera déclenché en fonction d'attributs personnalisés du contact.",
+      "pipelineStageChanged": "Le parcours sera déclenché lorsqu'un contact change d'étape dans le pipeline.",
       "selectType": "Sélectionnez un type de déclencheur pour voir sa description."
     },
     "operators": {
@@ -1681,6 +1685,21 @@
         "criado": "Créé",
         "atualizado": "Mis à jour"
       }
+    },
+    "pipelineStageChanged": {
+      "pipeline": "Pipeline",
+      "fromStage": "Étape d'origine",
+      "toStage": "Étape de destination",
+      "selectPipeline": "Sélectionnez un pipeline (optionnel)",
+      "loadingPipelines": "Chargement des pipelines...",
+      "loadingStages": "Chargement des étapes...",
+      "noPipelinesFound": "Aucun pipeline trouvé dans le compte.",
+      "anyStage": "Toute étape",
+      "anyPipeline": "tout pipeline",
+      "anyStageTransition": "Le parcours sera déclenché sur toute transition d'étape du pipeline.",
+      "summary": "Déclenché lorsqu'un contact change dans {{pipeline}}, de {{from}} à {{to}}.",
+      "loadError": "Erreur de chargement des pipelines:",
+      "loadErrorBanner": "Impossible de charger les pipelines. Vérifiez votre connexion et rouvrez ce node."
     },
     "customAttribute": {
       "configuration": "Configuration de l'attribut personnalisé",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -108,7 +108,8 @@
           "contactCreated": "Contatto Creato",
           "contactUpdated": "Contatto Aggiornato",
           "label": "Etichetta",
-          "customAttribute": "Attributo Personalizzato"
+          "customAttribute": "Attributo Personalizzato",
+          "pipelineStageChanged": "Stage della Pipeline Cambiato"
         },
         "descriptions": {
           "manual": "Attivazione manuale",
@@ -147,7 +148,8 @@
           "daysWeek": "{{count}} giorno/sett",
           "daysWeekPlural": "{{count}} giorni/sett",
           "daysWeekAt": "{{count}} giorno/sett alle {{time}}",
-          "daysWeekPluralAt": "{{count}} giorni/sett alle {{time}}"
+          "daysWeekPluralAt": "{{count}} giorni/sett alle {{time}}",
+          "anyStageTransition": "Attivato a qualsiasi transizione di stage"
         }
       },
       "wait": {
@@ -1631,7 +1633,8 @@
       "contactCreated": "Contatto Creato",
       "contactUpdated": "Contatto Aggiornato",
       "label": "Etichetta",
-      "customAttribute": "Attributo Personalizzato"
+      "customAttribute": "Attributo Personalizzato",
+      "pipelineStageChanged": "Stage della Pipeline Cambiato"
     },
     "descriptions": {
       "manual": "I contatti verranno aggiunti manualmente al percorso.",
@@ -1642,6 +1645,7 @@
       "contactUpdated": "Il percorso verrà attivato quando un contatto viene aggiornato. Puoi configurare quali campi devono essere modificati.",
       "label": "Il percorso verrà attivato quando un'etichetta viene applicata al contatto.",
       "customAttribute": "Il percorso verrà attivato in base agli attributi personalizzati del contatto.",
+      "pipelineStageChanged": "Il percorso verrà attivato quando un contatto cambia stage nella pipeline.",
       "selectType": "Seleziona un tipo di trigger per vedere la sua descrizione."
     },
     "operators": {
@@ -1693,6 +1697,21 @@
         "criado": "Creato",
         "atualizado": "Aggiornato"
       }
+    },
+    "pipelineStageChanged": {
+      "pipeline": "Pipeline",
+      "fromStage": "Stage di origine",
+      "toStage": "Stage di destinazione",
+      "selectPipeline": "Seleziona una pipeline (opzionale)",
+      "loadingPipelines": "Caricamento pipeline...",
+      "loadingStages": "Caricamento stage...",
+      "noPipelinesFound": "Nessuna pipeline trovata nell'account.",
+      "anyStage": "Qualsiasi stage",
+      "anyPipeline": "qualsiasi pipeline",
+      "anyStageTransition": "Il percorso sarà attivato a qualsiasi transizione di stage della pipeline.",
+      "summary": "Attivato quando un contatto cambia in {{pipeline}}, da {{from}} a {{to}}.",
+      "loadError": "Errore caricamento pipeline:",
+      "loadErrorBanner": "Impossibile caricare le pipeline. Controlla la connessione e riapri questo node."
     },
     "customAttribute": {
       "configuration": "Configurazione dell'Attributo Personalizzato",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -108,7 +108,8 @@
           "contactCreated": "Contato Criado",
           "contactUpdated": "Contato Atualizado",
           "label": "Etiqueta",
-          "customAttribute": "Atributo Personalizado"
+          "customAttribute": "Atributo Personalizado",
+          "pipelineStageChanged": "Stage do Pipeline Alterado"
         },
         "descriptions": {
           "manual": "Disparo manual",
@@ -147,7 +148,8 @@
           "daysWeek": "{{count}} dia/sem",
           "daysWeekPlural": "{{count}} dias/sem",
           "daysWeekAt": "{{count}} dia/sem às {{time}}",
-          "daysWeekPluralAt": "{{count}} dias/sem às {{time}}"
+          "daysWeekPluralAt": "{{count}} dias/sem às {{time}}",
+          "anyStageTransition": "Disparado em qualquer mudança de stage"
         }
       },
       "wait": {
@@ -1626,7 +1628,8 @@
       "contactCreated": "Contato Criado",
       "contactUpdated": "Contato Atualizado",
       "label": "Etiqueta",
-      "customAttribute": "Atributo Personalizado"
+      "customAttribute": "Atributo Personalizado",
+      "pipelineStageChanged": "Stage do Pipeline Alterado"
     },
     "descriptions": {
       "manual": "Contatos serão adicionados manualmente à jornada.",
@@ -1637,6 +1640,7 @@
       "contactUpdated": "Jornada será disparada quando um contato for atualizado. Você pode configurar quais campos devem ser alterados.",
       "label": "Jornada será disparada quando uma etiqueta for aplicada ao contato.",
       "customAttribute": "Jornada será disparada baseada em atributos personalizados do contato.",
+      "pipelineStageChanged": "Jornada será disparada quando um contato mudar de stage no pipeline.",
       "selectType": "Selecione um tipo de trigger para ver sua descrição."
     },
     "operators": {
@@ -1688,6 +1692,21 @@
         "criado": "Criado",
         "atualizado": "Atualizado"
       }
+    },
+    "pipelineStageChanged": {
+      "pipeline": "Pipeline",
+      "fromStage": "Stage de origem",
+      "toStage": "Stage de destino",
+      "selectPipeline": "Selecione um pipeline (opcional)",
+      "loadingPipelines": "Carregando pipelines...",
+      "loadingStages": "Carregando stages...",
+      "noPipelinesFound": "Nenhum pipeline encontrado na conta.",
+      "anyStage": "Qualquer stage",
+      "anyPipeline": "qualquer pipeline",
+      "anyStageTransition": "A jornada será disparada em qualquer transição de stage no pipeline.",
+      "summary": "Disparado quando um contato muda em {{pipeline}}, de {{from}} para {{to}}.",
+      "loadError": "Erro ao carregar pipelines:",
+      "loadErrorBanner": "Não foi possível carregar os pipelines. Verifique sua conexão e reabra este node."
     },
     "customAttribute": {
       "configuration": "Configuração do Atributo Personalizado",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -108,7 +108,8 @@
           "contactCreated": "Contato Criado",
           "contactUpdated": "Contato Atualizado",
           "label": "Etiqueta",
-          "customAttribute": "Atributo Personalizado"
+          "customAttribute": "Atributo Personalizado",
+          "pipelineStageChanged": "Stage da Pipeline Alterado"
         },
         "descriptions": {
           "manual": "Disparo manual",
@@ -147,7 +148,8 @@
           "daysWeek": "{{count}} dia/sem",
           "daysWeekPlural": "{{count}} dias/sem",
           "daysWeekAt": "{{count}} dia/sem às {{time}}",
-          "daysWeekPluralAt": "{{count}} dias/sem às {{time}}"
+          "daysWeekPluralAt": "{{count}} dias/sem às {{time}}",
+          "anyStageTransition": "Disparado em qualquer mudança de stage"
         }
       },
       "wait": {
@@ -1619,7 +1621,8 @@
       "contactCreated": "Contato Criado",
       "contactUpdated": "Contato Atualizado",
       "label": "Etiqueta",
-      "customAttribute": "Atributo Personalizado"
+      "customAttribute": "Atributo Personalizado",
+      "pipelineStageChanged": "Stage da Pipeline Alterado"
     },
     "descriptions": {
       "manual": "Contatos serão adicionados manualmente à jornada.",
@@ -1630,6 +1633,7 @@
       "contactUpdated": "Jornada será disparada quando um contato for atualizado. Você pode configurar quais campos devem ser alterados.",
       "label": "Jornada será disparada quando uma etiqueta for aplicada ao contato.",
       "customAttribute": "Jornada será disparada baseada em atributos personalizados do contato.",
+      "pipelineStageChanged": "A jornada será disparada quando um contato mudar de stage na pipeline.",
       "selectType": "Selecione um tipo de trigger para ver sua descrição."
     },
     "operators": {
@@ -1681,6 +1685,21 @@
         "criado": "Criado",
         "atualizado": "Atualizado"
       }
+    },
+    "pipelineStageChanged": {
+      "pipeline": "Pipeline",
+      "fromStage": "Stage de origem",
+      "toStage": "Stage de destino",
+      "selectPipeline": "Selecione uma pipeline (opcional)",
+      "loadingPipelines": "A carregar pipelines...",
+      "loadingStages": "A carregar stages...",
+      "noPipelinesFound": "Nenhuma pipeline encontrada na conta.",
+      "anyStage": "Qualquer stage",
+      "anyPipeline": "qualquer pipeline",
+      "anyStageTransition": "A jornada será disparada em qualquer transição de stage na pipeline.",
+      "summary": "Disparado quando um contato muda em {{pipeline}}, de {{from}} para {{to}}.",
+      "loadError": "Erro ao carregar pipelines:",
+      "loadErrorBanner": "Não foi possível carregar as pipelines. Verifique a sua ligação e reabra este node."
     },
     "customAttribute": {
       "configuration": "Configuração do Atributo Personalizado",

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -672,6 +672,12 @@ function JourneyFlowEditor() {
             webhookSecret: triggerNode.data.webhookSecret,
             webhookMethod: triggerNode.data.webhookMethod,
             expectedHeaders: triggerNode.data.expectedHeaders,
+            pipelineId: triggerNode.data.pipelineId,
+            pipelineName: triggerNode.data.pipelineName,
+            fromStageId: triggerNode.data.fromStageId,
+            fromStageName: triggerNode.data.fromStageName,
+            toStageId: triggerNode.data.toStageId,
+            toStageName: triggerNode.data.toStageName,
           },
         }));
 


### PR DESCRIPTION
## Summary

Adds a new **Pipeline Stage Changed** trigger variant to the Customer Journey canvas. Users can now configure a journey to fire when a contact moves between stages of a pipeline — with optional filters for pipeline, from-stage, and to-stage. Companion to backend changes in `evo-ai-crm-community` (publisher) and `evo-flow` (manifest entry).

## Scope note (reinterpretation of card text)

The card description asked for a brand-new node `<PipelineStageChangedTrigger>` under `src/components/journey/nodes/trigger/`. After **EVO-1271** shipped, the trigger area uses a single `journey-trigger-node` with `triggerType` variants (manual / event / segment / webhook / contactCreated / contactUpdated / label / customAttribute). This PR adds a **9th variant** `'pipelineStageChanged'` with a specialised cascading-dropdown panel — matches the UX the card prescribed (pipeline + from/to selectors) but fits the post-EVO-1271 architecture instead of inventing a parallel node type.

## Changes

- `JourneyTriggerNode.tsx`: extend `triggerType` union with `'pipelineStageChanged'`; add `pipelineId`/`pipelineName`/`fromStageId`/`fromStageName`/`toStageId`/`toStageName` to `JourneyTriggerNodeData`; add canvas-card label + description cases.
- `components/PipelineStageChangedConfiguration.tsx` (new): cascading panel — pipeline dropdown (loads via `pipelinesService.getPipelines`), then from/to stage dropdowns (cascading via `pipelinesService.getPipelineStages(pipelineId)`). Each stage select offers an explicit \"Any stage\" sentinel so the user can leave it empty. Error banner on fetch failure. Info banner summarises the active filter (or \"any stage transition\" when all three are empty).
- `JourneyTriggerPanel.tsx`: wire the new variant into the panel state machine + save handler; hard-set `eventName = 'pipeline.stage_changed'` on save so the journey runtime can match by event name.
- `TriggerTypeSelector.tsx` / `TriggerDescription.tsx` / `components/index.ts`: register the new variant.
- i18n: new keys under `flowEditor.nodes.trigger.types.pipelineStageChanged` + `flowEditor.nodes.trigger.descriptions.anyStageTransition` + the full `triggerComponents.pipelineStageChanged.*` block, added to all 6 locales (en, pt-BR, pt, es, fr, it).
- `journey-parity.spec.ts`: whitelist `Pipeline` and `Pipeline #{{pipelineId}}` (CRM convention used identically across pt-BR and en, same as EVO-1265 already established).

## Security

- Pipelines/stages data fetched via the existing authenticated `pipelinesService` — same auth surface as the rest of the journey UI. No new endpoints, no new auth flow.
- No `dangerouslySetInnerHTML`; no `any` introduced in new code.

## Test plan

- `pnpm exec tsc -b --noEmit` — exit 0
- `pnpm exec vitest run src/components/journey/nodes/trigger src/i18n/locales/journey-parity.spec.ts` — 36/36 (7 new specs in `PipelineStageChangedConfiguration.spec.tsx` covering pipeline load, cascade, save shape, empty/error states, plus pre-existing trigger + i18n parity tests)
- Manual smoke confirmed locally — selecting `pipelineStageChanged`, picking pipeline + from + to, saving the journey, then moving a conversation between those stages in the kanban: the CRM publishes `pipeline.stage_changed` to evo-flow (`[EvoFlow] published path=/events/track` log) and the receiver acknowledges it (`[api] Received track event: pipeline.stage_changed`).

## Known limitations (out of scope — same setup gaps documented in the CRM PR)

The full session-creation chain (event-process → journey-trigger-processor → Temporal worker) requires Kafka topic provisioning and the worker mode running. Tracked separately:

- **EVO-1200** — auto-provision Kafka topics on boot
- **EVO-1229** — sync `.env.example` and write per-mode READMEs
- **EVO-1571** — Done; established `QUEUE_MODE=direct` for Tracking, does not cover Journey

## Changed Files

- `src/components/journey/nodes/trigger/JourneyTriggerNode.tsx`
- `src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx`
- `src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.tsx` (new)
- `src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.spec.tsx` (new)
- `src/components/journey/nodes/trigger/components/TriggerDescription.tsx`
- `src/components/journey/nodes/trigger/components/TriggerTypeSelector.tsx`
- `src/components/journey/nodes/trigger/components/index.ts`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/journey.json`
- `src/i18n/locales/journey-parity.spec.ts`

## Linked Issue

- EVO-1266 — https://linear.app/evoai/issue/EVO-1266

## Related PRs

- `evo-flow` PR #16 — manifest entry: https://github.com/evolution-foundation/evo-flow/pull/16
- `evo-ai-crm-community` PR #110 — publisher + listener: https://github.com/evolution-foundation/evo-ai-crm-community/pull/110