### PR TITLE
feat(frontend): commit Journey node-type manifest as cross-repo parity source (EVO-1634)

### DIFF
--- a/src/pages/Customer/Journey/journey-node-manifest.json
+++ b/src/pages/Customer/Journey/journey-node-manifest.json
@@ -1,0 +1,30 @@
+{
+  "description": "Source-of-truth list of Customer Journey palette node types. The evo-flow Temporal executor MUST have a case for each, or the node no-ops at runtime (EVO-1634). Kept in sync with JourneyFlowEditor.tsx nodeTypes by journey-node-manifest.spec.ts.",
+  "nodeTypes": [
+    "add-label-node",
+    "assign-agent-node",
+    "assign-bot-node",
+    "assign-team-node",
+    "assign-to-pipeline-node",
+    "change-priority-node",
+    "conditional-node",
+    "defer-conversation-node",
+    "exit-journey-node",
+    "journey-trigger-node",
+    "mute-conversation-node",
+    "remove-label-node",
+    "resolve-conversation-node",
+    "scheduled-action-node",
+    "send-canned-response-node",
+    "send-email-team-node",
+    "send-message-node",
+    "send-transcript-node",
+    "send-webhook-node",
+    "set-variable-node",
+    "split-node",
+    "transfer-journey-node",
+    "update-contact-node",
+    "update-custom-attribute-node",
+    "wait-node"
+  ]
+}

--- a/src/pages/Customer/Journey/journey-node-manifest.spec.ts
+++ b/src/pages/Customer/Journey/journey-node-manifest.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import manifest from './journey-node-manifest.json';
+
+// Parity guard (EVO-1634): the manifest is the cross-repo contract the evo-flow
+// Temporal executor reads to assert every Journey palette node has an executor
+// case. This test keeps the manifest honest against the real JourneyFlowEditor
+// `nodeTypes` so it can't silently drift.
+describe('journey node manifest parity (EVO-1634)', () => {
+  it('lists exactly the node types referenced in JourneyFlowEditor', () => {
+    const src = readFileSync(
+      resolve(process.cwd(), 'src/pages/Customer/Journey/JourneyFlowEditor.tsx'),
+      'utf8',
+    );
+    const referenced = Array.from(
+      new Set([...src.matchAll(/'([a-z-]+-node)':/g)].map(m => m[1])),
+    ).sort();
+
+    expect([...manifest.nodeTypes].sort()).toEqual(referenced);
+  });
+});


### PR DESCRIPTION
## Summary
Commits the **Journey node-type manifest** as the cross-repo source of truth for palette ↔ executor parity — part of **EVO-1634**.

The evo-flow coverage guard (`journey-execution.coverage.spec.ts`) reads this manifest to assert that **every** action node the Journey palette can produce has a non-`default` executor branch, so a newly-added palette node can no longer silently no-op at runtime.

- `journey-node-manifest.json` — committed list of the 25 palette `nodeType`s.
- `journey-node-manifest.spec.ts` — vitest that fails if the manifest drifts from the node types actually referenced in `JourneyFlowEditor.tsx`.

This is additive-only (no UI/behavior change); it locks the palette as the canonical list the runtime is checked against.

## Validation
- `pnpm exec tsc -b --noEmit`
- `pnpm test src/pages/Customer/Journey/journey-node-manifest.spec.ts` (manifest ↔ editor in sync)

## Changed Files
- `src/pages/Customer/Journey/journey-node-manifest.json`
- `src/pages/Customer/Journey/journey-node-manifest.spec.ts`

## Related PRs
- evo-flow#25 — executor node wiring + coverage guard that consumes this manifest
- evo-ai-crm-community#116 — CRM endpoints for the wired nodes

## Linked Issue
- EVO-1634

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a committed Journey node-type manifest and associated tests to enforce palette-to-executor parity across repositories.

New Features:
- Introduce a version-controlled Journey node-type manifest as the canonical list of palette node types.

Enhancements:
- Wire the Journey execution coverage guard to consume the node-type manifest as the source of truth for palette-to-executor parity.

Tests:
- Add a unit test to ensure the Journey node-type manifest stays in sync with the node types referenced by the Journey flow editor.