### PR TITLE
fix(frontend): apply account language change instantly without reload (EVO-1636)

### DIFF
--- a/src/pages/Customer/Settings/Account/AccountSettings.tsx
+++ b/src/pages/Customer/Settings/Account/AccountSettings.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { type Locale } from '@/i18n/config';
 import {
   Input,
   Label,
@@ -52,7 +53,7 @@ function SectionLayout({
 }
 
 export default function AccountSettings() {
-  const { t } = useLanguage('accountSettings');
+  const { t, changeLanguage } = useLanguage('accountSettings');
   const { can, isReady: permissionsReady } = useUserPermissions();
   const normalizeAccountLocale = (locale?: string | null): string => {
     if (!locale) return 'pt-BR';
@@ -192,12 +193,15 @@ export default function AccountSettings() {
 
     setSaving(true);
     try {
+      const normalizedLocale = normalizeAccountLocale(formData.locale);
       await accountService.updateAccount({
         name: formData.name,
-        locale: normalizeAccountLocale(formData.locale),
+        locale: normalizedLocale,
         domain: formData.domain,
         support_email: formData.supportEmail,
       });
+
+      changeLanguage(normalizedLocale as Locale);
 
       toast.success(t('messages.success.generalUpdated'));
       await loadAccountData(); // Recarregar dados


### PR DESCRIPTION
## Summary

`/settings/account` persisted the chosen language to the backend but never switched the running SPA, so the new language only took effect after a manual F5 (EVO-1636).

- `handleGeneralSubmit` now calls the existing `useLanguage().changeLanguage` after a successful `updateAccount` — it runs `i18n.changeLanguage` (reactive re-render via react-i18next, `useSuspense:false` + default `bindI18n`) and persists to `localStorage`.
- The normalized locale is computed once and reused for both the API payload and the language switch, so the persisted value and the applied value cannot drift.
- Placed inside the `try`, after the `await`, so the UI does not switch if the save fails.

## Security
N/A — client-side UI behavior only.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec eslint src/pages/Customer/Settings/Account/AccountSettings.tsx` — no new issues
- Manual smoke: `/settings/account` → change language → Save → UI switches instantly, no F5; selection persists after a real reload.

## Changed Files
- `src/pages/Customer/Settings/Account/AccountSettings.tsx`

## Linked Issue
- EVO-1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Apply language changes in the account settings page immediately after saving, keeping the persisted and active locales in sync.

New Features:
- Switch the SPA language instantly on successful account settings save based on the selected locale.

Bug Fixes:
- Prevent mismatches between the locale saved to the backend and the locale applied in the UI by reusing a normalized locale value.