### PR TITLE
fix(frontend): persist all Flow Builder editor mutations to the store (EVO-1643)

### DIFF
--- a/src/components/base/BaseDefaultEdge.tsx
+++ b/src/components/base/BaseDefaultEdge.tsx
@@ -17,6 +17,7 @@ export default function BaseDefaultEdge({
   targetPosition,
   style = {},
   selected,
+  data,
 }: EdgeProps) {
   const { setEdges } = useReactFlow();
 
@@ -30,8 +31,17 @@ export default function BaseDefaultEdge({
     borderRadius: 15,
   });
 
+  // EVO-1643: prefer the canvas-provided handler (passed via edge `data`),
+  // which removes the edge AND notifies the editor store. The bare setEdges
+  // fallback keeps standalone usage working but does not persist on save.
   const onEdgeClick = () => {
-    setEdges((edges) => edges.filter((edge) => edge.id !== id));
+    const deleteEdge = (data as { handleDeleteEdge?: (edgeId: string) => void } | undefined)
+      ?.handleDeleteEdge;
+    if (deleteEdge) {
+      deleteEdge(id);
+    } else {
+      setEdges((edges) => edges.filter((edge) => edge.id !== id));
+    }
   };
 
   return (

--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -1,5 +1,6 @@
 import { act, render } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { useEffect } from 'react';
 
 beforeAll(() => {
   if (!window.matchMedia) {
@@ -33,12 +34,16 @@ vi.mock('@xyflow/react', async importOriginal => {
         </div>
       );
     }),
+    // jsdom has no real flow viewport; the drop handler only needs a position.
+    useReactFlow: () => ({
+      screenToFlowPosition: (p: { x: number; y: number }) => p,
+    }),
   };
 });
 
 import { ReactFlowProvider } from '@xyflow/react';
 import { BaseFlowCanvas } from './BaseFlowCanvas';
-import { DnDProvider } from '@/contexts/DnDContext';
+import { DnDProvider, useDnD } from '@/contexts/DnDContext';
 import { DarkModeProvider } from '@/contexts/ThemeContext';
 
 const NoopNode = () => <div />;
@@ -223,5 +228,92 @@ describe('BaseFlowCanvas — EVO-1573 edge propagation', () => {
     });
 
     expect(onFlowDataChange).not.toHaveBeenCalled();
+  });
+});
+
+// EVO-1643: dropping an action node from the palette went through handleDrop's
+// default branch, which added the node to canvas state via setNodes but never
+// notified the editor store — so the save snapshot kept only the trigger and
+// dropped every action node. These tests fail on pre-fix `develop`.
+function DnDTypeSetter({ value }: { value: string }) {
+  const { setType } = useDnD();
+  useEffect(() => {
+    setType(value);
+  }, [value, setType]);
+  return null;
+}
+
+function renderCanvasForDrop(opts: {
+  onFlowDataChange?: ReturnType<typeof vi.fn>;
+  onFlowDataChangeExtended?: ReturnType<typeof vi.fn>;
+  dndType: string;
+}) {
+  return render(
+    <DarkModeProvider>
+      <DnDProvider>
+        <ReactFlowProvider>
+          <DnDTypeSetter value={opts.dndType} />
+          <BaseFlowCanvas
+            nodeTypes={{ noop: NoopNode }}
+            initialNodes={
+              [{ id: 'trigger-1', type: 'noop', position: { x: 0, y: 0 }, data: {} }] as never
+            }
+            initialEdges={[] as never}
+            onFlowDataChange={opts.onFlowDataChange}
+            onFlowDataChangeExtended={opts.onFlowDataChangeExtended}
+          />
+        </ReactFlowProvider>
+      </DnDProvider>
+    </DarkModeProvider>,
+  );
+}
+
+describe('BaseFlowCanvas — EVO-1643 drop propagation', () => {
+  it('propagates a dropped node to onFlowDataChange so the save snapshot keeps it', () => {
+    const onFlowDataChange = vi.fn();
+    renderCanvasForDrop({ onFlowDataChange, dndType: 'send-canned-response-node' });
+
+    const props = reactFlowMocks.capturedProps.current!;
+    expect(props).toBeTruthy();
+    onFlowDataChange.mockClear();
+
+    act(() => {
+      (props.onDrop as (e: unknown) => void)({
+        preventDefault: () => {},
+        clientX: 120,
+        clientY: 120,
+      });
+    });
+
+    expect(onFlowDataChange).toHaveBeenCalled();
+    const lastCall = onFlowDataChange.mock.lastCall as
+      | [Array<{ id: string; type: string }>, unknown]
+      | undefined;
+    expect(lastCall).toBeTruthy();
+    expect(lastCall![0].map(n => n.id)).toContain('trigger-1');
+    expect(lastCall![0].some(n => n.type === 'send-canned-response-node')).toBe(true);
+    expect(lastCall![0]).toHaveLength(2);
+  });
+
+  it('propagates a dropped node via onFlowDataChangeExtended', () => {
+    const onFlowDataChangeExtended = vi.fn();
+    renderCanvasForDrop({ onFlowDataChangeExtended, dndType: 'assign-to-pipeline-node' });
+
+    const props = reactFlowMocks.capturedProps.current!;
+    onFlowDataChangeExtended.mockClear();
+
+    act(() => {
+      (props.onDrop as (e: unknown) => void)({
+        preventDefault: () => {},
+        clientX: 80,
+        clientY: 80,
+      });
+    });
+
+    expect(onFlowDataChangeExtended).toHaveBeenCalled();
+    const arg = onFlowDataChangeExtended.mock.lastCall?.[0] as {
+      nodes: Array<{ type: string }>;
+    };
+    expect(arg.nodes.some(n => n.type === 'assign-to-pipeline-node')).toBe(true);
   });
 });

--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { useEffect } from 'react';
 
@@ -315,5 +315,92 @@ describe('BaseFlowCanvas — EVO-1643 drop propagation', () => {
       nodes: Array<{ type: string }>;
     };
     expect(arg.nodes.some(n => n.type === 'assign-to-pipeline-node')).toBe(true);
+  });
+});
+
+// EVO-1643 (extended): node delete + duplicate (context menu) and edge delete
+// (trash button) also bypassed the store pre-fix. Each is now routed through a
+// BaseFlowCanvas handler that fires onFlowDataChange.
+describe('BaseFlowCanvas — EVO-1643 mutation propagation', () => {
+  function openContextMenu(props: Record<string, unknown>, nodeId: string) {
+    act(() => {
+      (props.onNodeContextMenu as (e: unknown, n: unknown) => void)(
+        { preventDefault: () => {}, clientX: 10, clientY: 10 },
+        { id: nodeId },
+      );
+    });
+  }
+
+  it('node delete via context menu removes the node + its edges and propagates', () => {
+    const onFlowDataChange = vi.fn();
+    const { container } = renderCanvas({
+      onFlowDataChange,
+      initialNodes: [
+        { id: 'trigger-1', type: 'noop', position: { x: 0, y: 0 }, data: {} },
+        { id: 'action-1', type: 'noop', position: { x: 200, y: 0 }, data: {} },
+      ],
+      initialEdges: [{ id: 'e1', source: 'trigger-1', target: 'action-1' }],
+    });
+    const props = reactFlowMocks.capturedProps.current!;
+    openContextMenu(props, 'action-1');
+    onFlowDataChange.mockClear();
+
+    const menu = container.querySelector('.context-menu');
+    expect(menu).toBeTruthy();
+    const buttons = menu!.querySelectorAll('button');
+    fireEvent.click(buttons[buttons.length - 1]); // last default action = delete
+
+    expect(onFlowDataChange).toHaveBeenCalled();
+    const lastCall = onFlowDataChange.mock.lastCall as [
+      Array<{ id: string }>,
+      Array<{ id: string }>,
+    ];
+    expect(lastCall[0].map(n => n.id)).toEqual(['trigger-1']);
+    expect(lastCall[1].map(e => e.id)).toEqual([]);
+  });
+
+  it('node duplicate via context menu adds a copy and propagates', () => {
+    const onFlowDataChange = vi.fn();
+    const { container } = renderCanvas({
+      onFlowDataChange,
+      initialNodes: [{ id: 'action-1', type: 'noop', position: { x: 0, y: 0 }, data: {} }],
+    });
+    const props = reactFlowMocks.capturedProps.current!;
+    openContextMenu(props, 'action-1');
+    onFlowDataChange.mockClear();
+
+    const menu = container.querySelector('.context-menu');
+    const buttons = menu!.querySelectorAll('button');
+    fireEvent.click(buttons[0]); // first default action = duplicate
+
+    expect(onFlowDataChange).toHaveBeenCalled();
+    const nodes = (onFlowDataChange.mock.lastCall as [Array<{ id: string }>, unknown])[0];
+    expect(nodes).toHaveLength(2);
+    expect(nodes.some(n => n.id.startsWith('action-1-copy-'))).toBe(true);
+  });
+
+  it('edge delete (handleDeleteEdge via edge data) propagates to onFlowDataChange', () => {
+    const onFlowDataChange = vi.fn();
+    renderCanvas({
+      onFlowDataChange,
+      initialEdges: [
+        { id: 'e1', source: 'n1', target: 'n2' },
+        { id: 'e2', source: 'n2', target: 'n1' },
+      ],
+    });
+    const props = reactFlowMocks.capturedProps.current!;
+    const handleDeleteEdge = (
+      props.defaultEdgeOptions as { data?: { handleDeleteEdge?: (id: string) => void } }
+    )?.data?.handleDeleteEdge;
+    expect(handleDeleteEdge).toBeTypeOf('function');
+    onFlowDataChange.mockClear();
+
+    act(() => {
+      handleDeleteEdge!('e1');
+    });
+
+    expect(onFlowDataChange).toHaveBeenCalled();
+    const lastCall = onFlowDataChange.mock.lastCall as [unknown, Array<{ id: string }>];
+    expect(lastCall[1].map(e => e.id)).toEqual(['e2']);
   });
 });

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -530,14 +530,67 @@ export function BaseFlowCanvas({
     ...reactFlowProps,
   };
 
+  // EVO-1643: every mutation that bypasses xyflow's change pipeline must
+  // notify the editor store, otherwise the change is lost on the next save
+  // (same class as the drop fix). Compute the bare value, set it, fire the
+  // store callbacks after — never inside the updater (StrictMode purity).
   const handleDeleteEdge = useCallback(
-    (id: any) => {
-      setEdges(edges => {
-        const left = edges.filter((edge: any) => edge.id !== id);
-        return left;
-      });
+    (id: string) => {
+      const updatedEdges = edges.filter(edge => edge.id !== id);
+      setEdges(updatedEdges);
+      if (onFlowDataChange) {
+        onFlowDataChange(nodes, updatedEdges);
+      }
+      if (onFlowDataChangeExtended) {
+        onFlowDataChangeExtended({ nodes, edges: updatedEdges, variables: flowVariables });
+      }
     },
-    [setEdges],
+    [edges, setEdges, nodes, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
+  );
+
+  const handleDeleteNode = useCallback(
+    (nodeId: string) => {
+      const updatedNodes = nodes.filter(node => node.id !== nodeId);
+      const updatedEdges = edges.filter(
+        edge => edge.source !== nodeId && edge.target !== nodeId,
+      );
+      setNodes(updatedNodes);
+      setEdges(updatedEdges);
+      if (onFlowDataChange) {
+        onFlowDataChange(updatedNodes, updatedEdges);
+      }
+      if (onFlowDataChangeExtended) {
+        onFlowDataChangeExtended({
+          nodes: updatedNodes,
+          edges: updatedEdges,
+          variables: flowVariables,
+        });
+      }
+    },
+    [nodes, edges, setNodes, setEdges, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
+  );
+
+  const handleDuplicateNode = useCallback(
+    (nodeId: string) => {
+      const original = nodes.find(node => node.id === nodeId);
+      if (!original) return;
+      const copy: Node = {
+        ...original,
+        id: `${original.id}-copy-${Date.now()}`,
+        position: { x: original.position.x + 50, y: original.position.y + 50 },
+        selected: false,
+        dragging: false,
+      };
+      const updatedNodes = nodes.concat(copy);
+      setNodes(updatedNodes);
+      if (onFlowDataChange) {
+        onFlowDataChange(updatedNodes, edges);
+      }
+      if (onFlowDataChangeExtended) {
+        onFlowDataChangeExtended({ nodes: updatedNodes, edges, variables: flowVariables });
+      }
+    },
+    [nodes, edges, setNodes, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
   );
 
   return (
@@ -681,7 +734,7 @@ export function BaseFlowCanvas({
             nodeId={contextMenu.nodeId}
             onClose={() => setContextMenu({ show: false, x: 0, y: 0 })}
             onDeleteNode={nodeId => {
-              setNodes(nds => nds.filter(n => n.id !== nodeId));
+              handleDeleteNode(nodeId);
               setContextMenu({ show: false, x: 0, y: 0 });
             }}
           />
@@ -692,7 +745,11 @@ export function BaseFlowCanvas({
             nodeId={contextMenu.nodeId}
             onClose={() => setContextMenu({ show: false, x: 0, y: 0 })}
             onDeleteNode={nodeId => {
-              setNodes(nds => nds.filter(n => n.id !== nodeId));
+              handleDeleteNode(nodeId);
+              setContextMenu({ show: false, x: 0, y: 0 });
+            }}
+            onDuplicateNode={nodeId => {
+              handleDuplicateNode(nodeId);
               setContextMenu({ show: false, x: 0, y: 0 });
             }}
           />

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -385,8 +385,24 @@ export function BaseFlowCanvas({
           data: { label: `${type} node` },
         };
 
-        // Adicionar o novo node
-        setNodes(nds => nds.concat(newNode));
+        // EVO-1643: drops bypass xyflow's NodeChange path, so the new node
+        // reached canvas state via setNodes but never the editor store — on
+        // save the snapshot kept only the trigger and dropped every action
+        // node. Mirror the EVO-1573 edge fix: set the bare value and fire the
+        // store callbacks after (keep setNodes pure so StrictMode's
+        // double-invoke can't double-notify).
+        const updatedNodes = nodes.concat(newNode);
+        setNodes(updatedNodes);
+        if (onFlowDataChange) {
+          onFlowDataChange(updatedNodes, edges);
+        }
+        if (onFlowDataChangeExtended) {
+          onFlowDataChangeExtended({
+            nodes: updatedNodes,
+            edges,
+            variables: flowVariables,
+          });
+        }
         
         // Limpar o type do DnD context para sair do modo de drag
         setType(null);
@@ -402,7 +418,18 @@ export function BaseFlowCanvas({
         }, 10);
       }
     },
-    [type, screenToFlowPosition, onDrop, setNodes, setType],
+    [
+      type,
+      screenToFlowPosition,
+      onDrop,
+      setNodes,
+      setType,
+      nodes,
+      edges,
+      onFlowDataChange,
+      onFlowDataChangeExtended,
+      flowVariables,
+    ],
   );
 
   // Context menu

--- a/src/components/base/BaseFlowContextMenu.tsx
+++ b/src/components/base/BaseFlowContextMenu.tsx
@@ -1,4 +1,3 @@
-import { useReactFlow, Node, Edge } from "@xyflow/react";
 import { Copy, Trash2, Settings, type LucideIcon } from "lucide-react";
 import { useCallback } from "react";
 import { useLanguage } from '@/hooks/useLanguage';
@@ -20,6 +19,7 @@ export interface BaseFlowContextMenuProps {
   nodeId?: string;
   onClose: () => void;
   onDeleteNode: (nodeId: string) => void;
+  onDuplicateNode?: (nodeId: string) => void;
 
   // Configurações customizadas
   title?: string;
@@ -40,6 +40,7 @@ export function BaseFlowContextMenu({
   nodeId,
   onClose,
   onDeleteNode,
+  onDuplicateNode,
   title,
   actions = [],
   showDefaultActions = true,
@@ -50,46 +51,22 @@ export function BaseFlowContextMenu({
   itemClassName,
 }: BaseFlowContextMenuProps) {
   const { t } = useLanguage('common');
-  const { getNode, setNodes, addNodes, setEdges } = useReactFlow();
   const finalTitle = title || t('base.flow.node.options');
 
-  // Ações padrão
+  // Delegate mutations to the parent so they flow through the editor store
+  // (EVO-1643). Doing setNodes/addNodes here via useReactFlow bypassed
+  // onFlowDataChange, so duplicates/deletes were lost on the next save.
   const duplicateNode = useCallback(() => {
     if (!nodeId) return;
-
-    const node = getNode(nodeId);
-    if (!node) {
-      console.error(`Node with id ${nodeId} not found.`);
-      return;
-    }
-
-    const position = {
-      x: node.position.x + 50,
-      y: node.position.y + 50,
-    };
-
-    addNodes({
-      ...node,
-      id: `${node.id}-copy-${Date.now()}`,
-      position,
-      selected: false,
-      dragging: false,
-    });
-
+    onDuplicateNode?.(nodeId);
     onClose();
-  }, [nodeId, getNode, addNodes, onClose]);
+  }, [nodeId, onDuplicateNode, onClose]);
 
   const deleteNode = useCallback(() => {
     if (!nodeId) return;
-
-    setNodes((nodes: Node[]) => nodes.filter((node) => node.id !== nodeId));
-    setEdges((edges: Edge[]) =>
-      edges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId),
-    );
-
     onDeleteNode(nodeId);
     onClose();
-  }, [nodeId, setNodes, setEdges, onDeleteNode, onClose]);
+  }, [nodeId, onDeleteNode, onClose]);
 
   const editNode = useCallback(() => {
     if (!nodeId) return;


### PR DESCRIPTION
## Summary

Flow Builder mutations that went through direct xyflow setters (`setNodes`/`setEdges`/`addNodes`) never notified the editor store (`useFlowEditorStore`), so the save snapshot omitted them — changes were lost on reload. Same root cause as EVO-1573 (edges), now closed for every editor mutation the Journey uses.

Fixed paths (each verified manually + by regression test):
- **Drop** an action node from the palette — `BaseFlowCanvas.handleDrop` default branch now fires `onFlowDataChange`/`onFlowDataChangeExtended`.
- **Delete node** (context menu) — centralized in `handleDeleteNode` (removes the node + its connected edges) with store notification.
- **Duplicate node** (context menu) — centralized in `handleDuplicateNode`.
- **Delete edge** (trash button) — `handleDeleteEdge` now propagates; `BaseDefaultEdge` uses the canvas-provided handler (passed via edge `data`) instead of its own `setEdges`.

`BaseFlowContextMenu` no longer mutates via `useReactFlow` — it delegates delete/duplicate to the parent through props. All handlers follow the EVO-1573 pattern (compute bare value → set → fire callbacks after, never inside the updater).

This unblocks the EVO-1634 executor wiring end-to-end: user-built journeys now actually persist their action nodes.

## Security
N/A — client-side editor state only.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm test src/components/base/BaseFlowCanvas.spec.tsx` — 10/10 (5 EVO-1573 + 2 drop + 3 new: node delete / node duplicate / edge delete)
- `pnpm exec eslint <changed files>` — no new issues (net -2 pre-existing `any` removed)
- Manual smoke: drop / delete node / duplicate node / delete edge → Save → reload → all persist.

## Changed Files
- `src/components/base/BaseFlowCanvas.tsx`
- `src/components/base/BaseFlowContextMenu.tsx`
- `src/components/base/BaseDefaultEdge.tsx`
- `src/components/base/BaseFlowCanvas.spec.tsx`

## Linked Issue
- EVO-1643

🤖 Generated with [Claude Code](https://claude.com/claude-code)