### PR TITLE
fix(frontend): prefetch conversation list pages before reaching the bottom (EVO-1617)

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -411,7 +411,23 @@ describe('ChatSidebar scroll pagination (EVO-1407)', () => {
     await screen.findByText('Test Contact');
 
     const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
-    setScrollDimensions(scrollEl, 800, 600, 680);
+    setScrollDimensions(scrollEl, 5000, 600, 4700);
+
+    await act(async () => { fireEvent.scroll(scrollEl); });
+
+    await waitFor(() => expect(loadMore).toHaveBeenCalledTimes(1));
+  });
+
+  it('prefetches well before reaching the bottom (CA-1b anticipated threshold)', async () => {
+    const loadMore = vi.fn().mockResolvedValue(undefined);
+    overrideContext = makePaginatedContext(true, loadMore);
+    render(<ChatSidebar {...defaultProps} />);
+    await screen.findByText('Test Contact');
+
+    const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
+    // clientHeight 600 → threshold = max(600, 900) = 900px. distanceToBottom = 700px:
+    // far beyond the old 120px gate, yet still triggers the prefetch.
+    setScrollDimensions(scrollEl, 5000, 600, 3700);
 
     await act(async () => { fireEvent.scroll(scrollEl); });
 
@@ -425,7 +441,8 @@ describe('ChatSidebar scroll pagination (EVO-1407)', () => {
     await screen.findByText('Test Contact');
 
     const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
-    setScrollDimensions(scrollEl, 800, 600, 0);
+    // distanceToBottom = 5000 - 0 - 600 = 4400px, well past the 900px threshold.
+    setScrollDimensions(scrollEl, 5000, 600, 0);
 
     await act(async () => { fireEvent.scroll(scrollEl); });
 

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -102,6 +102,12 @@ interface ChatSidebarProps {
   canBulkResolve?: boolean;
 }
 
+// Prefetch the next page well before the user reaches the end so the loading
+// state is not perceived while scrolling. Anticipated by ~1.5 viewport heights,
+// with a floor for short viewports.
+const PREFETCH_VIEWPORT_FACTOR = 1.5;
+const MIN_PREFETCH_DISTANCE_PX = 600;
+
 const ChatSidebar = ({
   mobileView,
   searchInput,
@@ -557,7 +563,11 @@ const ChatSidebar = ({
     if (!hasNextPage) return;
 
     const distanceToBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
-    if (distanceToBottom > 120) return;
+    const prefetchThreshold = Math.max(
+      MIN_PREFETCH_DISTANCE_PX,
+      container.clientHeight * PREFETCH_VIEWPORT_FACTOR,
+    );
+    if (distanceToBottom > prefetchThreshold) return;
 
     // Update throttle timestamp only after confirming we are near the bottom
     lastScrollTimeRef.current = now;


### PR DESCRIPTION
## Summary
- Replaces the fixed `120px` load-more gate in the chat sidebar with an anticipated, viewport-relative threshold (`max(600px, ~1.5 × viewport height)`), so the next page is prefetched well before the user reaches the end of the conversation list.
- Under normal network conditions the loading state is no longer perceived while scrolling.
- Existing concurrency guard (`loadingMoreRef`), `has_next_page` check, scroll-position restoration, and the loading skeleton fallback are unchanged.

## Changes
- `src/components/chat/chat-sidebar/ChatSidebar.tsx` — anticipated prefetch threshold via named constants (`PREFETCH_VIEWPORT_FACTOR`, `MIN_PREFETCH_DISTANCE_PX`).
- `src/components/chat/chat-sidebar/ChatSidebar.spec.tsx` — scroll-pagination tests updated to a taller list; new case asserting prefetch fires ~700px from the bottom (well beyond the old 120px gate).

## Validation
- `pnpm exec tsc -b --noEmit` — pass
- `eslint` (changed files) — pass
- `pnpm exec vitest run ChatSidebar.spec.tsx` — 12/12 pass

## Acceptance Criteria (EVO-1617)
- [x] Next page begins loading before the user reaches the bottom (anticipated threshold)
- [x] No duplicate/overlapping load-more requests (existing `loadingMoreRef` guard)
- [x] Pagination stops on the last page (`has_next_page` respected)
- [x] Scroll position preserved across page appends (existing restoration)
- [x] Loading indicator still appears as a fallback for slow networks

## Linked Issue
- EVO-1617

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust chat sidebar scroll pagination to prefetch conversation pages earlier based on viewport-relative thresholds.

Bug Fixes:
- Ensure the next page of conversations loads well before reaching the bottom of the chat sidebar to avoid visible loading during normal scrolling.

Tests:
- Update chat sidebar scroll pagination tests for a taller conversation list and add coverage for the new anticipated prefetch threshold behavior.