### PR TITLE
feat(frontend): add dedicated header button to toggle contact sidebar (EVO-1616)

### DIFF
--- a/src/components/chat/chat-header/ChatHeader.spec.tsx
+++ b/src/components/chat/chat-header/ChatHeader.spec.tsx
@@ -84,6 +84,8 @@ const defaultProps = {
   onBackClick: vi.fn(),
   onCloseConversation: vi.fn(),
   onContactSidebarOpen: vi.fn(),
+  isContactSidebarOpen: false,
+  onContactSidebarToggle: vi.fn(),
   onMarkAsRead: vi.fn(),
   onMarkAsUnread: vi.fn(),
   onMarkAsOpen: vi.fn(),
@@ -502,5 +504,49 @@ describe('ChatHeader pipeline', () => {
       expect(toast.error).toHaveBeenCalledWith('pipeline.moveError');
       expect(toast.error).not.toHaveBeenCalledWith('pipeline.addError');
     });
+  });
+});
+
+describe('ChatHeader contact panel', () => {
+  beforeEach(() => {
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([]);
+  });
+
+  it('keeps avatar click opening the contact sidebar (existing behavior preserved)', async () => {
+    const onContactSidebarOpen = vi.fn();
+    render(<ChatHeader {...defaultProps} onContactSidebarOpen={onContactSidebarOpen} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId('contact-avatar'));
+
+    expect(onContactSidebarOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles the contact sidebar from the dedicated header button', async () => {
+    const onContactSidebarToggle = vi.fn();
+    render(
+      <ChatHeader
+        {...defaultProps}
+        isContactSidebarOpen={false}
+        onContactSidebarToggle={onContactSidebarToggle}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'chatHeader.openContactPanel' }));
+
+    expect(onContactSidebarToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects open state through the close label on the toggle button', () => {
+    render(<ChatHeader {...defaultProps} isContactSidebarOpen />);
+
+    expect(
+      screen.getByRole('button', { name: 'chatHeader.closeContactPanel' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'chatHeader.openContactPanel' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -23,7 +23,15 @@ import {
   Archive,
   GitBranch,
   Check,
+  PanelRightOpen,
+  PanelRightClose,
 } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@evoapi/design-system/tooltip';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -53,6 +61,8 @@ interface ChatHeaderProps {
   onBackClick: () => void;
   onCloseConversation: () => void;
   onContactSidebarOpen: () => void;
+  isContactSidebarOpen: boolean;
+  onContactSidebarToggle: () => void;
   onMarkAsRead: (conversation: Conversation) => void;
   onMarkAsUnread: (conversation: Conversation) => void;
   onMarkAsOpen: (conversation: Conversation) => void;
@@ -83,6 +93,8 @@ const ChatHeader = ({
   onBackClick,
   onCloseConversation,
   onContactSidebarOpen,
+  isContactSidebarOpen,
+  onContactSidebarToggle,
   onMarkAsRead,
   onMarkAsUnread,
   onMarkAsOpen,
@@ -545,6 +557,10 @@ const ChatHeader = ({
     );
   };
 
+  const contactPanelLabel = isContactSidebarOpen
+    ? t('chatHeader.closeContactPanel')
+    : t('chatHeader.openContactPanel');
+
   return (
     <div className="flex-shrink-0 p-4 border-b bg-background/95 backdrop-blur-sm">
       <div className="flex items-center justify-between">
@@ -604,6 +620,32 @@ const ChatHeader = ({
 
           {/* Dropdown de ações da conversa */}
           {renderConversationStatusDropdown()}
+
+          {/* Botão abrir/fechar painel de contato */}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onContactSidebarToggle}
+                  aria-label={contactPanelLabel}
+                  className={
+                    isContactSidebarOpen
+                      ? 'text-primary hover:text-primary/80'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }
+                >
+                  {isContactSidebarOpen ? (
+                    <PanelRightClose className="h-4 w-4" />
+                  ) : (
+                    <PanelRightOpen className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{contactPanelLabel}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
           {/* Botão fechar conversa */}
           <Button

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -301,7 +301,9 @@
     "status": "Status:",
     "openConversation": "Open Conversation",
     "closeConversation": "Close conversation",
-    "phoneNumber": "Phone number"
+    "phoneNumber": "Phone number",
+    "openContactPanel": "Open contact details",
+    "closeContactPanel": "Close contact details"
   },
   "chatSidebar": {
     "searchPlaceholder": "Search conversations...",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -296,7 +296,9 @@
     "status": "Estado:",
     "openConversation": "Abrir Conversación",
     "closeConversation": "Cerrar conversación",
-    "phoneNumber": "Número de teléfono"
+    "phoneNumber": "Número de teléfono",
+    "openContactPanel": "Abrir detalles del contacto",
+    "closeContactPanel": "Cerrar detalles del contacto"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversaciones...",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -296,7 +296,9 @@
     "status": "Statut :",
     "openConversation": "Ouvrir la Conversation",
     "closeConversation": "Fermer la conversation",
-    "phoneNumber": "Numéro de téléphone"
+    "phoneNumber": "Numéro de téléphone",
+    "openContactPanel": "Ouvrir les détails du contact",
+    "closeContactPanel": "Fermer les détails du contact"
   },
   "chatSidebar": {
     "searchPlaceholder": "Rechercher des conversations...",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -296,7 +296,9 @@
     "status": "Stato:",
     "openConversation": "Apri Conversazione",
     "closeConversation": "Chiudi conversazione",
-    "phoneNumber": "Numero di telefono"
+    "phoneNumber": "Numero di telefono",
+    "openContactPanel": "Apri dettagli contatto",
+    "closeContactPanel": "Chiudi dettagli contatto"
   },
   "chatSidebar": {
     "searchPlaceholder": "Cerca conversazioni...",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -301,7 +301,9 @@
     "status": "Status:",
     "openConversation": "Abrir Conversa",
     "closeConversation": "Fechar conversa",
-    "phoneNumber": "Número de telefone"
+    "phoneNumber": "Número de telefone",
+    "openContactPanel": "Abrir detalhes do contato",
+    "closeContactPanel": "Fechar detalhes do contato"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversas...",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -296,7 +296,9 @@
     "status": "Status:",
     "openConversation": "Abrir Conversa",
     "closeConversation": "Fechar conversa",
-    "phoneNumber": "Número de telefone"
+    "phoneNumber": "Número de telefone",
+    "openContactPanel": "Abrir detalhes do contato",
+    "closeContactPanel": "Fechar detalhes do contato"
   },
   "chatSidebar": {
     "searchPlaceholder": "Buscar conversas...",

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -804,6 +804,8 @@ const Chat = () => {
                 onBackClick={() => setMobileView('list')}
                 onCloseConversation={handleCloseConversation}
                 onContactSidebarOpen={() => setIsContactSidebarOpen(true)}
+                isContactSidebarOpen={isContactSidebarOpen}
+                onContactSidebarToggle={() => setIsContactSidebarOpen(v => !v)}
                 onMarkAsRead={handleMarkAsRead}
                 onMarkAsUnread={handleMarkAsUnread}
                 onMarkAsOpen={handleMarkAsOpen}


### PR DESCRIPTION
## Summary
- Adds a dedicated, discoverable toggle button in the chat header (next to the close-conversation control) that opens/closes the contact details sidebar on the conversation view (`/conversations/:conversation_id`).
- Preserves the existing shortcut: clicking the contact avatar in the header still opens the sidebar.
- Button uses dynamic `PanelRightOpen` / `PanelRightClose` icons, a tooltip, and a state-aware accessible label (show/hide pattern).

## Changes
- `src/components/chat/chat-header/ChatHeader.tsx` — new `isContactSidebarOpen` + `onContactSidebarToggle` props; toggle button with tooltip and `aria-label`.
- `src/pages/Customer/Chat/Chat.tsx` — wires the new props to the existing `isContactSidebarOpen` state.
- `src/i18n/locales/{en,es,fr,it,pt,pt-BR}/chat.json` — `openContactPanel` / `closeContactPanel` keys.
- `src/components/chat/chat-header/ChatHeader.spec.tsx` — tests: toggle dispatch, preserved avatar behavior, open-state label.

## Validation
- `pnpm exec tsc -b --noEmit` — pass
- `eslint` (changed files) — pass
- `pnpm exec vitest run ChatHeader.spec.tsx Chat.spec.tsx` — 19/19 pass

## Acceptance Criteria (EVO-1616)
- [x] Dedicated button next to the close control
- [x] Clicking the button opens the contact sidebar
- [x] Avatar click still opens the sidebar (preserved)
- [x] Discoverable affordance (icon + tooltip + aria-label)
- [x] Consistent open/closed behavior (toggle)

## Linked Issue
- EVO-1616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a dedicated toggle control in the chat header to open and close the contact details sidebar while preserving existing avatar-triggered behavior.

New Features:
- Introduce a header button to toggle the contact sidebar with dynamic icons, tooltip, and accessible labeling.

Enhancements:
- Wire chat header components to the existing contact sidebar state to keep the sidebar open/closed state in sync across interactions.

Tests:
- Add unit tests to verify avatar-click behavior is preserved, the new toggle button dispatches the correct callback, and the button label reflects the open/closed state.