### PR TITLE
feat(frontend): Send Canned Response journey action node (EVO-1257)

### DIFF
--- a/src/components/journey/nodes/actions/action-nodes.ts
+++ b/src/components/journey/nodes/actions/action-nodes.ts
@@ -27,6 +27,7 @@ export * from './update-custom-attribute';
 
 // Messaging
 export * from './send-message';
+export * from './send-canned-response';
 export * from './send-transcript';
 export * from './send-email-team';
 

--- a/src/components/journey/nodes/actions/send-canned-response/SendCannedResponseNode.tsx
+++ b/src/components/journey/nodes/actions/send-canned-response/SendCannedResponseNode.tsx
@@ -1,0 +1,98 @@
+import { MessageSquareReply, Settings } from 'lucide-react';
+import { BaseFlowNode } from '@/components/base';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface SendCannedResponseOption {
+  id: string;
+  label: string;
+}
+
+export interface SendCannedResponseNodeData {
+  label: string;
+  description?: string;
+  canned_response_id?: string;
+  canned_response_label?: string;
+  formDataOptions?: {
+    cannedResponses: SendCannedResponseOption[];
+  };
+}
+
+export interface SendCannedResponseNodeType {
+  id: string;
+  type: 'send-canned-response-node';
+  position: { x: number; y: number };
+  data: SendCannedResponseNodeData;
+}
+
+interface SendCannedResponseNodeProps {
+  selected: boolean;
+  data: SendCannedResponseNodeData;
+  id: string;
+}
+
+export function SendCannedResponseNode({ selected, data, id }: SendCannedResponseNodeProps) {
+  const { t } = useLanguage('journey');
+
+  const getResponseLabel = () => {
+    if (data.canned_response_label) return data.canned_response_label;
+
+    if (data.canned_response_id && data.formDataOptions?.cannedResponses) {
+      const response = data.formDataOptions.cannedResponses.find(
+        r => r.id.toString() === data.canned_response_id?.toString(),
+      );
+      return (
+        response?.label ||
+        t('flowEditor.nodes.sendCannedResponse.responseNumber', {
+          responseId: data.canned_response_id,
+        })
+      );
+    }
+
+    return t('flowEditor.nodes.sendCannedResponse.selectResponse');
+  };
+
+  const responseLabel = getResponseLabel();
+  const hasResponseSelected = !!data.canned_response_id;
+
+  return (
+    <BaseFlowNode
+      selected={selected}
+      hasTarget={true}
+      borderColor="blue"
+      isExecuting={false}
+      hasSource={true}
+      nodeId={id}
+      sourceHandleId="send-canned-response-output"
+      targetHandleId="send-canned-response-input"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center">
+            <MessageSquareReply className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-medium text-foreground truncate">
+              {t('flowEditor.nodes.sendCannedResponse.name')}
+            </h3>
+          </div>
+          <div className="flex-shrink-0">
+            <Settings className="w-3 h-3 text-muted-foreground" />
+          </div>
+        </div>
+
+        <div className="p-2 rounded-md bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
+          <p className="text-xs text-blue-800 dark:text-blue-200 leading-relaxed">
+            {hasResponseSelected ? (
+              <>
+                {t('flowEditor.nodes.sendCannedResponse.sendingResponse')}{' '}
+                <strong>{responseLabel}</strong>
+              </>
+            ) : (
+              t('flowEditor.nodes.sendCannedResponse.noResponseSelected')
+            )}
+          </p>
+        </div>
+      </div>
+    </BaseFlowNode>
+  );
+}

--- a/src/components/journey/nodes/actions/send-canned-response/SendCannedResponsePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/send-canned-response/SendCannedResponsePanel.spec.tsx
@@ -1,0 +1,199 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SendCannedResponsePanel } from './SendCannedResponsePanel';
+import { SendCannedResponseNodeData } from './SendCannedResponseNode';
+import '@/i18n/config';
+
+vi.mock('@/services/cannedResponses/cannedResponsesService', () => ({
+  cannedResponsesService: {
+    getCannedResponses: vi.fn(),
+  },
+}));
+
+import { cannedResponsesService } from '@/services/cannedResponses/cannedResponsesService';
+
+const mockGetCannedResponses = cannedResponsesService.getCannedResponses as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+const CANNED = [
+  { id: 'cr-1', short_code: 'greeting', content: 'Hi there', created_at: '' },
+  { id: 'cr-2', short_code: 'bye', content: 'Goodbye', created_at: '' },
+];
+
+function makeData(overrides: Partial<SendCannedResponseNodeData> = {}): SendCannedResponseNodeData {
+  return {
+    label: 'Send Canned Response',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SendCannedResponsePanel', () => {
+  it('shows the loading placeholder while canned responses are fetching', async () => {
+    let resolveFn: (value: unknown) => void = () => {};
+    mockGetCannedResponses.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveFn = resolve;
+        }),
+    );
+
+    render(
+      <SendCannedResponsePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('combobox')).toBeTruthy();
+
+    resolveFn({ data: CANNED });
+    await waitFor(() => expect(mockGetCannedResponses).toHaveBeenCalled());
+  });
+
+  it('renders the canned responses returned by the service inside the select', async () => {
+    mockGetCannedResponses.mockResolvedValueOnce({ data: CANNED });
+    const user = userEvent.setup();
+
+    render(
+      <SendCannedResponsePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCannedResponses).toHaveBeenCalled());
+    await user.click(screen.getByRole('combobox'));
+
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('/greeting')).toBeTruthy();
+    expect(within(listbox).getByText('/bye')).toBeTruthy();
+  });
+
+  it('keeps Save disabled until a canned response is selected, then enables it', async () => {
+    mockGetCannedResponses.mockResolvedValueOnce({ data: CANNED });
+    const user = userEvent.setup();
+
+    render(
+      <SendCannedResponsePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCannedResponses).toHaveBeenCalled());
+
+    const saveBtn = screen.getByRole('button', { name: /save|salvar|guardar|enregistrer|salva/i });
+    expect(saveBtn).toBeDisabled();
+
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('/greeting'));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /save|salvar|guardar|enregistrer|salva/i }),
+      ).not.toBeDisabled(),
+    );
+  });
+
+  it('emits onUpdate with canned_response_id + canned_response_label on save (AC1 contract)', async () => {
+    mockGetCannedResponses.mockResolvedValueOnce({ data: CANNED });
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <SendCannedResponsePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={onUpdate}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCannedResponses).toHaveBeenCalled());
+    await user.click(screen.getByRole('combobox'));
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('/bye'));
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /save|salvar|guardar|enregistrer|salva/i,
+    });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    const saveCall = onUpdate.mock.calls.find(
+      ([, payload]) => payload?.canned_response_id === 'cr-2',
+    );
+    expect(saveCall).toBeTruthy();
+    expect(saveCall?.[0]).toBe('n1');
+    expect(saveCall?.[1]).toMatchObject({
+      canned_response_id: 'cr-2',
+      canned_response_label: '/bye',
+      formDataOptions: {
+        cannedResponses: [
+          { id: 'cr-1', label: '/greeting' },
+          { id: 'cr-2', label: '/bye' },
+        ],
+      },
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows the empty-state message when zero canned responses are returned', async () => {
+    mockGetCannedResponses.mockResolvedValueOnce({ data: [] });
+
+    render(
+      <SendCannedResponsePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCannedResponses).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText(
+        /no canned responses found|nenhuma resposta r[áa]pida|no se encontraron respuestas|aucune r[ée]ponse|nessuna risposta/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('renders an error banner when the fetch fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetCannedResponses.mockRejectedValueOnce(new Error('boom'));
+
+    render(
+      <SendCannedResponsePanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    expect(
+      await screen.findByText(
+        /could not load canned responses|n[ãa]o foi poss[íi]vel carregar|no se pudieron cargar|impossible de charger|impossibile caricare/i,
+      ),
+    ).toBeTruthy();
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/journey/nodes/actions/send-canned-response/SendCannedResponsePanel.tsx
+++ b/src/components/journey/nodes/actions/send-canned-response/SendCannedResponsePanel.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Label,
+} from '@evoapi/design-system';
+import { AlertCircle, MessageSquareReply } from 'lucide-react';
+import { SendCannedResponseNodeData, SendCannedResponseOption } from './SendCannedResponseNode';
+import { cannedResponsesService } from '@/services/cannedResponses/cannedResponsesService';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { useLanguage } from '@/hooks/useLanguage';
+
+interface SendCannedResponsePanelProps {
+  nodeId: string;
+  data: SendCannedResponseNodeData;
+  onUpdate: (nodeId: string, newData: SendCannedResponseNodeData) => void;
+  onClose: () => void;
+}
+
+const buildLabel = (shortCode?: string, content?: string): string => {
+  if (shortCode) return `/${shortCode}`;
+  return (content ?? '').slice(0, 60);
+};
+
+export function SendCannedResponsePanel({
+  nodeId,
+  data,
+  onUpdate,
+  onClose,
+}: SendCannedResponsePanelProps) {
+  const { t } = useLanguage('journey');
+  const [cannedResponseId, setCannedResponseId] = useState<string>(
+    data.canned_response_id?.toString() || '',
+  );
+  const [originalCannedResponseId] = useState<string>(
+    () => data.canned_response_id?.toString() || '',
+  );
+  const [cannedResponses, setCannedResponses] = useState<SendCannedResponseOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+
+  useEffect(() => {
+    const loadCannedResponses = async () => {
+      try {
+        setLoading(true);
+        setLoadError(false);
+        const response = await cannedResponsesService.getCannedResponses();
+        const list = (response?.data || []).map(cr => ({
+          id: cr.id.toString(),
+          label: buildLabel(cr.short_code, cr.content),
+        }));
+        setCannedResponses(list);
+      } catch (error) {
+        console.error(t('panels.sendCannedResponse.loadDataError'), error);
+        setLoadError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadCannedResponses();
+  }, []);
+
+  const handleSave = () => {
+    const selected = cannedResponses.find(r => r.id === cannedResponseId);
+
+    const updatedData: SendCannedResponseNodeData = {
+      ...data,
+      canned_response_id: cannedResponseId || '',
+      canned_response_label: selected?.label || '',
+      formDataOptions: { cannedResponses },
+    };
+
+    onUpdate(nodeId, updatedData);
+    onClose();
+  };
+
+  const dirty = useMemo(
+    () => cannedResponseId !== originalCannedResponseId,
+    [cannedResponseId, originalCannedResponseId],
+  );
+  const isValid = Boolean(cannedResponseId);
+
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.sendCannedResponse.title')}
+      icon={<MessageSquareReply className="h-5 w-5 text-blue-500" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+    >
+      <div className="space-y-4">
+        {loadError && (
+          <FlowFeedbackBanner variant="error">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" />
+              <span>{t('panels.sendCannedResponse.loadErrorBanner')}</span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.sendCannedResponse.response')}
+          </Label>
+          <Select value={cannedResponseId} onValueChange={setCannedResponseId} disabled={loading}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.sendCannedResponse.response')}
+            >
+              <SelectValue
+                placeholder={
+                  loading
+                    ? t('panels.sendCannedResponse.loadingResponses')
+                    : t('panels.sendCannedResponse.selectResponse')
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {cannedResponses.map(response => (
+                <SelectItem
+                  key={response.id}
+                  value={response.id}
+                  className="text-sidebar-foreground"
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-md bg-blue-100 dark:bg-blue-950/30 text-blue-500 flex items-center justify-center">
+                      <MessageSquareReply className="w-4 h-4" />
+                    </div>
+                    <div className="font-medium truncate">{response.label}</div>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {!loading && cannedResponses.length === 0 && (
+            <p className="text-sm text-sidebar-foreground/60">
+              {t('panels.sendCannedResponse.noResponsesFound')}
+            </p>
+          )}
+        </div>
+
+        {cannedResponseId && (
+          <FlowFeedbackBanner variant="info">
+            <div className="flex items-center gap-2">
+              <MessageSquareReply className="w-4 h-4" />
+              <span>
+                {t('panels.sendCannedResponse.willSendResponse')}{' '}
+                <strong>
+                  {cannedResponses.find(r => r.id === cannedResponseId)?.label ||
+                    `${t('panels.sendCannedResponse.response')} #${cannedResponseId}`}
+                </strong>
+              </span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
+      </div>
+    </NodeConfigModal>
+  );
+}

--- a/src/components/journey/nodes/actions/send-canned-response/index.ts
+++ b/src/components/journey/nodes/actions/send-canned-response/index.ts
@@ -1,0 +1,2 @@
+export * from './SendCannedResponseNode';
+export * from './SendCannedResponsePanel';

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -324,6 +324,14 @@
         "assignTo": "Assign conversation to",
         "noPipelineSelected": "No pipeline selected"
       },
+      "sendCannedResponse": {
+        "name": "Send Canned Response",
+        "description": "Sends a pre-written canned response to the conversation",
+        "selectResponse": "Select canned response",
+        "responseNumber": "Response #{{responseId}}",
+        "sendingResponse": "Send canned response",
+        "noResponseSelected": "No canned response selected"
+      },
       "muteConversation": {
         "name": "Mute Conversation",
         "description": "The conversation will be muted and will not generate notifications for Agents"
@@ -884,6 +892,16 @@
       "conversationWillBeAssigned": "The conversation will be assigned to the pipeline",
       "replacesAnyPrevious": "this replaces any previous pipeline assignment",
       "loadErrorBanner": "Could not load pipelines. Check your connection and try reopening this node."
+    },
+    "sendCannedResponse": {
+      "title": "Configure Send Canned Response",
+      "loadDataError": "Error loading canned responses:",
+      "response": "Canned response",
+      "loadingResponses": "Loading canned responses...",
+      "selectResponse": "Select a canned response",
+      "noResponsesFound": "No canned responses found. Create one first.",
+      "willSendResponse": "The conversation will receive the canned response",
+      "loadErrorBanner": "Could not load canned responses. Check your connection and try reopening this node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -324,6 +324,14 @@
         "assignTo": "Asignar conversación al",
         "noPipelineSelected": "Ningún pipeline seleccionado"
       },
+      "sendCannedResponse": {
+        "name": "Enviar Respuesta Predefinida",
+        "description": "Envía una respuesta predefinida a la conversación",
+        "selectResponse": "Seleccionar respuesta predefinida",
+        "responseNumber": "Respuesta n.º {{responseId}}",
+        "sendingResponse": "Enviar respuesta predefinida",
+        "noResponseSelected": "Ninguna respuesta predefinida seleccionada"
+      },
       "muteConversation": {
         "name": "Silenciar Conversación",
         "description": "La conversación será silenciada y no generará más notificaciones para los agentes"
@@ -879,6 +887,16 @@
       "conversationWillBeAssigned": "La conversación será asignada al pipeline",
       "replacesAnyPrevious": "esto reemplaza cualquier asignación previa de pipeline",
       "loadErrorBanner": "No se pudieron cargar los pipelines. Verifica tu conexión y reabre este node."
+    },
+    "sendCannedResponse": {
+      "title": "Configurar Enviar Respuesta Predefinida",
+      "loadDataError": "Error al cargar las respuestas predefinidas:",
+      "response": "Respuesta predefinida",
+      "loadingResponses": "Cargando respuestas predefinidas...",
+      "selectResponse": "Selecciona una respuesta predefinida",
+      "noResponsesFound": "No se encontraron respuestas predefinidas. Crea una primero.",
+      "willSendResponse": "La conversación recibirá la respuesta predefinida",
+      "loadErrorBanner": "No se pudieron cargar las respuestas predefinidas. Comprueba tu conexión y vuelve a abrir este nodo."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -324,6 +324,14 @@
         "assignTo": "Attribuer la conversation au",
         "noPipelineSelected": "Aucune pipeline sélectionnée"
       },
+      "sendCannedResponse": {
+        "name": "Envoyer une Réponse Prédéfinie",
+        "description": "Envoie une réponse prédéfinie à la conversation",
+        "selectResponse": "Sélectionner une réponse prédéfinie",
+        "responseNumber": "Réponse #{{responseId}}",
+        "sendingResponse": "Envoyer une réponse prédéfinie",
+        "noResponseSelected": "Aucune réponse prédéfinie sélectionnée"
+      },
       "muteConversation": {
         "name": "Mettre en sourdine la conversation",
         "description": "La conversation sera mise en sourdine et ne générera plus de notifications pour les Agents"
@@ -879,6 +887,16 @@
       "conversationWillBeAssigned": "La conversation sera attribuée au pipeline",
       "replacesAnyPrevious": "cela remplace toute attribution de pipeline précédente",
       "loadErrorBanner": "Impossible de charger les pipelines. Vérifiez votre connexion et rouvrez ce node."
+    },
+    "sendCannedResponse": {
+      "title": "Configurer Envoyer une Réponse Prédéfinie",
+      "loadDataError": "Erreur lors du chargement des réponses prédéfinies :",
+      "response": "Réponse prédéfinie",
+      "loadingResponses": "Chargement des réponses prédéfinies...",
+      "selectResponse": "Sélectionnez une réponse prédéfinie",
+      "noResponsesFound": "Aucune réponse prédéfinie trouvée. Créez-en une d'abord.",
+      "willSendResponse": "La conversation recevra la réponse prédéfinie",
+      "loadErrorBanner": "Impossible de charger les réponses prédéfinies. Vérifiez votre connexion et rouvrez ce nœud."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -336,6 +336,14 @@
         "assignTo": "Assegna conversazione alla",
         "noPipelineSelected": "Nessuna pipeline selezionata"
       },
+      "sendCannedResponse": {
+        "name": "Invia Risposta Predefinita",
+        "description": "Invia una risposta predefinita alla conversazione",
+        "selectResponse": "Seleziona risposta predefinita",
+        "responseNumber": "Risposta #{{responseId}}",
+        "sendingResponse": "Invia risposta predefinita",
+        "noResponseSelected": "Nessuna risposta predefinita selezionata"
+      },
       "muteConversation": {
         "name": "Silenzia Conversazione",
         "description": "La conversazione verrà silenziata e non genererà più notifiche per gli Agenti"
@@ -891,6 +899,16 @@
       "conversationWillBeAssigned": "La conversazione sarà assegnata alla pipeline",
       "replacesAnyPrevious": "questo sostituisce qualsiasi assegnazione precedente di pipeline",
       "loadErrorBanner": "Impossibile caricare le pipeline. Controlla la connessione e riapri questo node."
+    },
+    "sendCannedResponse": {
+      "title": "Configura Invia Risposta Predefinita",
+      "loadDataError": "Errore nel caricamento delle risposte predefinite:",
+      "response": "Risposta predefinita",
+      "loadingResponses": "Caricamento risposte predefinite...",
+      "selectResponse": "Seleziona una risposta predefinita",
+      "noResponsesFound": "Nessuna risposta predefinita trovata. Creane una prima.",
+      "willSendResponse": "La conversazione riceverà la risposta predefinita",
+      "loadErrorBanner": "Impossibile caricare le risposte predefinite. Controlla la connessione e riapri questo nodo."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -324,6 +324,14 @@
         "assignTo": "Atribuir conversa ao",
         "noPipelineSelected": "Nenhum pipeline selecionado"
       },
+      "sendCannedResponse": {
+        "name": "Enviar Resposta Rápida",
+        "description": "Envia uma resposta rápida pré-definida para a conversa",
+        "selectResponse": "Selecionar resposta rápida",
+        "responseNumber": "Resposta #{{responseId}}",
+        "sendingResponse": "Enviar resposta rápida",
+        "noResponseSelected": "Nenhuma resposta rápida selecionada"
+      },
       "muteConversation": {
         "name": "Silenciar Conversa",
         "description": "A conversa será silenciada e não gerará mais notificações para os atendentes"
@@ -884,6 +892,16 @@
       "conversationWillBeAssigned": "A conversa será atribuída ao pipeline",
       "replacesAnyPrevious": "isso substitui qualquer atribuição anterior de pipeline",
       "loadErrorBanner": "Não foi possível carregar os pipelines. Verifique sua conexão e reabra este node."
+    },
+    "sendCannedResponse": {
+      "title": "Configurar Enviar Resposta Rápida",
+      "loadDataError": "Erro ao carregar respostas rápidas:",
+      "response": "Resposta rápida",
+      "loadingResponses": "Carregando respostas rápidas...",
+      "selectResponse": "Selecione uma resposta rápida",
+      "noResponsesFound": "Nenhuma resposta rápida encontrada. Crie uma primeiro.",
+      "willSendResponse": "A conversa receberá a resposta rápida",
+      "loadErrorBanner": "Não foi possível carregar as respostas rápidas. Verifique sua conexão e reabra este node."
     },
     "changePriority": {
       "title": "Configurar Prioridade",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -324,6 +324,14 @@
         "assignTo": "Atribuir conversa à",
         "noPipelineSelected": "Nenhuma pipeline selecionada"
       },
+      "sendCannedResponse": {
+        "name": "Enviar Resposta Rápida",
+        "description": "Envia uma resposta rápida pré-definida para a conversa",
+        "selectResponse": "Selecionar resposta rápida",
+        "responseNumber": "Resposta #{{responseId}}",
+        "sendingResponse": "Enviar resposta rápida",
+        "noResponseSelected": "Nenhuma resposta rápida selecionada"
+      },
       "muteConversation": {
         "name": "Silenciar Conversa",
         "description": "A conversa será silenciada e não gerará mais notificações para os atendentes"
@@ -879,6 +887,16 @@
       "conversationWillBeAssigned": "A conversa será atribuída à pipeline",
       "replacesAnyPrevious": "isto substitui qualquer atribuição anterior de pipeline",
       "loadErrorBanner": "Não foi possível carregar as pipelines. Verifique a sua ligação e reabra este node."
+    },
+    "sendCannedResponse": {
+      "title": "Configurar Enviar Resposta Rápida",
+      "loadDataError": "Erro ao carregar respostas rápidas:",
+      "response": "Resposta rápida",
+      "loadingResponses": "Carregando respostas rápidas...",
+      "selectResponse": "Selecione uma resposta rápida",
+      "noResponsesFound": "Nenhuma resposta rápida encontrada. Crie uma primeiro.",
+      "willSendResponse": "A conversa receberá a resposta rápida",
+      "loadErrorBanner": "Não foi possível carregar as respostas rápidas. Verifique sua conexão e reabra este node."
     },
     "changePriority": {
       "title": "Configure Priority",

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -53,6 +53,7 @@ import {
   AssignTeamNode,
   AssignBotNode,
   AssignToPipelineNode,
+  SendCannedResponseNode,
   SendEmailTeamNode,
   SendTranscriptNode,
   MuteConversationNode,
@@ -80,6 +81,7 @@ import {
   AssignTeamPanel,
   AssignBotPanel,
   AssignToPipelinePanel,
+  SendCannedResponsePanel,
   SendEmailTeamPanel,
   SendTranscriptPanel,
   MuteConversationPanel,
@@ -102,6 +104,7 @@ import {
   MoveRight,
   ArrowRight,
   MessageSquare,
+  MessageSquareReply,
   Variable,
   Users,
   Mail,
@@ -175,6 +178,7 @@ function JourneyFlowEditor() {
       'assign-team-node': AssignTeamNode,
       'assign-bot-node': AssignBotNode,
       'assign-to-pipeline-node': AssignToPipelineNode,
+      'send-canned-response-node': SendCannedResponseNode,
       'send-email-team-node': SendEmailTeamNode,
       'send-transcript-node': SendTranscriptNode,
       'mute-conversation-node': MuteConversationNode,
@@ -309,6 +313,15 @@ function JourneyFlowEditor() {
         category: 'communication',
         description: t('flowEditor.nodes.sendMessage.description'),
         searchKeywords: ['chat', 'text', 'reply', 'whatsapp', 'sms', 'communicate', 'send'],
+      },
+      {
+        id: 'send-canned-response-node',
+        name: t('flowEditor.nodes.sendCannedResponse.name'),
+        icon: MessageSquareReply,
+        color: 'text-blue-400',
+        category: 'communication',
+        description: t('flowEditor.nodes.sendCannedResponse.description'),
+        searchKeywords: ['canned', 'quick', 'reply', 'preset', 'template', 'response', 'faq'],
       },
       {
         id: 'send-webhook-node',
@@ -468,6 +481,7 @@ function JourneyFlowEditor() {
       'exit-journey-node': flowTokens.node.exit.border,
       'transfer-journey-node': flowTokens.node.exit.border,
       'send-message-node': flowTokens.node.action.message.border,
+      'send-canned-response-node': flowTokens.node.action.message.border,
       'send-transcript-node': flowTokens.node.action.message.border,
       'send-email-team-node': flowTokens.node.action.message.border,
       'send-webhook-node': flowTokens.node.action.webhook.border,
@@ -542,6 +556,8 @@ function JourneyFlowEditor() {
           return <AssignBotPanel {...commonProps} />;
         case 'assign-to-pipeline-node':
           return <AssignToPipelinePanel {...commonProps} />;
+        case 'send-canned-response-node':
+          return <SendCannedResponsePanel {...commonProps} />;
         case 'send-email-team-node':
           return <SendEmailTeamPanel {...commonProps} />;
         case 'send-transcript-node':


### PR DESCRIPTION
## Summary
- Adds the **Send Canned Response** action node to the Journey / Flow Builder, mirroring the Assign-to-Pipeline node pattern (EVO-1265).
- The node persists `type: send-canned-response-node` + `data.canned_response_id`; the CRM `FlowExecutionService` handler that consumes it already exists. Backend resilience (AC3) ships in the sibling CRM PR.

## Changes
- `src/components/journey/nodes/actions/send-canned-response/` — `SendCannedResponseNode`, `SendCannedResponsePanel` (`NodeConfigModal variant="simple"`, options from `cannedResponsesService`), `index.ts`, panel spec.
- `src/components/journey/nodes/actions/action-nodes.ts` — barrel export.
- `src/pages/Customer/Journey/JourneyFlowEditor.tsx` — `nodeTypes`, communication palette entry, `renderConfigPanel` case, miniMap color.
- `src/i18n/locales/{en,pt-BR,es,pt,it,fr}/journey.json` — node + panel keys.

## Security
- No new endpoint. Consumes the existing `GET /api/v1/canned_responses` (own auth). Node config is an id reference; rendered text only (no `dangerouslySetInnerHTML`).

## Test plan
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` — pass
- `evo-ai-frontend-community: eslint` (changed files) — 0 errors
- `evo-ai-frontend-community: pnpm exec vitest run SendCannedResponsePanel.spec.tsx` — 6/6
- 6 locale JSON files validated

## Related PRs
- crm (AC3 resilience + handler): https://github.com/evolution-foundation/evo-ai-crm-community/pull/114

## Linked Issue
- EVO-1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new Send Canned Response journey action node and configuration panel to the flow editor.

New Features:
- Introduce a Send Canned Response action node type to the journey flow builder, including palette entry and mini-map styling.
- Add a configuration panel for selecting canned responses backed by the existing cannedResponsesService.

Documentation:
- Localize the Send Canned Response node labels and panel text across supported languages.

Tests:
- Add unit tests for the SendCannedResponsePanel covering loading, selection, empty state, error handling, and update behavior.