### PR TITLE
fix(sessions): add missing Paused stat card to SessionsViewer grid (EVO-1417)

### DIFF
--- a/src/components/journey/SessionsViewer.spec.tsx
+++ b/src/components/journey/SessionsViewer.spec.tsx
@@ -62,6 +62,7 @@ describe('SessionsViewer — defensive stats handling', () => {
     expect(statCount('sessions-stat-total')).toBe('12');
     expect(statCount('sessions-stat-active')).toBe('3');
     expect(statCount('sessions-stat-waiting')).toBe('2');
+    expect(statCount('sessions-stat-paused')).toBe('1');
     expect(statCount('sessions-stat-completed')).toBe('4');
     expect(statCount('sessions-stat-failed')).toBe('1');
     expect(statCount('sessions-stat-cancelled')).toBe('1');
@@ -121,6 +122,7 @@ describe('SessionsViewer — defensive stats handling', () => {
     expect(statCount('sessions-stat-total')).toBe('5');
     expect(statCount('sessions-stat-active')).toBe('5');
     expect(statCount('sessions-stat-waiting')).toBe('0');
+    expect(statCount('sessions-stat-paused')).toBe('0');
     expect(statCount('sessions-stat-completed')).toBe('0');
     expect(statCount('sessions-stat-failed')).toBe('0');
     expect(statCount('sessions-stat-cancelled')).toBe('0');
@@ -148,6 +150,7 @@ describe('SessionsViewer — defensive stats handling', () => {
     // critically: no crash.
     expect(statCount('sessions-stat-total')).toBe('0');
     expect(statCount('sessions-stat-active')).toBe('0');
+    expect(statCount('sessions-stat-paused')).toBe('0');
   });
 
   it('does NOT render the stats grid when the stats request fails (stats stays null)', async () => {

--- a/src/components/journey/SessionsViewer.tsx
+++ b/src/components/journey/SessionsViewer.tsx
@@ -208,7 +208,7 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
         {/* Stats Cards */}
         {stats && (
           <div className="p-6 border-b border-sidebar-border" data-testid="sessions-stats-grid">
-            <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
+            <div className="grid grid-cols-2 md:grid-cols-7 gap-3">
               <Card className="bg-sidebar-accent" data-testid="sessions-stat-total">
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-sidebar-foreground">{stats.total ?? 0}</div>
@@ -225,6 +225,12 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
                 <CardContent className="p-4">
                   <div className="text-2xl font-bold text-blue-500">{stats.byStatus?.waiting ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.waiting')}</div>
+                </CardContent>
+              </Card>
+              <Card className="bg-yellow-500/10 border-yellow-500/20" data-testid="sessions-stat-paused">
+                <CardContent className="p-4">
+                  <div className="text-2xl font-bold text-yellow-500">{stats.byStatus?.paused ?? 0}</div>
+                  <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.paused')}</div>
                 </CardContent>
               </Card>
               <Card className="bg-emerald-500/10 border-emerald-500/20" data-testid="sessions-stat-completed">

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1813,6 +1813,7 @@
         "total": "Total",
         "active": "Active",
         "waiting": "Waiting",
+        "paused": "Paused",
         "completed": "Completed",
         "failed": "Failed",
         "cancelled": "Cancelled"

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1813,6 +1813,7 @@
         "total": "Total",
         "active": "Ativas",
         "waiting": "Aguardando",
+        "paused": "Pausadas",
         "completed": "Concluídas",
         "failed": "Falhas",
         "cancelled": "Canceladas"

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -1811,6 +1811,7 @@
         "total": "Total",
         "active": "Ativas",
         "waiting": "Aguardando",
+        "paused": "Pausadas",
         "completed": "Concluídas",
         "failed": "Falhas",
         "cancelled": "Canceladas"


### PR DESCRIPTION
## Summary

- Adds the 7th stat card (Paused) to `SessionsViewer` so the grid mirrors all session statuses tracked by the backend; previously sessions in `paused` state were invisible in the aggregate counters.
- Inserts the card between Waiting and Completed (per AC visual ordering), uses the `yellow-500` palette from `getStatusConfig().paused`, and adds `data-testid="sessions-stat-paused"` following the EVO-1254 convention.
- Adds spec coverage in the populated, partial-byStatus, and envelope-leak regression cases.

## Scope clarifications vs Linear card

- **Grid layout UX decision**: the card offered two paths (`md:grid-cols-7` vs keep 6 cols and wrap). Chose `md:grid-cols-7` — linear horizontal at desktop, wraps as 4×2 on mobile. Matches the AC visual ordering claim.
- **i18n rescope**: the card's "Scope — outside" subscope claimed "No i18n changes". That referred to `sessions.viewer.status.paused`; the **stats** card label uses `sessions.viewer.stats.paused`, which did not exist in any locale. Added to `en` and `pt-BR` (strict parity pair enforced by `journey-parity.spec.ts`) plus `pt` (manual consistency). `es/fr/it` already have a pre-existing drift where the entire `sessions.viewer` block is absent — out of scope per parity-spec lines 63–68.

## Validation

- [x] `pnpm exec tsc -b --noEmit` — clean
- [x] `pnpm test src/components/journey/SessionsViewer` — 6/6 pass
- [x] `pnpm test src/i18n/locales/journey-parity` — 14/14 pass
- [ ] Manual smoke: open a journey with paused sessions, verify the Paused card renders with the correct count and yellow palette

## Backend dependency

`byStatus.paused` confirmed emitted by `evo-flow/src/modules/journeys/services/journey-sessions.service.ts:253-266`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a Paused sessions stat card to the SessionsViewer grid and align translations and tests with the new status.

New Features:
- Surface paused sessions as a dedicated stat card in the SessionsViewer grid, using the backend byStatus.paused count.

Bug Fixes:
- Ensure paused sessions are included in aggregated session statistics rather than being omitted from the UI.

Enhancements:
- Adjust the SessionsViewer stats grid layout to accommodate a seventh status card on desktop and mobile.

Tests:
- Extend SessionsViewer specs to cover paused-status counts across populated, partial, and failure scenarios.

Chores:
- Add the sessions.viewer.stats.paused i18n string to supported locales to label the new Paused stat card.