### PR TITLE
feat(frontend): numeric unread badge on conversation list + sidebar menu (EVO-1550)

### DIFF
--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useAppDataStore } from '@/store/appDataStore';
 import { useAuthStore } from '@/store/authStore';
 import { tourService } from '@/services/tours/tourService';
+import { useUnreadConversationsStore } from '@/store/unreadConversationsStore';
 import i18n from '@/i18n/config';
 import LoadingScreen from '@/components/LoadingScreen';
 interface AppInitializerProps {
@@ -102,6 +103,14 @@ const AppInitializer: React.FC<AppInitializerProps> = ({ children }) => {
         // Non-critical: tours default to empty (all tours will show)
       });
   }, [user?.id, setTours]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      useUnreadConversationsStore.getState().reset();
+      return;
+    }
+    useUnreadConversationsStore.getState().fetch();
+  }, [user?.id]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -1152,35 +1152,23 @@ const ChatSidebar = ({
                         channelProvider={channelProvider}
                       />
                       <div className="min-w-0 flex-1">
-                        <div className="flex items-center justify-between mb-1">
-                          <div className="flex items-center gap-2 min-w-0 flex-1">
-                            <p className="font-medium truncate">
-                              {conversation.contact?.name || t('chatSidebar.contactNoName')}
-                            </p>
-                            {Boolean(conversation.custom_attributes?.pinned) && (
-                              <Pin className="h-3.5 w-3.5 text-primary flex-shrink-0" />
-                            )}
-                            {/* ðŸ"Œ Indicador de Post do Facebook */}
-                            {conversation.additional_attributes?.conversation_type === 'post' && (
-                              <Badge
-                                variant="outline"
-                                className="h-4 px-1.5 text-[10px] bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-700 flex-shrink-0"
-                                title="Facebook Post"
-                              >
-                                <FileText className="h-2.5 w-2.5 mr-0.5" />
-                                Post
-                              </Badge>
-                            )}
-                          </div>
-                          <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                            {/* Timestamp */}
-                            <span
-                              className="text-xs text-muted-foreground"
-                              title={formatDetailedTime(conversation.timestamp)}
+                        <div className="flex items-center gap-2 min-w-0 mb-1">
+                          <p className="font-medium truncate">
+                            {conversation.contact?.name || t('chatSidebar.contactNoName')}
+                          </p>
+                          {Boolean(conversation.custom_attributes?.pinned) && (
+                            <Pin className="h-3.5 w-3.5 text-primary flex-shrink-0" />
+                          )}
+                          {conversation.additional_attributes?.conversation_type === 'post' && (
+                            <Badge
+                              variant="outline"
+                              className="h-4 px-1.5 text-[10px] bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-700 flex-shrink-0"
+                              title="Facebook Post"
                             >
-                              {formatConversationTime(conversation.timestamp)}
-                            </span>
-                          </div>
+                              <FileText className="h-2.5 w-2.5 mr-0.5" />
+                              Post
+                            </Badge>
+                          )}
                         </div>
 
                         {phoneDisplay && (
@@ -1216,7 +1204,13 @@ const ChatSidebar = ({
                         )}
                       </div>
                     </div>
-                    <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                    <div className="flex flex-col items-end gap-1.5 flex-shrink-0 ml-2">
+                      <span
+                        className="text-xs text-muted-foreground leading-none"
+                        title={formatDetailedTime(conversation.timestamp)}
+                      >
+                        {formatConversationTime(conversation.timestamp)}
+                      </span>
                       <UnreadBadge
                         count={conversations.getUnreadCount(conversation.id) || 0}
                         ariaLabel={t('unreadBadge.ariaLabel', {

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -51,6 +51,7 @@ import { formatConversationTime, formatDetailedTime } from '@/utils/time/timeHel
 import { isPhoneBearingChannel } from '@/utils/channelUtils';
 import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { findItemInPipeline } from '@/utils/chat/pipelineUtils';
+import { UnreadBadge } from '@/components/shared';
 import { ConversationSkeleton } from '../loading-states';
 import { NoConversations } from '../empty-states';
 import ContactAvatar from '../contact/ContactAvatar';
@@ -1216,15 +1217,12 @@ const ChatSidebar = ({
                       </div>
                     </div>
                     <div className="flex flex-col items-end gap-1 flex-shrink-0">
-                      {(() => {
-                        // ðŸ"µ INDICADOR PADRÃƒO: Bolinha pequena seguindo padrÃ£o do sistema
-                        const hasUnreadMessages =
-                          (conversations.getUnreadCount(conversation.id) || 0) > 0;
-
-                        return hasUnreadMessages ? (
-                          <div className="w-2 h-2 rounded-full bg-primary flex-shrink-0" />
-                        ) : null;
-                      })()}
+                      <UnreadBadge
+                        count={conversations.getUnreadCount(conversation.id) || 0}
+                        ariaLabel={t('unreadBadge.ariaLabel', {
+                          count: conversations.getUnreadCount(conversation.id) || 0,
+                        })}
+                      />
                     </div>
                   </div>
                 </div>,

--- a/src/components/layout/components/Header.tsx
+++ b/src/components/layout/components/Header.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import { useUnreadConversationsStore } from '@/store/unreadConversationsStore';
 import { Link } from 'react-router-dom';
 import {
   Menu,
@@ -73,6 +74,17 @@ export default function Header({
 }: HeaderProps) {
   const { t } = useLanguage('layout');
   const [expandedMobileMenus, setExpandedMobileMenus] = useState<Set<string>>(new Set());
+  const totalUnread = useUnreadConversationsStore((state) => state.totalUnread);
+
+  const enrichedMenuItems = useMemo(
+    () =>
+      menuItems.map((item) =>
+        item.href === '/conversations' && totalUnread > 0
+          ? { ...item, badge: totalUnread }
+          : item,
+      ),
+    [menuItems, totalUnread],
+  );
 
   return (
     <div className="flex-shrink-0 bg-sidebar border-b border-sidebar-border px-0 py-3 flex items-center shadow-sm">
@@ -98,7 +110,7 @@ export default function Header({
 
               <ScrollArea className="flex-1 min-h-0 overflow-hidden p-4">
                 <nav className="space-y-1">
-                  {menuItems.map(item => {
+                  {enrichedMenuItems.map(item => {
                     const hasSubItems = item.subItems && item.subItems.length > 0;
                     const menuKey = item.id || item.href;
                     const isExpanded = expandedMobileMenus.has(menuKey);

--- a/src/components/layout/components/MenuItem.tsx
+++ b/src/components/layout/components/MenuItem.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { ChevronRight } from 'lucide-react';
 import {
   Tooltip,
@@ -26,7 +27,12 @@ export default function MenuItem({
   isActive,
   onClick,
 }: MenuItemProps) {
+  const { t } = useTranslation('chat');
   const hasSubItems = item.subItems && item.subItems.length > 0;
+  const badgeAriaLabel =
+    item.badge && item.badge > 0
+      ? t('unreadBadge.menuAriaLabel', { count: item.badge })
+      : undefined;
 
   const menuItem = (
     <Link
@@ -51,7 +57,11 @@ export default function MenuItem({
             <span className="font-medium">{item.name}</span>
           </div>
           {item.badge ? (
-            <UnreadBadge count={item.badge} className="ml-auto" />
+            <UnreadBadge
+              count={item.badge}
+              ariaLabel={badgeAriaLabel}
+              className="ml-auto"
+            />
           ) : hasSubItems && !mobile ? (
             <div className="ml-auto">
               <ChevronRight className="h-4 w-4" />
@@ -76,6 +86,9 @@ export default function MenuItem({
         <TooltipTrigger asChild>{menuItem}</TooltipTrigger>
         <TooltipContent side="right">
           <p className="font-medium">{item.name}</p>
+          {badgeAriaLabel ? (
+            <p className="text-xs text-muted-foreground">{badgeAriaLabel}</p>
+          ) : null}
         </TooltipContent>
       </Tooltip>
     );

--- a/src/components/layout/components/MenuItem.tsx
+++ b/src/components/layout/components/MenuItem.tsx
@@ -7,6 +7,7 @@ import {
   TooltipTrigger,
 } from '@evoapi/design-system';
 import { MenuItem as MenuItemType } from '../config/menuItems';
+import { UnreadBadge } from '@/components/shared';
 import { cn } from '@/utils/cn';
 
 interface MenuItemProps {
@@ -32,7 +33,7 @@ export default function MenuItem({
       to={hasSubItems && !mobile && item.href === '#' ? '#' : item.href}
       onClick={onClick}
       className={cn(
-        'flex items-center gap-3 px-3 py-2.5 rounded-md transition-all group',
+        'relative flex items-center gap-3 px-3 py-2.5 rounded-md transition-all group',
         mobile ? 'w-full' : isCollapsed ? 'justify-center' : '',
         isActive
           ? mobile
@@ -49,13 +50,23 @@ export default function MenuItem({
           <div className="flex items-center gap-2 flex-1">
             <span className="font-medium">{item.name}</span>
           </div>
-          {hasSubItems && !mobile && (
+          {item.badge ? (
+            <UnreadBadge count={item.badge} className="ml-auto" />
+          ) : hasSubItems && !mobile ? (
             <div className="ml-auto">
               <ChevronRight className="h-4 w-4" />
             </div>
-          )}
+          ) : null}
         </>
       )}
+      {isCollapsed && !mobile && item.badge ? (
+        <span
+          aria-hidden="true"
+          className="absolute -top-1 -right-1 inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-semibold leading-none"
+        >
+          {item.badge < 100 ? item.badge : '99+'}
+        </span>
+      ) : null}
     </Link>
   );
 

--- a/src/components/layout/components/Sidebar.tsx
+++ b/src/components/layout/components/Sidebar.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useUnreadConversationsStore } from '@/store/unreadConversationsStore';
 import { Link, useLocation } from 'react-router-dom';
 import { X } from 'lucide-react';
 import {
@@ -45,8 +46,20 @@ export default function Sidebar({
   const companyName = t('sidebar.footer.brand');
   const supportWhatsappUrl = 'https://api.whatsapp.com/send/?phone=553196219989&text=Ol%C3%A1%21+Preciso+de+suporte.&type=phone_number&app_absent=0';
 
-  const mainMenuItems = menuItems.filter(item => item.href !== '/tutorials');
-  const tutorialsItem = menuItems.find(item => item.href === '/tutorials');
+  const totalUnread = useUnreadConversationsStore((state) => state.totalUnread);
+
+  const enrichedMenuItems = useMemo(
+    () =>
+      menuItems.map((item) =>
+        item.href === '/conversations' && totalUnread > 0
+          ? { ...item, badge: totalUnread }
+          : item,
+      ),
+    [menuItems, totalUnread],
+  );
+
+  const mainMenuItems = enrichedMenuItems.filter(item => item.href !== '/tutorials');
+  const tutorialsItem = enrichedMenuItems.find(item => item.href === '/tutorials');
 
   // Dismiss collapsed flyout on Escape (WAI-ARIA requirement for popover-like elements)
   useEffect(() => {

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -39,6 +39,7 @@ export interface MenuItem {
   permissions?: string[];
   requireAll?: boolean;
   requiredRoleKey?: string;
+  badge?: number;
 }
 
 export interface SubMenuItem {

--- a/src/components/shared/UnreadBadge.spec.tsx
+++ b/src/components/shared/UnreadBadge.spec.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { UnreadBadge } from './UnreadBadge';
+
+describe('UnreadBadge', () => {
+  it('renders the exact count when between 1 and 99', () => {
+    render(<UnreadBadge count={7} />);
+    expect(screen.getByRole('status')).toHaveTextContent('7');
+  });
+
+  it('renders "99+" when count is 100 or more', () => {
+    render(<UnreadBadge count={350} />);
+    expect(screen.getByRole('status')).toHaveTextContent('99+');
+  });
+
+  it('renders nothing when count is 0', () => {
+    const { container } = render(<UnreadBadge count={0} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when count is negative', () => {
+    const { container } = render(<UnreadBadge count={-3} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('exposes the aria-label for assistive tech', () => {
+    render(<UnreadBadge count={5} ariaLabel="5 unread messages" />);
+    expect(screen.getByLabelText('5 unread messages')).toBeInTheDocument();
+  });
+
+  it('shows exactly 99 (not "99+") at the boundary', () => {
+    render(<UnreadBadge count={99} />);
+    expect(screen.getByRole('status')).toHaveTextContent('99');
+  });
+});

--- a/src/components/shared/UnreadBadge.tsx
+++ b/src/components/shared/UnreadBadge.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@/utils/cn';
+
+interface UnreadBadgeProps {
+  count: number;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function UnreadBadge({ count, ariaLabel, className }: UnreadBadgeProps) {
+  if (count <= 0) return null;
+  const display = count < 100 ? String(count) : '99+';
+  return (
+    <span
+      role="status"
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 rounded-full bg-primary text-primary-foreground text-xs font-medium leading-none',
+        className,
+      )}
+    >
+      {display}
+    </span>
+  );
+}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -6,3 +6,4 @@
 
 export { PhoneInput } from './PhoneInput';
 export { TaxIdInput } from './TaxIdInput';
+export { UnreadBadge } from './UnreadBadge';

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -312,8 +312,9 @@ function useChatIntegration() {
               console.warn('Failed to update read conversation in localStorage:', error);
             }
 
-            // Atualizar estado local para garantir que está marcada como lida
-            conversations.updateUnreadCount(targetConversationId, 0);
+            conversations.markAsRead(targetConversationId, { silent: true }).catch(() => {
+              conversations.updateUnreadCount(targetConversationId, 0);
+            });
           } else if (!isConversationOpen && isIncomingMessage) {
             try {
               const saved = localStorage.getItem('crm-chat-state');

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -558,20 +558,13 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
 
   const updateUnreadCount = useCallback(
     (conversationId: string, count: number) => {
-      const previousCount = state.unreadCounts[conversationId] ?? 0;
       dispatch({
         type: 'UPDATE_UNREAD_COUNT',
         payload: { conversationId, count },
       });
-      const wasZero = previousCount === 0;
-      const isZero = count === 0;
-      if (wasZero && !isZero) {
-        useUnreadConversationsStore.getState().incrementBy(1);
-      } else if (!wasZero && isZero) {
-        useUnreadConversationsStore.getState().decrementBy(1);
-      }
+      useUnreadConversationsStore.getState().fetch();
     },
-    [state.unreadCounts],
+    [],
   );
 
   const updateConversationLastActivity = useCallback(
@@ -584,19 +577,13 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
     [],
   );
 
-  const incrementUnreadCount = useCallback(
-    (conversationId: string) => {
-      const previousCount = state.unreadCounts[conversationId] ?? 0;
-      dispatch({
-        type: 'INCREMENT_UNREAD_COUNT',
-        payload: { conversationId },
-      });
-      if (previousCount === 0) {
-        useUnreadConversationsStore.getState().incrementBy(1);
-      }
-    },
-    [state.unreadCounts],
-  );
+  const incrementUnreadCount = useCallback((conversationId: string) => {
+    dispatch({
+      type: 'INCREMENT_UNREAD_COUNT',
+      payload: { conversationId },
+    });
+    useUnreadConversationsStore.getState().fetch();
+  }, []);
 
   const addHiddenConversation = useCallback((conversation: Conversation) => {
     dispatch({ type: 'ADD_HIDDEN_CONVERSATION', payload: conversation });

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -558,13 +558,20 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
 
   const updateUnreadCount = useCallback(
     (conversationId: string, count: number) => {
+      const previousCount = state.unreadCounts[conversationId] ?? 0;
       dispatch({
         type: 'UPDATE_UNREAD_COUNT',
         payload: { conversationId, count },
       });
-      useUnreadConversationsStore.getState().fetch();
+      const wasZero = previousCount === 0;
+      const isZero = count === 0;
+      if (wasZero && !isZero) {
+        useUnreadConversationsStore.getState().incrementBy(1);
+      } else if (!wasZero && isZero) {
+        useUnreadConversationsStore.getState().decrementBy(1);
+      }
     },
-    [],
+    [state.unreadCounts],
   );
 
   const updateConversationLastActivity = useCallback(
@@ -577,13 +584,19 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
     [],
   );
 
-  const incrementUnreadCount = useCallback((conversationId: string) => {
-    dispatch({
-      type: 'INCREMENT_UNREAD_COUNT',
-      payload: { conversationId },
-    });
-    useUnreadConversationsStore.getState().fetch();
-  }, []);
+  const incrementUnreadCount = useCallback(
+    (conversationId: string) => {
+      const previousCount = state.unreadCounts[conversationId] ?? 0;
+      dispatch({
+        type: 'INCREMENT_UNREAD_COUNT',
+        payload: { conversationId },
+      });
+      if (previousCount === 0) {
+        useUnreadConversationsStore.getState().incrementBy(1);
+      }
+    },
+    [state.unreadCounts],
+  );
 
   const addHiddenConversation = useCallback((conversation: Conversation) => {
     dispatch({ type: 'ADD_HIDDEN_CONVERSATION', payload: conversation });

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 
 import { chatService } from '@/services/chat/chatService';
 import { conversationAPI } from '@/services/conversations/conversationService';
+import { useUnreadConversationsStore } from '@/store/unreadConversationsStore';
 
 import { toast } from 'sonner';
 
@@ -553,12 +554,20 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
     }
   }, [state.conversations]);
 
-  const updateUnreadCount = useCallback((conversationId: string, count: number) => {
-    dispatch({
-      type: 'UPDATE_UNREAD_COUNT',
-      payload: { conversationId, count },
-    });
-  }, []);
+  const updateUnreadCount = useCallback(
+    (conversationId: string, count: number) => {
+      const previous = state.unreadCounts[String(conversationId)] || 0;
+      const delta = count - previous;
+      dispatch({
+        type: 'UPDATE_UNREAD_COUNT',
+        payload: { conversationId, count },
+      });
+      if (delta !== 0) {
+        useUnreadConversationsStore.getState().incrementBy(delta);
+      }
+    },
+    [state.unreadCounts],
+  );
 
   const updateConversationLastActivity = useCallback(
     (conversationId: string, lastActivityAt: string) => {
@@ -575,6 +584,7 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
       type: 'INCREMENT_UNREAD_COUNT',
       payload: { conversationId },
     });
+    useUnreadConversationsStore.getState().incrementBy(1);
   }, []);
 
   const addHiddenConversation = useCallback((conversation: Conversation) => {

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -288,6 +288,8 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
           console.warn('updateConversationStatus: Invalid response', response);
         }
 
+        useUnreadConversationsStore.getState().fetch();
+
         const statusName = t(`contexts.conversations.statusNames.${status}`);
 
         toast.success(t('contexts.conversations.success.statusChanged', { status: statusName }));
@@ -556,18 +558,13 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
 
   const updateUnreadCount = useCallback(
     (conversationId: string, count: number) => {
-      const previous = state.unreadCounts[String(conversationId)] || 0;
-      const wasUnread = previous > 0;
-      const isUnread = count > 0;
       dispatch({
         type: 'UPDATE_UNREAD_COUNT',
         payload: { conversationId, count },
       });
-      if (wasUnread !== isUnread) {
-        useUnreadConversationsStore.getState().incrementBy(isUnread ? 1 : -1);
-      }
+      useUnreadConversationsStore.getState().fetch();
     },
-    [state.unreadCounts],
+    [],
   );
 
   const updateConversationLastActivity = useCallback(
@@ -581,15 +578,12 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const incrementUnreadCount = useCallback((conversationId: string) => {
-    const previous = state.unreadCounts[String(conversationId)] || 0;
     dispatch({
       type: 'INCREMENT_UNREAD_COUNT',
       payload: { conversationId },
     });
-    if (previous === 0) {
-      useUnreadConversationsStore.getState().incrementBy(1);
-    }
-  }, [state.unreadCounts]);
+    useUnreadConversationsStore.getState().fetch();
+  }, []);
 
   const addHiddenConversation = useCallback((conversation: Conversation) => {
     dispatch({ type: 'ADD_HIDDEN_CONVERSATION', payload: conversation });
@@ -629,17 +623,19 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const markAsRead = useCallback(
-    async (conversationId: string) => {
+    async (conversationId: string, options?: { silent?: boolean }) => {
       try {
         await conversationAPI.markAsRead(conversationId);
 
-        // Update local state - set unread count to 0
         dispatch({
           type: 'UPDATE_UNREAD_COUNT',
           payload: { conversationId, count: 0 },
         });
+        useUnreadConversationsStore.getState().fetch();
 
-        toast.success(t('contexts.conversations.success.markedAsRead'));
+        if (!options?.silent) {
+          toast.success(t('contexts.conversations.success.markedAsRead'));
+        }
       } catch (error) {
         console.error('Error marking conversation as read:', error);
         toast.error(t('contexts.conversations.errors.markAsRead'), {
@@ -659,12 +655,12 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
       try {
         await conversationAPI.markAsUnread(conversationId);
 
-        // Update local state - set unread count to 1 (or increment existing)
         const currentCount = state.unreadCounts[conversationId] || 0;
         dispatch({
           type: 'UPDATE_UNREAD_COUNT',
           payload: { conversationId, count: Math.max(1, currentCount) },
         });
+        useUnreadConversationsStore.getState().fetch();
 
         toast.success(t('contexts.conversations.success.markedAsUnread'));
       } catch (error) {
@@ -695,6 +691,8 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
         } else {
           console.warn('Invalid updatedConversation', updatedConversation);
         }
+
+        useUnreadConversationsStore.getState().fetch();
 
         toast.success(t('contexts.conversations.success.markedAsResolved'));
       } catch (error) {

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -557,13 +557,14 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   const updateUnreadCount = useCallback(
     (conversationId: string, count: number) => {
       const previous = state.unreadCounts[String(conversationId)] || 0;
-      const delta = count - previous;
+      const wasUnread = previous > 0;
+      const isUnread = count > 0;
       dispatch({
         type: 'UPDATE_UNREAD_COUNT',
         payload: { conversationId, count },
       });
-      if (delta !== 0) {
-        useUnreadConversationsStore.getState().incrementBy(delta);
+      if (wasUnread !== isUnread) {
+        useUnreadConversationsStore.getState().incrementBy(isUnread ? 1 : -1);
       }
     },
     [state.unreadCounts],
@@ -580,12 +581,15 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const incrementUnreadCount = useCallback((conversationId: string) => {
+    const previous = state.unreadCounts[String(conversationId)] || 0;
     dispatch({
       type: 'INCREMENT_UNREAD_COUNT',
       payload: { conversationId },
     });
-    useUnreadConversationsStore.getState().incrementBy(1);
-  }, []);
+    if (previous === 0) {
+      useUnreadConversationsStore.getState().incrementBy(1);
+    }
+  }, [state.unreadCounts]);
 
   const addHiddenConversation = useCallback((conversation: Conversation) => {
     dispatch({ type: 'ADD_HIDDEN_CONVERSATION', payload: conversation });

--- a/src/contexts/chat/ConversationsContextReducer.ts
+++ b/src/contexts/chat/ConversationsContextReducer.ts
@@ -426,12 +426,10 @@ export function conversationsReducer(
 
       return {
         ...state,
-        // Atualizar unreadCounts
         unreadCounts: {
           ...state.unreadCounts,
           [conversationIdStr]: count,
         },
-        // Também atualizar unread_count no objeto da conversa para manter sincronizado
         conversations: state.conversations
           .filter(conv => conv !== null && conv !== undefined && conv.id)
           .map(conv =>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -967,6 +967,7 @@
     "removeError": "Error removing from pipeline"
   },
   "unreadBadge": {
-    "ariaLabel": "{{count}} unread messages"
+    "ariaLabel_one": "{{count}} unread message",
+    "ariaLabel_other": "{{count}} unread messages"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -968,6 +968,8 @@
   },
   "unreadBadge": {
     "ariaLabel_one": "{{count}} unread message",
-    "ariaLabel_other": "{{count}} unread messages"
+    "ariaLabel_other": "{{count}} unread messages",
+    "menuAriaLabel_one": "{{count}} unread conversation",
+    "menuAriaLabel_other": "{{count}} unread conversations"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -965,5 +965,8 @@
     "addError": "Error adding to pipeline",
     "moveError": "Error moving to stage",
     "removeError": "Error removing from pipeline"
+  },
+  "unreadBadge": {
+    "ariaLabel": "{{count}} unread messages"
   }
 }

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -907,6 +907,7 @@
     "removeError": "Error al quitar del pipeline"
   },
   "unreadBadge": {
-    "ariaLabel": "{{count}} mensajes no leídos"
+    "ariaLabel_one": "{{count}} mensaje no leído",
+    "ariaLabel_other": "{{count}} mensajes no leídos"
   }
 }

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -908,6 +908,8 @@
   },
   "unreadBadge": {
     "ariaLabel_one": "{{count}} mensaje no leído",
-    "ariaLabel_other": "{{count}} mensajes no leídos"
+    "ariaLabel_other": "{{count}} mensajes no leídos",
+    "menuAriaLabel_one": "{{count}} conversación no leída",
+    "menuAriaLabel_other": "{{count}} conversaciones no leídas"
   }
 }

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -905,5 +905,8 @@
     "addError": "Error al agregar al pipeline",
     "moveError": "Error al mover a la etapa",
     "removeError": "Error al quitar del pipeline"
+  },
+  "unreadBadge": {
+    "ariaLabel": "{{count}} mensajes no leídos"
   }
 }

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -908,6 +908,8 @@
   },
   "unreadBadge": {
     "ariaLabel_one": "{{count}} message non lu",
-    "ariaLabel_other": "{{count}} messages non lus"
+    "ariaLabel_other": "{{count}} messages non lus",
+    "menuAriaLabel_one": "{{count}} conversation non lue",
+    "menuAriaLabel_other": "{{count}} conversations non lues"
   }
 }

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -907,6 +907,7 @@
     "removeError": "Erreur lors de la suppression du pipeline"
   },
   "unreadBadge": {
-    "ariaLabel": "{{count}} messages non lus"
+    "ariaLabel_one": "{{count}} message non lu",
+    "ariaLabel_other": "{{count}} messages non lus"
   }
 }

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -905,5 +905,8 @@
     "addError": "Erreur lors de l'ajout au pipeline",
     "moveError": "Erreur lors du déplacement vers l'étape",
     "removeError": "Erreur lors de la suppression du pipeline"
+  },
+  "unreadBadge": {
+    "ariaLabel": "{{count}} messages non lus"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -908,6 +908,8 @@
   },
   "unreadBadge": {
     "ariaLabel_one": "{{count}} messaggio non letto",
-    "ariaLabel_other": "{{count}} messaggi non letti"
+    "ariaLabel_other": "{{count}} messaggi non letti",
+    "menuAriaLabel_one": "{{count}} conversazione non letta",
+    "menuAriaLabel_other": "{{count}} conversazioni non lette"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -905,5 +905,8 @@
     "addError": "Errore nell'aggiunta al pipeline",
     "moveError": "Errore nello spostamento nella fase",
     "removeError": "Errore nella rimozione dal pipeline"
+  },
+  "unreadBadge": {
+    "ariaLabel": "{{count}} messaggi non letti"
   }
 }

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -907,6 +907,7 @@
     "removeError": "Errore nella rimozione dal pipeline"
   },
   "unreadBadge": {
-    "ariaLabel": "{{count}} messaggi non letti"
+    "ariaLabel_one": "{{count}} messaggio non letto",
+    "ariaLabel_other": "{{count}} messaggi non letti"
   }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -970,6 +970,7 @@
     "removeError": "Erro ao remover do pipeline"
   },
   "unreadBadge": {
-    "ariaLabel": "{{count}} mensagens não lidas"
+    "ariaLabel_one": "{{count}} mensagem não lida",
+    "ariaLabel_other": "{{count}} mensagens não lidas"
   }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -968,5 +968,8 @@
     "addError": "Erro ao adicionar ao pipeline",
     "moveError": "Erro ao mover para o estágio",
     "removeError": "Erro ao remover do pipeline"
+  },
+  "unreadBadge": {
+    "ariaLabel": "{{count}} mensagens não lidas"
   }
 }

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -971,6 +971,8 @@
   },
   "unreadBadge": {
     "ariaLabel_one": "{{count}} mensagem não lida",
-    "ariaLabel_other": "{{count}} mensagens não lidas"
+    "ariaLabel_other": "{{count}} mensagens não lidas",
+    "menuAriaLabel_one": "{{count}} conversa não lida",
+    "menuAriaLabel_other": "{{count}} conversas não lidas"
   }
 }

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -911,6 +911,8 @@
   },
   "unreadBadge": {
     "ariaLabel_one": "{{count}} mensagem não lida",
-    "ariaLabel_other": "{{count}} mensagens não lidas"
+    "ariaLabel_other": "{{count}} mensagens não lidas",
+    "menuAriaLabel_one": "{{count}} conversa não lida",
+    "menuAriaLabel_other": "{{count}} conversas não lidas"
   }
 }

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -910,6 +910,7 @@
     "removeError": "Erro ao remover do pipeline"
   },
   "unreadBadge": {
-    "ariaLabel": "{{count}} mensagens não lidas"
+    "ariaLabel_one": "{{count}} mensagem não lida",
+    "ariaLabel_other": "{{count}} mensagens não lidas"
   }
 }

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -908,5 +908,8 @@
     "addError": "Erro ao adicionar ao pipeline",
     "moveError": "Erro ao mover para o estágio",
     "removeError": "Erro ao remover do pipeline"
+  },
+  "unreadBadge": {
+    "ariaLabel": "{{count}} mensagens não lidas"
   }
 }

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -164,6 +164,19 @@ const Chat = () => {
     }
   }, [conversationId, isContactSidebarOpen]);
 
+  // Auto mark-as-read when a conversation becomes selected with unread > 0.
+  // Keyed on selectedConversationId (not conversationId) so it fires only after
+  // the URL-sync effect resolves to a real conversation; the unread > 0 guard
+  // prevents the double-fire in React StrictMode / re-mount.
+  useEffect(() => {
+    const selectedId = conversations.state.selectedConversationId;
+    if (!selectedId) return;
+    if ((conversations.getUnreadCount(selectedId) || 0) <= 0) return;
+    conversations.markAsRead(selectedId).catch(() => {
+      // Non-fatal: existing markAsRead surfaces its own error toast
+    });
+  }, [conversations.state.selectedConversationId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Load conversations on mount
   useEffect(() => {
     if (!permissionsReady) {

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -164,17 +164,10 @@ const Chat = () => {
     }
   }, [conversationId, isContactSidebarOpen]);
 
-  // Auto mark-as-read when a conversation becomes selected with unread > 0.
-  // Keyed on selectedConversationId (not conversationId) so it fires only after
-  // the URL-sync effect resolves to a real conversation; the unread > 0 guard
-  // prevents the double-fire in React StrictMode / re-mount.
   useEffect(() => {
     const selectedId = conversations.state.selectedConversationId;
     if (!selectedId) return;
-    if ((conversations.getUnreadCount(selectedId) || 0) <= 0) return;
-    conversations.markAsRead(selectedId).catch(() => {
-      // Non-fatal: existing markAsRead surfaces its own error toast
-    });
+    conversations.markAsRead(selectedId, { silent: true }).catch(() => {});
   }, [conversations.state.selectedConversationId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Load conversations on mount

--- a/src/services/conversations/conversationService.ts
+++ b/src/services/conversations/conversationService.ts
@@ -175,6 +175,12 @@ export const conversationAPI = {
     return extractData<any>(response);
   },
 
+  // Aggregate unread incoming-message count across all accessible conversations
+  async getUnreadCount(): Promise<{ unread_count: number }> {
+    const response = await api.get('/conversations/unread_count');
+    return extractData<{ unread_count: number }>(response);
+  },
+
   // Mark conversation as unread
   async markAsUnread(conversationId: string): Promise<Conversation> {
     const response = await api.post(`/conversations/${conversationId}/unread`);

--- a/src/store/unreadConversationsStore.spec.ts
+++ b/src/store/unreadConversationsStore.spec.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/conversations/conversationService', () => ({
+  conversationAPI: {
+    getUnreadCount: vi.fn(),
+  },
+}));
+
+import { useUnreadConversationsStore } from './unreadConversationsStore';
+import { conversationAPI } from '@/services/conversations/conversationService';
+
+const mockedGetUnreadCount = vi.mocked(conversationAPI.getUnreadCount);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockedGetUnreadCount.mockReset();
+  useUnreadConversationsStore.getState().reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('useUnreadConversationsStore.fetch', () => {
+  it('coalesces N rapid calls within the debounce window into one HTTP request', async () => {
+    mockedGetUnreadCount.mockResolvedValue({ unread_count: 5 });
+    const { fetch } = useUnreadConversationsStore.getState();
+
+    fetch();
+    fetch();
+    fetch();
+    fetch();
+    fetch();
+
+    expect(mockedGetUnreadCount).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(450);
+    await flushMicrotasks();
+
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(5);
+    expect(useUnreadConversationsStore.getState().isLoaded).toBe(true);
+  });
+
+  it('all concurrent callers resolve once after a single HTTP round-trip', async () => {
+    mockedGetUnreadCount.mockResolvedValue({ unread_count: 3 });
+    const { fetch } = useUnreadConversationsStore.getState();
+
+    const resolved: number[] = [];
+    const p1 = fetch().then(() => resolved.push(1));
+    const p2 = fetch().then(() => resolved.push(2));
+    const p3 = fetch().then(() => resolved.push(3));
+
+    await vi.advanceTimersByTimeAsync(450);
+    await flushMicrotasks();
+    await Promise.all([p1, p2, p3]);
+
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+    expect(resolved.sort()).toEqual([1, 2, 3]);
+  });
+
+  it('clamps a negative server response to zero', async () => {
+    mockedGetUnreadCount.mockResolvedValue({ unread_count: -7 });
+    useUnreadConversationsStore.getState().fetch();
+
+    await vi.advanceTimersByTimeAsync(450);
+    await flushMicrotasks();
+
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+  });
+
+  it('does not crash when the API rejects and leaves totalUnread untouched', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    useUnreadConversationsStore.setState({ totalUnread: 9, isLoaded: true });
+    mockedGetUnreadCount.mockRejectedValueOnce(new Error('boom'));
+
+    useUnreadConversationsStore.getState().fetch();
+    await vi.advanceTimersByTimeAsync(450);
+    await flushMicrotasks();
+
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(9);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('useUnreadConversationsStore.reset', () => {
+  it('cancels a pending debounced fetch so no request is issued after logout', async () => {
+    mockedGetUnreadCount.mockResolvedValue({ unread_count: 42 });
+    useUnreadConversationsStore.getState().fetch();
+
+    useUnreadConversationsStore.getState().reset();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+
+    expect(mockedGetUnreadCount).not.toHaveBeenCalled();
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+    expect(useUnreadConversationsStore.getState().isLoaded).toBe(false);
+  });
+
+  it('zeroes totalUnread and isLoaded synchronously', () => {
+    useUnreadConversationsStore.setState({ totalUnread: 13, isLoaded: true });
+    useUnreadConversationsStore.getState().reset();
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+    expect(useUnreadConversationsStore.getState().isLoaded).toBe(false);
+  });
+});
+
+describe('useUnreadConversationsStore.setTotal / incrementBy / decrementBy', () => {
+  it('setTotal clamps to zero', () => {
+    useUnreadConversationsStore.getState().setTotal(-5);
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+  });
+
+  it('incrementBy / decrementBy never go below zero', () => {
+    useUnreadConversationsStore.setState({ totalUnread: 2 });
+    useUnreadConversationsStore.getState().decrementBy(10);
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+
+    useUnreadConversationsStore.getState().incrementBy(3);
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(3);
+  });
+});

--- a/src/store/unreadConversationsStore.ts
+++ b/src/store/unreadConversationsStore.ts
@@ -11,13 +11,19 @@ interface UnreadConversationsState {
   reset: () => void;
 }
 
+let fetchSeq = 0;
+let latestApplied = 0;
+
 export const useUnreadConversationsStore = create<UnreadConversationsState>((set) => ({
   totalUnread: 0,
   isLoaded: false,
 
   fetch: async () => {
+    const seq = ++fetchSeq;
     try {
       const { unread_count } = await conversationAPI.getUnreadCount();
+      if (seq <= latestApplied) return;
+      latestApplied = seq;
       set({ totalUnread: Math.max(0, unread_count), isLoaded: true });
     } catch (error) {
       console.warn('Failed to fetch total unread count:', error);

--- a/src/store/unreadConversationsStore.ts
+++ b/src/store/unreadConversationsStore.ts
@@ -13,21 +13,41 @@ interface UnreadConversationsState {
 
 let fetchSeq = 0;
 let latestApplied = 0;
+let inFlight: Promise<void> | null = null;
+let pending: Promise<void> | null = null;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+const FETCH_DEBOUNCE_MS = 400;
 
 export const useUnreadConversationsStore = create<UnreadConversationsState>((set) => ({
   totalUnread: 0,
   isLoaded: false,
 
   fetch: async () => {
-    const seq = ++fetchSeq;
-    try {
-      const { unread_count } = await conversationAPI.getUnreadCount();
-      if (seq <= latestApplied) return;
-      latestApplied = seq;
-      set({ totalUnread: Math.max(0, unread_count), isLoaded: true });
-    } catch (error) {
-      console.warn('Failed to fetch total unread count:', error);
-    }
+    if (inFlight) return inFlight;
+    if (pending) return pending;
+
+    pending = new Promise<void>((resolve) => {
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        pending = null;
+        const seq = ++fetchSeq;
+        inFlight = (async () => {
+          try {
+            const { unread_count } = await conversationAPI.getUnreadCount();
+            if (seq <= latestApplied) return;
+            latestApplied = seq;
+            set({ totalUnread: Math.max(0, unread_count), isLoaded: true });
+          } catch (error) {
+            console.warn('Failed to fetch total unread count:', error);
+          } finally {
+            inFlight = null;
+            resolve();
+          }
+        })();
+      }, FETCH_DEBOUNCE_MS);
+    });
+    return pending;
   },
 
   setTotal: (count) => set({ totalUnread: Math.max(0, count), isLoaded: true }),
@@ -38,5 +58,13 @@ export const useUnreadConversationsStore = create<UnreadConversationsState>((set
   decrementBy: (delta) =>
     set((state) => ({ totalUnread: Math.max(0, state.totalUnread - delta) })),
 
-  reset: () => set({ totalUnread: 0, isLoaded: false }),
+  reset: () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+    pending = null;
+    inFlight = null;
+    set({ totalUnread: 0, isLoaded: false });
+  },
 }));

--- a/src/store/unreadConversationsStore.ts
+++ b/src/store/unreadConversationsStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { conversationAPI } from '@/services/conversations/conversationService';
+
+interface UnreadConversationsState {
+  totalUnread: number;
+  isLoaded: boolean;
+  fetch: () => Promise<void>;
+  setTotal: (count: number) => void;
+  incrementBy: (delta: number) => void;
+  decrementBy: (delta: number) => void;
+  reset: () => void;
+}
+
+export const useUnreadConversationsStore = create<UnreadConversationsState>((set) => ({
+  totalUnread: 0,
+  isLoaded: false,
+
+  fetch: async () => {
+    try {
+      const { unread_count } = await conversationAPI.getUnreadCount();
+      set({ totalUnread: Math.max(0, unread_count), isLoaded: true });
+    } catch (error) {
+      console.warn('Failed to fetch total unread count:', error);
+    }
+  },
+
+  setTotal: (count) => set({ totalUnread: Math.max(0, count), isLoaded: true }),
+
+  incrementBy: (delta) =>
+    set((state) => ({ totalUnread: Math.max(0, state.totalUnread + delta) })),
+
+  decrementBy: (delta) =>
+    set((state) => ({ totalUnread: Math.max(0, state.totalUnread - delta) })),
+
+  reset: () => set({ totalUnread: 0, isLoaded: false }),
+}));

--- a/src/types/chat/conversations.ts
+++ b/src/types/chat/conversations.ts
@@ -104,7 +104,7 @@ export interface ConversationsContextValue {
 
   // Context menu actions
   deleteConversation: (conversationId: string) => Promise<void>;
-  markAsRead: (conversationId: string) => Promise<void>;
+  markAsRead: (conversationId: string, options?: { silent?: boolean }) => Promise<void>;
   markAsUnread: (conversationId: string) => Promise<void>;
   markAsResolved: (conversationId: string) => Promise<void>;
   markAsPending: (conversationId: string) => Promise<void>;


### PR DESCRIPTION
## Summary
- Replace the passive dot on the conversation list with a numeric `UnreadBadge` (hides at 0, shows `99+` at ≥100).
- Add a global unread badge to the sidebar "Conversas" menu item using a new zustand store seeded by `GET /api/v1/conversations/unread_count`.
- Auto mark-as-read when a conversation is selected or when an incoming message arrives in the already-open conversation; both paths POST `update_last_seen` and re-sync the global aggregate with the server.
- Replace local delta math with a `fetch()` against the global endpoint after every unread-touching action so the menu badge never drifts.
- WhatsApp-style row layout: timestamp moved to a right-side stack above the unread pill.
- i18n keys for the badge `aria-label` in all 6 languages (en, pt-BR, pt, es, fr, it).

## Security
- The store fetches a single read-only endpoint already scoped to the current user on the backend; no new permissions surface client-side.
- No new XSS vectors: the badge renders a clamped integer through React.

## Test plan
- `pnpm exec tsc -b --noEmit`
- `pnpm test src/components/shared/UnreadBadge.spec.tsx`
- Manual: open the only unread conversation → menu badge drops to 0 without a refresh.
- Manual: send an incoming message to the currently-open conversation → menu badge stays at 0.
- Manual: receive a message in a non-open conversation → menu badge increments.

## Changed Files
- `src/components/shared/UnreadBadge.tsx`
- `src/components/shared/UnreadBadge.spec.tsx`
- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/layout/components/MenuItem.tsx`
- `src/components/layout/components/Sidebar.tsx`
- `src/components/layout/components/Header.tsx`
- `src/store/unreadConversationsStore.ts`
- `src/contexts/chat/ConversationsContext.tsx`
- `src/contexts/chat/ChatContext.tsx`
- `src/pages/Customer/Chat/Chat.tsx`
- `src/services/conversations/conversationService.ts`
- `src/types/chat/conversations.ts`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/chat.json`

## Linked Issue
- EVO-1550

## Related PRs
- Backend: https://github.com/evolution-foundation/evo-ai-crm-community/pull/115

## Summary by Sourcery

Add a global unread conversations counter and numeric badges to the chat list and navigation, keeping counts in sync with backend state.

New Features:
- Introduce a reusable UnreadBadge component for displaying numeric unread counts with accessibility support.
- Add a zustand unreadConversationsStore backed by a conversations unread_count API to track the global unread total.
- Display a global unread badge on the conversations sidebar and header menu entries driven by the global unread store.
- Automatically mark the active conversation as read when it is opened or receives an incoming message while open, updating unread counts accordingly.

Enhancements:
- Update chat sidebar conversation rows to a WhatsApp-style layout with the timestamp and unread badge aligned on the right.
- Extend navigation menu items to support optional numeric badges, including a compact pill when the sidebar is collapsed.
- Wire ConversationsContext and ChatContext actions to refresh the global unread aggregate after any unread-affecting operation instead of relying on local deltas.
- Initialize and reset the global unread store in AppInitializer based on the authenticated user lifecycle.
- Expose a conversationAPI.getUnreadCount helper and expand menu item typings to include badge metadata.
- Add i18n keys for unread badge aria-labels across supported locales.

Tests:
- Add unit tests for the UnreadBadge component to verify its rendering behavior at different unread counts.