### PR TITLE
fix(automation): team multi-select for send_email_to_team in the form (EVO-1646)

### DIFF
--- a/src/components/automation/ActionRow.spec.tsx
+++ b/src/components/automation/ActionRow.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -23,7 +23,13 @@ const emptyFormData: AutomationFormData = {
   messageTemplates: [],
 };
 
-function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
+function Wrapper({
+  defaultValues,
+  formData = emptyFormData,
+}: {
+  defaultValues: AutomationRuleFormData;
+  formData?: AutomationFormData;
+}) {
   const methods = useForm<AutomationRuleFormData>({
     resolver: zodResolver(automationRuleSchema),
     defaultValues,
@@ -33,7 +39,7 @@ function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
       <ActionRow
         control={methods.control}
         index={0}
-        formData={emptyFormData}
+        formData={formData}
         onRemove={() => {}}
         onActionChange={() => {}}
       />
@@ -55,6 +61,49 @@ describe('ActionRow', () => {
     const { container } = render(<Wrapper defaultValues={defaults} />);
     expect(container.querySelector('button[aria-label*="remove"]')).toBeTruthy();
     expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  // EVO-1646: send_email_to_team must expose a team multi-select.
+  it('renders a team checkbox per team for send_email_to_team and toggles selection', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'send_email_to_team', action_params: [{ team_ids: [], message: '' }] }],
+    };
+    const formData: AutomationFormData = {
+      ...emptyFormData,
+      teams: [
+        { id: '9324e2c6-6365-4924-99d4-6cd7c2d5e9bc', name: 'Sales' },
+        { id: 'a1b2c3d4-0000-4924-99d4-6cd7c2d5e9bc', name: 'Support' },
+      ],
+    };
+    render(<Wrapper defaultValues={defaults} formData={formData} />);
+    expect(screen.getByText('Sales')).toBeTruthy();
+    expect(screen.getByText('Support')).toBeTruthy();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].getAttribute('aria-checked')).toBe('false');
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0].getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('shows the no-teams message for send_email_to_team when no teams exist', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'send_email_to_team', action_params: [{ team_ids: [], message: '' }] }],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+    expect(screen.getByText(/send_email_to_team_no_teams/)).toBeTruthy();
   });
 
   it('renders the no-params placeholder for resolve_conversation', () => {

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Textarea,
   Button,
+  Checkbox,
 } from '@evoapi/design-system';
 import { Trash2 } from 'lucide-react';
 import {
@@ -313,15 +314,47 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
               team_ids: [],
               message: '',
             };
+            const selectedIds = ((current.team_ids as Array<string | number>) ?? []).map(String);
+            const toggleTeam = (id: string) => {
+              const next = selectedIds.includes(id)
+                ? selectedIds.filter((t) => t !== id)
+                : [...selectedIds, id];
+              field.onChange([{ ...current, team_ids: next, message: current.message ?? '' }]);
+            };
             return (
-              <Textarea
-                value={(current.message as string) ?? ''}
-                onChange={(e) =>
-                  field.onChange([{ ...current, message: e.target.value }])
-                }
-                placeholder={t('form.fields.actionRow.params.send_email_to_team')}
-                rows={2}
-              />
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t('form.fields.actionRow.params.send_email_to_team_teams')}
+                </label>
+                <div className="space-y-1 max-h-32 overflow-y-auto rounded-md border p-2">
+                  {formData.teams.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      {t('form.fields.actionRow.params.send_email_to_team_no_teams')}
+                    </p>
+                  ) : (
+                    formData.teams.map((team) => {
+                      const id = String(team.id);
+                      return (
+                        <label key={id} className="flex items-center gap-2 text-sm cursor-pointer">
+                          <Checkbox
+                            checked={selectedIds.includes(id)}
+                            onCheckedChange={() => toggleTeam(id)}
+                          />
+                          {team.name}
+                        </label>
+                      );
+                    })
+                  )}
+                </div>
+                <Textarea
+                  value={(current.message as string) ?? ''}
+                  onChange={(e) =>
+                    field.onChange([{ ...current, message: e.target.value }])
+                  }
+                  placeholder={t('form.fields.actionRow.params.send_email_to_team')}
+                  rows={2}
+                />
+              </div>
             );
           }}
         />

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Pick a pipeline",
           "update_pipeline_stage": "Pick a pipeline stage",
           "send_email_to_team": "Email body",
+          "send_email_to_team_teams": "Teams",
+          "send_email_to_team_no_teams": "No teams available",
           "create_pipeline_task": "Task title",
           "create_pipeline_task_description": "Description (optional)",
           "create_pipeline_task_type": "Type (optional)",

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Escolha um pipeline",
           "update_pipeline_stage": "Escolha um estágio",
           "send_email_to_team": "Corpo do email",
+          "send_email_to_team_teams": "Times",
+          "send_email_to_team_no_teams": "Nenhum time disponível",
           "create_pipeline_task": "Título da tarefa",
           "create_pipeline_task_description": "Descrição (opcional)",
           "create_pipeline_task_type": "Tipo (opcional)",


### PR DESCRIPTION
## EVO-1646 — send_email_to_team sem seletor de time na UI

Adiciona multi-select de times (checkbox list, populado por `formData.teams`) no renderer de `send_email_to_team` no `ActionRow`, gravando os UUIDs em `action_params[0].team_ids` (mantém o textarea da mensagem). Resolve a ação que era inconfigurável (`team_ids` ficava `[]` → submit travado).

- i18n: `send_email_to_team_teams` / `send_email_to_team_no_teams` (en + pt-BR).
- +2 specs no `ActionRow.spec` (render dos times + toggle; estado vazio).

**Stacked sobre EVO-1639** (depende do schema `entityIdSchema` que aceita UUID string) — merge após #141.

Parte da EVO-1637.