### PR TITLE
fix(frontend): pipeline stage change from conversation list context menu (EVO-1618)

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -345,6 +345,79 @@ describe('ChatSidebar pipeline', () => {
       });
     });
   });
+
+  const makeNestedPipeline = () => {
+    const item = {
+      id: 'item-99',
+      item_id: '42',
+      stage_id: 'stage-1',
+      pipeline_id: 'p1',
+      type: 'conversation',
+      is_lead: false,
+      created_at: '',
+      updated_at: '',
+    };
+    return {
+      id: 'p1',
+      name: 'Pipeline p1',
+      pipeline_type: 'custom' as const,
+      visibility: 'public' as const,
+      is_active: true,
+      stages: [
+        { id: 'stage-1', name: 'Lead', color: '#000', position: 0, created_at: '', updated_at: '', items: [item] },
+        { id: 'stage-2', name: 'Qualified', color: '#000', position: 1, created_at: '', updated_at: '', items: [] },
+      ],
+      items: [],
+      created_at: '',
+      updated_at: '',
+    };
+  };
+
+  it('moves stage via right-click when items are nested under stage.items (real API shape, EVO-1618)', async () => {
+    const pipeline = makeNestedPipeline();
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pipeline] as never);
+    vi.mocked(pipelinesService.moveItem).mockResolvedValue({ success: true, message: '' });
+
+    render(<ChatSidebar {...defaultProps} />);
+    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    await openContextMenuPipelineStage(user, 'Pipeline p1', 'Qualified');
+
+    await waitFor(() => {
+      expect(pipelinesService.moveItem).toHaveBeenCalledWith({
+        pipeline_id: 'p1',
+        item_id: 'item-99',
+        from_stage_id: 'stage-1',
+        to_stage_id: 'stage-2',
+      });
+      expect(pipelinesService.addItemToPipeline).not.toHaveBeenCalled();
+    });
+  });
+
+  it('shows moveError toast (no silent return) when the item cannot be resolved', async () => {
+    const pipeline = {
+      ...makeNestedPipeline(),
+      stages: [
+        { id: 'stage-1', name: 'Lead', color: '#000', position: 0, created_at: '', updated_at: '', items: [] },
+        { id: 'stage-2', name: 'Qualified', color: '#000', position: 1, created_at: '', updated_at: '', items: [] },
+      ],
+    };
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pipeline] as never);
+
+    render(<ChatSidebar {...defaultProps} />);
+    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    await openContextMenuPipelineStage(user, 'Pipeline p1', 'Qualified');
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('pipeline.moveError');
+      expect(pipelinesService.moveItem).not.toHaveBeenCalled();
+    });
+  });
 });
 
 const makePaginatedContext = (hasNextPage: boolean, loadMoreFn = vi.fn().mockResolvedValue(undefined)) => {

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -50,6 +50,7 @@ import {
 import { formatConversationTime, formatDetailedTime } from '@/utils/time/timeHelpers';
 import { isPhoneBearingChannel } from '@/utils/channelUtils';
 import { formatContactPhone } from '@/utils/contact/formatContactPhone';
+import { findItemInPipeline } from '@/utils/chat/pipelineUtils';
 import { ConversationSkeleton } from '../loading-states';
 import { NoConversations } from '../empty-states';
 import ContactAvatar from '../contact/ContactAvatar';
@@ -248,11 +249,12 @@ const ChatSidebar = ({
       const existingInOtherPipelines = currentPipelines.filter(p => p.id !== pipeline.id);
 
       if (existingInSamePipeline) {
-        const item = existingInSamePipeline.items?.find(
-          i => String(i.item_id) === convId,
-        );
+        const item = findItemInPipeline(existingInSamePipeline, convId);
         const itemId = item?.id;
-        if (!itemId) return;
+        if (!itemId) {
+          toast.error(t('pipeline.moveError'));
+          return;
+        }
         try {
           await pipelinesService.moveItem({
             pipeline_id: pipeline.id,
@@ -277,7 +279,7 @@ const ChatSidebar = ({
         if (existingInOtherPipelines.length > 0) {
           const removeResults = await Promise.allSettled(
             existingInOtherPipelines.map(p => {
-              const item = p.items?.find(i => String(i.item_id) === convId);
+              const item = findItemInPipeline(p, convId);
               return item?.id
                 ? pipelinesService.removeItemFromPipeline(p.id, item.id)
                 : Promise.resolve();
@@ -316,9 +318,12 @@ const ChatSidebar = ({
   const handleRemoveFromPipeline = useCallback(
     async (conversation: Conversation, pipeline: Pipeline) => {
       const convId = String(conversation.id);
-      const item = pipeline.items?.find(i => String(i.item_id) === convId);
+      const item = findItemInPipeline(pipeline, convId);
       const itemId = item?.id;
-      if (!itemId) return;
+      if (!itemId) {
+        toast.error(t('pipeline.removeError'));
+        return;
+      }
       try {
         await pipelinesService.removeItemFromPipeline(pipeline.id, itemId);
         toast.success(t('pipeline.removeSuccess'));
@@ -389,9 +394,9 @@ const ChatSidebar = ({
                   <>
                     {(pipeline.stages ?? []).map(stage => {
                       const convInThisPipeline = currentPipelines.find(p => p.id === pipeline.id);
-                      const currentItem = convInThisPipeline?.items?.find(
-                        i => String(i.item_id) === convId,
-                      );
+                      const currentItem = convInThisPipeline
+                        ? findItemInPipeline(convInThisPipeline, convId)
+                        : undefined;
                       const isCurrentStage = currentItem?.stage_id === stage.id;
 
                       return (


### PR DESCRIPTION
## Summary
- Changing a conversation's pipeline stage from the **conversation list context menu** (right-click / row dropdown) silently did nothing — no change, no toast.
- Root cause: `ChatSidebar` located the existing pipeline item only in top-level `pipeline.items`, which `GET /pipelines/by_conversation/:id` does not populate (items are nested under `stage.items`). `itemId` came back `undefined` and the handler returned early.
- The same defect affected cross-pipeline reassignment, the dedicated "remove from pipeline" action, and the current-stage checkmark indicator.

## Fix
- Replace all four top-level `.items?.find(...)` lookups in `ChatSidebar.tsx` with the shared `findItemInPipeline` helper (already used by `ChatHeader`), which searches both `pipeline.items` and `stage.items`.
- Surface an error toast on the unresolved-item paths (`moveError` / `removeError`) instead of returning silently.
- Backend verified correct (`PipelineItem#move_to_stage` persists); no backend change.

## Changes
- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/chat/chat-sidebar/ChatSidebar.spec.tsx` — +2 tests: move dispatch with items nested under `stage.items`; `moveError` toast when the item cannot be resolved.

## Validation
- `pnpm exec tsc -b --noEmit` — pass
- `eslint` (changed files) — pass
- `pnpm exec vitest run ChatSidebar.spec.tsx` — 14/14 pass

## Acceptance Criteria (EVO-1618)
- [x] Stage change via the ChatSidebar context menu persists
- [x] Item resolved via `findItemInPipeline` (handles `stage.items` nesting)
- [x] Cross-pipeline reassignment resolves items correctly
- [x] Error toast shown on unresolved item (no silent return)
- [x] Tests cover the nested-`stage.items` move path

## Linked Issue
- EVO-1618

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix pipeline stage changes from the chat sidebar context menu so conversation pipeline items are correctly located and operations no longer fail silently.

Bug Fixes:
- Ensure stage changes and cross-pipeline moves from the ChatSidebar context menu work when items are nested under stage.items instead of the top-level items array.
- Show error toasts when pipeline items cannot be resolved for move or removal instead of failing silently.
- Correct the current-stage indicator to handle items resolved from nested stage.items.

Tests:
- Add coverage for moving a conversation between stages via the context menu when pipeline items are nested under stage.items.
- Add coverage to assert an error toast is shown and no move is attempted when the pipeline item cannot be resolved.