### PR TITLE
fix(automation): team multi-select for send_email_to_team in the form (EVO-1646)

### DIFF
--- a/src/components/automation/ActionRow.spec.tsx
+++ b/src/components/automation/ActionRow.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -23,7 +23,13 @@ const emptyFormData: AutomationFormData = {
   messageTemplates: [],
 };
 
-function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
+function Wrapper({
+  defaultValues,
+  formData = emptyFormData,
+}: {
+  defaultValues: AutomationRuleFormData;
+  formData?: AutomationFormData;
+}) {
   const methods = useForm<AutomationRuleFormData>({
     resolver: zodResolver(automationRuleSchema),
     defaultValues,
@@ -33,7 +39,7 @@ function Wrapper({ defaultValues }: { defaultValues: AutomationRuleFormData }) {
       <ActionRow
         control={methods.control}
         index={0}
-        formData={emptyFormData}
+        formData={formData}
         onRemove={() => {}}
         onActionChange={() => {}}
       />
@@ -55,6 +61,49 @@ describe('ActionRow', () => {
     const { container } = render(<Wrapper defaultValues={defaults} />);
     expect(container.querySelector('button[aria-label*="remove"]')).toBeTruthy();
     expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  // EVO-1646: send_email_to_team must expose a team multi-select.
+  it('renders a team checkbox per team for send_email_to_team and toggles selection', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'send_email_to_team', action_params: [{ team_ids: [], message: '' }] }],
+    };
+    const formData: AutomationFormData = {
+      ...emptyFormData,
+      teams: [
+        { id: '9324e2c6-6365-4924-99d4-6cd7c2d5e9bc', name: 'Sales' },
+        { id: 'a1b2c3d4-0000-4924-99d4-6cd7c2d5e9bc', name: 'Support' },
+      ],
+    };
+    render(<Wrapper defaultValues={defaults} formData={formData} />);
+    expect(screen.getByText('Sales')).toBeTruthy();
+    expect(screen.getByText('Support')).toBeTruthy();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBe(2);
+    expect(checkboxes[0].getAttribute('aria-checked')).toBe('false');
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0].getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('shows the no-teams message for send_email_to_team when no teams exist', () => {
+    const defaults: AutomationRuleFormData = {
+      name: 'Test',
+      description: '',
+      event_name: 'conversation_created',
+      active: true,
+      mode: 'simple',
+      conditions: [],
+      actions: [{ action_name: 'send_email_to_team', action_params: [{ team_ids: [], message: '' }] }],
+    };
+    render(<Wrapper defaultValues={defaults} />);
+    expect(screen.getByText(/send_email_to_team_no_teams/)).toBeTruthy();
   });
 
   it('renders the no-params placeholder for resolve_conversation', () => {

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Textarea,
   Button,
+  Checkbox,
 } from '@evoapi/design-system';
 import { Trash2 } from 'lucide-react';
 import {
@@ -313,15 +314,47 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
               team_ids: [],
               message: '',
             };
+            const selectedIds = ((current.team_ids as Array<string | number>) ?? []).map(String);
+            const toggleTeam = (id: string) => {
+              const next = selectedIds.includes(id)
+                ? selectedIds.filter((t) => t !== id)
+                : [...selectedIds, id];
+              field.onChange([{ ...current, team_ids: next, message: current.message ?? '' }]);
+            };
             return (
-              <Textarea
-                value={(current.message as string) ?? ''}
-                onChange={(e) =>
-                  field.onChange([{ ...current, message: e.target.value }])
-                }
-                placeholder={t('form.fields.actionRow.params.send_email_to_team')}
-                rows={2}
-              />
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-muted-foreground">
+                  {t('form.fields.actionRow.params.send_email_to_team_teams')}
+                </label>
+                <div className="space-y-1 max-h-32 overflow-y-auto rounded-md border p-2">
+                  {formData.teams.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">
+                      {t('form.fields.actionRow.params.send_email_to_team_no_teams')}
+                    </p>
+                  ) : (
+                    formData.teams.map((team) => {
+                      const id = String(team.id);
+                      return (
+                        <label key={id} className="flex items-center gap-2 text-sm cursor-pointer">
+                          <Checkbox
+                            checked={selectedIds.includes(id)}
+                            onCheckedChange={() => toggleTeam(id)}
+                          />
+                          {team.name}
+                        </label>
+                      );
+                    })
+                  )}
+                </div>
+                <Textarea
+                  value={(current.message as string) ?? ''}
+                  onChange={(e) =>
+                    field.onChange([{ ...current, message: e.target.value }])
+                  }
+                  placeholder={t('form.fields.actionRow.params.send_email_to_team')}
+                  rows={2}
+                />
+              </div>
             );
           }}
         />

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Pick a pipeline",
           "update_pipeline_stage": "Pick a pipeline stage",
           "send_email_to_team": "Email body",
+          "send_email_to_team_teams": "Teams",
+          "send_email_to_team_no_teams": "No teams available",
           "create_pipeline_task": "Task title",
           "create_pipeline_task_description": "Description (optional)",
           "create_pipeline_task_type": "Type (optional)",

--- a/src/i18n/locales/es/automation.json
+++ b/src/i18n/locales/es/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Elige un pipeline",
           "update_pipeline_stage": "Elige una etapa del pipeline",
           "send_email_to_team": "Cuerpo del correo",
+          "send_email_to_team_teams": "Equipos",
+          "send_email_to_team_no_teams": "No hay equipos disponibles",
           "create_pipeline_task": "Título de la tarea",
           "create_pipeline_task_description": "Descripción (opcional)",
           "create_pipeline_task_type": "Tipo (opcional)",

--- a/src/i18n/locales/fr/automation.json
+++ b/src/i18n/locales/fr/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Choisir un pipeline",
           "update_pipeline_stage": "Choisir une étape du pipeline",
           "send_email_to_team": "Corps de l'e-mail",
+          "send_email_to_team_teams": "Équipes",
+          "send_email_to_team_no_teams": "Aucune équipe disponible",
           "create_pipeline_task": "Titre de la tâche",
           "create_pipeline_task_description": "Description (facultatif)",
           "create_pipeline_task_type": "Type (facultatif)",

--- a/src/i18n/locales/it/automation.json
+++ b/src/i18n/locales/it/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Scegli una pipeline",
           "update_pipeline_stage": "Scegli una fase della pipeline",
           "send_email_to_team": "Corpo dell'email",
+          "send_email_to_team_teams": "Team",
+          "send_email_to_team_no_teams": "Nessun team disponibile",
           "create_pipeline_task": "Titolo dell'attività",
           "create_pipeline_task_description": "Descrizione (facoltativo)",
           "create_pipeline_task_type": "Tipo (facoltativo)",

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Escolha um pipeline",
           "update_pipeline_stage": "Escolha um estágio",
           "send_email_to_team": "Corpo do email",
+          "send_email_to_team_teams": "Times",
+          "send_email_to_team_no_teams": "Nenhum time disponível",
           "create_pipeline_task": "Título da tarefa",
           "create_pipeline_task_description": "Descrição (opcional)",
           "create_pipeline_task_type": "Tipo (opcional)",

--- a/src/i18n/locales/pt/automation.json
+++ b/src/i18n/locales/pt/automation.json
@@ -125,6 +125,8 @@
           "assign_to_pipeline": "Escolha um pipeline",
           "update_pipeline_stage": "Escolha um estágio",
           "send_email_to_team": "Corpo do email",
+          "send_email_to_team_teams": "Times",
+          "send_email_to_team_no_teams": "Nenhum time disponível",
           "create_pipeline_task": "Título da tarefa",
           "create_pipeline_task_description": "Descrição (opcional)",
           "create_pipeline_task_type": "Tipo (opcional)",


### PR DESCRIPTION
Replaces #142, which GitHub auto-closed when #141 (EVO-1639) merged and its base branch was deleted. Rebased onto `develop` and reopened fresh.

## Summary
Adds the missing team multi-select to the `send_email_to_team` action in the automation form. Without it `team_ids` stayed `[]`, and since the schema requires `team_ids.min(1)` (fixed in EVO-1639/#141) the action was unconfigurable — the Save button never unlocked when it was selected.

- `ActionRow.tsx`: checkbox list reading `formData.teams`, writing UUIDs to `action_params[0].team_ids` via `field.onChange`, with an empty-state and the message textarea preserved.
- i18n: `send_email_to_team_teams` / `send_email_to_team_no_teams` now in **all six** locales (en, pt-BR + the es/fr/it/pt that were missing → review follow-up).

## Test plan
- `npx tsc --noEmit` → clean.
- `vitest run ActionRow.spec.tsx` → 4 passing (team checkbox render + toggle, no-teams empty-state).
- All 6 automation locales parse and carry both new keys.

## Notes
- Rebased `--onto origin/develop 910c998` to drop the squashed EVO-1639 commit and replay only the EVO-1646 delta. Part of EVO-1637.