### PR TITLE
feat(frontend): pipeline-stage condition in Journey Conditional node (EVO-1256)

### DIFF
--- a/src/components/journey/environment-manager/EnvironmentManager.tsx
+++ b/src/components/journey/environment-manager/EnvironmentManager.tsx
@@ -122,6 +122,16 @@ export const getSystemVariables = (t: any): VariableOption[] => [
     description: t('environmentManager.systemVariables.journey.currentStepDescription'),
     category: t('environmentManager.categories.journey'),
   },
+
+  // Conversa
+  {
+    value: '{{conversation.pipeline_stage_id}}',
+    label: t('environmentManager.systemVariables.conversation.pipelineStageId'),
+    description: t(
+      'environmentManager.systemVariables.conversation.pipelineStageIdDescription',
+    ),
+    category: t('environmentManager.categories.conversation'),
+  },
 ];
 
 export function EnvironmentManager({

--- a/src/components/journey/environment-manager/VariableSelect.tsx
+++ b/src/components/journey/environment-manager/VariableSelect.tsx
@@ -164,6 +164,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                   t('environmentManager.categories.event'),
                   t('environmentManager.categories.webhook'),
                   t('environmentManager.categories.journey'),
+                  t('environmentManager.categories.conversation'),
                 ].map(category => {
                   const categoryVars = SYSTEM_VARIABLES.filter(v => v.category === category);
                   if (categoryVars.length === 0) return null;

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -3,6 +3,9 @@ import { BaseFlowNode } from '@/components/base';
 import { Handle, Position, useEdges } from '@xyflow/react';
 import { cn } from '@/lib/utils';
 import { useLanguage } from '@/hooks/useLanguage';
+import { usePipelineStageNames } from '@/hooks/usePipelineStageNames';
+
+export const PIPELINE_STAGE_FIELD = '{{conversation.pipeline_stage_id}}';
 
 export interface Condition {
   id: string;
@@ -10,6 +13,8 @@ export interface Condition {
   field: string;
   operator: string;
   value: any;
+  /** Human-readable label for `value` when it is an opaque id (e.g. a pipeline stage). Display-only. */
+  valueLabel?: string;
   customVariable?: string;
 }
 
@@ -56,6 +61,11 @@ interface ConditionalNodeProps {
 export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
   const edges = useEdges();
   const { t } = useLanguage('journey');
+
+  const hasPipelineStageCondition = (data.paths || []).some(path =>
+    (path.conditions || []).some(condition => condition.field === PIPELINE_STAGE_FIELD),
+  );
+  const stageNames = usePipelineStageNames(hasPipelineStageCondition);
 
   // Verificar se um handle está conectado
   const isHandleConnected = (handleId: string) => {
@@ -221,7 +231,13 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
                   {needsValue(condition.operator) && condition.value && (
                     <>
                       {' '}
-                      <span className="text-green-700 dark:text-green-400 font-medium">"{condition.value}"</span>
+                      <span className="text-green-700 dark:text-green-400 font-medium">
+                        "
+                        {stageNames.get(condition.value) ||
+                          condition.valueLabel ||
+                          condition.value}
+                        "
+                      </span>
                     </>
                   )}
                 </div>

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -73,6 +73,9 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
       'system.current_time': t('panels.conditional.fieldLabels.systemCurrentTime'),
       'system.current_day': t('panels.conditional.fieldLabels.systemCurrentDay'),
       'system.current_date': t('panels.conditional.fieldLabels.systemCurrentDate'),
+      '{{conversation.pipeline_stage_id}}': t(
+        'panels.conditional.fieldLabels.conversationPipelineStage',
+      ),
     };
     return fieldLabels[field] || field;
   };

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
@@ -143,6 +143,7 @@ describe('ConditionalPanel — pipeline stage picker', () => {
       field: PIPELINE_STAGE_FIELD,
       operator: 'equals',
       value: 'stage-2',
+      valueLabel: '[Sales] Won',
     });
   });
 

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConditionalPanel } from './ConditionalPanel';
+import { ConditionalNodeData } from './ConditionalNode';
+import '@/i18n/config';
+
+vi.mock('@/services/pipelines/pipelinesService', () => ({
+  pipelinesService: {
+    getPipelines: vi.fn(),
+    getPipelineStages: vi.fn(),
+  },
+}));
+
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
+const mockGetPipelineStages =
+  pipelinesService.getPipelineStages as unknown as ReturnType<typeof vi.fn>;
+
+const PIPELINE_STAGE_FIELD = '{{conversation.pipeline_stage_id}}';
+
+const PIPELINES = [{ id: 'pipe-1', name: 'Sales' }];
+const STAGES = [
+  { id: 'stage-1', name: 'New' },
+  { id: 'stage-2', name: 'Won' },
+];
+
+function dataWithStageCondition(value = ''): ConditionalNodeData {
+  return {
+    paths: [
+      {
+        id: 'path-1',
+        name: 'Stage path',
+        color: 'green',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'cond-1',
+            type: 'custom',
+            field: PIPELINE_STAGE_FIELD,
+            operator: 'equals',
+            value,
+          },
+        ],
+      },
+    ],
+  } as ConditionalNodeData;
+}
+
+function dataWithContactCondition(): ConditionalNodeData {
+  return {
+    paths: [
+      {
+        id: 'path-1',
+        name: 'Contact path',
+        color: 'green',
+        logicalOperator: 'AND',
+        conditions: [
+          {
+            id: 'cond-1',
+            type: 'contact',
+            field: '{{contact.email}}',
+            operator: 'equals',
+            value: '',
+          },
+        ],
+      },
+    ],
+  } as ConditionalNodeData;
+}
+
+// The value picker is one of several comboboxes in the panel; identify it by
+// the stage placeholder it shows while no stage is selected.
+function getStageTrigger(): HTMLElement {
+  const trigger = screen
+    .getAllByRole('combobox')
+    .find(el => /select a stage|selecione um est/i.test(el.textContent || ''));
+  if (!trigger) throw new Error('stage picker trigger not found');
+  return trigger;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ConditionalPanel — pipeline stage picker', () => {
+  it('loads pipelines + stages and renders them in the value picker when the field is the pipeline stage', async () => {
+    mockGetPipelines.mockResolvedValue({ data: PIPELINES });
+    mockGetPipelineStages.mockResolvedValue({ data: STAGES });
+    const user = userEvent.setup();
+
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithStageCondition()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() => expect(mockGetPipelineStages).toHaveBeenCalledWith('pipe-1'));
+
+    await user.click(getStageTrigger());
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('[Sales] New')).toBeTruthy();
+    expect(within(listbox).getByText('[Sales] Won')).toBeTruthy();
+  });
+
+  it('persists the selected stage id (not a raw typed value) on save', async () => {
+    mockGetPipelines.mockResolvedValue({ data: PIPELINES });
+    mockGetPipelineStages.mockResolvedValue({ data: STAGES });
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithStageCondition()}
+        onUpdate={onUpdate}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() => expect(mockGetPipelineStages).toHaveBeenCalled());
+
+    await user.click(getStageTrigger());
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('[Sales] Won'));
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /save|salvar|guardar|enregistrer|salva/i,
+    });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    expect(onUpdate).toHaveBeenCalled();
+    const [, updatedData] = onUpdate.mock.calls[0];
+    expect(updatedData.paths[0].conditions[0]).toMatchObject({
+      field: PIPELINE_STAGE_FIELD,
+      operator: 'equals',
+      value: 'stage-2',
+    });
+  });
+
+  it('does not fetch pipelines when no condition uses the pipeline stage field', async () => {
+    mockGetPipelines.mockResolvedValue({ data: PIPELINES });
+
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithContactCondition()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    // Let any effects settle, then assert the lazy loader stayed gated.
+    await waitFor(() => expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0));
+    expect(mockGetPipelines).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -21,6 +21,15 @@ import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableInput, VariableSelect } from '@/components/journey/environment-manager';
 import { v4 as uuidv4 } from 'uuid';
 import { useLanguage } from '@/hooks/useLanguage';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+const PIPELINE_STAGE_FIELD = '{{conversation.pipeline_stage_id}}';
+const PIPELINE_STAGE_OPERATORS = ['equals', 'not_equals'];
+
+interface StageOption {
+  id: string;
+  label: string;
+}
 
 interface ConditionalPanelProps {
   nodeId: string;
@@ -67,6 +76,7 @@ export function ConditionalPanel({
   ];
 
   const [activePathId, setActivePathId] = useState<string>('');
+  const [stageOptions, setStageOptions] = useState<StageOption[]>([]);
 
   useEffect(() => {
     setFormData({
@@ -78,6 +88,44 @@ export function ConditionalPanel({
       setActivePathId(data.paths[0].id);
     }
   }, [data]);
+
+  const hasPipelineStageCondition = useMemo(
+    () =>
+      formData.paths.some(path =>
+        path.conditions.some(condition => condition.field === PIPELINE_STAGE_FIELD),
+      ),
+    [formData.paths],
+  );
+
+  useEffect(() => {
+    if (!hasPipelineStageCondition || stageOptions.length > 0) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const pipelinesResponse = await pipelinesService.getPipelines();
+        const pipelines = pipelinesResponse?.data ?? [];
+
+        const stagesByPipeline = await Promise.all(
+          pipelines.map(async pipeline => {
+            const stagesResponse = await pipelinesService.getPipelineStages(pipeline.id);
+            return (stagesResponse?.data ?? []).map(stage => ({
+              id: stage.id,
+              label: `[${pipeline.name}] ${stage.name}`,
+            }));
+          }),
+        );
+
+        if (!cancelled) setStageOptions(stagesByPipeline.flat());
+      } catch {
+        // Stage picker stays empty on failure; reopening the panel retries.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasPipelineStageCondition, stageOptions.length]);
 
   const handleSave = () => {
     onUpdate(nodeId, formData);
@@ -190,9 +238,27 @@ export function ConditionalPanel({
     [formData, originalData],
   );
 
+  const handleFieldChange = (pathId: string, condition: Condition, field: string) => {
+    const updates: Partial<Condition> = { field };
+    if (field === PIPELINE_STAGE_FIELD) {
+      // Pipeline-stage conditions only support id equality; reset incompatible
+      // operator/value carried over from a previous field selection.
+      if (!PIPELINE_STAGE_OPERATORS.includes(condition.operator)) {
+        updates.operator = 'equals';
+      }
+      updates.value = '';
+    }
+    updateCondition(pathId, condition.id, updates);
+  };
+
   const renderCondition = (pathId: string, condition: Condition, index: number) => {
     const path = formData.paths.find(p => p.id === pathId);
     if (!path) return null;
+
+    const isPipelineStageField = condition.field === PIPELINE_STAGE_FIELD;
+    const operatorOptions = isPipelineStageField
+      ? OPERATORS.filter(option => PIPELINE_STAGE_OPERATORS.includes(option.value))
+      : OPERATORS;
 
     return (
       <div
@@ -214,7 +280,7 @@ export function ConditionalPanel({
             <Label className="text-xs">{t('panels.conditional.field')}</Label>
             <VariableSelect
               value={condition.field || ''}
-              onValueChange={value => updateCondition(pathId, condition.id, { field: value })}
+              onValueChange={value => handleFieldChange(pathId, condition, value)}
               placeholder={t('panels.conditional.placeholders.selectVariable')}
               journeyId={journeyId}
               className="w-full"
@@ -232,7 +298,7 @@ export function ConditionalPanel({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="bg-sidebar border-sidebar-border">
-                {OPERATORS.map(option => (
+                {operatorOptions.map(option => (
                   <SelectItem
                     key={option.value}
                     value={option.value}
@@ -247,7 +313,29 @@ export function ConditionalPanel({
 
           <div className="col-span-4">
             <Label className="text-xs">{t('panels.conditional.value')}</Label>
-            {needsValue(condition.operator) ? (
+            {isPipelineStageField ? (
+              <Select
+                value={condition.value || ''}
+                onValueChange={value => updateCondition(pathId, condition.id, { value })}
+              >
+                <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+                  <SelectValue
+                    placeholder={t('panels.conditional.placeholders.selectStage')}
+                  />
+                </SelectTrigger>
+                <SelectContent className="bg-sidebar border-sidebar-border">
+                  {stageOptions.map(option => (
+                    <SelectItem
+                      key={option.id}
+                      value={option.id}
+                      className="text-sidebar-foreground"
+                    >
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : needsValue(condition.operator) ? (
               <VariableInput
                 value={condition.value || ''}
                 onChange={e => updateCondition(pathId, condition.id, { value: e.target.value })}

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -15,7 +15,12 @@ import {
   TabsTrigger,
 } from '@evoapi/design-system';
 import { GitBranch, Plus, Trash2, Copy } from 'lucide-react';
-import { ConditionalNodeData, ConditionalPath, Condition } from './ConditionalNode';
+import {
+  ConditionalNodeData,
+  ConditionalPath,
+  Condition,
+  PIPELINE_STAGE_FIELD,
+} from './ConditionalNode';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableInput, VariableSelect } from '@/components/journey/environment-manager';
@@ -23,7 +28,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { useLanguage } from '@/hooks/useLanguage';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
 
-const PIPELINE_STAGE_FIELD = '{{conversation.pipeline_stage_id}}';
 const PIPELINE_STAGE_OPERATORS = ['equals', 'not_equals'];
 
 interface StageOption {
@@ -239,7 +243,8 @@ export function ConditionalPanel({
   );
 
   const handleFieldChange = (pathId: string, condition: Condition, field: string) => {
-    const updates: Partial<Condition> = { field };
+    // Any field change invalidates a previously denormalized value label.
+    const updates: Partial<Condition> = { field, valueLabel: undefined };
     if (field === PIPELINE_STAGE_FIELD) {
       // Pipeline-stage conditions only support id equality; reset incompatible
       // operator/value carried over from a previous field selection.
@@ -316,7 +321,12 @@ export function ConditionalPanel({
             {isPipelineStageField ? (
               <Select
                 value={condition.value || ''}
-                onValueChange={value => updateCondition(pathId, condition.id, { value })}
+                onValueChange={value =>
+                  updateCondition(pathId, condition.id, {
+                    value,
+                    valueLabel: stageOptions.find(option => option.id === value)?.label,
+                  })
+                }
               >
                 <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
                   <SelectValue
@@ -338,7 +348,12 @@ export function ConditionalPanel({
             ) : needsValue(condition.operator) ? (
               <VariableInput
                 value={condition.value || ''}
-                onChange={e => updateCondition(pathId, condition.id, { value: e.target.value })}
+                onChange={e =>
+                  updateCondition(pathId, condition.id, {
+                    value: e.target.value,
+                    valueLabel: undefined,
+                  })
+                }
                 placeholder={t('panels.conditional.value')}
                 className="bg-sidebar border-sidebar-border text-sidebar-foreground"
                 journeyId={journeyId}
@@ -451,7 +466,7 @@ export function ConditionalPanel({
           </Select>
         </div>
 
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <Button variant="outline" size="sm" onClick={() => addCondition(path.id, 'trigger')}>
             <Plus className="w-4 h-4 mr-1" />
             {t('panels.conditional.trigger')}

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -245,12 +245,16 @@ export function ConditionalPanel({
   const handleFieldChange = (pathId: string, condition: Condition, field: string) => {
     // Any field change invalidates a previously denormalized value label.
     const updates: Partial<Condition> = { field, valueLabel: undefined };
+    const wasPipelineStage = condition.field === PIPELINE_STAGE_FIELD;
     if (field === PIPELINE_STAGE_FIELD) {
       // Pipeline-stage conditions only support id equality; reset incompatible
       // operator/value carried over from a previous field selection.
       if (!PIPELINE_STAGE_OPERATORS.includes(condition.operator)) {
         updates.operator = 'equals';
       }
+      updates.value = '';
+    } else if (wasPipelineStage) {
+      // Leaving the stage field: drop the stale stage id left in the value input.
       updates.value = '';
     }
     updateCondition(pathId, condition.id, updates);

--- a/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
+++ b/src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx
@@ -120,7 +120,7 @@ export function NodeConfigModal(props: NodeConfigModalProps) {
           </div>
         </DialogHeader>
 
-        <div className="px-6 py-4">
+        <div className="px-6 py-4 max-h-[70vh] overflow-y-auto">
           {props.variant === 'simple' ? props.children : null}
 
           {props.variant === 'tabs' ? (

--- a/src/hooks/usePipelineStageNames.ts
+++ b/src/hooks/usePipelineStageNames.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+type StageNameMap = Map<string, string>;
+
+// Module-level cache shared across every Conditional node on the canvas, so the
+// pipeline/stage lookup runs once instead of per node instance.
+let cache: StageNameMap | null = null;
+let inFlight: Promise<StageNameMap> | null = null;
+let cachedAt = 0;
+const CACHE_TTL = 5 * 60 * 1000;
+
+async function loadStageNames(): Promise<StageNameMap> {
+  const map: StageNameMap = new Map();
+  const pipelinesResponse = await pipelinesService.getPipelines();
+  const pipelines = pipelinesResponse?.data ?? [];
+
+  const stagesByPipeline = await Promise.all(
+    pipelines.map(async pipeline => {
+      const stagesResponse = await pipelinesService.getPipelineStages(pipeline.id);
+      return { pipeline, stages: stagesResponse?.data ?? [] };
+    }),
+  );
+
+  for (const { pipeline, stages } of stagesByPipeline) {
+    for (const stage of stages) {
+      map.set(stage.id, `[${pipeline.name}] ${stage.name}`);
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Returns a `stageId -> "[Pipeline] Stage"` map for display purposes (resolving
+ * opaque stage ids stored in conditions). Fetches lazily and only when enabled,
+ * sharing a single request across all consumers.
+ */
+export function usePipelineStageNames(enabled: boolean): StageNameMap {
+  const [map, setMap] = useState<StageNameMap>(() =>
+    cache && Date.now() - cachedAt < CACHE_TTL ? cache : new Map(),
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (cache && Date.now() - cachedAt < CACHE_TTL) {
+      setMap(cache);
+      return;
+    }
+
+    let cancelled = false;
+
+    if (!inFlight) {
+      inFlight = loadStageNames()
+        .then(result => {
+          cache = result;
+          cachedAt = Date.now();
+          return result;
+        })
+        .catch(() => new Map<string, string>());
+    }
+
+    const pending = inFlight;
+    pending.then(result => {
+      if (!cancelled) setMap(result);
+    });
+    // Allow a failed fetch to be retried by the next consumer.
+    pending.finally(() => {
+      if (inFlight === pending && !cache) inFlight = null;
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return map;
+}

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -453,6 +453,10 @@
         "currentStep": "Current Step",
         "startDateDescription": "Journey start date",
         "currentStepDescription": "Current step of the journey"
+      },
+      "conversation": {
+        "pipelineStageId": "Pipeline stage",
+        "pipelineStageIdDescription": "Current pipeline stage of the conversation"
       }
     },
     "categories": {
@@ -460,6 +464,7 @@
       "event": "Event",
       "webhook": "Webhook",
       "journey": "Journey",
+      "conversation": "Conversation",
       "others": "Others"
     },
     "form": {
@@ -948,7 +953,8 @@
         "eventProperties": "Event properties",
         "systemCurrentTime": "Current time",
         "systemCurrentDay": "Day of the week",
-        "systemCurrentDate": "Current date"
+        "systemCurrentDate": "Current date",
+        "conversationPipelineStage": "Pipeline stage"
       },
       "operators": {
         "equals": "Equals",
@@ -1018,7 +1024,8 @@
         "clickToCreateFirst": "Click on \"Add Path\" to create your first conditional path"
       },
       "placeholders": {
-        "selectVariable": "Select variable..."
+        "selectVariable": "Select variable...",
+        "selectStage": "Select a stage..."
       }
     },
     "deferConversation": {

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -453,6 +453,10 @@
         "currentStep": "Passo Atual",
         "startDateDescription": "Data de início da jornada",
         "currentStepDescription": "Passo atual da jornada"
+      },
+      "conversation": {
+        "pipelineStageId": "Estágio do pipeline",
+        "pipelineStageIdDescription": "Estágio atual do pipeline da conversa"
       }
     },
     "categories": {
@@ -460,6 +464,7 @@
       "event": "Evento",
       "webhook": "Webhook",
       "journey": "Jornada",
+      "conversation": "Conversa",
       "others": "Outros"
     },
     "form": {
@@ -948,7 +953,8 @@
         "eventProperties": "Propriedades do evento",
         "systemCurrentTime": "Hora atual",
         "systemCurrentDay": "Dia da semana",
-        "systemCurrentDate": "Data atual"
+        "systemCurrentDate": "Data atual",
+        "conversationPipelineStage": "Estágio do pipeline"
       },
       "operators": {
         "equals": "Igual a",
@@ -1018,7 +1024,8 @@
         "clickToCreateFirst": "Clique em \"Adicionar Caminho\" para criar seu primeiro caminho condicional"
       },
       "placeholders": {
-        "selectVariable": "Selecionar variável..."
+        "selectVariable": "Selecionar variável...",
+        "selectStage": "Selecione um estágio..."
       }
     },
     "deferConversation": {


### PR DESCRIPTION
## Summary
- Expose the conversation's **pipeline stage** as a selectable field in the Journey Flow Builder Conditional node, persisting `{{conversation.pipeline_stage_id}}` for evo-flow to evaluate.
- New `conversation` system-variable category (`EnvironmentManager` + `VariableSelect`); value is chosen via a **stage picker** (`[Pipeline] Stage`, lazily loaded), not a raw UUID; operators restricted to equals/not_equals.
- Node card shows the readable stage name (cached `usePipelineStageNames` lookup + denormalized `valueLabel`) instead of the raw id.
- i18n en + pt-BR.

### Post-test layout fixes (surfaced during manual validation)
- `NodeConfigModal`: scrollable body (`max-h-[70vh] overflow-y-auto`) so tall panels no longer clip fields/footer.
- `ConditionalPanel`: `flex-wrap` on the condition-type buttons row to stop horizontal overflow.

## Security
- Read-only reuse of `pipelinesService` (`GET /pipelines`, `GET /pipelines/:id/pipeline_stages`); no new endpoints. No `dangerouslySetInnerHTML`.

## Test plan
- `pnpm exec tsc -b --noEmit`
- `pnpm test` → `ConditionalPanel.spec.tsx` (picker renders loaded stages, persists the stage id + label, loader gated when no stage condition) and `NodeConfigModal.spec.tsx` (regression)
- Manual: Journey → Conditional → field "Conversa › Estágio do pipeline" → stage picker → save; node card shows `[Pipeline] Stage`.

## Changed Files
- `src/components/journey/environment-manager/EnvironmentManager.tsx`
- `src/components/journey/environment-manager/VariableSelect.tsx`
- `src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx`
- `src/components/journey/nodes/actions/conditional/ConditionalNode.tsx`
- `src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx`
- `src/components/journey/shared/NodeConfigModal/NodeConfigModal.tsx`
- `src/hooks/usePipelineStageNames.ts`
- `src/i18n/locales/{en,pt-BR}/journey.json`

## Linked Issue
- EVO-1256

## Related PRs
- evo-flow (backend evaluation): https://github.com/evolution-foundation/evo-flow/pull/18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for using the conversation pipeline stage as a condition in journey flows and improve conditional node usability and layout.

New Features:
- Expose the conversation pipeline stage as a selectable system variable in the journey conditional node.
- Provide a dedicated pipeline stage picker that loads stages from pipelines and stores the selected stage id and label in conditions.
- Display human-readable pipeline stage names on conditional node cards instead of raw ids.

Enhancements:
- Introduce a shared hook to lazily load and cache pipeline stage names across conditional nodes.
- Add a new conversation category to the environment manager variable selector.
- Make the node configuration modal body scrollable to prevent content clipping on tall panels.
- Allow conditional panel condition-type buttons to wrap to avoid horizontal overflow.

Documentation:
- Add English and Portuguese-Brazilian i18n strings for the new conversation pipeline stage field and related UI copy.

Tests:
- Add unit tests for the conditional panel pipeline stage picker, including lazy loading behavior and persistence of the selected stage.
- Extend node configuration modal tests to cover the scrollable layout behavior.