### PR TITLE
fix(frontend): paginate conversation list with current query and preserve total (EVO-1671)

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -995,8 +995,8 @@ const ChatSidebar = ({
         {/* Filter Actions */}
         <div className="flex items-center justify-between">
           <span className="text-sm text-muted-foreground">
-            {(conversations.state.conversationsPagination?.total ?? visibleConversations.length)}{' '}
-            {(conversations.state.conversationsPagination?.total ?? visibleConversations.length) === 1
+            {(conversations.state.conversationsPagination?.total || visibleConversations.length)}{' '}
+            {(conversations.state.conversationsPagination?.total || visibleConversations.length) === 1
               ? t('chatSidebar.conversation')
               : t('chatSidebar.conversations')}
           </span>

--- a/src/contexts/chat/ConversationsContext.spec.tsx
+++ b/src/contexts/chat/ConversationsContext.spec.tsx
@@ -396,4 +396,65 @@ describe('ConversationsContext reducer', () => {
       expect(matchesConversationId(b, '42')).toBe(true);
     });
   });
+
+  describe('APPEND_CONVERSATIONS pagination (EVO-1671)', () => {
+    const baseState = (total: number, page = 1, totalPages = 5) => ({
+      ...initialState,
+      conversations: [makeConversation({ id: 'c1', uuid: 'c1' })],
+      conversationsPagination: {
+        page,
+        page_size: 20,
+        total,
+        total_pages: totalPages,
+        has_next_page: page < totalPages,
+      },
+    });
+
+    it('preserves the previous total when the appended page reports total 0', () => {
+      const state = baseState(81, 1, 5);
+      const next = conversationsReducer(state, {
+        type: 'APPEND_CONVERSATIONS',
+        payload: {
+          conversations: [makeConversation({ id: 'c2', uuid: 'c2' })],
+          pagination: { page: 2, page_size: 20, total: 0, total_pages: 0 },
+        },
+      });
+
+      expect(next.conversationsPagination?.total).toBe(81);
+      expect(next.conversationsPagination?.total_pages).toBe(5);
+      expect(next.conversationsPagination?.page).toBe(2);
+      expect(next.conversationsPagination?.has_next_page).toBe(true);
+      expect(next.conversations).toHaveLength(2);
+    });
+
+    it('keeps has_next_page false once the last page is appended', () => {
+      const state = baseState(81, 4, 5);
+      const next = conversationsReducer(state, {
+        type: 'APPEND_CONVERSATIONS',
+        payload: {
+          conversations: [makeConversation({ id: 'c2', uuid: 'c2' })],
+          pagination: { page: 5, page_size: 20, total: 81, total_pages: 5 },
+        },
+      });
+
+      expect(next.conversationsPagination?.total).toBe(81);
+      expect(next.conversationsPagination?.page).toBe(5);
+      expect(next.conversationsPagination?.has_next_page).toBe(false);
+    });
+
+    it('honors a valid total from the appended page', () => {
+      const state = baseState(40, 1, 2);
+      const next = conversationsReducer(state, {
+        type: 'APPEND_CONVERSATIONS',
+        payload: {
+          conversations: [makeConversation({ id: 'c2', uuid: 'c2' })],
+          pagination: { page: 2, page_size: 20, total: 42, total_pages: 3 },
+        },
+      });
+
+      expect(next.conversationsPagination?.total).toBe(42);
+      expect(next.conversationsPagination?.total_pages).toBe(3);
+      expect(next.conversationsPagination?.has_next_page).toBe(true);
+    });
+  });
 });

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -14,7 +14,7 @@ import { toast } from 'sonner';
 import { extractConversationsData } from '@/utils/chat/responseHelpers';
 import { isActionNotSupported } from '@/utils/chat/actionSupport';
 
-import { Contact, Conversation, ConversationListParams } from '@/types/chat/api';
+import { Contact, Conversation, ConversationListParams, ConversationsQuery } from '@/types/chat/api';
 import { PaginationMeta } from '@/types/core';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 import { matchesConversationId } from '@/utils/chat/conversationMatcher';
@@ -28,6 +28,9 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   const loadingSpecificRef = useRef<Set<string>>(new Set());
   const selectionLockRef = useRef(false);
   const lastCleanupRef = useRef(0);
+  // The query that produced the current list, so load-more replays the SAME
+  // request for the next page instead of an unfiltered GET /conversations.
+  const currentQueryRef = useRef<ConversationsQuery>({ kind: 'list', params: { status: 'open' } });
 
   const findConversationByAnyId = useCallback(
     (conversationId: string) => {
@@ -53,6 +56,11 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
       try {
         const requestedPage = Number(params?.page || 1);
         const shouldAppend = requestedPage > 1;
+        if (!shouldAppend) {
+          const listParams: ConversationListParams = { ...(params ?? {}) };
+          delete listParams.page;
+          currentQueryRef.current = { kind: 'list', params: listParams };
+        }
         const response = await chatService.getConversations(params);
 
         if (!response || !response.data) {
@@ -117,8 +125,31 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
       return;
     }
 
-    await loadConversations({ page: currentPage + 1 });
-  }, [state.conversationsPagination, state.conversationsLoading, loadConversations]);
+    const nextPage = currentPage + 1;
+    const query = currentQueryRef.current;
+
+    // Advanced-filter lists came from POST /conversations/filter; replay that
+    // same request for the next page (loadConversations only knows GET).
+    if (query.kind === 'filter') {
+      loadingRef.current = true;
+      dispatch({ type: 'SET_CONVERSATIONS_LOADING', payload: true });
+      try {
+        const response = await chatService.filterConversations({ ...query.request, page: nextPage });
+        const { conversations, pagination: nextPagination } = extractConversationsData(response);
+        dispatch({ type: 'APPEND_CONVERSATIONS', payload: { conversations, pagination: nextPagination } });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : t('contexts.conversations.errors.loadConversations');
+        dispatch({ type: 'SET_CONVERSATIONS_ERROR', payload: errorMessage });
+        dispatch({ type: 'SET_CONVERSATIONS_LOADING', payload: false });
+      } finally {
+        loadingRef.current = false;
+      }
+      return;
+    }
+
+    await loadConversations({ ...query.params, page: nextPage });
+  }, [state.conversationsPagination, state.conversationsLoading, loadConversations, t]);
 
   const loadSpecificConversation = useCallback(
     async (conversationId: string): Promise<Conversation | null> => {
@@ -187,7 +218,10 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const setConversations = useCallback(
-    (conversations: Conversation[], pagination: PaginationMeta) => {
+    (conversations: Conversation[], pagination: PaginationMeta, query?: ConversationsQuery) => {
+      if (query) {
+        currentQueryRef.current = query;
+      }
       dispatch({ type: 'SET_CONVERSATIONS', payload: { conversations, pagination } });
     },
     [],

--- a/src/contexts/chat/ConversationsContextReducer.ts
+++ b/src/contexts/chat/ConversationsContextReducer.ts
@@ -1,5 +1,7 @@
 import { ConversationsState, ConversationsAction } from '@/types/chat/conversations';
 import { Conversation } from '@/types/chat/api';
+import { PaginationMeta } from '@/types/core';
+import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 import { matchesConversationId } from '@/utils/chat/conversationMatcher';
 
 // Helper para verificar se uma conversa foi marcada como lida no localStorage
@@ -139,10 +141,35 @@ export function conversationsReducer(
         existingById.set(String(conv.id), conv);
       });
 
+      const mergedConversations = Array.from(existingById.values());
+
+      // A load-more page must never shrink the authoritative count. If a later
+      // page reports a missing/zero total (e.g. parse fallback for a differently
+      // shaped response), keep the previous total instead of overwriting it —
+      // otherwise the displayed count drops to 0 and has_next_page turns false,
+      // killing the infinite scroll mid-list.
+      const incoming = action.payload.pagination;
+      const prev = state.conversationsPagination;
+      const pageSize = incoming.page_size || prev?.page_size || DEFAULT_PAGE_SIZE;
+      const total = incoming.total && incoming.total > 0 ? incoming.total : (prev?.total ?? mergedConversations.length);
+      const total_pages =
+        incoming.total_pages && incoming.total_pages > 0
+          ? incoming.total_pages
+          : (prev?.total_pages || Math.max(1, Math.ceil(total / pageSize)));
+      const page = incoming.page || (prev?.page ?? 1) + 1;
+      const mergedPagination: PaginationMeta = {
+        ...incoming,
+        page,
+        page_size: pageSize,
+        total,
+        total_pages,
+        has_next_page: page < total_pages,
+      };
+
       return {
         ...state,
-        conversations: Array.from(existingById.values()),
-        conversationsPagination: action.payload.pagination,
+        conversations: mergedConversations,
+        conversationsPagination: mergedPagination,
         conversationsLoading: false,
         conversationsError: null,
         unreadCounts: {

--- a/src/contexts/chat/FiltersContext.tsx
+++ b/src/contexts/chat/FiltersContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useReducer, useCallback } from 'react
 import { toast } from 'sonner';
 import { chatService } from '@/services/chat/chatService';
 import { extractConversationsData } from '@/utils/chat/responseHelpers';
-import { ConversationFilter, QuickFilterTab, Conversation } from '@/types/chat/api';
+import { ConversationFilter, QuickFilterTab, Conversation, ConversationsQuery } from '@/types/chat/api';
 import { PaginationMeta } from '@/types/core';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
@@ -80,12 +80,12 @@ interface FiltersContextValue {
   setFilters: (filters: ConversationFilter[]) => void;
   applyFilters: (
     filters: ConversationFilter[],
-    onSuccess: (conversations: Conversation[], pagination: PaginationMeta) => void,
+    onSuccess: (conversations: Conversation[], pagination: PaginationMeta, query?: ConversationsQuery) => void,
     onError: (error: string) => void,
   ) => Promise<void>;
   applySearch: (
     searchTerm: string,
-    onSuccess: (conversations: Conversation[], pagination: PaginationMeta) => void,
+    onSuccess: (conversations: Conversation[], pagination: PaginationMeta, query?: ConversationsQuery) => void,
     onError: (error: string) => void,
   ) => Promise<void>;
   setQuickFilter: (tab: QuickFilterTab) => void;
@@ -110,7 +110,7 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
   const applyFilters = useCallback(
     async (
       filters: ConversationFilter[],
-      onSuccess: (conversations: Conversation[], pagination: PaginationMeta) => void,
+      onSuccess: (conversations: Conversation[], pagination: PaginationMeta, query?: ConversationsQuery) => void,
       onError: (error: string) => void,
     ) => {
       dispatch({ type: 'SET_APPLYING_FILTERS', payload: true });
@@ -121,19 +121,19 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
           // Se não há filtros, carregar conversas normais
           const response = await chatService.getConversations();
           const { conversations, pagination } = extractConversationsData(response);
-          onSuccess(conversations, pagination);
+          onSuccess(conversations, pagination, { kind: 'list', params: {} });
         } else if (shouldUseAdvancedFilters(filters)) {
           // Usar filtros avançados (POST /filter)
           const filterRequest = convertFiltersToApiFormat(filters);
           const response = await chatService.filterConversations(filterRequest);
           const { conversations, pagination } = extractConversationsData(response);
-          onSuccess(conversations, pagination);
+          onSuccess(conversations, pagination, { kind: 'filter', request: filterRequest });
         } else {
           // Usar filtros simples (GET /conversations)
           const params = convertFiltersToUrlParams(filters);
           const response = await chatService.getConversations(params);
           const { conversations, pagination } = extractConversationsData(response);
-          onSuccess(conversations, pagination);
+          onSuccess(conversations, pagination, { kind: 'list', params });
         }
       } catch (error) {
         const errorMessage =
@@ -152,7 +152,7 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
   const applySearch = useCallback(
     async (
       searchTerm: string,
-      onSuccess: (conversations: Conversation[], pagination: PaginationMeta) => void,
+      onSuccess: (conversations: Conversation[], pagination: PaginationMeta, query?: ConversationsQuery) => void,
       onError: (error: string) => void,
     ) => {
       dispatch({ type: 'SET_SEARCH_TERM', payload: searchTerm });
@@ -166,7 +166,7 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
           try {
             const response = await chatService.getConversations();
             const { conversations, pagination } = extractConversationsData(response);
-            onSuccess(conversations, pagination);
+            onSuccess(conversations, pagination, { kind: 'list', params: {} });
           } catch (error) {
             const errorMessage =
               error instanceof Error
@@ -194,7 +194,7 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
             };
             const response = await chatService.filterConversations(filterRequest);
             const { conversations, pagination } = extractConversationsData(response);
-            onSuccess(conversations, pagination);
+            onSuccess(conversations, pagination, { kind: 'filter', request: filterRequest });
             return;
           } else {
             const filterParams = convertFiltersToUrlParams(state.activeFilters);
@@ -204,7 +204,7 @@ export function FiltersProvider({ children }: { children: React.ReactNode }) {
 
         const response = await chatService.getConversations(finalParams);
         const { conversations, pagination } = extractConversationsData(response);
-        onSuccess(conversations, pagination);
+        onSuccess(conversations, pagination, { kind: 'list', params: finalParams });
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : t('contexts.filters.errors.search');

--- a/src/hooks/chat/useFilterHandlers.ts
+++ b/src/hooks/chat/useFilterHandlers.ts
@@ -15,9 +15,9 @@ export const useFilterHandlers = () => {
       return new Promise<void>((resolve, reject) => {
         filters.applyFilters(
           apiFilters,
-          (conversationsResult, pagination) => {
+          (conversationsResult, pagination, query) => {
             // Atualizar o estado das conversas com os resultados do filtro
-            conversations.setConversations(conversationsResult, pagination);
+            conversations.setConversations(conversationsResult, pagination, query);
 
             // 💾 PERSISTIR: Salvar filtros aplicados no localStorage
             saveConversationFilters(newFilters);
@@ -53,8 +53,8 @@ export const useFilterHandlers = () => {
       if (filters.state.activeFilters.length > 0) {
         await filters.applyFilters(
           filters.state.activeFilters,
-          (conversationsResult, pagination) => {
-            conversations.setConversations(conversationsResult, pagination);
+          (conversationsResult, pagination, query) => {
+            conversations.setConversations(conversationsResult, pagination, query);
           },
           error => {
             console.error('❌ Erro ao recarregar filtros:', error);
@@ -65,8 +65,8 @@ export const useFilterHandlers = () => {
       else if (filters.state.searchTerm.trim().length > 0) {
         await filters.applySearch(
           filters.state.searchTerm,
-          (conversationsResult, pagination) => {
-            conversations.setConversations(conversationsResult, pagination);
+          (conversationsResult, pagination, query) => {
+            conversations.setConversations(conversationsResult, pagination, query);
           },
           error => {
             console.error('❌ Erro ao recarregar busca:', error);

--- a/src/types/chat/api.ts
+++ b/src/types/chat/api.ts
@@ -380,6 +380,13 @@ export interface MessageListParams {
   after?: string;
 }
 
+// Describes the query that produced the current conversation list, so pagination
+// (load-more) can replay the SAME request for the next page instead of falling
+// back to an unfiltered GET.
+export type ConversationsQuery =
+  | { kind: 'list'; params: ConversationListParams }
+  | { kind: 'filter'; request: FilterRequest };
+
 // Aliases para compatibilidade com código legado
 export type ConversationParams = ConversationListParams;
 export type MessageParams = SendMessageRequest;

--- a/src/types/chat/conversations.ts
+++ b/src/types/chat/conversations.ts
@@ -1,4 +1,4 @@
-import { Conversation, ConversationListParams, Contact } from './api';
+import { Conversation, ConversationListParams, Contact, ConversationsQuery } from './api';
 import { PaginationMeta } from '@/types/core';
 
 export interface ConversationsState {
@@ -55,7 +55,11 @@ export interface ConversationsContextValue {
   // Conversation actions
   loadConversations: (params?: ConversationListParams) => Promise<void>;
   loadMoreConversations: () => Promise<void>;
-  setConversations: (conversations: Conversation[], pagination: PaginationMeta) => void;
+  setConversations: (
+    conversations: Conversation[],
+    pagination: PaginationMeta,
+    query?: ConversationsQuery,
+  ) => void;
   loadSpecificConversation: (conversationId: string) => Promise<Conversation | null>;
   selectConversation: (conversationId: string | null) => void;
   updateConversationStatus: (


### PR DESCRIPTION
## Summary

Fixes the conversation list (`/conversations`) pagination: the header showed the correct API total (e.g. "81") on first load, but scrolling reset it to **0** and the infinite scroll stopped mid-list, so only a subset of conversations was ever shown.

Root cause was two compounding defects:
1. `loadMoreConversations` re-fetched with only `{ page }`, dropping the `status`/filters that produced the current list — page 2 hit `GET /conversations` unfiltered, a different query (and response shape) than page 1.
2. `APPEND_CONVERSATIONS` overwrote `conversationsPagination` wholesale, so a page whose meta normalized to `total: 0` zeroed the count and turned `has_next_page` false (the header count `?? visibleConversations.length` did not catch `0`).

## Fix
- Track the query that produced the list (`ConversationsQuery` = list params **or** a filter request) and **replay the same request** for the next page in load-more — `GET /conversations` for lists, `POST /conversations/filter` for advanced filters.
- `APPEND_CONVERSATIONS` now **preserves `total`/`total_pages`** when a later page reports `0`/missing and recomputes `has_next_page = page < total_pages`.
- Header count falls back to the visible length when `total` is `0`.

## Security
- Frontend-only; no endpoint or auth changes. Load-more now sends the same scoped query (status/filters) it already used for page 1.

## Test plan
- `frontend: pnpm exec tsc -b --noEmit`
- `frontend: pnpm exec eslint <changed files>` (0 errors)
- `frontend: pnpm exec vitest run src/contexts/chat/ConversationsContext.spec.tsx` (21 tests; +3 for APPEND pagination)
- Manual smoke: default view scrolls through all conversations with a stable count; active filter / quick-tab keeps the same filter across pages; search paginates within the search.

## Changed Files
- `src/types/chat/api.ts` — `ConversationsQuery` type
- `src/contexts/chat/ConversationsContext.tsx` — track current query; load-more replays it
- `src/contexts/chat/ConversationsContextReducer.ts` — APPEND preserves total/total_pages
- `src/contexts/chat/FiltersContext.tsx` — emit query descriptor on success
- `src/hooks/chat/useFilterHandlers.ts` — forward query descriptor to setConversations
- `src/types/chat/conversations.ts` — setConversations signature
- `src/components/chat/chat-sidebar/ChatSidebar.tsx` — count handles total 0
- `src/contexts/chat/ConversationsContext.spec.tsx` — APPEND pagination tests

## Scope note
This is the correctness fix. Scroll-transition smoothness (prefetch buffer + skeleton cushion on fast scroll / slow connections) is tracked separately as a follow-up to EVO-1617.

## Linked Issue
- EVO-1671