### PR TITLE
fix(automation): form UUID schemas, submit gate, required markers + i18n (EVO-1639)

### DIFF
--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -365,16 +365,15 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   <Input
-                    type="number"
                     value={
                       current.assigned_to_id != null && current.assigned_to_id !== ''
                         ? String(current.assigned_to_id)
                         : ''
                     }
                     onChange={(e) => {
-                      const raw = e.target.value;
-                      const num = raw === '' ? undefined : Number(raw);
-                      setField('assigned_to_id', Number.isNaN(num) ? undefined : num);
+                      // user ids are UUID strings — keep the raw value, don't coerce to Number
+                      const raw = e.target.value.trim();
+                      setField('assigned_to_id', raw === '' ? undefined : raw);
                     }}
                     placeholder={t('form.fields.actionRow.params.create_pipeline_task_assignee')}
                   />
@@ -417,19 +416,14 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
               field.onChange([{ ...current, attachment_ids: parsed }]);
             };
             const setInbox = (raw: string) => {
-              if (raw === '') {
+              const trimmed = raw.trim();
+              if (trimmed === '') {
                 const next = { ...current };
                 delete (next as Record<string, unknown>).inbox_id;
                 field.onChange([{ ...next, attachment_ids: ids }]);
               } else {
-                const num = Number(raw);
-                field.onChange([
-                  {
-                    ...current,
-                    attachment_ids: ids,
-                    inbox_id: Number.isNaN(num) ? undefined : num,
-                  },
-                ]);
+                // inbox ids are UUID strings — keep the raw value
+                field.onChange([{ ...current, attachment_ids: ids, inbox_id: trimmed }]);
               }
             };
             return (
@@ -440,7 +434,6 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
                   placeholder={t('form.fields.actionRow.params.send_attachment_ids')}
                 />
                 <Input
-                  type="number"
                   value={inboxId != null ? String(inboxId) : ''}
                   onChange={(e) => setInbox(e.target.value)}
                   placeholder={t('form.fields.actionRow.params.send_attachment_inbox')}

--- a/src/components/automation/ActionsBuilder.tsx
+++ b/src/components/automation/ActionsBuilder.tsx
@@ -29,7 +29,7 @@ export default function ActionsBuilder({ control, formData }: Props) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="text-base font-semibold">{t('form.fields.actions.label')}</h3>
+        <h3 className="text-base font-semibold">{t('form.fields.actions.label')} *</h3>
         <Button
           type="button"
           variant="outline"

--- a/src/components/automation/ConditionsBuilder.tsx
+++ b/src/components/automation/ConditionsBuilder.tsx
@@ -21,7 +21,12 @@ export default function ConditionsBuilder({ control, formData }: Props) {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="text-base font-semibold">{t('form.fields.conditions.label')}</h3>
+        <h3 className="text-base font-semibold">
+          {t('form.fields.conditions.label')}{' '}
+          <span className="text-xs font-normal text-muted-foreground">
+            ({t('form.fields.conditions.optional')})
+          </span>
+        </h3>
         <Button
           type="button"
           variant="outline"

--- a/src/components/automation/EventSelector.tsx
+++ b/src/components/automation/EventSelector.tsx
@@ -38,7 +38,7 @@ export default function EventSelector({ control, disabled }: Props) {
       name="event_name"
       render={({ field, fieldState }) => (
         <div className="space-y-2">
-          <label className="text-sm font-medium">{t('form.fields.event.label')}</label>
+          <label className="text-sm font-medium">{t('form.fields.event.label')} *</label>
           <Select
             value={field.value ?? ''}
             onValueChange={field.onChange}

--- a/src/components/automation/__snapshots__/EventSelector.spec.tsx.snap
+++ b/src/components/automation/__snapshots__/EventSelector.spec.tsx.snap
@@ -9,6 +9,7 @@ exports[`Automation EventSelector (EVO-1263) > matches the closed-trigger snapsh
       class="text-sm font-medium"
     >
       Trigger event
+       *
     </label>
     <button
       aria-autocomplete="none"

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -79,6 +79,7 @@ import ptTemplates from './locales/pt/templates.json';
 import ptCustomAttributes from './locales/pt/customAttributes.json';
 import ptLabels from './locales/pt/labels.json';
 import ptMacros from './locales/pt/macros.json';
+import ptAutomation from './locales/pt/automation.json';
 import ptTeams from './locales/pt/teams.json';
 import ptUsers from './locales/pt/users.json';
 import ptMarketplace from './locales/pt/marketplace.json';
@@ -178,6 +179,7 @@ import esTemplates from './locales/es/templates.json';
 import esCustomAttributes from './locales/es/customAttributes.json';
 import esLabels from './locales/es/labels.json';
 import esMacros from './locales/es/macros.json';
+import esAutomation from './locales/es/automation.json';
 import esTeams from './locales/es/teams.json';
 import esUsers from './locales/es/users.json';
 import esMarketplace from './locales/es/marketplace.json';
@@ -227,6 +229,7 @@ import frTemplates from './locales/fr/templates.json';
 import frCustomAttributes from './locales/fr/customAttributes.json';
 import frLabels from './locales/fr/labels.json';
 import frMacros from './locales/fr/macros.json';
+import frAutomation from './locales/fr/automation.json';
 import frTeams from './locales/fr/teams.json';
 import frUsers from './locales/fr/users.json';
 import frMarketplace from './locales/fr/marketplace.json';
@@ -276,6 +279,7 @@ import itTemplates from './locales/it/templates.json';
 import itCustomAttributes from './locales/it/customAttributes.json';
 import itLabels from './locales/it/labels.json';
 import itMacros from './locales/it/macros.json';
+import itAutomation from './locales/it/automation.json';
 import itTeams from './locales/it/teams.json';
 import itUsers from './locales/it/users.json';
 import itMarketplace from './locales/it/marketplace.json';
@@ -450,6 +454,7 @@ const resources = {
     customAttributes: ptCustomAttributes,
     labels: ptLabels,
     macros: ptMacros,
+    automation: ptAutomation,
     teams: ptTeams,
     users: ptUsers,
     marketplace: ptMarketplace,
@@ -563,6 +568,7 @@ const resources = {
     customAttributes: esCustomAttributes,
     labels: esLabels,
     macros: esMacros,
+    automation: esAutomation,
     teams: esTeams,
     users: esUsers,
     marketplace: esMarketplace,
@@ -619,6 +625,7 @@ const resources = {
     customAttributes: frCustomAttributes,
     labels: frLabels,
     macros: frMacros,
+    automation: frAutomation,
     teams: frTeams,
     users: frUsers,
     marketplace: frMarketplace,
@@ -675,6 +682,7 @@ const resources = {
     customAttributes: itCustomAttributes,
     labels: itLabels,
     macros: itMacros,
+    automation: itAutomation,
     teams: itTeams,
     users: itUsers,
     marketplace: itMarketplace,

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -64,6 +64,7 @@
       },
       "conditions": {
         "label": "Conditions",
+        "optional": "optional",
         "addRow": "Add condition",
         "empty": "No conditions — this rule will fire on every event."
       },

--- a/src/i18n/locales/es/automation.json
+++ b/src/i18n/locales/es/automation.json
@@ -1,0 +1,249 @@
+{
+  "page": {
+    "title": "Automatizaciones",
+    "subtitle": "{{count}} reglas de automatización",
+    "searchPlaceholder": "Buscar por nombre",
+    "newAutomation": "Nueva automatización",
+    "bulkDelete": "Eliminar seleccionados",
+    "clearSelection": "Limpiar ({{count}})",
+    "loading": "Cargando...",
+    "empty": {
+      "title": "Aún no hay automatizaciones",
+      "description": "Crea reglas que se activen con eventos como nuevas conversaciones, contactos y cambios de etapa del pipeline.",
+      "action": "Crea tu primera automatización"
+    }
+  },
+  "table": {
+    "columns": {
+      "name": "Nombre",
+      "event": "Evento",
+      "status": "Estado",
+      "actionsCount": "Acciones",
+      "createdAt": "Creado"
+    },
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva"
+    },
+    "actions": {
+      "edit": "Editar",
+      "clone": "Clonar",
+      "delete": "Eliminar"
+    }
+  },
+  "form": {
+    "title": {
+      "create": "Nueva automatización",
+      "edit": "Editar automatización"
+    },
+    "tabs": {
+      "settings": "Configuración",
+      "logs": "Registros"
+    },
+    "fields": {
+      "name": "Nombre",
+      "namePlaceholder": "p. ej. Notificar a ventas cuando la conversación pase a Ganada",
+      "description": "Descripción",
+      "descriptionPlaceholder": "Contexto opcional para tu equipo",
+      "active": "Activa",
+      "event": {
+        "label": "Evento desencadenante",
+        "placeholder": "Selecciona un evento",
+        "hint": "Consejo: para reaccionar a una transición (p. ej. el estado pasó de Abierto a Resuelto, o se agregó una etiqueta), usa el operador \"Atributo cambiado\". El simple \"Igual a\" se vuelve a activar en cada actualización mientras el valor permanezca igual.",
+        "options": {
+          "conversation_created": "Conversación creada",
+          "conversation_updated": "Conversación actualizada",
+          "conversation_opened": "Conversación abierta",
+          "message_created": "Mensaje creado",
+          "pipeline_stage_updated": "Etapa del pipeline actualizada",
+          "contact_created": "Contacto creado",
+          "contact_updated": "Contacto actualizado",
+          "conversation_resolved": "Conversación resuelta",
+          "conversation_status_changed": "Estado de conversación cambiado"
+        }
+      },
+      "conditions": {
+        "label": "Condiciones",
+        "optional": "opcional",
+        "addRow": "Agregar condición",
+        "empty": "Sin condiciones — esta regla se activará en cada evento."
+      },
+      "actions": {
+        "label": "Acciones",
+        "addRow": "Agregar acción",
+        "empty": "Agrega al menos una acción.",
+        "send_message": "Enviar mensaje",
+        "send_canned_response": "Enviar respuesta predefinida",
+        "send_template": "Enviar plantilla",
+        "add_label": "Agregar etiqueta",
+        "remove_label": "Quitar etiqueta",
+        "send_email_to_team": "Enviar correo al equipo",
+        "assign_team": "Asignar equipo",
+        "assign_agent": "Asignar agente",
+        "send_webhook_event": "Enviar evento de webhook",
+        "mute_conversation": "Silenciar conversación",
+        "send_attachment": "Enviar adjunto",
+        "change_status": "Cambiar estado",
+        "resolve_conversation": "Resolver conversación",
+        "snooze_conversation": "Posponer conversación",
+        "change_priority": "Cambiar prioridad",
+        "send_email_transcript": "Enviar transcripción por correo",
+        "assign_to_pipeline": "Asignar al pipeline",
+        "update_pipeline_stage": "Actualizar etapa del pipeline",
+        "create_pipeline_task": "Crear tarea del pipeline"
+      },
+      "conditionRow": {
+        "attribute": "Atributo",
+        "operator": "Operador",
+        "value": "Valor",
+        "from": "Desde",
+        "to": "Hasta",
+        "remove": "Quitar condición",
+        "noValueNeeded": "No se necesita valor"
+      },
+      "boolean": {
+        "true": "Sí",
+        "false": "No"
+      },
+      "actionRow": {
+        "action": "Acción",
+        "remove": "Quitar acción",
+        "selectActionFirst": "Selecciona una acción para configurar",
+        "noParams": "No se requieren parámetros",
+        "params": {
+          "send_message": "Contenido del mensaje",
+          "send_canned_response": "Elige una respuesta predefinida",
+          "send_template": "Elige una plantilla",
+          "send_webhook_event": "URL del webhook",
+          "send_email_transcript": "Correo del destinatario",
+          "assign_team": "Elige un equipo",
+          "assign_agent": "Elige un agente",
+          "add_label": "Elige una etiqueta",
+          "remove_label": "Elige una etiqueta",
+          "change_priority": "Elige una prioridad",
+          "change_status": "Elige un estado",
+          "assign_to_pipeline": "Elige un pipeline",
+          "update_pipeline_stage": "Elige una etapa del pipeline",
+          "send_email_to_team": "Cuerpo del correo",
+          "create_pipeline_task": "Título de la tarea",
+          "create_pipeline_task_description": "Descripción (opcional)",
+          "create_pipeline_task_type": "Tipo (opcional)",
+          "create_pipeline_task_priority": "Prioridad (opcional)",
+          "create_pipeline_task_assignee": "ID de usuario asignado (opcional)",
+          "create_pipeline_task_due_in": "Vence en (p. ej., 2d, 1w)",
+          "send_attachment_ids": "IDs de adjuntos (separados por comas)",
+          "send_attachment_inbox": "ID del canal (opcional)"
+        }
+      },
+      "operators": {
+        "equal_to": "Igual a",
+        "not_equal_to": "Distinto de",
+        "contains": "Contiene",
+        "does_not_contain": "No contiene",
+        "is_present": "Está presente",
+        "is_not_present": "No está presente",
+        "is_greater_than": "Mayor que",
+        "is_less_than": "Menor que",
+        "days_before": "Días antes",
+        "starts_with": "Comienza con",
+        "attribute_changed": "Atributo cambiado",
+        "is_in": "Está en",
+        "is_not_in": "No está en",
+        "labels": {
+          "equal_to": "Tiene esta etiqueta",
+          "not_equal_to": "No tiene esta etiqueta",
+          "attribute_changed": "Etiqueta cambiada"
+        }
+      },
+      "attributes": {
+        "status": "Estado",
+        "assignee_id": "Asignado",
+        "inbox_id": "Canal",
+        "team_id": "Equipo",
+        "priority": "Prioridad",
+        "labels": "Etiquetas",
+        "country_code": "Código de país",
+        "referer": "Referente",
+        "mail_subject": "Asunto del correo",
+        "content": "Contenido del mensaje",
+        "message_type": "Tipo de mensaje",
+        "name": "Nombre",
+        "email": "Correo electrónico",
+        "phone_number": "Número de teléfono",
+        "identifier": "Identificador",
+        "city": "Ciudad",
+        "company": "Empresa",
+        "blocked": "Bloqueado",
+        "pipeline_id": "Pipeline",
+        "pipeline_stage_id": "Etapa del pipeline"
+      }
+    },
+    "buttons": {
+      "create": "Crear",
+      "update": "Guardar",
+      "saving": "Guardando...",
+      "cancel": "Cancelar"
+    }
+  },
+  "dialog": {
+    "delete": {
+      "title": "Eliminar automatización",
+      "description": "¿Seguro que deseas eliminar \"{{name}}\"? Esta acción no se puede deshacer.",
+      "confirm": "Eliminar",
+      "cancel": "Cancelar",
+      "deleting": "Eliminando..."
+    },
+    "bulkDelete": {
+      "title": "Eliminar automatizaciones",
+      "description": "¿Seguro que deseas eliminar {{count}} automatizaciones? Esta acción no se puede deshacer.",
+      "confirm": "Eliminar todas",
+      "cancel": "Cancelar",
+      "deleting": "Eliminando..."
+    }
+  },
+  "logs": {
+    "title": "Registros de ejecución",
+    "description": "Ejecuciones más recientes de esta regla de automatización.",
+    "refresh": "Actualizar",
+    "empty": "Aún no hay ejecuciones registradas para esta regla.",
+    "filters": {
+      "all": "Todos los estados",
+      "matched": "Coincidió",
+      "no_match": "Sin coincidencia",
+      "skipped": "Omitido",
+      "error": "Error"
+    },
+    "status": {
+      "matched": "Coincidió",
+      "no_match": "Sin coincidencia",
+      "skipped": "Omitido",
+      "error": "Error"
+    },
+    "detail": {
+      "timeline": "Cronología",
+      "payload": "Carga útil"
+    }
+  },
+  "messages": {
+    "loadError": "Error al cargar las automatizaciones",
+    "bulkDeletePartial": "{{success}} eliminadas, {{failed}} fallidas",
+    "ruleNotFound": "Regla de automatización no encontrada",
+    "createSuccess": "Automatización creada",
+    "createError": "Error al crear la automatización",
+    "updateSuccess": "Automatización actualizada",
+    "updateError": "Error al actualizar la automatización",
+    "deleteSuccess": "Automatización eliminada",
+    "deleteError": "Error al eliminar la automatización",
+    "bulkDeleteSuccess": "{{count}} automatizaciones eliminadas",
+    "bulkDeleteError": "Error al eliminar las automatizaciones",
+    "cloneSuccess": "Automatización clonada",
+    "cloneError": "Error al clonar la automatización",
+    "permissionDenied": {
+      "read": "No tienes permiso para ver automatizaciones",
+      "create": "No tienes permiso para crear automatizaciones",
+      "update": "No tienes permiso para editar automatizaciones",
+      "delete": "No tienes permiso para eliminar automatizaciones",
+      "clone": "No tienes permiso para clonar automatizaciones"
+    }
+  }
+}

--- a/src/i18n/locales/fr/automation.json
+++ b/src/i18n/locales/fr/automation.json
@@ -1,0 +1,249 @@
+{
+  "page": {
+    "title": "Automatisations",
+    "subtitle": "{{count}} règles d'automatisation",
+    "searchPlaceholder": "Rechercher par nom",
+    "newAutomation": "Nouvelle automatisation",
+    "bulkDelete": "Supprimer la sélection",
+    "clearSelection": "Effacer ({{count}})",
+    "loading": "Chargement...",
+    "empty": {
+      "title": "Aucune automatisation pour le moment",
+      "description": "Créez des règles qui se déclenchent sur des événements comme les nouvelles conversations, les contacts et les changements d'étape du pipeline.",
+      "action": "Créer votre première automatisation"
+    }
+  },
+  "table": {
+    "columns": {
+      "name": "Nom",
+      "event": "Événement",
+      "status": "Statut",
+      "actionsCount": "Actions",
+      "createdAt": "Créé le"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "actions": {
+      "edit": "Modifier",
+      "clone": "Cloner",
+      "delete": "Supprimer"
+    }
+  },
+  "form": {
+    "title": {
+      "create": "Nouvelle automatisation",
+      "edit": "Modifier l'automatisation"
+    },
+    "tabs": {
+      "settings": "Paramètres",
+      "logs": "Journaux"
+    },
+    "fields": {
+      "name": "Nom",
+      "namePlaceholder": "ex. Notifier les ventes quand une conversation passe à Gagné",
+      "description": "Description",
+      "descriptionPlaceholder": "Contexte facultatif pour votre équipe",
+      "active": "Active",
+      "event": {
+        "label": "Événement déclencheur",
+        "placeholder": "Sélectionner un événement",
+        "hint": "Astuce : pour réagir à une transition (par ex. un statut passé de Ouvert à Résolu, ou l'ajout d'une étiquette), utilisez l'opérateur \"Attribut modifié\". Le simple \"Égal à\" se redéclenche à chaque mise à jour tant que la valeur reste identique.",
+        "options": {
+          "conversation_created": "Conversation créée",
+          "conversation_updated": "Conversation mise à jour",
+          "conversation_opened": "Conversation ouverte",
+          "message_created": "Message créé",
+          "pipeline_stage_updated": "Étape du pipeline mise à jour",
+          "contact_created": "Contact créé",
+          "contact_updated": "Contact mis à jour",
+          "conversation_resolved": "Conversation résolue",
+          "conversation_status_changed": "Statut de la conversation modifié"
+        }
+      },
+      "conditions": {
+        "label": "Conditions",
+        "optional": "facultatif",
+        "addRow": "Ajouter une condition",
+        "empty": "Aucune condition — cette règle se déclenchera à chaque événement."
+      },
+      "actions": {
+        "label": "Actions",
+        "addRow": "Ajouter une action",
+        "empty": "Ajoutez au moins une action.",
+        "send_message": "Envoyer un message",
+        "send_canned_response": "Envoyer une réponse prédéfinie",
+        "send_template": "Envoyer un modèle",
+        "add_label": "Ajouter une étiquette",
+        "remove_label": "Retirer une étiquette",
+        "send_email_to_team": "Envoyer un e-mail à l'équipe",
+        "assign_team": "Affecter une équipe",
+        "assign_agent": "Affecter un agent",
+        "send_webhook_event": "Envoyer un événement webhook",
+        "mute_conversation": "Mettre la conversation en sourdine",
+        "send_attachment": "Envoyer une pièce jointe",
+        "change_status": "Changer le statut",
+        "resolve_conversation": "Résoudre la conversation",
+        "snooze_conversation": "Reporter la conversation",
+        "change_priority": "Changer la priorité",
+        "send_email_transcript": "Envoyer la transcription par e-mail",
+        "assign_to_pipeline": "Affecter à un pipeline",
+        "update_pipeline_stage": "Mettre à jour l'étape du pipeline",
+        "create_pipeline_task": "Créer une tâche de pipeline"
+      },
+      "conditionRow": {
+        "attribute": "Attribut",
+        "operator": "Opérateur",
+        "value": "Valeur",
+        "from": "De",
+        "to": "À",
+        "remove": "Supprimer la condition",
+        "noValueNeeded": "Aucune valeur requise"
+      },
+      "boolean": {
+        "true": "Oui",
+        "false": "Non"
+      },
+      "actionRow": {
+        "action": "Action",
+        "remove": "Supprimer l'action",
+        "selectActionFirst": "Sélectionnez une action à configurer",
+        "noParams": "Aucun paramètre requis",
+        "params": {
+          "send_message": "Contenu du message",
+          "send_canned_response": "Choisir une réponse prédéfinie",
+          "send_template": "Choisir un modèle",
+          "send_webhook_event": "URL du webhook",
+          "send_email_transcript": "E-mail du destinataire",
+          "assign_team": "Choisir une équipe",
+          "assign_agent": "Choisir un agent",
+          "add_label": "Choisir une étiquette",
+          "remove_label": "Choisir une étiquette",
+          "change_priority": "Choisir une priorité",
+          "change_status": "Choisir un statut",
+          "assign_to_pipeline": "Choisir un pipeline",
+          "update_pipeline_stage": "Choisir une étape du pipeline",
+          "send_email_to_team": "Corps de l'e-mail",
+          "create_pipeline_task": "Titre de la tâche",
+          "create_pipeline_task_description": "Description (facultatif)",
+          "create_pipeline_task_type": "Type (facultatif)",
+          "create_pipeline_task_priority": "Priorité (facultatif)",
+          "create_pipeline_task_assignee": "ID de l'utilisateur affecté (facultatif)",
+          "create_pipeline_task_due_in": "Échéance dans (ex. 2d, 1w)",
+          "send_attachment_ids": "ID des pièces jointes (séparés par des virgules)",
+          "send_attachment_inbox": "ID du canal (facultatif)"
+        }
+      },
+      "operators": {
+        "equal_to": "Égal à",
+        "not_equal_to": "Différent de",
+        "contains": "Contient",
+        "does_not_contain": "Ne contient pas",
+        "is_present": "Est présent",
+        "is_not_present": "N'est pas présent",
+        "is_greater_than": "Supérieur à",
+        "is_less_than": "Inférieur à",
+        "days_before": "Jours avant",
+        "starts_with": "Commence par",
+        "attribute_changed": "Attribut modifié",
+        "is_in": "Fait partie de",
+        "is_not_in": "Ne fait pas partie de",
+        "labels": {
+          "equal_to": "Possède cette étiquette",
+          "not_equal_to": "Ne possède pas cette étiquette",
+          "attribute_changed": "Étiquette modifiée"
+        }
+      },
+      "attributes": {
+        "status": "Statut",
+        "assignee_id": "Personne affectée",
+        "inbox_id": "Canal",
+        "team_id": "Équipe",
+        "priority": "Priorité",
+        "labels": "Étiquettes",
+        "country_code": "Code pays",
+        "referer": "Référent",
+        "mail_subject": "Objet de l'e-mail",
+        "content": "Contenu du message",
+        "message_type": "Type de message",
+        "name": "Nom",
+        "email": "E-mail",
+        "phone_number": "Numéro de téléphone",
+        "identifier": "Identifiant",
+        "city": "Ville",
+        "company": "Entreprise",
+        "blocked": "Bloqué",
+        "pipeline_id": "Pipeline",
+        "pipeline_stage_id": "Étape du pipeline"
+      }
+    },
+    "buttons": {
+      "create": "Créer",
+      "update": "Enregistrer",
+      "saving": "Enregistrement...",
+      "cancel": "Annuler"
+    }
+  },
+  "dialog": {
+    "delete": {
+      "title": "Supprimer l'automatisation",
+      "description": "Êtes-vous sûr de vouloir supprimer « {{name}} » ? Cette action est irréversible.",
+      "confirm": "Supprimer",
+      "cancel": "Annuler",
+      "deleting": "Suppression..."
+    },
+    "bulkDelete": {
+      "title": "Supprimer les automatisations",
+      "description": "Êtes-vous sûr de vouloir supprimer {{count}} automatisations ? Cette action est irréversible.",
+      "confirm": "Tout supprimer",
+      "cancel": "Annuler",
+      "deleting": "Suppression..."
+    }
+  },
+  "logs": {
+    "title": "Journaux d'exécution",
+    "description": "Exécutions les plus récentes de cette règle d'automatisation.",
+    "refresh": "Actualiser",
+    "empty": "Aucune exécution enregistrée pour le moment pour cette règle.",
+    "filters": {
+      "all": "Tous les statuts",
+      "matched": "Correspondance",
+      "no_match": "Aucune correspondance",
+      "skipped": "Ignoré",
+      "error": "Erreur"
+    },
+    "status": {
+      "matched": "Correspondance",
+      "no_match": "Aucune correspondance",
+      "skipped": "Ignoré",
+      "error": "Erreur"
+    },
+    "detail": {
+      "timeline": "Chronologie",
+      "payload": "Charge utile"
+    }
+  },
+  "messages": {
+    "loadError": "Échec du chargement des automatisations",
+    "bulkDeletePartial": "{{success}} supprimées, {{failed}} échouées",
+    "ruleNotFound": "Règle d'automatisation introuvable",
+    "createSuccess": "Automatisation créée",
+    "createError": "Échec de la création de l'automatisation",
+    "updateSuccess": "Automatisation mise à jour",
+    "updateError": "Échec de la mise à jour de l'automatisation",
+    "deleteSuccess": "Automatisation supprimée",
+    "deleteError": "Échec de la suppression de l'automatisation",
+    "bulkDeleteSuccess": "{{count}} automatisations supprimées",
+    "bulkDeleteError": "Échec de la suppression des automatisations",
+    "cloneSuccess": "Automatisation clonée",
+    "cloneError": "Échec du clonage de l'automatisation",
+    "permissionDenied": {
+      "read": "Vous n'avez pas la permission de consulter les automatisations",
+      "create": "Vous n'avez pas la permission de créer des automatisations",
+      "update": "Vous n'avez pas la permission de modifier des automatisations",
+      "delete": "Vous n'avez pas la permission de supprimer des automatisations",
+      "clone": "Vous n'avez pas la permission de cloner des automatisations"
+    }
+  }
+}

--- a/src/i18n/locales/it/automation.json
+++ b/src/i18n/locales/it/automation.json
@@ -1,0 +1,249 @@
+{
+  "page": {
+    "title": "Automazioni",
+    "subtitle": "{{count}} regole di automazione",
+    "searchPlaceholder": "Cerca per nome",
+    "newAutomation": "Nuova automazione",
+    "bulkDelete": "Elimina selezionati",
+    "clearSelection": "Deseleziona ({{count}})",
+    "loading": "Caricamento...",
+    "empty": {
+      "title": "Nessuna automazione ancora",
+      "description": "Crea regole che si attivano su eventi come nuove conversazioni, contatti e cambi di fase della pipeline.",
+      "action": "Crea la tua prima automazione"
+    }
+  },
+  "table": {
+    "columns": {
+      "name": "Nome",
+      "event": "Evento",
+      "status": "Stato",
+      "actionsCount": "Azioni",
+      "createdAt": "Creato"
+    },
+    "status": {
+      "active": "Attiva",
+      "inactive": "Inattiva"
+    },
+    "actions": {
+      "edit": "Modifica",
+      "clone": "Clona",
+      "delete": "Elimina"
+    }
+  },
+  "form": {
+    "title": {
+      "create": "Nuova automazione",
+      "edit": "Modifica automazione"
+    },
+    "tabs": {
+      "settings": "Impostazioni",
+      "logs": "Log"
+    },
+    "fields": {
+      "name": "Nome",
+      "namePlaceholder": "es. Avvisa le vendite quando la conversazione entra in Vinta",
+      "description": "Descrizione",
+      "descriptionPlaceholder": "Contesto facoltativo per il tuo team",
+      "active": "Attiva",
+      "event": {
+        "label": "Evento trigger",
+        "placeholder": "Seleziona un evento",
+        "hint": "Suggerimento: per reagire a una transizione (es. stato passato da Aperto a Risolto, oppure un'etichetta è stata aggiunta), usa l'operatore \"Attributo cambiato\". Il semplice \"Uguale a\" si riattiva ad ogni aggiornamento finché il valore rimane lo stesso.",
+        "options": {
+          "conversation_created": "Conversazione creata",
+          "conversation_updated": "Conversazione aggiornata",
+          "conversation_opened": "Conversazione aperta",
+          "message_created": "Messaggio creato",
+          "pipeline_stage_updated": "Fase della pipeline aggiornata",
+          "contact_created": "Contatto creato",
+          "contact_updated": "Contatto aggiornato",
+          "conversation_resolved": "Conversazione risolta",
+          "conversation_status_changed": "Stato della conversazione cambiato"
+        }
+      },
+      "conditions": {
+        "label": "Condizioni",
+        "optional": "facoltativo",
+        "addRow": "Aggiungi condizione",
+        "empty": "Nessuna condizione — questa regola si attiverà ad ogni evento."
+      },
+      "actions": {
+        "label": "Azioni",
+        "addRow": "Aggiungi azione",
+        "empty": "Aggiungi almeno un'azione.",
+        "send_message": "Invia messaggio",
+        "send_canned_response": "Invia risposta predefinita",
+        "send_template": "Invia template",
+        "add_label": "Aggiungi etichetta",
+        "remove_label": "Rimuovi etichetta",
+        "send_email_to_team": "Invia email al team",
+        "assign_team": "Assegna team",
+        "assign_agent": "Assegna operatore",
+        "send_webhook_event": "Invia evento webhook",
+        "mute_conversation": "Silenzia conversazione",
+        "send_attachment": "Invia allegato",
+        "change_status": "Cambia stato",
+        "resolve_conversation": "Risolvi conversazione",
+        "snooze_conversation": "Posticipa conversazione",
+        "change_priority": "Cambia priorità",
+        "send_email_transcript": "Invia trascrizione via email",
+        "assign_to_pipeline": "Assegna alla pipeline",
+        "update_pipeline_stage": "Aggiorna fase della pipeline",
+        "create_pipeline_task": "Crea attività della pipeline"
+      },
+      "conditionRow": {
+        "attribute": "Attributo",
+        "operator": "Operatore",
+        "value": "Valore",
+        "from": "Da",
+        "to": "A",
+        "remove": "Rimuovi condizione",
+        "noValueNeeded": "Nessun valore necessario"
+      },
+      "boolean": {
+        "true": "Sì",
+        "false": "No"
+      },
+      "actionRow": {
+        "action": "Azione",
+        "remove": "Rimuovi azione",
+        "selectActionFirst": "Seleziona un'azione da configurare",
+        "noParams": "Nessun parametro richiesto",
+        "params": {
+          "send_message": "Contenuto del messaggio",
+          "send_canned_response": "Scegli una risposta predefinita",
+          "send_template": "Scegli un template",
+          "send_webhook_event": "URL del webhook",
+          "send_email_transcript": "Email del destinatario",
+          "assign_team": "Scegli un team",
+          "assign_agent": "Scegli un operatore",
+          "add_label": "Scegli un'etichetta",
+          "remove_label": "Scegli un'etichetta",
+          "change_priority": "Scegli una priorità",
+          "change_status": "Scegli uno stato",
+          "assign_to_pipeline": "Scegli una pipeline",
+          "update_pipeline_stage": "Scegli una fase della pipeline",
+          "send_email_to_team": "Corpo dell'email",
+          "create_pipeline_task": "Titolo dell'attività",
+          "create_pipeline_task_description": "Descrizione (facoltativo)",
+          "create_pipeline_task_type": "Tipo (facoltativo)",
+          "create_pipeline_task_priority": "Priorità (facoltativo)",
+          "create_pipeline_task_assignee": "ID utente assegnatario (facoltativo)",
+          "create_pipeline_task_due_in": "Scadenza tra (es. 2d, 1w)",
+          "send_attachment_ids": "ID allegati (separati da virgola)",
+          "send_attachment_inbox": "ID canale (facoltativo)"
+        }
+      },
+      "operators": {
+        "equal_to": "Uguale a",
+        "not_equal_to": "Diverso da",
+        "contains": "Contiene",
+        "does_not_contain": "Non contiene",
+        "is_present": "È presente",
+        "is_not_present": "Non è presente",
+        "is_greater_than": "Maggiore di",
+        "is_less_than": "Minore di",
+        "days_before": "Giorni prima",
+        "starts_with": "Inizia con",
+        "attribute_changed": "Attributo cambiato",
+        "is_in": "È in",
+        "is_not_in": "Non è in",
+        "labels": {
+          "equal_to": "Ha questa etichetta",
+          "not_equal_to": "Non ha questa etichetta",
+          "attribute_changed": "Etichetta cambiata"
+        }
+      },
+      "attributes": {
+        "status": "Stato",
+        "assignee_id": "Assegnatario",
+        "inbox_id": "Canale",
+        "team_id": "Team",
+        "priority": "Priorità",
+        "labels": "Etichette",
+        "country_code": "Codice paese",
+        "referer": "Referer",
+        "mail_subject": "Oggetto dell'email",
+        "content": "Contenuto del messaggio",
+        "message_type": "Tipo di messaggio",
+        "name": "Nome",
+        "email": "Email",
+        "phone_number": "Numero di telefono",
+        "identifier": "Identificatore",
+        "city": "Città",
+        "company": "Azienda",
+        "blocked": "Bloccato",
+        "pipeline_id": "Pipeline",
+        "pipeline_stage_id": "Fase della pipeline"
+      }
+    },
+    "buttons": {
+      "create": "Crea",
+      "update": "Salva",
+      "saving": "Salvataggio...",
+      "cancel": "Annulla"
+    }
+  },
+  "dialog": {
+    "delete": {
+      "title": "Elimina automazione",
+      "description": "Sei sicuro di voler eliminare \"{{name}}\"? Questa operazione non può essere annullata.",
+      "confirm": "Elimina",
+      "cancel": "Annulla",
+      "deleting": "Eliminazione..."
+    },
+    "bulkDelete": {
+      "title": "Elimina automazioni",
+      "description": "Sei sicuro di voler eliminare {{count}} automazioni? Questa operazione non può essere annullata.",
+      "confirm": "Elimina tutto",
+      "cancel": "Annulla",
+      "deleting": "Eliminazione..."
+    }
+  },
+  "logs": {
+    "title": "Log di esecuzione",
+    "description": "Esecuzioni più recenti di questa regola di automazione.",
+    "refresh": "Aggiorna",
+    "empty": "Nessuna esecuzione ancora registrata per questa regola.",
+    "filters": {
+      "all": "Tutti gli stati",
+      "matched": "Corrispondente",
+      "no_match": "Nessuna corrispondenza",
+      "skipped": "Saltato",
+      "error": "Errore"
+    },
+    "status": {
+      "matched": "Corrispondente",
+      "no_match": "Nessuna corrispondenza",
+      "skipped": "Saltato",
+      "error": "Errore"
+    },
+    "detail": {
+      "timeline": "Cronologia",
+      "payload": "Payload"
+    }
+  },
+  "messages": {
+    "loadError": "Impossibile caricare le automazioni",
+    "bulkDeletePartial": "{{success}} eliminati, {{failed}} non riusciti",
+    "ruleNotFound": "Regola di automazione non trovata",
+    "createSuccess": "Automazione creata",
+    "createError": "Impossibile creare l'automazione",
+    "updateSuccess": "Automazione aggiornata",
+    "updateError": "Impossibile aggiornare l'automazione",
+    "deleteSuccess": "Automazione eliminata",
+    "deleteError": "Impossibile eliminare l'automazione",
+    "bulkDeleteSuccess": "{{count}} automazioni eliminate",
+    "bulkDeleteError": "Impossibile eliminare le automazioni",
+    "cloneSuccess": "Automazione clonata",
+    "cloneError": "Impossibile clonare l'automazione",
+    "permissionDenied": {
+      "read": "Non hai il permesso di visualizzare le automazioni",
+      "create": "Non hai il permesso di creare automazioni",
+      "update": "Non hai il permesso di modificare le automazioni",
+      "delete": "Non hai il permesso di eliminare le automazioni",
+      "clone": "Non hai il permesso di clonare le automazioni"
+    }
+  }
+}

--- a/src/i18n/locales/pt/automation.json
+++ b/src/i18n/locales/pt/automation.json
@@ -146,14 +146,14 @@
         "is_less_than": "Menor que",
         "days_before": "Dias antes",
         "starts_with": "Começa com",
+        "attribute_changed": "Atributo mudou",
+        "is_in": "Está em",
+        "is_not_in": "Não está em",
         "labels": {
           "equal_to": "Tem esta etiqueta",
           "not_equal_to": "Não tem esta etiqueta",
           "attribute_changed": "Etiqueta mudou"
-        },
-        "attribute_changed": "Atributo mudou",
-        "is_in": "Está em",
-        "is_not_in": "Não está em"
+        }
       },
       "attributes": {
         "status": "Status",

--- a/src/lib/events-manifest/index.ts
+++ b/src/lib/events-manifest/index.ts
@@ -32,7 +32,9 @@ export function getEventsByDtoType(dtoType: EventDtoType): EventCatalogEntry[] {
 export function getEventLabel(eventName: string, locale: Locale | string): string {
   const entry = getEvent(eventName);
   if (!entry) return eventName;
-  return locale.toString().toLowerCase().startsWith('pt') ? entry.labelPt : entry.labelEn;
+  // Defensive: a nullish locale (e.g. before i18n is ready, as in unit tests)
+  // must not crash the selector — fall back to English labels.
+  return String(locale ?? '').toLowerCase().startsWith('pt') ? entry.labelPt : entry.labelEn;
 }
 
 export function isCustomEvent(eventName: string): boolean {

--- a/src/pages/Customer/Automation/AutomationForm.spec.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import AutomationForm from './AutomationForm';
 
@@ -30,6 +30,20 @@ vi.mock('@/services/pipelines/pipelinesService', () => ({
   pipelinesService: {
     getPipelines: vi.fn().mockResolvedValue({ data: [] }),
     getPipelineStages: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+// useAutomationFormData also loads canned responses + message templates
+// (added by EVO-1263). Mock them so the form-data load resolves in tests.
+vi.mock('@/services/cannedResponses/cannedResponsesService', () => ({
+  cannedResponsesService: {
+    getCannedResponses: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+vi.mock('@/services/channels/messageTemplatesService', () => ({
+  default: {
+    getTemplates: vi.fn().mockResolvedValue({ data: [] }),
   },
 }));
 
@@ -121,6 +135,36 @@ describe('AutomationForm', () => {
     await waitFor(() => {
       expect(screen.getAllByText(/form\.fields\.conditionRow\.from/).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/form\.fields\.conditionRow\.to/).length).toBeGreaterThan(0);
+    });
+  });
+
+  it('enables the submit button with NO conditions once name + action are validly filled', async () => {
+    const { container } = renderForm('create');
+    await waitFor(() => {
+      expect(screen.getByText(/form\.title\.create/)).toBeTruthy();
+    });
+
+    const submit = screen.getByRole('button', {
+      name: /form\.buttons\.create/,
+    }) as HTMLButtonElement;
+
+    // Default action (send_message) has an empty message and name is blank → blocked.
+    expect(submit.disabled).toBe(true);
+
+    // Fill the name; still blocked because the action message is empty.
+    const nameInput = container.querySelector('input#name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'My rule' } });
+    expect(submit.disabled).toBe(true);
+
+    // Fill the action message — WITHOUT adding any condition.
+    const msgInput = screen.getByPlaceholderText(
+      /params\.send_message/,
+    ) as HTMLInputElement;
+    fireEvent.change(msgInput, { target: { value: 'Hello' } });
+
+    // Conditions are empty (optional) and all required fields are valid → enabled.
+    await waitFor(() => {
+      expect(submit.disabled).toBe(false);
     });
   });
 

--- a/src/pages/Customer/Automation/AutomationForm.tsx
+++ b/src/pages/Customer/Automation/AutomationForm.tsx
@@ -54,13 +54,23 @@ export default function AutomationForm({ mode }: Props) {
   const methods = useForm<AutomationRuleFormData>({
     resolver: zodResolver(automationRuleSchema),
     defaultValues: DEFAULTS,
+    mode: 'onChange',
   });
   const {
     control,
     handleSubmit,
     reset,
+    watch,
     formState: { errors },
   } = methods;
+
+  // Gate the submit button on whether the current values would actually pass
+  // the schema. We derive this directly from `safeParse` instead of RHF's
+  // `formState.isValid`, which is unreliable here: with nested `useFieldArray`
+  // (conditions/actions) + Controllers, `isValid` does not consistently
+  // recompute the aggregate, leaving the button stuck disabled even after the
+  // form is fully and validly filled. This mirrors the exact onSubmit check.
+  const canSubmit = automationRuleSchema.safeParse(watch()).success;
 
   useEffect(() => {
     if (mode !== 'edit' || !id) return;
@@ -229,7 +239,7 @@ export default function AutomationForm({ mode }: Props) {
           >
             {t('form.buttons.cancel')}
           </Button>
-          <Button type="submit" disabled={submitting}>
+          <Button type="submit" disabled={submitting || !canSubmit}>
             {submitting
               ? t('form.buttons.saving')
               : mode === 'create'

--- a/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
@@ -75,4 +75,23 @@ describe('actionRegistry', () => {
     const result = actionRegistry.create_pipeline_task.schema.safeParse(valid);
     expect(result.success).toBe(true);
   });
+
+  // Regression: team/agent ids are UUID strings in this app. The previous
+  // `number|null` schema rejected every real selection, so the form stayed
+  // invalid (submit button disabled) after picking a team or agent.
+  it('accepts UUID string ids and the null unassign sentinel for assign_team/assign_agent', () => {
+    const uuid = '9324e2c6-6365-4924-99d4-6cd7c2d5e9bc';
+    for (const actionName of ['assign_team', 'assign_agent'] as const) {
+      expect(actionRegistry[actionName].schema.safeParse([uuid]).success).toBe(true);
+      expect(actionRegistry[actionName].schema.safeParse([null]).success).toBe(true);
+    }
+  });
+
+  // Regression: same UUID-vs-number bug class for nested entity ids.
+  it('accepts UUID string ids for send_email_to_team.team_ids, send_attachment.inbox_id, create_pipeline_task.assigned_to_id', () => {
+    const uuid = '9324e2c6-6365-4924-99d4-6cd7c2d5e9bc';
+    expect(actionRegistry.send_email_to_team.schema.safeParse([{ team_ids: [uuid], message: 'hi' }]).success).toBe(true);
+    expect(actionRegistry.send_attachment.schema.safeParse([{ attachment_ids: [uuid], inbox_id: uuid }]).success).toBe(true);
+    expect(actionRegistry.create_pipeline_task.schema.safeParse([{ title: 'T', assigned_to_id: uuid }]).success).toBe(true);
+  });
 });

--- a/src/pages/Customer/Automation/registries/actionRegistry.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.ts
@@ -7,23 +7,34 @@ const sendMessageSchema = z.tuple([z.string().min(1)]);
 
 const labelListSchema = z.array(idValueSchema).min(1);
 
+// Team/agent/inbox/user ids are UUID strings in this app (not Chatwoot-legacy
+// integers). Accept string|number so real selections validate; number kept for
+// robustness/legacy.
+const entityIdSchema = z.union([z.string().min(1), z.number()]);
+
 const sendEmailToTeamSchema = z.tuple([
   z.object({
-    team_ids: z.array(z.number()).min(1),
+    team_ids: z.array(entityIdSchema).min(1),
     message: z.string().min(1),
   }),
 ]);
 
-const assignTeamSchema = z.tuple([z.union([z.number(), z.null()])]);
+// Team/agent ids are UUID strings in this app — the Chatwoot-legacy integer
+// assumption (number|null) silently rejected every real selection, leaving the
+// rule invalid (button never enabled / submit blocked). `null` is the unassign
+// sentinel the select emits when cleared; number is kept for legacy/robustness.
+const assignTargetSchema = z.tuple([z.union([z.string().min(1), z.number(), z.null()])]);
 
-const assignAgentSchema = z.tuple([z.union([z.number(), z.null()])]);
+const assignTeamSchema = assignTargetSchema;
+
+const assignAgentSchema = assignTargetSchema;
 
 const sendWebhookEventSchema = z.tuple([z.string().url()]);
 
 const sendAttachmentSchema = z.tuple([
   z.object({
     attachment_ids: z.array(idValueSchema).min(1),
-    inbox_id: z.number().optional(),
+    inbox_id: entityIdSchema.optional(),
   }),
 ]);
 
@@ -50,7 +61,7 @@ const createPipelineTaskSchema = z.tuple([
     description: z.string().optional(),
     task_type: z.string().optional(),
     priority: z.string().optional(),
-    assigned_to_id: z.number().optional(),
+    assigned_to_id: entityIdSchema.optional(),
     due_in: z.string().optional(),
   }),
 ]);


### PR DESCRIPTION
## EVO-1639 — Form de automação: schemas UUID, botão travado, UX/i18n

**Fix:**
- Schemas zod aceitam IDs **UUID** (`assign_team`/`assign_agent`/`team_ids`/`inbox_id`/`assigned_to_id`) — antes `number` travava o submit; inputs preservam UUID.
- Botão 'Criar' via `safeParse(watch())` (o `formState.isValid` não recomputava com `useFieldArray`).
- `*` em obrigatórios, '(opcional)' em condições; i18n `automation.json` p/ es/fr/it/pt.
- Hardening: `getEventLabel` não crasha com locale nullish (corrige baseline do `AutomationForm.spec` quebrado no develop — EVO-1263).

**Pendente (follow-up):** `send_email_to_team` precisa de seletor de time na UI.

**Testes:** suite de automação **104 verdes**; tsc limpo.

Parte da EVO-1637.