### PR TITLE
feat(frontend): channel overview hub with derived status (EVO-1554)

### DIFF
--- a/src/components/channels/ChannelStatusBadge.tsx
+++ b/src/components/channels/ChannelStatusBadge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from '@evoapi/design-system';
+import { cn } from '@/utils/cn';
+import { useLanguage } from '@/hooks/useLanguage';
+import { ChannelHealthStatus } from '@/utils/channelStatus';
+
+interface ChannelStatusBadgeProps {
+  status: ChannelHealthStatus;
+  className?: string;
+}
+
+const dotClasses: Record<ChannelHealthStatus, string> = {
+  active: 'bg-emerald-500',
+  attention: 'bg-amber-500',
+  available: 'bg-sidebar-foreground/30',
+};
+
+export default function ChannelStatusBadge({ status, className }: ChannelStatusBadgeProps) {
+  const { t } = useLanguage('channels');
+
+  return (
+    <Badge variant="outline" className={cn('gap-1.5 font-normal', className)}>
+      <span className={cn('h-2 w-2 rounded-full', dotClasses[status])} aria-hidden="true" />
+      {t(`overview.statusLabel.${status}`)}
+    </Badge>
+  );
+}

--- a/src/components/channels/ChannelTypeCard.tsx
+++ b/src/components/channels/ChannelTypeCard.tsx
@@ -70,7 +70,9 @@ export default function ChannelTypeCard({ typeStatus, onAdd, onManage }: Channel
 
         <div className="flex items-center justify-between mt-auto pt-1">
           <ChannelStatusBadge status={status} />
-          <span className="text-xs text-sidebar-foreground/60 truncate ml-2">{summary}</span>
+          {isConfigured && (
+            <span className="text-xs text-sidebar-foreground/60 truncate ml-2">{summary}</span>
+          )}
         </div>
       </CardContent>
 

--- a/src/components/channels/ChannelTypeCard.tsx
+++ b/src/components/channels/ChannelTypeCard.tsx
@@ -1,0 +1,100 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@evoapi/design-system';
+import { HelpCircle, Plus, Settings } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { ChannelTypeStatus } from '@/utils/channelStatus';
+import ChannelIcon from './ChannelIcon';
+import ChannelStatusBadge from './ChannelStatusBadge';
+
+interface ChannelTypeCardProps {
+  typeStatus: ChannelTypeStatus;
+  onAdd: (typeStatus: ChannelTypeStatus) => void;
+  onManage: (typeStatus: ChannelTypeStatus) => void;
+}
+
+export default function ChannelTypeCard({ typeStatus, onAdd, onManage }: ChannelTypeCardProps) {
+  const { t } = useLanguage('channels');
+  const { type, total, activeCount, attentionCount, status } = typeStatus;
+  const isConfigured = total > 0;
+
+  const summary = isConfigured
+    ? [
+        activeCount > 0 ? t('overview.summary.active', { count: activeCount }) : null,
+        attentionCount > 0 ? t('overview.summary.attention', { count: attentionCount }) : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    : t('overview.summary.notConfigured');
+
+  // Inline contextual help text per channel type, falling back to the catalog
+  // description when no dedicated help copy exists for the type yet.
+  const helpText = t(`overview.help.${type.id}`, { defaultValue: type.description });
+
+  return (
+    <Card className="group relative flex flex-col bg-sidebar border-sidebar-border hover:bg-sidebar-accent/30 transition-all duration-300 hover:shadow-lg hover:shadow-black/10 overflow-hidden">
+      <CardContent className="flex flex-1 flex-col p-4 gap-3">
+        <div className="flex items-start gap-3">
+          <ChannelIcon channelType={type.type} size="lg" />
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-1.5">
+              <h3 className="font-semibold text-base truncate text-sidebar-foreground">
+                {type.name}
+              </h3>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t('overview.actions.howToConfigure')}
+                    className="text-sidebar-foreground/40 hover:text-sidebar-foreground transition-colors"
+                  >
+                    <HelpCircle className="h-4 w-4" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent className="w-72 text-sm">
+                  <p className="font-medium mb-1 text-sidebar-foreground">
+                    {t('overview.actions.howToConfigure')}
+                  </p>
+                  <p className="text-sidebar-foreground/70">{helpText}</p>
+                </PopoverContent>
+              </Popover>
+            </div>
+            <p className="text-xs text-sidebar-foreground/60 line-clamp-2">{type.description}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between mt-auto pt-1">
+          <ChannelStatusBadge status={status} />
+          <span className="text-xs text-sidebar-foreground/60 truncate ml-2">{summary}</span>
+        </div>
+      </CardContent>
+
+      <div className="flex border-t border-sidebar-border">
+        {isConfigured ? (
+          <Button
+            variant="ghost"
+            className="flex-1 rounded-none h-11 text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/40"
+            onClick={() => onManage(typeStatus)}
+          >
+            <Settings className="h-4 w-4 mr-2" />
+            {t('overview.actions.manage')}
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            className="flex-1 rounded-none h-11 text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/40"
+            onClick={() => onAdd(typeStatus)}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            {t('overview.actions.add')}
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/channels/ChannelTypeHub.spec.tsx
+++ b/src/components/channels/ChannelTypeHub.spec.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChannelTypeHub from './ChannelTypeHub';
+import { Inbox } from '@/types/channels/inbox';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+// Icon rendering depends on brand assets; not relevant to the hub logic under test.
+vi.mock('./ChannelIcon', () => ({ default: () => null }));
+
+const inbox = (overrides: Partial<Inbox>): Inbox =>
+  ({ id: 'i', name: 'n', channel_id: 'c', channel_type: 'whatsapp', ...overrides }) as Inbox;
+
+const noop = () => {};
+
+describe('ChannelTypeHub', () => {
+  it('renders skeletons while loading', () => {
+    const { container } = render(
+      <ChannelTypeHub inboxes={[]} isLoading onAdd={noop} onManage={noop} />,
+    );
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+  });
+
+  it('shows every catalog type as available when there are no inboxes', () => {
+    render(<ChannelTypeHub inboxes={[]} isLoading={false} onAdd={noop} onManage={noop} />);
+    // All 8 catalog types are unconfigured -> all expose the "Add" action.
+    expect(screen.getAllByText('overview.actions.add')).toHaveLength(8);
+    expect(screen.queryByText('overview.actions.manage')).toBeNull();
+  });
+
+  it('switches a configured type to the manage action and flags attention', () => {
+    render(
+      <ChannelTypeHub
+        inboxes={[inbox({ channel_type: 'Channel::Whatsapp', reauthorization_required: true })]}
+        isLoading={false}
+        onAdd={noop}
+        onManage={noop}
+      />,
+    );
+    expect(screen.getAllByText('overview.actions.add')).toHaveLength(7);
+    expect(screen.getAllByText('overview.actions.manage')).toHaveLength(1);
+    expect(screen.getByText('overview.summary.attention')).toBeInTheDocument();
+  });
+});

--- a/src/components/channels/ChannelTypeHub.tsx
+++ b/src/components/channels/ChannelTypeHub.tsx
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import { Skeleton } from '@evoapi/design-system';
+import { useLanguage } from '@/hooks/useLanguage';
+import { Inbox } from '@/types/channels/inbox';
+import { getChannelTypes } from '@/constants/channelTypes';
+import { buildChannelTypeStatuses, ChannelTypeStatus } from '@/utils/channelStatus';
+import ChannelTypeCard from './ChannelTypeCard';
+
+interface ChannelTypeHubProps {
+  inboxes: Inbox[];
+  isLoading: boolean;
+  onAdd: (typeStatus: ChannelTypeStatus) => void;
+  onManage: (typeStatus: ChannelTypeStatus) => void;
+}
+
+export default function ChannelTypeHub({ inboxes, isLoading, onAdd, onManage }: ChannelTypeHubProps) {
+  const { t, currentLanguage } = useLanguage('channels');
+
+  // getChannelTypes() reads translated labels, so recompute when language changes.
+  const typeStatuses = useMemo(
+    () => buildChannelTypeStatuses(getChannelTypes(), inboxes),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [inboxes, currentLanguage],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {Array.from({ length: 8 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-44" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <h2 className="text-lg font-semibold text-sidebar-foreground">{t('overview.title')}</h2>
+        <p className="text-sm text-sidebar-foreground/60">{t('overview.subtitle')}</p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {typeStatuses.map(typeStatus => (
+          <ChannelTypeCard
+            key={typeStatus.type.id}
+            typeStatus={typeStatus}
+            onAdd={onAdd}
+            onManage={onManage}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/channels/index.ts
+++ b/src/components/channels/index.ts
@@ -3,6 +3,9 @@ export { default as ChannelsTable } from './ChannelsTable';
 export { default as ChannelsPagination } from './ChannelsPagination';
 export { default as ChannelIcon } from './ChannelIcon';
 export { default as ChannelCard } from './ChannelCard';
+export { default as ChannelTypeHub } from './ChannelTypeHub';
+export { default as ChannelTypeCard } from './ChannelTypeCard';
+export { default as ChannelStatusBadge } from './ChannelStatusBadge';
 
 // Channels Components
 export { default as WebWidgetForm } from './WebWidgetForm';

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1702,5 +1702,35 @@
     "cancel": "Cancel",
     "confirm": "Delete Channel",
     "deleting": "Deleting..."
+  },
+  "overview": {
+    "tabLabel": "Overview",
+    "title": "Channel overview",
+    "subtitle": "See every channel type, its status, and how to set it up.",
+    "statusLabel": {
+      "active": "Active",
+      "attention": "Needs attention",
+      "available": "Available"
+    },
+    "summary": {
+      "active": "{{count}} active",
+      "attention": "{{count}} need attention",
+      "notConfigured": "Not configured"
+    },
+    "actions": {
+      "add": "Add",
+      "manage": "Manage",
+      "howToConfigure": "How to set up"
+    },
+    "help": {
+      "website": "Embed a live-chat widget on your website so visitors can talk to your team in real time.",
+      "whatsapp": "Connect WhatsApp through a provider (WhatsApp Cloud, Evolution, Twilio and others) to send and receive messages.",
+      "telegram": "Connect a Telegram bot using its token to receive and reply to messages from Telegram users.",
+      "instagram": "Link your Instagram professional account to handle direct messages from the inbox.",
+      "facebook": "Link a Facebook page to manage Messenger conversations from the inbox.",
+      "sms": "Send and receive SMS through a provider such as Twilio or Bandwidth.",
+      "email": "Connect a mailbox (Gmail or Outlook) to turn emails into conversations.",
+      "api": "Use the channel API to integrate any custom or in-house system."
+    }
   }
 }

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1619,5 +1619,35 @@
     "cancel": "Cancelar",
     "confirm": "Eliminar Canal",
     "deleting": "Eliminando..."
+  },
+  "overview": {
+    "tabLabel": "Resumen",
+    "title": "Resumen de canales",
+    "subtitle": "Mira todos los tipos de canal, su estado y cómo configurarlos.",
+    "statusLabel": {
+      "active": "Activo",
+      "attention": "Requiere atención",
+      "available": "Disponible"
+    },
+    "summary": {
+      "active": "{{count}} activo(s)",
+      "attention": "{{count}} con atención",
+      "notConfigured": "No configurado"
+    },
+    "actions": {
+      "add": "Agregar",
+      "manage": "Gestionar",
+      "howToConfigure": "Cómo configurar"
+    },
+    "help": {
+      "website": "Inserta un widget de chat en vivo en tu sitio web para hablar con los visitantes en tiempo real.",
+      "whatsapp": "Conecta WhatsApp mediante un proveedor (WhatsApp Cloud, Evolution, Twilio y otros) para enviar y recibir mensajes.",
+      "telegram": "Conecta un bot de Telegram con su token para recibir y responder mensajes.",
+      "instagram": "Vincula tu cuenta profesional de Instagram para gestionar mensajes directos desde la bandeja.",
+      "facebook": "Vincula una página de Facebook para gestionar conversaciones de Messenger desde la bandeja.",
+      "sms": "Envía y recibe SMS mediante un proveedor como Twilio o Bandwidth.",
+      "email": "Conecta un buzón (Gmail u Outlook) para convertir correos en conversaciones.",
+      "api": "Usa la API de canales para integrar cualquier sistema propio o personalizado."
+    }
   }
 }

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1638,5 +1638,35 @@
     "cancel": "Annuler",
     "confirm": "Supprimer le Canal",
     "deleting": "Suppression..."
+  },
+  "overview": {
+    "tabLabel": "Aperçu",
+    "title": "Aperçu des canaux",
+    "subtitle": "Consultez tous les types de canaux, leur statut et comment les configurer.",
+    "statusLabel": {
+      "active": "Actif",
+      "attention": "Attention requise",
+      "available": "Disponible"
+    },
+    "summary": {
+      "active": "{{count}} actif(s)",
+      "attention": "{{count}} à vérifier",
+      "notConfigured": "Non configuré"
+    },
+    "actions": {
+      "add": "Ajouter",
+      "manage": "Gérer",
+      "howToConfigure": "Comment configurer"
+    },
+    "help": {
+      "website": "Intégrez un widget de chat en direct sur votre site pour échanger avec les visiteurs en temps réel.",
+      "whatsapp": "Connectez WhatsApp via un fournisseur (WhatsApp Cloud, Evolution, Twilio, etc.) pour envoyer et recevoir des messages.",
+      "telegram": "Connectez un bot Telegram à l'aide de son token pour recevoir et répondre aux messages.",
+      "instagram": "Reliez votre compte professionnel Instagram pour gérer les messages directs depuis la boîte de réception.",
+      "facebook": "Reliez une page Facebook pour gérer les conversations Messenger depuis la boîte de réception.",
+      "sms": "Envoyez et recevez des SMS via un fournisseur comme Twilio ou Bandwidth.",
+      "email": "Connectez une boîte mail (Gmail ou Outlook) pour transformer les e-mails en conversations.",
+      "api": "Utilisez l'API de canaux pour intégrer n'importe quel système personnalisé."
+    }
   }
 }

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1577,5 +1577,35 @@
     "cancel": "Annulla",
     "confirm": "Elimina Canale",
     "deleting": "Eliminazione..."
+  },
+  "overview": {
+    "tabLabel": "Panoramica",
+    "title": "Panoramica dei canali",
+    "subtitle": "Vedi tutti i tipi di canale, il loro stato e come configurarli.",
+    "statusLabel": {
+      "active": "Attivo",
+      "attention": "Richiede attenzione",
+      "available": "Disponibile"
+    },
+    "summary": {
+      "active": "{{count}} attivo/i",
+      "attention": "{{count}} da verificare",
+      "notConfigured": "Non configurato"
+    },
+    "actions": {
+      "add": "Aggiungi",
+      "manage": "Gestisci",
+      "howToConfigure": "Come configurare"
+    },
+    "help": {
+      "website": "Incorpora un widget di chat dal vivo sul tuo sito per parlare con i visitatori in tempo reale.",
+      "whatsapp": "Collega WhatsApp tramite un provider (WhatsApp Cloud, Evolution, Twilio e altri) per inviare e ricevere messaggi.",
+      "telegram": "Collega un bot Telegram usando il suo token per ricevere e rispondere ai messaggi.",
+      "instagram": "Collega il tuo account professionale Instagram per gestire i messaggi diretti dalla casella.",
+      "facebook": "Collega una pagina Facebook per gestire le conversazioni di Messenger dalla casella.",
+      "sms": "Invia e ricevi SMS tramite un provider come Twilio o Bandwidth.",
+      "email": "Collega una casella email (Gmail o Outlook) per trasformare le email in conversazioni.",
+      "api": "Usa l'API dei canali per integrare qualsiasi sistema personalizzato."
+    }
   }
 }

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1702,5 +1702,35 @@
     "cancel": "Cancelar",
     "confirm": "Excluir Canal",
     "deleting": "Excluindo..."
+  },
+  "overview": {
+    "tabLabel": "Visão geral",
+    "title": "Visão geral dos canais",
+    "subtitle": "Veja todos os tipos de canal, o status de cada um e como configurar.",
+    "statusLabel": {
+      "active": "Ativo",
+      "attention": "Requer atenção",
+      "available": "Disponível"
+    },
+    "summary": {
+      "active": "{{count}} ativo(s)",
+      "attention": "{{count}} com atenção",
+      "notConfigured": "Não configurado"
+    },
+    "actions": {
+      "add": "Adicionar",
+      "manage": "Gerenciar",
+      "howToConfigure": "Como configurar"
+    },
+    "help": {
+      "website": "Incorpore um widget de chat ao vivo no seu site para conversar com visitantes em tempo real.",
+      "whatsapp": "Conecte o WhatsApp por um provedor (WhatsApp Cloud, Evolution, Twilio e outros) para enviar e receber mensagens.",
+      "telegram": "Conecte um bot do Telegram usando o token para receber e responder mensagens.",
+      "instagram": "Vincule sua conta profissional do Instagram para tratar mensagens diretas pela caixa de entrada.",
+      "facebook": "Vincule uma página do Facebook para gerenciar conversas do Messenger pela caixa de entrada.",
+      "sms": "Envie e receba SMS por um provedor como Twilio ou Bandwidth.",
+      "email": "Conecte uma caixa de e-mail (Gmail ou Outlook) para transformar e-mails em conversas.",
+      "api": "Use a API de canais para integrar qualquer sistema próprio ou personalizado."
+    }
   }
 }

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1636,5 +1636,35 @@
     "cancel": "Cancelar",
     "confirm": "Excluir Canal",
     "deleting": "Excluindo..."
+  },
+  "overview": {
+    "tabLabel": "Visão geral",
+    "title": "Visão geral dos canais",
+    "subtitle": "Veja todos os tipos de canal, o status de cada um e como configurar.",
+    "statusLabel": {
+      "active": "Ativo",
+      "attention": "Requer atenção",
+      "available": "Disponível"
+    },
+    "summary": {
+      "active": "{{count}} ativo(s)",
+      "attention": "{{count}} com atenção",
+      "notConfigured": "Não configurado"
+    },
+    "actions": {
+      "add": "Adicionar",
+      "manage": "Gerenciar",
+      "howToConfigure": "Como configurar"
+    },
+    "help": {
+      "website": "Incorpore um widget de chat ao vivo no seu site para conversar com visitantes em tempo real.",
+      "whatsapp": "Conecte o WhatsApp por um provedor (WhatsApp Cloud, Evolution, Twilio e outros) para enviar e receber mensagens.",
+      "telegram": "Conecte um bot do Telegram usando o token para receber e responder mensagens.",
+      "instagram": "Vincule sua conta profissional do Instagram para tratar mensagens diretas pela caixa de entrada.",
+      "facebook": "Vincule uma página do Facebook para gerenciar conversas do Messenger pela caixa de entrada.",
+      "sms": "Envie e receba SMS por um provedor como Twilio ou Bandwidth.",
+      "email": "Conecte uma caixa de e-mail (Gmail ou Outlook) para transformar e-mails em conversas.",
+      "api": "Use a API de canais para integrar qualquer sistema próprio ou personalizado."
+    }
   }
 }

--- a/src/pages/Customer/Channels/Channels.tsx
+++ b/src/pages/Customer/Channels/Channels.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
   Input,
 } from '@evoapi/design-system';
-import { Trash2, Grid3X3, List, Layers } from 'lucide-react';
+import { Trash2, Grid3X3, List, Layers, LayoutGrid } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
@@ -23,7 +23,9 @@ import {
   ChannelsTable,
   ChannelsPagination,
   ChannelCard,
+  ChannelTypeHub,
 } from '@/components/channels';
+import { ChannelTypeStatus } from '@/utils/channelStatus';
 import EmptyState from '@/components/base/EmptyState';
 // table types imported where needed in ChannelsTable
 import { useNavigate } from 'react-router-dom';
@@ -42,7 +44,7 @@ export default function Channels() {
   const [totalCount, setTotalCount] = useState(0);
   const [perPage, setPerPage] = useState(24);
   const [isDeleting, setIsDeleting] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
+  const [viewMode, setViewMode] = useState<'overview' | 'cards' | 'table'>('overview');
   const [deleteModal, setDeleteModal] = useState<{
     isOpen: boolean;
     channel: Inbox | null;
@@ -97,6 +99,29 @@ export default function Channels() {
   const openChannelSettings = useCallback(
     (inbox: Inbox) => {
       navigate(`/channels/${inbox.id}/settings`);
+    },
+    [navigate],
+  );
+
+  const handleAddType = useCallback(() => {
+    if (permissionsLoading || !permissionsReady) {
+      return;
+    }
+
+    if (!can('channels', 'create')) {
+      toast.error(t('permissions.createDenied'));
+      return;
+    }
+    navigate('/channels/new');
+  }, [navigate, can, permissionsLoading, permissionsReady, t]);
+
+  const handleManageType = useCallback(
+    (typeStatus: ChannelTypeStatus) => {
+      if (typeStatus.total === 1) {
+        navigate(`/channels/${typeStatus.inboxes[0].id}/settings`);
+        return;
+      }
+      setViewMode('cards');
     },
     [navigate],
   );
@@ -185,10 +210,19 @@ export default function Channels() {
       <div className="flex items-center justify-end mb-3" data-tour="channels-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
+            variant={viewMode === 'overview' ? 'default' : 'ghost'}
+            size="sm"
+            onClick={() => setViewMode('overview')}
+            className="border-0 rounded-r-none"
+            title={t('overview.tabLabel')}
+          >
+            <LayoutGrid className="h-4 w-4" />
+          </Button>
+          <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}
             size="sm"
             onClick={() => setViewMode('cards')}
-            className="border-0 rounded-r-none"
+            className="border-0 rounded-none"
           >
             <Grid3X3 className="h-4 w-4" />
           </Button>
@@ -204,7 +238,14 @@ export default function Channels() {
       </div>
 
       <div className="flex-1 overflow-auto" data-tour="channels-list">
-        {isLoadingInboxes ? (
+        {viewMode === 'overview' ? (
+          <ChannelTypeHub
+            inboxes={inboxes}
+            isLoading={isLoadingInboxes}
+            onAdd={handleAddType}
+            onManage={handleManageType}
+          />
+        ) : isLoadingInboxes ? (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {Array.from({ length: 6 }).map((_, idx) => (
               <Skeleton key={idx} className="h-28" />
@@ -241,7 +282,7 @@ export default function Channels() {
       </div>
 
       {/* Pagination */}
-      {totalCount > 0 && (
+      {viewMode !== 'overview' && totalCount > 0 && (
         <div data-tour="channels-pagination">
           <ChannelsPagination
             currentPage={currentPage}

--- a/src/utils/channelStatus.spec.ts
+++ b/src/utils/channelStatus.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildChannelTypeStatuses,
+  deriveInboxStatus,
+  normalizeChannelTypeId,
+} from './channelStatus';
+import { Inbox } from '@/types/channels/inbox';
+import { ChannelType } from '@/types/channels/providers';
+
+const inbox = (overrides: Partial<Inbox>): Inbox =>
+  ({ id: 'i', name: 'n', channel_id: 'c', channel_type: 'whatsapp', ...overrides }) as Inbox;
+
+const types: ChannelType[] = [
+  { id: 'whatsapp', name: 'WhatsApp', description: '', type: 'whatsapp' },
+  { id: 'email', name: 'Email', description: '', type: 'email' },
+  { id: 'sms', name: 'SMS', description: '', type: 'sms' },
+];
+
+describe('normalizeChannelTypeId', () => {
+  it('maps Rails STI class names to catalog ids', () => {
+    expect(normalizeChannelTypeId('Channel::Whatsapp')).toBe('whatsapp');
+    expect(normalizeChannelTypeId('Channel::WebWidget')).toBe('web_widget');
+    expect(normalizeChannelTypeId('Channel::TwilioSms')).toBe('sms');
+    expect(normalizeChannelTypeId('Channel::FacebookPage')).toBe('facebook');
+  });
+
+  it('maps snake_case and already-normalized variants', () => {
+    expect(normalizeChannelTypeId('whatsapp_cloud')).toBe('whatsapp');
+    expect(normalizeChannelTypeId('web_widget')).toBe('web_widget');
+    expect(normalizeChannelTypeId('sms')).toBe('sms');
+  });
+
+  it('returns undefined for unknown or empty types', () => {
+    expect(normalizeChannelTypeId('Channel::Twitter')).toBeUndefined();
+    expect(normalizeChannelTypeId('')).toBeUndefined();
+    expect(normalizeChannelTypeId(undefined)).toBeUndefined();
+  });
+});
+
+describe('deriveInboxStatus', () => {
+  it('flags reauthorization as attention', () => {
+    expect(deriveInboxStatus(inbox({ reauthorization_required: true }))).toBe('attention');
+  });
+
+  it('treats a configured inbox without reauth as active', () => {
+    expect(deriveInboxStatus(inbox({ reauthorization_required: false }))).toBe('active');
+    expect(deriveInboxStatus(inbox({}))).toBe('active');
+  });
+});
+
+describe('buildChannelTypeStatuses', () => {
+  it('marks a type with no inboxes as available', () => {
+    const result = buildChannelTypeStatuses(types, []);
+    expect(result.every(r => r.status === 'available')).toBe(true);
+    expect(result.every(r => r.total === 0)).toBe(true);
+  });
+
+  it('aggregates active and attention counts per type', () => {
+    const result = buildChannelTypeStatuses(types, [
+      inbox({ id: 'w1', channel_type: 'Channel::Whatsapp' }),
+      inbox({ id: 'w2', channel_type: 'whatsapp', reauthorization_required: true }),
+      inbox({ id: 'e1', channel_type: 'Channel::Email' }),
+    ]);
+    const whatsapp = result.find(r => r.type.type === 'whatsapp')!;
+    const email = result.find(r => r.type.type === 'email')!;
+    const sms = result.find(r => r.type.type === 'sms')!;
+
+    expect(whatsapp).toMatchObject({ total: 2, activeCount: 1, attentionCount: 1, status: 'attention' });
+    expect(email).toMatchObject({ total: 1, activeCount: 1, attentionCount: 0, status: 'active' });
+    expect(sms).toMatchObject({ total: 0, status: 'available' });
+  });
+
+  it('ignores inboxes whose type is not in the catalog', () => {
+    const result = buildChannelTypeStatuses(types, [
+      inbox({ id: 't1', channel_type: 'Channel::Twitter' }),
+    ]);
+    expect(result.reduce((sum, r) => sum + r.total, 0)).toBe(0);
+  });
+});

--- a/src/utils/channelStatus.ts
+++ b/src/utils/channelStatus.ts
@@ -1,0 +1,86 @@
+import { Inbox } from '@/types/channels/inbox';
+import { ChannelType, ChannelTypeId } from '@/types/channels/providers';
+
+/**
+ * Derived channel health used by the Channels overview hub.
+ *
+ * This is a FRONTEND-ONLY derivation: the `/inboxes` API does not expose live
+ * connectivity (no last_sync / connection_state / health), only the
+ * `reauthorization_required` flag. We therefore derive a coarse status from the
+ * client data we already have instead of probing each channel at load time.
+ */
+export type ChannelHealthStatus = 'active' | 'attention' | 'available';
+
+export interface ChannelTypeStatus {
+  type: ChannelType;
+  inboxes: Inbox[];
+  total: number;
+  activeCount: number;
+  attentionCount: number;
+  status: ChannelHealthStatus;
+}
+
+// Maps the many shapes an `inbox.channel_type` can take (Rails STI class names
+// like 'Channel::Whatsapp', snake_case, or already-normalized ids) onto the
+// catalog `ChannelTypeId`. Keys are normalized: 'Channel::' stripped, lowercased,
+// spaces and underscores removed.
+const NORMALIZED_TYPE_MAP: Record<string, ChannelTypeId> = {
+  webwidget: 'web_widget',
+  website: 'web_widget',
+  whatsapp: 'whatsapp',
+  whatsappcloud: 'whatsapp',
+  whatsapp360dialog: 'whatsapp',
+  facebook: 'facebook',
+  facebookpage: 'facebook',
+  instagram: 'instagram',
+  telegram: 'telegram',
+  sms: 'sms',
+  twiliosms: 'sms',
+  email: 'email',
+  api: 'api',
+};
+
+export function normalizeChannelTypeId(channelType?: string | null): ChannelTypeId | undefined {
+  if (!channelType) return undefined;
+  const key = channelType.replace('Channel::', '').toLowerCase().replace(/[\s_]/g, '');
+  return NORMALIZED_TYPE_MAP[key];
+}
+
+/**
+ * Status of a single configured inbox. A configured inbox is always either
+ * `active` or `attention` — `available` only applies to a channel TYPE that has
+ * no configured inboxes at all.
+ */
+export function deriveInboxStatus(inbox: Inbox): Exclude<ChannelHealthStatus, 'available'> {
+  return inbox.reauthorization_required ? 'attention' : 'active';
+}
+
+/**
+ * Build the per-type status summary that drives the overview hub. Every catalog
+ * type is represented (even with zero inboxes), so new channel types added to
+ * `getChannelTypes()` surface automatically.
+ */
+export function buildChannelTypeStatuses(
+  channelTypes: ChannelType[],
+  inboxes: Inbox[],
+): ChannelTypeStatus[] {
+  return channelTypes.map(type => {
+    const matched = inboxes.filter(inbox => normalizeChannelTypeId(inbox.channel_type) === type.type);
+    const attentionCount = matched.filter(inbox => deriveInboxStatus(inbox) === 'attention').length;
+    const activeCount = matched.length - attentionCount;
+
+    let status: ChannelHealthStatus = 'available';
+    if (matched.length > 0) {
+      status = attentionCount > 0 ? 'attention' : 'active';
+    }
+
+    return {
+      type,
+      inboxes: matched,
+      total: matched.length,
+      activeCount,
+      attentionCount,
+      status,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **Channel Overview** view to the Channels page (`/channels`) — the new default in the existing view toggle (Overview · Cards · Table). It lists every channel **type** from the catalog (configured + available-to-add) with a derived health status and an inline "how to configure" popover. This is the frontend-only cut of EVO-1554; the create-channel wizard already existed and is untouched.

Status is **derived client-side** from existing inbox data — no live connectivity. The `/inboxes` API only exposes `reauthorization_required`, so each type aggregates to:
- **attention** — any inbox needs reauthorization
- **active** — at least one configured inbox
- **available** — none configured (available to add)

The grid is driven by `getChannelTypes()`, so any new channel **type** added to the catalog surfaces automatically.

## Security
- Frontend-only; no new endpoints, no new data exposure.
- Add/Manage actions reuse the existing `channels` permission checks (`create` gated on click, mirroring the current "New channel" button).

## Test plan
- `frontend: pnpm exec tsc -b --noEmit`
- `frontend: pnpm exec eslint <changed files>`
- `frontend: pnpm exec vitest run src/utils/channelStatus.spec.ts src/components/channels/ChannelTypeHub.spec.tsx` (11 tests)
- `frontend: pnpm exec vitest run src/i18n/locales/i18n-parity.spec.ts` (163 tests)
- Manual smoke: `/channels` opens on Overview; statuses derive correctly; help popover; Add → wizard; Manage → settings (1 channel) / Cards view (many); view toggle + locale switch.

## Changed Files
- `src/utils/channelStatus.ts` (+ `.spec.ts`) — `normalizeChannelTypeId`, `deriveInboxStatus`, `buildChannelTypeStatuses`
- `src/components/channels/ChannelStatusBadge.tsx`
- `src/components/channels/ChannelTypeCard.tsx`
- `src/components/channels/ChannelTypeHub.tsx` (+ `.spec.tsx`)
- `src/components/channels/index.ts`
- `src/pages/Customer/Channels/Channels.tsx` — new default "Overview" view
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/channels.json` — `overview.*` block

## Scope decisions & known limitations
- **No live connectivity** (no bulk `healthCheck()`): status is derived only. Real status (last_sync / connection_state) needs a Rails change to the `/inboxes` API that has no card yet — out of this cut.
- **No wizard type pre-selection**: would require touching `useChannelForm`; the card forbids reworking the wizard. `Add` lands on the wizard's first step (the type grid).
- **M1 (accepted as design):** the Overview is type-centric and shows only catalog (offerable) types. Configured channels of legacy/out-of-catalog types (e.g. `Channel::TwitterProfile`, `Channel::Line`) still appear in the Cards/Table views, not the Overview.
- **M2 (pre-existing):** `appDataStore.fetchInboxes` swallows fetch errors without exposing an error flag, so a failed load is indistinguishable from "no channels". Surfacing an error state needs a store change, out of this frontend-only cut.

## Linked Issue
- EVO-1554