### PR TITLE
fix(automation): allow UUID/string ids in assign_agent & assign_team schemas

### DIFF
--- a/src/pages/Customer/Automation/registries/actionRegistry.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.ts
@@ -9,14 +9,14 @@ const labelListSchema = z.array(idValueSchema).min(1);
 
 const sendEmailToTeamSchema = z.tuple([
   z.object({
-    team_ids: z.array(z.number()).min(1),
+    team_ids: z.array(idValueSchema).min(1),
     message: z.string().min(1),
   }),
 ]);
 
-const assignTeamSchema = z.tuple([z.union([z.number(), z.null()])]);
+const assignTeamSchema = z.tuple([z.union([z.string(), z.number(), z.null()])]);
 
-const assignAgentSchema = z.tuple([z.union([z.number(), z.null()])]);
+const assignAgentSchema = z.tuple([z.union([z.string(), z.number(), z.null()])]);
 
 const sendWebhookEventSchema = z.tuple([z.string().url()]);
 


### PR DESCRIPTION
## Problem

In the **Automation** rule builder, clicking **Create** silently does nothing when the rule uses the **Assign agent** or **Assign team** action (and **Send email to team**). No request is sent, no error toast appears — the form just stays open.

Root cause: the zod schemas for these actions only accept **numeric** ids:

```ts
const assignTeamSchema  = z.tuple([z.union([z.number(), z.null()])]);
const assignAgentSchema = z.tuple([z.union([z.number(), z.null()])]);
// sendEmailToTeamSchema.team_ids: z.array(z.number())
```

But users/teams are identified by **UUID strings** in the community stack. When an agent is picked, `SelectParam` builds `action_params: ["<uuid>"]`; `z.number()` rejects the string, react-hook-form's resolver fails validation, and `handleSubmit` never runs the submit handler — so it fails silently.

This makes **Assign agent / Assign team unusable** through the UI. The backend (`evo-ai-crm-community`) accepts these rules fine (verified: an `assign_agent` rule with a UUID `action_param` is valid), so the bug is purely client-side validation.

## Fix

Accept string ids (UUIDs) in addition to numbers, consistent with `idValueSchema` already used for labels:

```ts
const assignTeamSchema  = z.tuple([z.union([z.string(), z.number(), z.null()])]);
const assignAgentSchema = z.tuple([z.union([z.string(), z.number(), z.null()])]);
// team_ids: z.array(idValueSchema).min(1)
```

## How to reproduce

1. Automations → New automation, give it a name.
2. Action = **Assign agent**, pick any agent.
3. Click **Create** → nothing happens (no network request, no toast).
4. Switch the action to **Send message** with text → saves fine (string schema).

Reproduced on `v1.0.0-rc5` (latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix automation actions (Assign agent, Assign team, Send email to team) failing client-side validation when provided UUID string IDs instead of numeric IDs.