### PR TITLE
feat(trigger): split event config into Básico/Avançado tabs (EVO-1276)

### DIFF
--- a/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
@@ -19,7 +19,7 @@ export interface JourneyTriggerNodeData {
   eventName?: string;
   eventProperties?: Array<{
     path: string;
-    operator: { type: string; value?: any };
+    operator: { type: string; value?: unknown };
   }>;
   // Configurações de segmento
   segmentId?: string;
@@ -29,7 +29,7 @@ export interface JourneyTriggerNodeData {
   contactFields?: Array<{
     field: string;
     operator: string;
-    value?: any;
+    value?: unknown;
   }>;
   // Configurações de etiqueta
   labelId?: string;
@@ -52,7 +52,7 @@ export interface JourneyTriggerNodeData {
   conditions?: Array<{
     field?: string;
     operator?: string;
-    value?: any;
+    value?: unknown;
     eventName?: string;
     segmentId?: string;
   }>;

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
@@ -1,0 +1,194 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { JourneyTriggerPanel } from './JourneyTriggerPanel';
+import type { JourneyTriggerNodeData } from './JourneyTriggerNode';
+import '@/i18n/config';
+
+// VariableInput/VariableMapping pull journey variables via this hook; stub it so
+// the panel renders without a network call.
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+function renderPanel(data: Partial<JourneyTriggerNodeData> = {}) {
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <JourneyTriggerPanel
+      nodeId="node-1"
+      data={{ label: 'Trigger', triggerType: 'event', ...data }}
+      onUpdate={onUpdate}
+      onClose={onClose}
+      journeyId="test-journey-id"
+    />,
+  );
+  return { onUpdate, onClose };
+}
+
+// In the event-tabs layout the header trigger-type <Select> is the first
+// combobox; the Básico <EventSelector> is the second.
+async function selectEvent(user: ReturnType<typeof userEvent.setup>, label: RegExp) {
+  const comboboxes = screen.getAllByRole('combobox');
+  await user.click(comboboxes[1]);
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(label));
+}
+
+describe('JourneyTriggerPanel — event trigger tabs (EVO-1276)', () => {
+  it('AC1: opens in tabs mode with Básico active and the trigger-type selector in the header above the tabs', () => {
+    renderPanel();
+
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toBeTruthy();
+
+    // Básico tab active, with the event selector visible.
+    const basicTab = screen.getByRole('tab', { name: /Basic|Básico|Base|Basique/ });
+    expect(basicTab.getAttribute('aria-selected')).toBe('true');
+
+    // Header trigger-type selector sits ABOVE the tablist in document order.
+    const comboboxes = screen.getAllByRole('combobox');
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2);
+    const typeSelector = comboboxes[0];
+    expect(typeSelector.compareDocumentPosition(tablist) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('AC2: shows a count badge on Avançado when variable mappings exist and none when empty', () => {
+    renderPanel({
+      variableMappings: [{ id: 'm1', sourcePath: 'event.id', variableName: 'foo' }],
+    });
+    const badge = screen.getByLabelText(
+      /advanced data configured|configuração avançada preenchida|datos avanzados configurados|données avancées configurées|dati avanzati configurati/i,
+    );
+    expect(badge).toBeTruthy();
+    expect(badge.textContent).toContain('1');
+  });
+
+  it('AC2: shows no badge on Avançado when there are no variable mappings', () => {
+    renderPanel();
+    expect(
+      screen.queryByLabelText(
+        /advanced data configured|configuração avançada preenchida|datos avanzados configurados|données avancées configurées|dati avanzati configurati/i,
+      ),
+    ).toBeNull();
+  });
+
+  it('M1: an empty/placeholder mapping row does not light the Avançado badge', () => {
+    renderPanel({
+      variableMappings: [{ id: 'm1', sourcePath: '', variableName: '' }],
+    });
+    expect(
+      screen.queryByLabelText(
+        /advanced data configured|configuração avançada preenchida|datos avanzados configurados|données avancées configurées|dati avanzati configurati/i,
+      ),
+    ).toBeNull();
+  });
+
+  it('AC3: preserves entered values across a Básico→Avançado→Básico switch', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    // Enter custom mode and type a name in Básico.
+    await selectEvent(user, /custom event|evento personalizado/i);
+    const customInput = screen.getByPlaceholderText(
+      /custom event name|nome do evento custom/i,
+    ) as HTMLInputElement;
+    await user.type(customInput, 'button_clicked');
+
+    // Switch to Avançado and back.
+    await user.click(screen.getByRole('tab', { name: /Advanced|Avançado|Avanzado|Avanzato|Avancé/ }));
+    expect(screen.getByText(/capture event data|capturar dados do evento/i)).toBeTruthy();
+    await user.click(screen.getByRole('tab', { name: /Basic|Básico|Base|Basique/ }));
+
+    // Value survived via the lifted eventName.
+    expect(
+      (screen.getByPlaceholderText(/custom event name|nome do evento custom/i) as HTMLInputElement).value,
+    ).toBe('button_clicked');
+  });
+
+  it('F1: keeps "Custom event" mode across a tab round-trip even before a name is typed', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    // Enter custom mode but type nothing — the lifted eventName stays ''.
+    await selectEvent(user, /custom event|evento personalizado/i);
+    expect(screen.getByPlaceholderText(/custom event name|nome do evento custom/i)).toBeTruthy();
+
+    await user.click(screen.getByRole('tab', { name: /Advanced|Avançado|Avanzado|Avanzato|Avancé/ }));
+    await user.click(screen.getByRole('tab', { name: /Basic|Básico|Base|Basique/ }));
+
+    // Still in custom mode (forceMount kept EventBasicConfig mounted).
+    expect(screen.getByPlaceholderText(/custom event name|nome do evento custom/i)).toBeTruthy();
+  });
+
+  it('AC4: a basic-only config saves with eventProperties set and no variable mappings, then closes', async () => {
+    const user = userEvent.setup();
+    const { onUpdate, onClose } = renderPanel();
+
+    await selectEvent(user, /contact created|contato criado/i);
+    await user.type(screen.getByLabelText(/^id\s*\*?$/i), 'id-1');
+    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
+    expect(saved.eventProperties).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'id' }),
+        expect.objectContaining({ path: 'source' }),
+      ]),
+    );
+    expect(saved.variableMappings ?? []).toHaveLength(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('AC5: clicking Save with a required property empty while on Avançado snaps back to Básico without saving', async () => {
+    const user = userEvent.setup();
+    const { onUpdate, onClose } = renderPanel();
+
+    // Select an event with required fields but leave them empty → invalid.
+    await selectEvent(user, /contact created|contato criado/i);
+
+    // Move to Avançado, then attempt to save.
+    await user.click(screen.getByRole('tab', { name: /Advanced|Avançado|Avanzado|Avanzato|Avancé/ }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    // Bounced back to Básico; nothing persisted/closed.
+    const basicTab = screen.getByRole('tab', { name: /Basic|Básico|Base|Basique/ });
+    expect(basicTab.getAttribute('aria-selected')).toBe('true');
+    expect(onUpdate).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('AC6: selecting "Custom event" in Básico reveals the free-text custom-name input', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await selectEvent(user, /custom event|evento personalizado/i);
+    expect(
+      screen.getByPlaceholderText(/custom event name|nome do evento custom/i),
+    ).toBeTruthy();
+  });
+
+  it('AC7: a non-event trigger type renders the simple (non-tabbed) modal with its own config', () => {
+    renderPanel({ triggerType: 'segment' });
+    // No tabs at all.
+    expect(screen.queryByRole('tablist')).toBeNull();
+    expect(screen.queryByRole('tab')).toBeNull();
+    // The segment config block is rendered (proves the simple variant body, not just "no tabs").
+    expect(screen.getByText(/segment configuration|configuração de segmento|configuración de segmento|configuration du segment|configurazione segmento/i)).toBeTruthy();
+    // Trigger-type selector + Save chrome still present.
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+});

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -3,11 +3,13 @@ import { Play } from 'lucide-react';
 import { JourneyTriggerNodeData } from './JourneyTriggerNode';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { JourneyVariable } from '@/components/journey/environment-manager';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
   TriggerTypeSelector,
   TriggerDescription,
-  EventConfiguration,
+  EventBasicConfig,
+  EventAdvancedConfig,
   SegmentConfiguration,
   ContactConfiguration,
   LabelConfiguration,
@@ -51,15 +53,18 @@ export function JourneyTriggerPanel({
     data.triggerType === 'customAttribute',
   );
   const [showWebhookConfig, setShowWebhookConfig] = useState(data.triggerType === 'webhook');
-  // Required-field validity reported by EventConfiguration. True (non-blocking)
+  // Required-field validity reported by EventBasicConfig. True (non-blocking)
   // whenever the event config isn't shown, so other trigger types can always Save.
   const [eventPropsValid, setEventPropsValid] = useState(true);
+  // Active tab for the event trigger's Básico/Avançado layout (EVO-1276).
+  const [activeTab, setActiveTab] = useState<'basico' | 'avancado'>('basico');
 
   useEffect(() => {
     setFormData(data);
     setEventProperties(data.eventProperties || []);
     setContactFields(data.contactFields || []);
     if (data.triggerType !== 'event') setEventPropsValid(true);
+    setActiveTab('basico');
     setShowEventConfig(data.triggerType === 'event');
     setShowSegmentConfig(data.triggerType === 'segment');
     setShowContactConfig(['contactCreated', 'contactUpdated'].includes(data.triggerType));
@@ -69,6 +74,13 @@ export function JourneyTriggerPanel({
   }, [data]);
 
   const handleSave = () => {
+    // Event-tabs path uses an enabled Save + this guard (instead of saveDisabled)
+    // so an invalid save snaps the user back to Básico where the inline
+    // required-field error lives, rather than silently doing nothing. See EVO-1276.
+    if (showEventConfig && !eventPropsValid) {
+      setActiveTab('basico');
+      return;
+    }
     const updatedData = {
       ...formData,
       eventProperties: showEventConfig ? eventProperties : undefined,
@@ -108,6 +120,7 @@ export function JourneyTriggerPanel({
     setShowCustomAttributeConfig(value === 'customAttribute');
     setShowWebhookConfig(value === 'webhook');
     if (value !== 'event') setEventPropsValid(true);
+    setActiveTab('basico');
   };
 
   const handleEventNameChange = (name: string) => {
@@ -162,42 +175,104 @@ export function JourneyTriggerPanel({
     [formData, eventProperties, contactFields, originalData],
   );
 
+  // Count only fully-filled mappings — an empty placeholder row (added via
+  // "New Variable" but not yet completed) must NOT light the Avançado badge.
+  // Mirrors VariableMapping's own `validMappings` notion. See EVO-1276 review M1.
+  const variableMappingsCount = (formData.variableMappings ?? []).filter(
+    m => m.sourcePath && m.variableName,
+  ).length;
+
+  // Shared chrome props for both the tabs (event) and simple (other types) modals.
+  const commonModalProps = {
+    open: true as const,
+    title: t('panels.trigger.title'),
+    icon: <Play className="w-5 h-5 text-green-500" />,
+    onCancel: onClose,
+    onSave: handleSave,
+    dirty,
+    saveLabel: t('panels.actions.save'),
+    cancelLabel: t('panels.actions.cancel'),
+    savingAriaLabel: t('modal.actions.saving'),
+    contentClassName: 'max-w-[800px]',
+  };
+
+  // Event trigger type: Básico/Avançado tabs (EVO-1276). Save is enabled and the
+  // empty-required-field case is handled by handleSave's guard, so the user is
+  // bounced to Básico where the inline error is visible.
+  if (showEventConfig) {
+    const advancedBadge =
+      variableMappingsCount > 0 ? (
+        <span
+          aria-label={t('panels.trigger.tabs.advancedBadgeLabel')}
+          className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium leading-none text-primary-foreground"
+        >
+          {variableMappingsCount}
+        </span>
+      ) : undefined;
+
+    return (
+      <NodeConfigModal
+        {...commonModalProps}
+        variant="tabs"
+        value={activeTab}
+        onTabChange={value => setActiveTab(value as 'basico' | 'avancado')}
+        header={
+          <div className="space-y-4">
+            <TriggerTypeSelector value={formData.triggerType} onChange={handleTriggerTypeChange} />
+            <TriggerDescription triggerType={formData.triggerType} />
+          </div>
+        }
+        tabs={[
+          {
+            value: 'basico',
+            label: t('panels.trigger.tabs.basic'),
+            // Kept mounted so the selector's local custom-event mode survives a
+            // tab switch even before a name is typed (lifted eventName can't
+            // encode the empty-custom case). See EVO-1276 review F1.
+            forceMount: true,
+            content: (
+              <EventBasicConfig
+                eventName={formData.eventName || ''}
+                eventProperties={eventProperties}
+                onEventNameChange={handleEventNameChange}
+                onEventPropertiesChange={setEventProperties}
+                onValidityChange={setEventPropsValid}
+                journeyId={journeyId}
+              />
+            ),
+          },
+          {
+            value: 'avancado',
+            label: t('panels.trigger.tabs.advanced'),
+            badge: advancedBadge,
+            content: (
+              <div className="space-y-4">
+                <FlowFeedbackBanner variant="info" className="text-xs">
+                  {t('panels.trigger.advancedHelp')}
+                </FlowFeedbackBanner>
+                <EventAdvancedConfig
+                  eventProperties={eventProperties}
+                  variableMappings={formData.variableMappings || []}
+                  onVariableMappingsChange={mappings =>
+                    setFormData(prev => ({ ...prev, variableMappings: mappings }))
+                  }
+                  journeyId={journeyId}
+                />
+              </div>
+            ),
+          },
+        ]}
+      />
+    );
+  }
+
   return (
-    <NodeConfigModal
-      open
-      variant="simple"
-      title={t('panels.trigger.title')}
-      icon={<Play className="w-5 h-5 text-green-500" />}
-      onCancel={onClose}
-      onSave={handleSave}
-      dirty={dirty}
-      saveDisabled={showEventConfig && !eventPropsValid}
-      saveLabel={t('panels.actions.save')}
-      cancelLabel={t('panels.actions.cancel')}
-      savingAriaLabel={t('modal.actions.saving')}
-      contentClassName="max-w-[800px]"
-    >
+    <NodeConfigModal {...commonModalProps} variant="simple">
       {/* Tipo do Trigger */}
       <TriggerTypeSelector value={formData.triggerType} onChange={handleTriggerTypeChange} />
 
       {/* Descrição baseada no tipo */}
       <TriggerDescription triggerType={formData.triggerType} />
-
-      {/* Configuração de Evento */}
-      {showEventConfig && (
-        <EventConfiguration
-          eventName={formData.eventName || ''}
-          eventProperties={eventProperties}
-          onEventNameChange={handleEventNameChange}
-          onEventPropertiesChange={setEventProperties}
-          onValidityChange={setEventPropsValid}
-          variableMappings={formData.variableMappings || []}
-          onVariableMappingsChange={mappings =>
-            setFormData(prev => ({ ...prev, variableMappings: mappings }))
-          }
-          journeyId={journeyId}
-        />
-      )}
 
       {/* Configuração de Segmento */}
       {showSegmentConfig && (

--- a/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
@@ -16,7 +16,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 interface ContactField {
   field: string;
   operator: string;
-  value?: any;
+  value?: unknown;
 }
 
 interface ContactConfigurationProps {
@@ -227,7 +227,7 @@ export function ContactConfiguration({
                         {t('triggerComponents.contact.value')}
                       </Label>
                       <VariableInput
-                        value={field.value || ''}
+                        value={typeof field.value === 'string' ? field.value : ''}
                         onChange={e => updateField(index, { value: e.target.value })}
                         placeholder={t('triggerComponents.contact.enterValue')}
                         className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
@@ -279,7 +279,7 @@ export function ContactConfiguration({
                   return (
                     <li key={index}>
                       {fieldLabel} {operatorLabel.toLowerCase()}{' '}
-                      {needsValue(field.operator) && field.value && `"${field.value}"`}
+                      {needsValue(field.operator) && Boolean(field.value) && `"${String(field.value)}"`}
                     </li>
                   );
                 })}

--- a/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
@@ -99,6 +99,8 @@ export function CustomAttributeConfiguration({
     };
 
     loadAttributes();
+    // loadingAttributes is a guard flag, not an input — including it would re-run the fetch on every toggle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [t]);
 
   const selectedAttribute = availableAttributes.find(a => a.attribute_key === attributeName);

--- a/src/components/journey/nodes/trigger/components/EventAdvancedConfig.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventAdvancedConfig.spec.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { EventAdvancedConfig } from './EventAdvancedConfig';
+import type { DataMapping } from '@/components/journey/environment-manager';
+import type { EventProperty } from '@/lib/events-manifest';
+import '@/i18n/config';
+
+// useJourneyVariables hits the journey-variables endpoint via VariableSelect;
+// stub it so the advanced block renders without a network call.
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+function Harness({
+  initialEventProperties = [],
+  onVariableMappingsChange,
+}: {
+  initialEventProperties?: EventProperty[];
+  onVariableMappingsChange?: (m: DataMapping[]) => void;
+}) {
+  const [mappings, setMappings] = useState<DataMapping[]>([]);
+  return (
+    <EventAdvancedConfig
+      eventProperties={initialEventProperties}
+      variableMappings={mappings}
+      onVariableMappingsChange={next => {
+        setMappings(next);
+        onVariableMappingsChange?.(next);
+      }}
+      journeyId="test-journey-id"
+    />
+  );
+}
+
+describe('EventAdvancedConfig (EVO-1276)', () => {
+  it('renders the Capture Event Data block', () => {
+    render(<Harness />);
+    expect(
+      screen.getByText(/capture event data|capturar dados do evento/i),
+    ).toBeTruthy();
+  });
+
+  it('round-trips a new mapping through onVariableMappingsChange', async () => {
+    const onVariableMappingsChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onVariableMappingsChange={onVariableMappingsChange} />);
+
+    // Header + empty-state both expose an add button; either drives the round-trip.
+    await user.click(screen.getAllByRole('button', { name: /new|novo|nova|nouveau|nuovo/i })[0]);
+
+    const last = onVariableMappingsChange.mock.calls.at(-1)?.[0] as DataMapping[];
+    expect(last).toHaveLength(1);
+    expect(last[0]).toMatchObject({ sourcePath: '', variableName: '' });
+  });
+});

--- a/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { Label, Separator } from '@evoapi/design-system';
+import { VariableMapping, type DataMapping } from '@/components/journey/environment-manager';
+import { propertiesToRecord, type EventProperty } from '@/lib/events-manifest';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface EventAdvancedConfigProps {
+  eventProperties: EventProperty[];
+  variableMappings: DataMapping[];
+  onVariableMappingsChange: (mappings: DataMapping[]) => void;
+  journeyId?: string;
+}
+
+/**
+ * Avançado half of the event trigger config (EVO-1276): the "Capture Event Data"
+ * <VariableMapping> block. Stateless — it derives the available autocomplete
+ * `paths` from the lifted `eventProperties` and round-trips mappings through the
+ * parent. Extracted from EventConfiguration so the Avançado tab can render it
+ * without re-mounting the stateful selector that lives in EventBasicConfig.
+ */
+export function EventAdvancedConfig({
+  eventProperties,
+  variableMappings,
+  onVariableMappingsChange,
+  journeyId,
+}: EventAdvancedConfigProps) {
+  const { t } = useLanguage('journey');
+
+  const paths = useMemo(() => {
+    const basePaths = ['event.id', 'event.name', 'event.timestamp', 'event.user_id'];
+    const record = propertiesToRecord(eventProperties);
+    const propertyPaths = Object.keys(record).map((key) => `event.properties.${key}`);
+    return [...basePaths, ...propertyPaths];
+  }, [eventProperties]);
+
+  return (
+    <>
+      <Separator />
+      <div className="space-y-3">
+        <Label className="text-sm font-medium">
+          {t('triggerComponents.event.captureEventData')}
+        </Label>
+        <VariableMapping
+          mappings={variableMappings}
+          onMappingsChange={onVariableMappingsChange}
+          paths={paths}
+          journeyId={journeyId}
+          className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { EventBasicConfig } from './EventBasicConfig';
+import type { EventProperty } from '@/lib/events-manifest';
+import '@/i18n/config';
+
+// Focused coverage for the extracted Básico half (EVO-1276). The broader event
+// flow is already locked in by EventConfiguration.spec.tsx (which now drives this
+// component through composition); these tests assert the pieces this subcomponent
+// directly owns: validity reporting, the required-field marker, and the
+// preserve/clear switch dialog.
+
+interface HarnessProps {
+  initialEventName?: string;
+  initialEventProperties?: EventProperty[];
+  onEventPropertiesChange?: (props: EventProperty[]) => void;
+  onValidityChange?: (valid: boolean) => void;
+}
+
+function Harness({
+  initialEventName = '',
+  initialEventProperties = [],
+  onEventPropertiesChange,
+  onValidityChange,
+}: HarnessProps) {
+  const [eventName, setEventName] = useState(initialEventName);
+  const [eventProperties, setEventProperties] = useState<EventProperty[]>(initialEventProperties);
+  return (
+    <EventBasicConfig
+      eventName={eventName}
+      eventProperties={eventProperties}
+      onEventNameChange={setEventName}
+      onEventPropertiesChange={next => {
+        setEventProperties(next);
+        onEventPropertiesChange?.(next);
+      }}
+      onValidityChange={onValidityChange}
+      journeyId="test-journey-id"
+    />
+  );
+}
+
+async function selectEvent(user: ReturnType<typeof userEvent.setup>, label: RegExp) {
+  await user.click(screen.getAllByRole('combobox')[0]);
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(label));
+}
+
+describe('EventBasicConfig (EVO-1276)', () => {
+  it('reports validity = false with no event selected and flips to true once required fields are filled', async () => {
+    const onValidityChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onValidityChange={onValidityChange} />);
+
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+    await selectEvent(user, /contact created|contato criado/i);
+    expect(onValidityChange).toHaveBeenLastCalledWith(false); // id + source still empty
+
+    await user.type(screen.getByLabelText(/^id\s*\*?$/i), 'id-1');
+    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('renders required schema fields with a "*" marker', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await selectEvent(user, /message delivered|mensagem entregue/i);
+
+    const label = screen.getByText('message_id');
+    expect(within(label).getByText('*')).toBeTruthy();
+  });
+
+  it('prompts preserve/clear when switching events with existing values', async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+        ]}
+      />,
+    );
+
+    await selectEvent(user, /conversation created|conversa criada/i);
+    expect(
+      await screen.findByText(/preserve compatible values|preservar valores compatíveis/i),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
@@ -1,0 +1,244 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  Label,
+  Separator,
+} from '@evoapi/design-system';
+import { VariableInput } from '@/components/journey/environment-manager';
+import { EventSelector } from '@/components/journey/shared/EventSelector';
+import { EventPropertiesForm } from '@/components/journey/shared/EventPropertiesForm';
+import {
+  getEvent,
+  resolveLegacyEventName,
+  propertiesToRecord,
+  recordToProperties,
+  validateEventProperties,
+  preserveCompatibleValues,
+  type EventProperty,
+} from '@/lib/events-manifest';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface EventBasicConfigProps {
+  eventName: string;
+  eventProperties: EventProperty[];
+  onEventNameChange: (name: string) => void;
+  onEventPropertiesChange: (properties: EventProperty[]) => void;
+  // Optional: only the Flow Builder (JourneyTriggerPanel) gates Save on this.
+  // Campaigns/Wait omit it and rely on the inline required-field indicators
+  // <EventPropertiesForm> renders. See EVO-1275.
+  onValidityChange?: (valid: boolean) => void;
+  // Optional: in contexts without a journey (e.g. trigger-type Campaigns) it is
+  // omitted, so useJourneyVariables skips the fetch and the autocomplete degrades
+  // to system variables only — no 404. See EVO-1608.
+  journeyId?: string;
+}
+
+/**
+ * Básico half of the event trigger config (EVO-1276): the event selector, the
+ * custom-event free-text input, the schema-driven <EventPropertiesForm>, the
+ * preserve/clear switch dialog, and required-field validity reporting. Extracted
+ * verbatim from EventConfiguration so it can be consumed directly by the Básico
+ * tab without duplicating the stateful selector across tab subtrees.
+ */
+export function EventBasicConfig({
+  eventName,
+  eventProperties,
+  onEventNameChange,
+  onEventPropertiesChange,
+  onValidityChange,
+  journeyId,
+}: EventBasicConfigProps) {
+  const { t } = useLanguage('journey');
+
+  // selectorValue tracks which dropdown entry is rendered as selected
+  // (canonical event name OR the literal 'custom' placeholder); customName
+  // holds the free-text typed value when the user is in custom mode. The
+  // persisted `eventName` prop stays as the canonical name OR the custom
+  // string the user typed — never the literal 'custom'.
+  const [selectorValue, setSelectorValue] = useState<string>(
+    () => resolveLegacyEventName(eventName).selectorValue,
+  );
+  const [customName, setCustomName] = useState<string>(
+    () => resolveLegacyEventName(eventName).customName ?? '',
+  );
+
+  // Skip the re-derive effect when the prop is just echoing back our own
+  // onEventNameChange call. Without this, typing a name in the custom
+  // input that happens to be canonical would yank the user out of custom
+  // mode mid-keystroke.
+  const lastPushedRef = useRef<string>(eventName);
+
+  useEffect(() => {
+    if (lastPushedRef.current === eventName) return;
+    const resolved = resolveLegacyEventName(eventName);
+    setSelectorValue(resolved.selectorValue);
+    setCustomName(resolved.customName ?? '');
+    lastPushedRef.current = eventName;
+  }, [eventName]);
+
+  const isCustomMode = selectorValue === 'custom';
+  // The event identity the schema form reasons about: 'custom' in custom mode,
+  // otherwise the canonical selector value.
+  const formEventName = isCustomMode ? 'custom' : selectorValue;
+
+  // Option A bridge: the persisted shape stays the filter-condition array;
+  // derive the flat Record the form consumes WITHOUT mutating the source.
+  const record = useMemo(() => propertiesToRecord(eventProperties), [eventProperties]);
+
+  const canonicalDescription =
+    !isCustomMode && selectorValue ? getEvent(selectorValue)?.description : undefined;
+
+  // Emit validity to opted-in consumers, but only when it actually flips so we
+  // don't churn the parent's state on every keystroke.
+  const lastValidityRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    // An event trigger with no event chosen yet is not a savable config — treat
+    // the empty selection as invalid (formEventName === selectorValue, which is
+    // '' until something is picked; 'custom' once Custom is selected).
+    const valid =
+      formEventName === '' ? false : validateEventProperties(formEventName, record).valid;
+    if (lastValidityRef.current !== valid) {
+      lastValidityRef.current = valid;
+      onValidityChange?.(valid);
+    }
+  }, [formEventName, record, onValidityChange]);
+
+  // Pending event switch awaiting the user's preserve/clear decision.
+  const [pendingSwitch, setPendingSwitch] = useState<{ from: string; to: string } | null>(null);
+
+  const handleSelectorChange = ({ eventName: picked, isCustom }: { eventName: string; isCustom: boolean }) => {
+    const prevFormEvent = formEventName;
+    const nextFormEvent = isCustom ? 'custom' : picked;
+
+    // The event NAME (and selector) updates immediately so the schema reflects
+    // the new event; the properties decision is deferred to the confirm dialog.
+    if (isCustom) {
+      setSelectorValue('custom');
+      lastPushedRef.current = customName;
+      onEventNameChange(customName);
+    } else {
+      setSelectorValue(picked);
+      setCustomName('');
+      lastPushedRef.current = picked;
+      onEventNameChange(picked);
+    }
+
+    const identityChanged = prevFormEvent !== nextFormEvent;
+    const hasValues = Object.keys(record).length > 0;
+    if (identityChanged && hasValues) {
+      setPendingSwitch({ from: prevFormEvent, to: nextFormEvent });
+    }
+  };
+
+  const handleCustomNameChange = (next: string) => {
+    setCustomName(next);
+    lastPushedRef.current = next;
+    onEventNameChange(next);
+  };
+
+  const handlePropertiesRecordChange = (next: Record<string, unknown>) => {
+    onEventPropertiesChange(recordToProperties(next, eventProperties));
+  };
+
+  const handlePreserveValues = () => {
+    if (pendingSwitch) {
+      const kept = preserveCompatibleValues(record, pendingSwitch.from, pendingSwitch.to);
+      onEventPropertiesChange(recordToProperties(kept, eventProperties));
+    }
+    setPendingSwitch(null);
+  };
+
+  const handleClearValues = () => {
+    onEventPropertiesChange([]);
+    setPendingSwitch(null);
+  };
+
+  return (
+    <>
+      <Separator />
+      <div className="space-y-4">
+        <Label className="text-sidebar-foreground font-medium">
+          {t('triggerComponents.event.configuration')}
+        </Label>
+
+        {/* Nome do evento */}
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">{t('triggerComponents.event.eventName')}</Label>
+          <EventSelector
+            value={selectorValue || undefined}
+            onChange={handleSelectorChange}
+            className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+          />
+          {canonicalDescription && (
+            <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
+          )}
+          {isCustomMode && (
+            <div className="space-y-2 pt-1">
+              <Label htmlFor="custom-event-name" className="text-sm font-medium">
+                {t('triggerComponents.event.eventName')}
+              </Label>
+              <VariableInput
+                id="custom-event-name"
+                value={customName}
+                onChange={e => handleCustomNameChange(e.target.value)}
+                placeholder={t('triggerComponents.event.customEventNamePlaceholder')}
+                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                journeyId={journeyId}
+              />
+              <p className="text-xs text-amber-700 dark:text-amber-300">
+                {t('triggerComponents.event.customEventWarning')}
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Propriedades do evento */}
+        <div className="space-y-3">
+          <Label className="text-sidebar-foreground font-medium text-sm">
+            {t('triggerComponents.event.eventProperties')}
+          </Label>
+          <EventPropertiesForm
+            eventName={formEventName}
+            value={record}
+            onChange={handlePropertiesRecordChange}
+          />
+        </div>
+      </div>
+
+      {/* Preserve-compatible-values confirm on event switch */}
+      <AlertDialog
+        open={pendingSwitch !== null}
+        onOpenChange={open => {
+          // Dismissing (Esc) without an explicit choice would otherwise strand
+          // the newly-selected event with the previous event's values (incl.
+          // keys absent from the new schema). Default a dismiss to the safe
+          // Clear. Explicit Preserve/Clear close via state, not onOpenChange.
+          if (!open) handleClearValues();
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('triggerComponents.event.eventSwitch.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('triggerComponents.event.eventSwitch.body')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={handleClearValues}>
+              {t('triggerComponents.event.eventSwitch.clear')}
+            </Button>
+            <Button onClick={handlePreserveValues}>
+              {t('triggerComponents.event.eventSwitch.preserve')}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -1,28 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  Button,
-  Label,
-  Separator,
-} from '@evoapi/design-system';
-import { VariableInput, VariableMapping, type DataMapping } from '@/components/journey/environment-manager';
-import { EventSelector } from '@/components/journey/shared/EventSelector';
-import { EventPropertiesForm } from '@/components/journey/shared/EventPropertiesForm';
-import {
-  getEvent,
-  resolveLegacyEventName,
-  propertiesToRecord,
-  recordToProperties,
-  validateEventProperties,
-  preserveCompatibleValues,
-  type EventProperty,
-} from '@/lib/events-manifest';
-import { useLanguage } from '@/hooks/useLanguage';
+import { type DataMapping } from '@/components/journey/environment-manager';
+import { type EventProperty } from '@/lib/events-manifest';
+import { EventBasicConfig } from './EventBasicConfig';
+import { EventAdvancedConfig } from './EventAdvancedConfig';
 
 interface EventConfigurationProps {
   eventName: string;
@@ -41,6 +20,17 @@ interface EventConfigurationProps {
   journeyId?: string;
 }
 
+/**
+ * Composes the Básico (selector + properties) and Avançado (Capture Event Data)
+ * halves into one stacked block. The Flow Builder's tabbed layout (EVO-1276)
+ * consumes <EventBasicConfig> / <EventAdvancedConfig> directly per tab; the
+ * Campaigns/Wait (section="all") contexts keep using THIS composed component, so
+ * its public signature and visible layout are preserved. (One source-order nuance:
+ * the event-switch <AlertDialog> now lives inside EventBasicConfig, so it sits
+ * before the Avançado block in the tree — but it is portal-rendered and inert
+ * when closed, so the rendered output is unchanged.) The Avançado half renders
+ * only when `onVariableMappingsChange` is provided.
+ */
 export function EventConfiguration({
   eventName,
   eventProperties,
@@ -51,216 +41,26 @@ export function EventConfiguration({
   onVariableMappingsChange,
   journeyId,
 }: EventConfigurationProps) {
-  const { t } = useLanguage('journey');
-
-  // selectorValue tracks which dropdown entry is rendered as selected
-  // (canonical event name OR the literal 'custom' placeholder); customName
-  // holds the free-text typed value when the user is in custom mode. The
-  // persisted `eventName` prop stays as the canonical name OR the custom
-  // string the user typed — never the literal 'custom'.
-  const [selectorValue, setSelectorValue] = useState<string>(
-    () => resolveLegacyEventName(eventName).selectorValue,
-  );
-  const [customName, setCustomName] = useState<string>(
-    () => resolveLegacyEventName(eventName).customName ?? '',
-  );
-
-  // Skip the re-derive effect when the prop is just echoing back our own
-  // onEventNameChange call. Without this, typing a name in the custom
-  // input that happens to be canonical would yank the user out of custom
-  // mode mid-keystroke.
-  const lastPushedRef = useRef<string>(eventName);
-
-  useEffect(() => {
-    if (lastPushedRef.current === eventName) return;
-    const resolved = resolveLegacyEventName(eventName);
-    setSelectorValue(resolved.selectorValue);
-    setCustomName(resolved.customName ?? '');
-    lastPushedRef.current = eventName;
-  }, [eventName]);
-
-  const isCustomMode = selectorValue === 'custom';
-  // The event identity the schema form reasons about: 'custom' in custom mode,
-  // otherwise the canonical selector value.
-  const formEventName = isCustomMode ? 'custom' : selectorValue;
-
-  // Option A bridge: the persisted shape stays the filter-condition array;
-  // derive the flat Record the form consumes WITHOUT mutating the source.
-  const record = useMemo(() => propertiesToRecord(eventProperties), [eventProperties]);
-
-  const canonicalDescription =
-    !isCustomMode && selectorValue ? getEvent(selectorValue)?.description : undefined;
-
-  const generateEventPaths = () => {
-    const basePaths = ['event.id', 'event.name', 'event.timestamp', 'event.user_id'];
-    const propertyPaths = Object.keys(record).map((key) => `event.properties.${key}`);
-    return [...basePaths, ...propertyPaths];
-  };
-
-  // Emit validity to opted-in consumers, but only when it actually flips so we
-  // don't churn the parent's state on every keystroke.
-  const lastValidityRef = useRef<boolean | null>(null);
-  useEffect(() => {
-    // An event trigger with no event chosen yet is not a savable config — treat
-    // the empty selection as invalid (formEventName === selectorValue, which is
-    // '' until something is picked; 'custom' once Custom is selected).
-    const valid =
-      formEventName === '' ? false : validateEventProperties(formEventName, record).valid;
-    if (lastValidityRef.current !== valid) {
-      lastValidityRef.current = valid;
-      onValidityChange?.(valid);
-    }
-  }, [formEventName, record, onValidityChange]);
-
-  // Pending event switch awaiting the user's preserve/clear decision.
-  const [pendingSwitch, setPendingSwitch] = useState<{ from: string; to: string } | null>(null);
-
-  const handleSelectorChange = ({ eventName: picked, isCustom }: { eventName: string; isCustom: boolean }) => {
-    const prevFormEvent = formEventName;
-    const nextFormEvent = isCustom ? 'custom' : picked;
-
-    // The event NAME (and selector) updates immediately so the schema reflects
-    // the new event; the properties decision is deferred to the confirm dialog.
-    if (isCustom) {
-      setSelectorValue('custom');
-      lastPushedRef.current = customName;
-      onEventNameChange(customName);
-    } else {
-      setSelectorValue(picked);
-      setCustomName('');
-      lastPushedRef.current = picked;
-      onEventNameChange(picked);
-    }
-
-    const identityChanged = prevFormEvent !== nextFormEvent;
-    const hasValues = Object.keys(record).length > 0;
-    if (identityChanged && hasValues) {
-      setPendingSwitch({ from: prevFormEvent, to: nextFormEvent });
-    }
-  };
-
-  const handleCustomNameChange = (next: string) => {
-    setCustomName(next);
-    lastPushedRef.current = next;
-    onEventNameChange(next);
-  };
-
-  const handlePropertiesRecordChange = (next: Record<string, unknown>) => {
-    onEventPropertiesChange(recordToProperties(next, eventProperties));
-  };
-
-  const handlePreserveValues = () => {
-    if (pendingSwitch) {
-      const kept = preserveCompatibleValues(record, pendingSwitch.from, pendingSwitch.to);
-      onEventPropertiesChange(recordToProperties(kept, eventProperties));
-    }
-    setPendingSwitch(null);
-  };
-
-  const handleClearValues = () => {
-    onEventPropertiesChange([]);
-    setPendingSwitch(null);
-  };
-
   return (
     <>
-      <Separator />
-      <div className="space-y-4">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('triggerComponents.event.configuration')}
-        </Label>
-
-        {/* Nome do evento */}
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('triggerComponents.event.eventName')}</Label>
-          <EventSelector
-            value={selectorValue || undefined}
-            onChange={handleSelectorChange}
-            className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-          />
-          {canonicalDescription && (
-            <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
-          )}
-          {isCustomMode && (
-            <div className="space-y-2 pt-1">
-              <Label htmlFor="custom-event-name" className="text-sm font-medium">
-                {t('triggerComponents.event.eventName')}
-              </Label>
-              <VariableInput
-                id="custom-event-name"
-                value={customName}
-                onChange={e => handleCustomNameChange(e.target.value)}
-                placeholder={t('triggerComponents.event.customEventNamePlaceholder')}
-                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-                journeyId={journeyId}
-              />
-              <p className="text-xs text-amber-700 dark:text-amber-300">
-                {t('triggerComponents.event.customEventWarning')}
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* Propriedades do evento */}
-        <div className="space-y-3">
-          <Label className="text-sidebar-foreground font-medium text-sm">
-            {t('triggerComponents.event.eventProperties')}
-          </Label>
-          <EventPropertiesForm
-            eventName={formEventName}
-            value={record}
-            onChange={handlePropertiesRecordChange}
-          />
-        </div>
-      </div>
+      <EventBasicConfig
+        eventName={eventName}
+        eventProperties={eventProperties}
+        onEventNameChange={onEventNameChange}
+        onEventPropertiesChange={onEventPropertiesChange}
+        onValidityChange={onValidityChange}
+        journeyId={journeyId}
+      />
 
       {/* Mapeamento de Variáveis */}
       {onVariableMappingsChange && (
-        <>
-          <Separator />
-          <div className="space-y-3">
-            <Label className="text-sm font-medium">
-              {t('triggerComponents.event.captureEventData')}
-            </Label>
-            <VariableMapping
-              mappings={variableMappings}
-              onMappingsChange={onVariableMappingsChange}
-              paths={generateEventPaths()}
-              journeyId={journeyId}
-              className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
-            />
-          </div>
-        </>
+        <EventAdvancedConfig
+          eventProperties={eventProperties}
+          variableMappings={variableMappings}
+          onVariableMappingsChange={onVariableMappingsChange}
+          journeyId={journeyId}
+        />
       )}
-
-      {/* Preserve-compatible-values confirm on event switch */}
-      <AlertDialog
-        open={pendingSwitch !== null}
-        onOpenChange={open => {
-          // Dismissing (Esc) without an explicit choice would otherwise strand
-          // the newly-selected event with the previous event's values (incl.
-          // keys absent from the new schema). Default a dismiss to the safe
-          // Clear. Explicit Preserve/Clear close via state, not onOpenChange.
-          if (!open) handleClearValues();
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('triggerComponents.event.eventSwitch.title')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('triggerComponents.event.eventSwitch.body')}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <Button variant="outline" onClick={handleClearValues}>
-              {t('triggerComponents.event.eventSwitch.clear')}
-            </Button>
-            <Button onClick={handlePreserveValues}>
-              {t('triggerComponents.event.eventSwitch.preserve')}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 }

--- a/src/components/journey/nodes/trigger/components/LabelConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/LabelConfiguration.tsx
@@ -53,6 +53,8 @@ export function LabelConfiguration({
     };
 
     loadLabels();
+    // loadingLabels is a guard flag, not an input — including it would re-run the fetch on every toggle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [t]);
 
   const selectedLabel = availableLabels.find(l => l.id === labelId);

--- a/src/components/journey/nodes/trigger/components/SegmentConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/SegmentConfiguration.tsx
@@ -56,6 +56,8 @@ export function SegmentConfiguration({
     };
 
     loadSegments();
+    // loadingSegments is a guard flag, not an input — including it would re-run the fetch on every toggle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [t]);
 
   const selectedSegment = availableSegments.find(s => s.id === segmentId);

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
@@ -69,7 +69,10 @@ export function WebhookConfiguration({
     } else if (JSON.stringify(expectedHeaders) !== JSON.stringify(localHeaders)) {
       setLocalHeaders(expectedHeaders);
     }
-  }, [expectedHeaders]); // Remove localHeaders from dependencies
+    // localHeaders is intentionally excluded — it's our own mirror of expectedHeaders;
+    // including it would loop. Sync is driven solely by the incoming expectedHeaders prop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expectedHeaders]);
 
   const copyToClipboard = async (text: string) => {
     try {

--- a/src/components/journey/nodes/trigger/components/index.ts
+++ b/src/components/journey/nodes/trigger/components/index.ts
@@ -1,5 +1,7 @@
 export * from './ContactConfiguration';
 export * from './CustomAttributeConfiguration';
+export * from './EventBasicConfig';
+export * from './EventAdvancedConfig';
 export * from './EventConfiguration';
 export * from './LabelConfiguration';
 export * from './SegmentConfiguration';

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.spec.tsx
@@ -256,6 +256,149 @@ describe('NodeConfigModal — variant="tabs"', () => {
     await userEvent.click(screen.getByRole('tab', { name: 'Basic' }));
     expect((screen.getByLabelText('basic-input') as HTMLInputElement).value).toBe('changed');
   });
+
+  it('renders the optional header slot above the tablist and omits it when undefined (EVO-1276)', () => {
+    const { rerender } = render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        tabs={TABS}
+        header={<div data-testid="tabs-header">type selector</div>}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    const header = screen.getByTestId('tabs-header');
+    expect(header).toBeTruthy();
+    // The header must precede the tablist in document order.
+    const tablist = screen.getByRole('tablist');
+    expect(header.compareDocumentPosition(tablist) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    rerender(
+      <NodeConfigModal {...baseProps} variant="tabs" tabs={TABS}>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.queryByTestId('tabs-header')).toBeNull();
+  });
+
+  it('renders a tab badge inside its trigger and omits it when undefined (EVO-1276)', () => {
+    const { rerender } = render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        tabs={[
+          { value: 'basic', label: 'Basic', content: <div>basic body</div> },
+          {
+            value: 'advanced',
+            label: 'Advanced',
+            content: <div>advanced body</div>,
+            badge: <span data-testid="adv-badge">2</span>,
+          },
+        ]}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    const badge = screen.getByTestId('adv-badge');
+    expect(badge).toBeTruthy();
+    expect(within(screen.getByRole('tab', { name: /Advanced/ })).getByTestId('adv-badge')).toBeTruthy();
+
+    rerender(
+      <NodeConfigModal {...baseProps} variant="tabs" tabs={TABS}>
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.queryByTestId('adv-badge')).toBeNull();
+  });
+
+  it('follows the controlled value prop and still fires onTabChange on click (EVO-1276)', async () => {
+    const onTabChange = vi.fn();
+    const { rerender } = render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        tabs={TABS}
+        value="basic"
+        onTabChange={onTabChange}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByText('basic body')).toBeTruthy();
+
+    // Driving `value` from the parent switches the visible tab.
+    rerender(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        tabs={TABS}
+        value="advanced"
+        onTabChange={onTabChange}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    expect(screen.getByText('advanced body')).toBeTruthy();
+
+    // A user click still reports the change so the parent can update `value`.
+    await userEvent.click(screen.getByRole('tab', { name: 'Basic' }));
+    expect(onTabChange).toHaveBeenCalledWith('basic');
+  });
+
+  it('keeps a forceMount tab mounted while inactive (default tabs unmount) (EVO-1276 F1)', async () => {
+    // Baseline: a default (non-forced) tab's content unmounts when inactive.
+    const { unmount } = render(
+      <NodeConfigModal {...baseProps} variant="tabs" tabs={TABS}>
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(screen.queryByText('basic body')).toBeNull();
+    unmount();
+
+    // forceMount keeps the inactive tab's content in the DOM.
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        tabs={[
+          { value: 'basic', label: 'Basic', forceMount: true, content: <div>forced basic</div> },
+          { value: 'advanced', label: 'Advanced', content: <div>advanced body</div> },
+        ]}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    await userEvent.click(screen.getByRole('tab', { name: 'Advanced' }));
+    expect(screen.getByText('advanced body')).toBeTruthy();
+    expect(screen.getByText('forced basic')).toBeTruthy();
+  });
+
+  it('AC8 backward-compat: SendWebhookPanel-style usage (uncontrolled, defaultTab, string-encoded labels, no new props) is unaffected (EVO-1276)', async () => {
+    // Mirrors SendWebhookPanel's exact prop shape: no header/value/badge/forceMount.
+    render(
+      <NodeConfigModal
+        {...baseProps}
+        variant="tabs"
+        defaultTab="basic"
+        tabs={[
+          { value: 'basic', label: 'Basic', content: <div>basic pane</div> },
+          { value: 'headers', label: 'Headers (2)', content: <div>headers pane</div> },
+          { value: 'auth', label: 'Authentication ✓', content: <div>auth pane</div> },
+        ]}
+      >
+        body
+      </NodeConfigModal>,
+    );
+    // String-encoded label markers (the existing tab-indicator convention) survive verbatim.
+    expect(screen.getByRole('tab', { name: 'Headers (2)' })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: 'Authentication ✓' })).toBeTruthy();
+    // Uncontrolled: clicking switches content with no controlling `value` prop.
+    expect(screen.getByText('basic pane')).toBeTruthy();
+    await userEvent.click(screen.getByRole('tab', { name: 'Authentication ✓' }));
+    expect(screen.getByText('auth pane')).toBeTruthy();
+  });
 });
 
 describe('NodeConfigModal — variant="disclosure"', () => {

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
@@ -22,6 +22,20 @@ export type NodeConfigModalTab = {
   value: string;
   label: string;
   content: ReactNode;
+  /**
+   * Optional indicator rendered next to the tab label (e.g. a count dot
+   * signalling "this tab has data"). Purely visual — carry any a11y text on
+   * the node itself (aria-label). Default-off: tabs that omit it render
+   * exactly as before. See EVO-1276.
+   */
+  badge?: ReactNode;
+  /**
+   * Keep this tab's content mounted (Radix `forceMount`) even while another tab
+   * is active, so local component state inside it survives tab switches.
+   * Default-off → inactive tabs unmount as before. Use sparingly: only for tabs
+   * whose local state can't be reconstructed from lifted props. See EVO-1276.
+   */
+  forceMount?: boolean;
 };
 
 type CommonProps = {
@@ -64,6 +78,18 @@ type TabsVariantProps = CommonProps & {
   tabs: NodeConfigModalTab[];
   defaultTab?: string;
   onTabChange?: (value: string) => void;
+  /**
+   * Always-visible content rendered ABOVE the tab list (e.g. a type selector
+   * that must stay reachable from any tab). Omitted → no slot, identical to the
+   * pre-EVO-1276 layout. See EVO-1276.
+   */
+  header?: ReactNode;
+  /**
+   * Drives the active tab in controlled mode. When provided, the modal honors
+   * this value (and `onTabChange` becomes the change handler); when omitted, the
+   * tabs stay uncontrolled via `defaultTab`. See EVO-1276.
+   */
+  value?: string;
 };
 
 type DisclosureProps = CommonProps & {
@@ -125,18 +151,28 @@ export function NodeConfigModal(props: NodeConfigModalProps) {
 
           {props.variant === 'tabs' ? (
             <Tabs
-              defaultValue={props.defaultTab ?? props.tabs[0]?.value}
+              {...(props.value !== undefined
+                ? { value: props.value }
+                : { defaultValue: props.defaultTab ?? props.tabs[0]?.value })}
               onValueChange={props.onTabChange}
             >
+              {props.header ? <div className="mb-4">{props.header}</div> : null}
               <TabsList className="mb-4">
                 {props.tabs.map((tab) => (
                   <TabsTrigger key={tab.value} value={tab.value}>
                     {tab.label}
+                    {tab.badge ? (
+                      <span className="ml-1.5 inline-flex items-center">{tab.badge}</span>
+                    ) : null}
                   </TabsTrigger>
                 ))}
               </TabsList>
               {props.tabs.map((tab) => (
-                <TabsContent key={tab.value} value={tab.value}>
+                <TabsContent
+                  key={tab.value}
+                  value={tab.value}
+                  {...(tab.forceMount ? { forceMount: true } : {})}
+                >
                   {tab.content}
                 </TabsContent>
               ))}

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1183,7 +1183,13 @@
       },
       "nextCondition": "next condition",
       "cancel": "Cancel",
-      "save": "Save"
+      "save": "Save",
+      "tabs": {
+        "basic": "Basic",
+        "advanced": "Advanced",
+        "advancedBadgeLabel": "Advanced data configured"
+      },
+      "advancedHelp": "Map incoming event data to flow variables so later steps can reuse it. Reference a variable anywhere with {variable} syntax."
     },
     "setVariable": {
       "title": "Configure Set Variable",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -1183,7 +1183,13 @@
       },
       "nextCondition": "next condition",
       "cancel": "Cancel",
-      "save": "Save"
+      "save": "Save",
+      "tabs": {
+        "basic": "Básico",
+        "advanced": "Avanzado",
+        "advancedBadgeLabel": "Datos avanzados configurados"
+      },
+      "advancedHelp": "Asigna los datos del evento entrante a variables del flujo para reutilizarlos en pasos posteriores. Referencia una variable con la sintaxis {variable}."
     },
     "setVariable": {
       "title": "Configure Set Variable",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -1183,7 +1183,13 @@
       },
       "nextCondition": "next condition",
       "cancel": "Cancel",
-      "save": "Save"
+      "save": "Save",
+      "tabs": {
+        "basic": "Basique",
+        "advanced": "Avancé",
+        "advancedBadgeLabel": "Données avancées configurées"
+      },
+      "advancedHelp": "Associez les données de l'événement à des variables du flux pour les réutiliser dans les étapes suivantes. Référencez une variable avec la syntaxe {variable}."
     },
     "setVariable": {
       "title": "Configure Set Variable",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -1195,7 +1195,13 @@
       },
       "nextCondition": "next condition",
       "cancel": "Cancel",
-      "save": "Save"
+      "save": "Save",
+      "tabs": {
+        "basic": "Base",
+        "advanced": "Avanzato",
+        "advancedBadgeLabel": "Dati avanzati configurati"
+      },
+      "advancedHelp": "Mappa i dati dell'evento in arrivo su variabili del flusso per riutilizzarli nei passaggi successivi. Richiama una variabile con la sintassi {variable}."
     },
     "setVariable": {
       "title": "Configure Set Variable",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1183,7 +1183,13 @@
       },
       "nextCondition": "próxima condição",
       "cancel": "Cancelar",
-      "save": "Salvar"
+      "save": "Salvar",
+      "tabs": {
+        "basic": "Básico",
+        "advanced": "Avançado",
+        "advancedBadgeLabel": "Configuração avançada preenchida"
+      },
+      "advancedHelp": "Mapeie os dados do evento recebido para variáveis do fluxo e reutilize-os em etapas seguintes. Referencie uma variável com a sintaxe {variable}."
     },
     "setVariable": {
       "title": "Configurar Definir Variável",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -1183,7 +1183,13 @@
       },
       "nextCondition": "next condition",
       "cancel": "Cancel",
-      "save": "Save"
+      "save": "Save",
+      "tabs": {
+        "basic": "Básico",
+        "advanced": "Avançado",
+        "advancedBadgeLabel": "Configuração avançada preenchida"
+      },
+      "advancedHelp": "Mapeie os dados do evento recebido para variáveis do fluxo e reutilize-os em etapas seguintes. Referencie uma variável com a sintaxe {variable}."
     },
     "setVariable": {
       "title": "Configure Set Variable",


### PR DESCRIPTION
## Summary

**Stacked sobre a EVO-1275 (#127, ainda em review).** A base desta PR é `danilocarneiro/evo-1275-event-properties-schema-form`, **não** `develop` — a 1276 depende do `EventPropertiesForm` da 1275, que ainda não está em develop. **Reaponta para `develop` quando a #127 mergear.**

Reorganiza a config do **Trigger Event** em `NodeConfigModal variant="tabs"`:
- **Básico** (default): `EventSelector` (10.6) + `EventPropertiesForm` (10.7)
- **Avançado**: Capture Event Data + mapeamentos `{variable}` + help inline (`FlowFeedbackBanner`)

Os outros 5 tipos de trigger ficam inalterados em `variant="simple"`. Frontend-only, sem mudança de shape persistido.

## Mudanças principais
- `NodeConfigModal` tabs: props opcionais **default-off** — `header` (slot pré-tabs), `value` (tab controlada), `badge` e `forceMount` por tab. `SendWebhookPanel` (único outro consumer de tabs) e os variants simple/disclosure ficam idênticos.
- `EventConfiguration` dividido em `EventBasicConfig` (selector/props/switch-dialog/validity, stateful) + `EventAdvancedConfig` (VariableMapping, stateless). O wrapper mantém a API pública p/ os contextos Campaigns/Wait.
- `JourneyTriggerPanel`: evento → tabs com Save habilitado + guard no `handleSave` (volta p/ Básico quando falta a propriedade obrigatória). O badge do Avançado conta só mapeamentos preenchidos.
- i18n: 4 chaves novas nos 6 locales (`journey-parity` verde).

## Critérios de aceite (todos atendidos)
- **AC1** — abre em tabs, Básico ativo, type-selector no header acima das tabs
- **AC2** — badge no Avançado quando há mapeamento preenchido (linha vazia não conta)
- **AC3** — estado preservado ao trocar de tab (lifted state + `forceMount` no Básico)
- **AC4** — usuário básico salva sem abrir o Avançado
- **AC5** — Save inválido estando no Avançado volta p/ Básico e não salva/fecha
- **AC6** — Custom event mostra input livre
- **AC7** — tipos não-event seguem no modal simples
- **AC8** — `SendWebhookPanel` inalterado (coberto por teste backward-compat no `NodeConfigModal.spec`)

## Findings de review já resolvidos
Duas passadas adversariais (quick-dev + code-review):
- **F1** custom-event sem nome perdia o modo ao trocar de tab → `forceMount` no Básico.
- **M1** badge contava linhas de mapeamento vazias → passa a contar só `sourcePath && variableName`.
- **M2/L1/L2** lacunas de teste cobertas (backward-compat estilo SendWebhookPanel, unit de `forceMount`, AC7 reforçado).
- F2/F8 (doc/a11y) e os demais (verificados-safe / 1 falso-positivo).

## Test plan
- [x] `pnpm exec tsc -b --noEmit`
- [x] `pnpm lint` (trigger + NodeConfigModal limpos — erros **e** warnings)
- [x] `pnpm test` `trigger/` + `NodeConfigModal/` + `journey-parity` → **91/91**
- [ ] Smoke manual no evo-flow: abrir Trigger event (Básico default), adicionar mapeamento → badge aparece, alternar tabs → valores mantidos, salvar só com Básico, limpar required no Avançado → snap p/ Básico

## Notas
- Inclui também um commit `chore(trigger)` separado limpando **lint pré-existente** em 6 arquivos vizinhos do trigger (`no-explicit-any` → `unknown` + supressões `exhaustive-deps` documentadas) — fora do escopo funcional da 1276, feito a pedido. Fácil de revisar isolado.

Closes EVO-1276
