### PR TITLE
feat(contacts): mask lead PII for non-admin users (EVO-1551)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- N/A
+- **EVO-1551** Visual masking of contact PII (phone, email, WhatsApp identifier) on five render sites (chat sidebar, chat header, contact card, contacts table, contact details). Controlled by new `account.settings.mask_contact_pii` toggle in Account Settings (default OFF). Admin users always see full data; non-admin users see masked values with a `Lock` icon affordance, tooltip, and clipboard receiving the masked string. i18n added in 6 locales. Frontend-only feature — the API still returns full values.
 
 ### Changed
 

--- a/src/components/chat/contact-sidebar/ContactDetails.tsx
+++ b/src/components/chat/contact-sidebar/ContactDetails.tsx
@@ -3,9 +3,9 @@ import React, { useState } from 'react';
 
 import { useLanguage } from '@/hooks/useLanguage';
 import { useConversations } from '@/hooks/chat/useConversations';
+import { useContactPiiMasking } from '@/hooks/useContactPiiMasking';
 
 import { contactsService } from '@/services/contacts/contactsService';
-import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { unixTimestampToIso } from '@/utils/chat/contactTimestamp';
 
 import { Button } from '@evoapi/design-system/button';
@@ -23,6 +23,7 @@ import {
   Copy,
   Hash,
   Edit,
+  Lock,
 } from 'lucide-react';
 
 import { toast } from 'sonner';
@@ -40,6 +41,7 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ contact }) => {
   const { t } = useLanguage('chat');
 
   const { updateContactInConversations } = useConversations();
+  const { shouldMask, maskPhone, maskEmail, maskIdentifier } = useContactPiiMasking();
 
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [editingContact, setEditingContact] = useState<FullContact | null>(null);
@@ -140,26 +142,31 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ contact }) => {
           {contact?.phone_number && (
             <InfoField
               label={t('contactSidebar.contactDetails.fields.phone')}
-              value={formatContactPhone(contact.phone_number)}
-              copyValue={contact.phone_number}
+              value={maskPhone(contact.phone_number)}
+              copyValue={shouldMask ? maskPhone(contact.phone_number) : contact.phone_number}
               icon={<Phone className="h-4 w-4" />}
               copyable
+              isMasked={shouldMask}
             />
           )}
           {contact?.identifier && (
             <InfoField
               label={t('contactSidebar.contactDetails.fields.identifier')}
-              value={contact.identifier}
+              value={maskIdentifier(contact.identifier)}
+              copyValue={shouldMask ? maskIdentifier(contact.identifier) : contact.identifier}
               icon={<Hash className="h-4 w-4" />}
               copyable
+              isMasked={shouldMask}
             />
           )}
           {contact?.email && (
             <InfoField
               label={t('contactSidebar.contactDetails.fields.email')}
-              value={contact.email}
+              value={maskEmail(contact.email)}
+              copyValue={shouldMask ? maskEmail(contact.email) : contact.email}
               icon={<Mail className="h-4 w-4" />}
               copyable
+              isMasked={shouldMask}
             />
           )}
           {/* {contact?.location && (
@@ -309,6 +316,7 @@ interface InfoFieldProps {
   // the unformatted raw should be copied so integrations like `wa.me/<digits>`
   // keep working.
   copyValue?: string | null;
+  isMasked?: boolean;
 }
 
 const InfoField: React.FC<InfoFieldProps> = ({
@@ -317,6 +325,7 @@ const InfoField: React.FC<InfoFieldProps> = ({
   icon,
   copyable = false,
   copyValue,
+  isMasked = false,
 }) => {
   const { t } = useLanguage('chat');
 
@@ -324,9 +333,17 @@ const InfoField: React.FC<InfoFieldProps> = ({
     const target = copyValue ?? value;
     if (target) {
       navigator.clipboard.writeText(target);
-      toast.success(t('contactSidebar.contactDetails.copiedToClipboard'));
+      toast.success(
+        isMasked
+          ? t('contactSidebar.contactDetails.maskedValueCopied')
+          : t('contactSidebar.contactDetails.copiedToClipboard')
+      );
     }
   };
+
+  const protectedTitle = isMasked
+    ? t('contactSidebar.contactDetails.dataProtectedTooltip')
+    : undefined;
 
   return (
     <div className="flex items-center justify-between py-2 border-b border-border/50">
@@ -336,7 +353,10 @@ const InfoField: React.FC<InfoFieldProps> = ({
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-sm font-medium truncate max-w-48">
+        {isMasked && value && (
+          <Lock className="h-3 w-3 text-muted-foreground" aria-label={protectedTitle} />
+        )}
+        <span className="text-sm font-medium truncate max-w-48" title={protectedTitle}>
           {value || t('contactSidebar.contactDetails.notInformed')}
         </span>
 

--- a/src/components/chat/contact-sidebar/ContactHeader.tsx
+++ b/src/components/chat/contact-sidebar/ContactHeader.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Phone, Mail, MapPin, Hash } from 'lucide-react';
+import { Phone, Mail, MapPin, Hash, Lock } from 'lucide-react';
 import { Contact } from '@/types/chat/api';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
-import { formatContactPhone } from '@/utils/contact/formatContactPhone';
 import { isPresenceCapableChannel } from '@/utils/channelUtils';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useContactPiiMasking } from '@/hooks/useContactPiiMasking';
 
 interface ContactHeaderProps {
   contact: Contact | null;
@@ -22,9 +22,13 @@ const AVAILABILITY_DOT_CLASS: Record<AvailabilityStatus, string> = {
 
 const ContactHeader: React.FC<ContactHeaderProps> = ({ contact, channelType }) => {
   const { t } = useLanguage('chat');
+  const { shouldMask, maskPhone, maskEmail, maskIdentifier } = useContactPiiMasking();
 
   const availability = contact?.availability_status;
   const showPresence = isPresenceCapableChannel(channelType) && !!availability;
+  const protectedTitle = shouldMask
+    ? t('contactSidebar.contactDetails.dataProtectedTooltip')
+    : undefined;
 
   return (
     <div className="p-6 flex-shrink-0">
@@ -54,19 +58,34 @@ const ContactHeader: React.FC<ContactHeaderProps> = ({ contact, channelType }) =
             {contact?.phone_number && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Phone className="h-3 w-3 flex-shrink-0" />
-                <span className="truncate">{formatContactPhone(contact.phone_number)}</span>
+                {shouldMask && (
+                  <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                )}
+                <span className="truncate" title={protectedTitle}>
+                  {maskPhone(contact.phone_number)}
+                </span>
               </div>
             )}
             {contact?.identifier && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Hash className="h-3 w-3 flex-shrink-0" />
-                <span className="truncate">{contact.identifier}</span>
+                {shouldMask && (
+                  <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                )}
+                <span className="truncate" title={protectedTitle}>
+                  {maskIdentifier(contact.identifier)}
+                </span>
               </div>
             )}
             {contact?.email && (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Mail className="h-3 w-3 flex-shrink-0" />
-                <span className="truncate">{contact.email}</span>
+                {shouldMask && (
+                  <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                )}
+                <span className="truncate" title={protectedTitle}>
+                  {maskEmail(contact.email)}
+                </span>
               </div>
             )}
             {contact?.location && (

--- a/src/components/contacts/ContactCard.tsx
+++ b/src/components/contacts/ContactCard.tsx
@@ -1,9 +1,9 @@
 import { useLanguage } from '@/hooks/useLanguage';
 import { Button, Card, CardContent } from '@evoapi/design-system';
-import { Edit, MessageSquare, Eye, Trash } from 'lucide-react';
+import { Edit, MessageSquare, Eye, Trash, Lock } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
-import { formatContactPhone } from '@/utils/contact/formatContactPhone';
+import { useContactPiiMasking } from '@/hooks/useContactPiiMasking';
 import ContactStatusBadge from './ContactStatusBadge';
 import ContactTagsList from './ContactTagsList';
 import ContactTypeBadge from './ContactTypeBadge';
@@ -25,6 +25,8 @@ export default function ContactCard({
   onDelete,
 }: ContactCardProps) {
   const { t } = useLanguage('contacts');
+  const { shouldMask, maskPhone, maskEmail } = useContactPiiMasking();
+  const protectedTitle = shouldMask ? t('card.dataProtectedTooltip') : undefined;
 
   return (
     <Card className="group relative bg-sidebar border-sidebar-border hover:bg-sidebar-accent/30 transition-all duration-300 hover:shadow-lg hover:shadow-black/10 overflow-hidden">
@@ -39,7 +41,13 @@ export default function ContactCard({
               {contact.name}
             </h3>
             {contact.email && (
-              <p className="text-xs text-sidebar-foreground/60 truncate">{contact.email}</p>
+              <p
+                className="text-xs text-sidebar-foreground/60 truncate flex items-center gap-1"
+                title={protectedTitle}
+              >
+                {shouldMask && <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />}
+                {maskEmail(contact.email)}
+              </p>
             )}
           </div>
           <div className="flex flex-col gap-2">
@@ -55,7 +63,12 @@ export default function ContactCard({
           </div>
           <div className="flex items-center justify-between">
             <span>{t('card.phone')}</span>
-            <span className="font-mono">{formatContactPhone(contact.phone_number)}</span>
+            <span className="font-mono flex items-center gap-1" title={protectedTitle}>
+              {shouldMask && contact.phone_number && (
+                <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+              )}
+              {maskPhone(contact.phone_number)}
+            </span>
           </div>
           {contact.labels && contact.labels.length > 0 && (
             <div className="pt-2">

--- a/src/components/contacts/ContactDetails.tsx
+++ b/src/components/contacts/ContactDetails.tsx
@@ -37,11 +37,12 @@ import {
   // CalendarClock,
   Merge,
   Trash,
+  Lock,
 } from 'lucide-react';
 // import { ScheduledActionsList } from '@/components/scheduledActions';
 import { Contact } from '@/types/contacts';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
-import { formatContactPhone } from '@/utils/contact/formatContactPhone';
+import { useContactPiiMasking } from '@/hooks/useContactPiiMasking';
 import ContactPipelineItem from '@/components/pipelines/ContactPipelineItem';
 import ContactEventsTab from './ContactEventsTab';
 import ContactEventsErrorBoundary from './ContactEventsErrorBoundary';
@@ -72,6 +73,8 @@ export default function ContactDetails({
 }: ContactDetailsProps) {
   const { t } = useLanguage('contacts');
   const { can } = useUserPermissions();
+  const { shouldMask, maskPhone, maskEmail } = useContactPiiMasking();
+  const protectedTitle = shouldMask ? t('card.dataProtectedTooltip') : undefined;
   const [activeTab, setActiveTab] = useState('pipeline'); // Changed from 'scheduled-actions' to 'pipeline' (scheduled actions disabled)
   const [companiesSearch, setCompaniesSearch] = useState('');
   const [personsSearch, setPersonsSearch] = useState('');
@@ -250,13 +253,17 @@ export default function ContactDetails({
               {contact.email && (
                 <div className="flex items-center flex-wrap gap-2 mb-2">
                   <Mail className="h-4 w-4" />
-                  <span className="truncate">{contact.email}</span>
+                  {shouldMask && <Lock className="h-3 w-3" aria-label={protectedTitle} />}
+                  <span className="truncate" title={protectedTitle}>
+                    {maskEmail(contact.email)}
+                  </span>
                 </div>
               )}
               {contact.phone_number && (
                 <div className="flex items-center flex-wrap gap-2 mb-2">
                   <Phone className="h-4 w-4" />
-                  <span>{formatContactPhone(contact.phone_number)}</span>
+                  {shouldMask && <Lock className="h-3 w-3" aria-label={protectedTitle} />}
+                  <span title={protectedTitle}>{maskPhone(contact.phone_number)}</span>
                 </div>
               )}
             </div>
@@ -355,8 +362,25 @@ export default function ContactDetails({
                                   <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                                 </div>
                                 <div className="text-sm text-muted-foreground space-y-1">
-                                  {company.email && <div className="truncate">{company.email}</div>}
-                                  {company.phone_number && <div>{formatContactPhone(company.phone_number)}</div>}
+                                  {company.email && (
+                                    <div
+                                      className="truncate flex items-center gap-1"
+                                      title={protectedTitle}
+                                    >
+                                      {shouldMask && (
+                                        <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                                      )}
+                                      {maskEmail(company.email)}
+                                    </div>
+                                  )}
+                                  {company.phone_number && (
+                                    <div className="flex items-center gap-1" title={protectedTitle}>
+                                      {shouldMask && (
+                                        <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                                      )}
+                                      {maskPhone(company.phone_number)}
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                               <ContactTypeBadge type="company" />
@@ -414,8 +438,25 @@ export default function ContactDetails({
                                   <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
                                 </div>
                                 <div className="text-sm text-muted-foreground space-y-1">
-                                  {person.email && <div className="truncate">{person.email}</div>}
-                                  {person.phone_number && <div>{formatContactPhone(person.phone_number)}</div>}
+                                  {person.email && (
+                                    <div
+                                      className="truncate flex items-center gap-1"
+                                      title={protectedTitle}
+                                    >
+                                      {shouldMask && (
+                                        <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                                      )}
+                                      {maskEmail(person.email)}
+                                    </div>
+                                  )}
+                                  {person.phone_number && (
+                                    <div className="flex items-center gap-1" title={protectedTitle}>
+                                      {shouldMask && (
+                                        <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                                      )}
+                                      {maskPhone(person.phone_number)}
+                                    </div>
+                                  )}
                                 </div>
                               </div>
                               <ContactTypeBadge type="person" />

--- a/src/components/contacts/ContactsTable.tsx
+++ b/src/components/contacts/ContactsTable.tsx
@@ -1,9 +1,9 @@
 import { useLanguage } from '@/hooks/useLanguage';
-import { MessageSquare, Edit, Trash, Users } from 'lucide-react';
+import { MessageSquare, Edit, Trash, Users, Lock } from 'lucide-react';
 import { Contact } from '@/types/contacts';
 import { BaseTable, TableColumn, TableAction } from '@/components/base';
 import ContactAvatar from '@/components/chat/contact/ContactAvatar';
-import { formatContactPhone } from '@/utils/contact/formatContactPhone';
+import { useContactPiiMasking } from '@/hooks/useContactPiiMasking';
 import ContactStatusBadge from './ContactStatusBadge';
 import ContactTagsList from './ContactTagsList';
 import ContactTypeBadge from './ContactTypeBadge';
@@ -39,6 +39,8 @@ export default function ContactsTable({
   onSort,
 }: ContactsTableProps) {
   const { t } = useLanguage('contacts');
+  const { shouldMask, maskPhone, maskEmail } = useContactPiiMasking();
+  const protectedTitle = shouldMask ? t('card.dataProtectedTooltip') : undefined;
   const contactsList = contacts || [];
 
   // const formatLastActivity = (date: string) => {
@@ -69,12 +71,24 @@ export default function ContactsTable({
               {contact.name || t('table.noName')}
             </div>
             <div className="flex items-center gap-4 text-xs text-muted-foreground">
-              {contact.email && <span className="truncate">{contact.email}</span>}
+              {contact.email && (
+                <span className="truncate flex items-center gap-1" title={protectedTitle}>
+                  {shouldMask && (
+                    <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                  )}
+                  {maskEmail(contact.email)}
+                </span>
+              )}
               {contact.email && contact.phone_number && (
                 <span className="text-muted-foreground/50">|</span>
               )}
               {contact.phone_number && (
-                <span className="whitespace-nowrap">{formatContactPhone(contact.phone_number)}</span>
+                <span className="whitespace-nowrap flex items-center gap-1" title={protectedTitle}>
+                  {shouldMask && (
+                    <Lock className="h-3 w-3 flex-shrink-0" aria-label={protectedTitle} />
+                  )}
+                  {maskPhone(contact.phone_number)}
+                </span>
               )}
             </div>
           </div>

--- a/src/components/contacts/StartConversationModal.tsx
+++ b/src/components/contacts/StartConversationModal.tsx
@@ -269,11 +269,19 @@ export default function StartConversationModal({
     setLoading(true);
     try {
       // Build conversation data - match Vue implementation structure
+      // EVO-1551: when the PII masking flag is on, the backend omits
+      // source_id from /contactable_inboxes for PII-derived channels (WA/
+      // SMS/Email/Twilio) and rebuilds it server-side from contact_id +
+      // inbox_id. Only send source_id when the server actually gave us one
+      // (Instagram, BSUID-only WhatsApp, web widget, etc.) — sending an
+      // empty string used to break the builder.
       const conversationData: ConversationCreateData = {
         contact_id: contact.id,
         inbox_id: selectedInboxId,
-        source_id: selectedInbox?.source_id || '',
       };
+      if (selectedInbox?.source_id) {
+        conversationData.source_id = selectedInbox.source_id;
+      }
 
       // Add message or template params
       // Backend will process templates (both WhatsApp and Email) based on template_params

--- a/src/hooks/useContactPiiMasking.spec.tsx
+++ b/src/hooks/useContactPiiMasking.spec.tsx
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useContactPiiMasking } from './useContactPiiMasking';
+
+const mockAccountState: { account: any } = { account: null };
+const mockCurrentUser: { value: any } = { value: null };
+
+vi.mock('@/store/appDataStore', () => ({
+  useAppDataStore: (selector: (state: any) => any) => selector(mockAccountState),
+}));
+
+vi.mock('@/utils/auth', () => ({
+  useCurrentUser: () => mockCurrentUser.value,
+}));
+
+const setState = (flag: boolean | undefined, roleKey: string | null | undefined) => {
+  mockAccountState.account =
+    flag === undefined ? { settings: {} } : { settings: { mask_contact_pii: flag } };
+  mockCurrentUser.value =
+    roleKey === null ? null : roleKey === undefined ? { id: 1 } : { id: 1, role: { key: roleKey } };
+};
+
+describe('useContactPiiMasking', () => {
+  beforeEach(() => {
+    mockAccountState.account = null;
+    mockCurrentUser.value = null;
+  });
+
+  it('shouldMask=true when flag ON and user is non-admin', () => {
+    setState(true, 'agent');
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(true);
+    expect(result.current.maskPhone('+55 11 99999-9999')).toBe('+55 11 ****-9999');
+    expect(result.current.maskEmail('marcelo@gmail.com')).toBe('m***@gmail.com');
+    expect(result.current.maskIdentifier('5511999999999@s.whatsapp.net')).toBe(
+      '*********9999@s.whatsapp.net'
+    );
+  });
+
+  it.each(['administrator', 'account_owner', 'super_admin'])(
+    'shouldMask=false when flag ON but user role is admin-tier (%s)',
+    role => {
+      setState(true, role);
+      const { result } = renderHook(() => useContactPiiMasking());
+      expect(result.current.shouldMask).toBe(false);
+      expect(result.current.maskPhone('5511999999999')).toBe('+55 11 99999-9999');
+      expect(result.current.maskEmail('marcelo@gmail.com')).toBe('marcelo@gmail.com');
+      expect(result.current.maskIdentifier('5511999999999@s.whatsapp.net')).toBe(
+        '5511999999999@s.whatsapp.net'
+      );
+    }
+  );
+
+  it('shouldMask=false when flag OFF for non-admin', () => {
+    setState(false, 'agent');
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(false);
+    expect(result.current.maskPhone('5511999999999')).toBe('+55 11 99999-9999');
+    expect(result.current.maskEmail('marcelo@gmail.com')).toBe('marcelo@gmail.com');
+  });
+
+  it('shouldMask=false when flag OFF for admin', () => {
+    setState(false, 'administrator');
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(false);
+  });
+
+  it('masks supervisor/agent (non-admin tier) when flag ON', () => {
+    setState(true, 'supervisor');
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(true);
+  });
+
+  it('shouldMask=false when flag undefined (account.settings missing the key)', () => {
+    setState(undefined, 'agent');
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(false);
+    expect(result.current.maskEmail('marcelo@gmail.com')).toBe('marcelo@gmail.com');
+  });
+
+  it('masks when flag ON and user has no role defined (defensive: not-admin)', () => {
+    setState(true, undefined);
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(true);
+    expect(result.current.maskEmail('marcelo@gmail.com')).toBe('m***@gmail.com');
+  });
+
+  it('masks when flag ON and currentUser is null (defensive)', () => {
+    setState(true, null);
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(true);
+  });
+
+  it('does not crash when account is null', () => {
+    mockAccountState.account = null;
+    mockCurrentUser.value = { id: 1, role: { key: 'agent' } };
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.shouldMask).toBe(false);
+    expect(result.current.maskEmail('marcelo@gmail.com')).toBe('marcelo@gmail.com');
+  });
+
+  it('returns null for null phone input even when masking', () => {
+    setState(true, 'agent');
+    const { result } = renderHook(() => useContactPiiMasking());
+    expect(result.current.maskPhone(null)).toBeNull();
+    expect(result.current.maskEmail(null)).toBeNull();
+    expect(result.current.maskIdentifier(null)).toBeNull();
+  });
+});

--- a/src/hooks/useContactPiiMasking.ts
+++ b/src/hooks/useContactPiiMasking.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { useAppDataStore } from '@/store/appDataStore';
+import { useCurrentUser } from '@/utils/auth';
+import { isAdminRole } from '@/constants/roles';
+import { formatContactPhone } from '@/utils/contact/formatContactPhone';
+import {
+  maskPhone as maskPhoneRaw,
+  maskEmail as maskEmailRaw,
+  maskIdentifier as maskIdentifierRaw,
+} from '@/utils/contact/maskContactPii';
+
+interface UseContactPiiMasking {
+  shouldMask: boolean;
+  maskPhone: (raw: string | null | undefined) => string | null;
+  maskEmail: (raw: string | null | undefined) => string | null;
+  maskIdentifier: (raw: string | null | undefined) => string | null;
+}
+
+/**
+ * Returns mask-aware formatters for contact PII (phone, email, identifier).
+ *
+ * Mascaramento ativa quando `account.settings.mask_contact_pii === true` E o
+ * usuário atual NÃO é administrator. Sem role definida = tratado como não-admin
+ * (defensivo). Quando inativo, `maskPhone` ainda passa pelo `formatContactPhone`
+ * para manter o comportamento atual de formatação BR.
+ */
+export function useContactPiiMasking(): UseContactPiiMasking {
+  const account = useAppDataStore(state => state.account);
+  const currentUser = useCurrentUser();
+
+  const flagEnabled = account?.settings?.mask_contact_pii === true;
+  const roleKey = currentUser?.role?.key;
+  const isAdmin = !!roleKey && isAdminRole(roleKey);
+  const shouldMask = flagEnabled && !isAdmin;
+
+  return useMemo(
+    () => ({
+      shouldMask,
+      maskPhone: raw => {
+        const formatted = formatContactPhone(raw);
+        if (!shouldMask) return formatted;
+        return maskPhoneRaw(formatted);
+      },
+      maskEmail: raw => {
+        if (!shouldMask) return raw ?? null;
+        return maskEmailRaw(raw);
+      },
+      maskIdentifier: raw => {
+        if (!shouldMask) return raw ?? null;
+        return maskIdentifierRaw(raw);
+      },
+    }),
+    [shouldMask]
+  );
+}

--- a/src/i18n/locales/en/accountSettings.json
+++ b/src/i18n/locales/en/accountSettings.json
@@ -22,6 +22,10 @@
     "accountDeletion": {
       "title": "Account Deletion",
       "description": "Permanently delete your account and all data"
+    },
+    "maskContactPii": {
+      "title": "Mask Contact Data",
+      "description": "Hide phone, email and identifier from non-admin users to discourage contacting leads outside the system."
     }
   },
   "fields": {
@@ -80,7 +84,9 @@
       "audioTranscriptionDisabled": "Audio transcription disabled",
       "accountDeleted": "Account marked for deletion",
       "deletionCancelled": "Account deletion cancelled",
-      "accountIdCopied": "Account ID copied to clipboard"
+      "accountIdCopied": "Account ID copied to clipboard",
+      "maskPiiEnabled": "Contact data masking enabled",
+      "maskPiiDisabled": "Contact data masking disabled"
     },
     "error": {
       "loadFailed": "Failed to load account data",
@@ -90,7 +96,8 @@
       "audioTranscriptionFailed": "Error changing audio transcription",
       "deleteFailed": "Error marking account for deletion",
       "cancelDeletionFailed": "Error cancelling deletion",
-      "minTime": "Minimum time is 10 minutes"
+      "minTime": "Minimum time is 10 minutes",
+      "maskPiiFailed": "Failed to update contact data masking"
     }
   },
   "validation": {

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -412,7 +412,9 @@
         "lastActivity": "Last activity"
       },
       "notInformed": "Not informed",
-      "copiedToClipboard": "Copied to clipboard"
+      "copiedToClipboard": "Copied to clipboard",
+      "maskedValueCopied": "Masked value copied — ask an admin for full access if needed",
+      "dataProtectedTooltip": "Data protected by account policy"
     },
     "customAttributes": {
       "noAttributes": "No custom attributes configured",

--- a/src/i18n/locales/en/contacts.json
+++ b/src/i18n/locales/en/contacts.json
@@ -7,7 +7,8 @@
       "viewDetails": "View details",
       "edit": "Edit contact",
       "delete": "Delete contact"
-    }
+    },
+    "dataProtectedTooltip": "Data protected by account policy"
   },
   "details": {
     "title": "Contact Details",

--- a/src/i18n/locales/es/accountSettings.json
+++ b/src/i18n/locales/es/accountSettings.json
@@ -22,6 +22,10 @@
     "accountDeletion": {
       "title": "Eliminación de la cuenta",
       "description": "Elimine permanentemente su cuenta y todos los datos"
+    },
+    "maskContactPii": {
+      "title": "Enmascarar Datos del Contacto",
+      "description": "Oculta teléfono, email e identificador para usuarios no admin, desalentando el contacto con leads fuera del sistema."
     }
   },
   "fields": {
@@ -80,7 +84,9 @@
       "audioTranscriptionDisabled": "Transcripción de audio deshabilitada",
       "accountDeleted": "Cuenta marcada para eliminación",
       "deletionCancelled": "Eliminación de la cuenta cancelada",
-      "accountIdCopied": "ID de la cuenta copiado al portapapeles"
+      "accountIdCopied": "ID de la cuenta copiado al portapapeles",
+      "maskPiiEnabled": "Enmascaramiento de datos del contacto activado",
+      "maskPiiDisabled": "Enmascaramiento de datos del contacto desactivado"
     },
     "error": {
       "loadFailed": "No se pudieron cargar los datos de la cuenta",
@@ -90,7 +96,8 @@
       "audioTranscriptionFailed": "Error al cambiar la transcripción de audio",
       "deleteFailed": "Error al marcar la cuenta para su eliminación",
       "cancelDeletionFailed": "Error al cancelar la eliminación",
-      "minTime": "El tiempo mínimo es de 10 minutos"
+      "minTime": "El tiempo mínimo es de 10 minutos",
+      "maskPiiFailed": "Error al actualizar el enmascaramiento de datos del contacto"
     }
   },
   "validation": {

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -399,7 +399,9 @@
         "lastActivity": "Última actividad"
       },
       "notInformed": "No informado",
-      "copiedToClipboard": "Copiado al portapapeles"
+      "copiedToClipboard": "Copiado al portapapeles",
+      "maskedValueCopied": "Valor enmascarado copiado — pide acceso al admin si necesitas el dato completo",
+      "dataProtectedTooltip": "Datos protegidos por la política de la cuenta"
     },
     "customAttributes": {
       "noAttributes": "No hay atributos personalizados configurados",

--- a/src/i18n/locales/es/contacts.json
+++ b/src/i18n/locales/es/contacts.json
@@ -7,7 +7,8 @@
       "viewDetails": "Ver detalles",
       "edit": "Editar contacto",
       "delete": "Eliminar contacto"
-    }
+    },
+    "dataProtectedTooltip": "Datos protegidos por la política de la cuenta"
   },
   "details": {
     "title": "Detalles del Contacto",

--- a/src/i18n/locales/fr/accountSettings.json
+++ b/src/i18n/locales/fr/accountSettings.json
@@ -22,6 +22,10 @@
     "accountDeletion": {
       "title": "Suppression du Compte",
       "description": "Supprimez définitivement votre compte et toutes les données"
+    },
+    "maskContactPii": {
+      "title": "Masquer les Données du Contact",
+      "description": "Masque le téléphone, e-mail et identifiant pour les utilisateurs non-admin, décourageant le contact avec les leads hors système."
     }
   },
   "fields": {
@@ -80,7 +84,9 @@
       "audioTranscriptionDisabled": "Transcription audio désactivée",
       "accountDeleted": "Compte marqué pour suppression",
       "deletionCancelled": "Suppression du compte annulée",
-      "accountIdCopied": "ID du compte copié dans le presse-papiers"
+      "accountIdCopied": "ID du compte copié dans le presse-papiers",
+      "maskPiiEnabled": "Masquage des données du contact activé",
+      "maskPiiDisabled": "Masquage des données du contact désactivé"
     },
     "error": {
       "loadFailed": "Impossible de charger les données du compte",
@@ -90,7 +96,8 @@
       "audioTranscriptionFailed": "Erreur lors de la modification de la transcription audio",
       "deleteFailed": "Erreur lors du marquage du compte pour suppression",
       "cancelDeletionFailed": "Erreur lors de l'annulation de la suppression",
-      "minTime": "Le délai minimum est de 10 minutes"
+      "minTime": "Le délai minimum est de 10 minutes",
+      "maskPiiFailed": "Échec de la mise à jour du masquage des données du contact"
     }
   },
   "validation": {

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -399,7 +399,9 @@
         "lastActivity": "Dernière activité"
       },
       "notInformed": "Non renseigné",
-      "copiedToClipboard": "Copié dans le presse-papiers"
+      "copiedToClipboard": "Copié dans le presse-papiers",
+      "maskedValueCopied": "Valeur masquée copiée — demandez à un admin l’accès complet si nécessaire",
+      "dataProtectedTooltip": "Données protégées par la politique du compte"
     },
     "customAttributes": {
       "noAttributes": "Aucun attribut personnalisé configuré",

--- a/src/i18n/locales/fr/contacts.json
+++ b/src/i18n/locales/fr/contacts.json
@@ -7,7 +7,8 @@
       "viewDetails": "Voir les détails",
       "edit": "Modifier le contact",
       "delete": "Supprimer le contact"
-    }
+    },
+    "dataProtectedTooltip": "Données protégées par la politique du compte"
   },
   "details": {
     "title": "Détails du Contact",

--- a/src/i18n/locales/it/accountSettings.json
+++ b/src/i18n/locales/it/accountSettings.json
@@ -22,6 +22,10 @@
     "accountDeletion": {
       "title": "Eliminazione account",
       "description": "Elimina definitivamente il tuo account e tutti i dati"
+    },
+    "maskContactPii": {
+      "title": "Maschera Dati del Contatto",
+      "description": "Nasconde telefono, email e identificatore agli utenti non-admin, scoraggiando il contatto con i lead fuori dal sistema."
     }
   },
   "fields": {
@@ -80,7 +84,9 @@
       "audioTranscriptionDisabled": "Trascrizione audio disabilitata",
       "accountDeleted": "Account contrassegnato per l'eliminazione",
       "deletionCancelled": "Eliminazione account annullata",
-      "accountIdCopied": "ID account copiato negli appunti"
+      "accountIdCopied": "ID account copiato negli appunti",
+      "maskPiiEnabled": "Mascheramento dei dati del contatto attivato",
+      "maskPiiDisabled": "Mascheramento dei dati del contatto disattivato"
     },
     "error": {
       "loadFailed": "Impossibile caricare i dati dell'account",
@@ -90,7 +96,8 @@
       "audioTranscriptionFailed": "Errore durante la modifica della trascrizione audio",
       "deleteFailed": "Errore durante la contrassegnazione dell'account per l'eliminazione",
       "cancelDeletionFailed": "Errore durante l'annullamento dell'eliminazione",
-      "minTime": "Il tempo minimo è di 10 minuti"
+      "minTime": "Il tempo minimo è di 10 minuti",
+      "maskPiiFailed": "Impossibile aggiornare il mascheramento dei dati del contatto"
     }
   },
   "validation": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -399,7 +399,9 @@
         "lastActivity": "Ultima attività"
       },
       "notInformed": "Non informato",
-      "copiedToClipboard": "Copiato negli appunti"
+      "copiedToClipboard": "Copiato negli appunti",
+      "maskedValueCopied": "Valore mascherato copiato — chiedi accesso all’admin se ti serve il dato completo",
+      "dataProtectedTooltip": "Dati protetti dalla politica dell’account"
     },
     "customAttributes": {
       "noAttributes": "Nessun attributo personalizzato configurato",

--- a/src/i18n/locales/it/contacts.json
+++ b/src/i18n/locales/it/contacts.json
@@ -7,7 +7,8 @@
       "viewDetails": "Vedi dettagli",
       "edit": "Modifica contatto",
       "delete": "Elimina contatto"
-    }
+    },
+    "dataProtectedTooltip": "Dati protetti dalla politica dell’account"
   },
   "details": {
     "title": "Dettagli del Contatto",

--- a/src/i18n/locales/pt-BR/accountSettings.json
+++ b/src/i18n/locales/pt-BR/accountSettings.json
@@ -22,6 +22,10 @@
     "accountDeletion": {
       "title": "Exclusão da Conta",
       "description": "Exclua permanentemente sua conta e todos os dados"
+    },
+    "maskContactPii": {
+      "title": "Mascarar Dados do Contato",
+      "description": "Oculta telefone, email e identificador para usuários não-admin, desencorajando contato com leads fora do sistema."
     }
   },
   "fields": {
@@ -80,7 +84,9 @@
       "audioTranscriptionDisabled": "Transcrição de áudio desabilitada",
       "accountDeleted": "Conta marcada para exclusão",
       "deletionCancelled": "Exclusão da conta cancelada",
-      "accountIdCopied": "ID da conta copiado para a área de transferência"
+      "accountIdCopied": "ID da conta copiado para a área de transferência",
+      "maskPiiEnabled": "Mascaramento de dados do contato ativado",
+      "maskPiiDisabled": "Mascaramento de dados do contato desativado"
     },
     "error": {
       "loadFailed": "Não foi possível carregar os dados da conta",
@@ -90,7 +96,8 @@
       "audioTranscriptionFailed": "Erro ao alterar transcrição de áudio",
       "deleteFailed": "Erro ao marcar conta para exclusão",
       "cancelDeletionFailed": "Erro ao cancelar exclusão",
-      "minTime": "Tempo mínimo é de 10 minutos"
+      "minTime": "Tempo mínimo é de 10 minutos",
+      "maskPiiFailed": "Erro ao atualizar mascaramento de dados do contato"
     }
   },
   "validation": {

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -412,7 +412,9 @@
         "lastActivity": "Última atividade"
       },
       "notInformed": "Não informado",
-      "copiedToClipboard": "Copiado para a área de transferência"
+      "copiedToClipboard": "Copiado para a área de transferência",
+      "maskedValueCopied": "Valor mascarado copiado — peça acesso ao admin se precisar do dado completo",
+      "dataProtectedTooltip": "Dados protegidos pela política da conta"
     },
     "customAttributes": {
       "noAttributes": "Nenhum atributo personalizado configurado",

--- a/src/i18n/locales/pt-BR/contacts.json
+++ b/src/i18n/locales/pt-BR/contacts.json
@@ -7,7 +7,8 @@
       "viewDetails": "Ver detalhes",
       "edit": "Editar contato",
       "delete": "Deletar contato"
-    }
+    },
+    "dataProtectedTooltip": "Dados protegidos pela política da conta"
   },
   "details": {
     "title": "Detalhes do Contato",

--- a/src/i18n/locales/pt/accountSettings.json
+++ b/src/i18n/locales/pt/accountSettings.json
@@ -22,6 +22,10 @@
     "accountDeletion": {
       "title": "Exclusão da Conta",
       "description": "Exclua permanentemente sua conta e todos os dados"
+    },
+    "maskContactPii": {
+      "title": "Mascarar Dados do Contacto",
+      "description": "Oculta telefone, email e identificador para utilizadores não-admin, desencorajando contacto com leads fora do sistema."
     }
   },
   "fields": {
@@ -80,7 +84,9 @@
       "audioTranscriptionDisabled": "Transcrição de áudio desabilitada",
       "accountDeleted": "Conta marcada para exclusão",
       "deletionCancelled": "Exclusão da conta cancelada",
-      "accountIdCopied": "ID da conta copiado para a área de transferência"
+      "accountIdCopied": "ID da conta copiado para a área de transferência",
+      "maskPiiEnabled": "Mascaramento de dados do contacto activado",
+      "maskPiiDisabled": "Mascaramento de dados do contacto desactivado"
     },
     "error": {
       "loadFailed": "Não foi possível carregar os dados da conta",
@@ -90,7 +96,8 @@
       "audioTranscriptionFailed": "Erro ao alterar transcrição de áudio",
       "deleteFailed": "Erro ao marcar conta para exclusão",
       "cancelDeletionFailed": "Erro ao cancelar exclusão",
-      "minTime": "Tempo mínimo é de 10 minutos"
+      "minTime": "Tempo mínimo é de 10 minutos",
+      "maskPiiFailed": "Erro ao actualizar mascaramento de dados do contacto"
     }
   },
   "validation": {

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -399,7 +399,9 @@
         "lastActivity": "Última atividade"
       },
       "notInformed": "Não informado",
-      "copiedToClipboard": "Copiado para a área de transferência"
+      "copiedToClipboard": "Copiado para a área de transferência",
+      "maskedValueCopied": "Valor mascarado copiado — peça acesso ao admin se precisar do dado completo",
+      "dataProtectedTooltip": "Dados protegidos pela política da conta"
     },
     "customAttributes": {
       "noAttributes": "Nenhum atributo personalizado configurado",

--- a/src/i18n/locales/pt/contacts.json
+++ b/src/i18n/locales/pt/contacts.json
@@ -7,7 +7,8 @@
       "viewDetails": "Ver detalhes",
       "edit": "Editar contato",
       "delete": "Deletar contato"
-    }
+    },
+    "dataProtectedTooltip": "Dados protegidos pela política da conta"
   },
   "details": {
     "title": "Detalhes do Contato",

--- a/src/pages/Customer/Settings/Account/AccountSettings.tsx
+++ b/src/pages/Customer/Settings/Account/AccountSettings.tsx
@@ -15,8 +15,11 @@ import {
 } from '@evoapi/design-system';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
+import { useCurrentUser } from '@/utils/auth';
+import { isAdminRole } from '@/constants/roles';
 import BaseHeader from '@/components/base/BaseHeader';
 import { accountService } from '@/services/account/accountService';
+import { useAppDataStore } from '@/store/appDataStore';
 import type { Account, FormDataOptions } from '@/types/settings';
 import { Copy } from 'lucide-react';
 
@@ -55,6 +58,8 @@ function SectionLayout({
 export default function AccountSettings() {
   const { t, changeLanguage } = useLanguage('accountSettings');
   const { can, isReady: permissionsReady } = useUserPermissions();
+  const currentUser = useCurrentUser();
+  const isAdmin = !!currentUser?.role?.key && isAdminRole(currentUser.role.key);
   const normalizeAccountLocale = (locale?: string | null): string => {
     if (!locale) return 'pt-BR';
     const normalized = locale.replace('_', '-');
@@ -76,6 +81,7 @@ export default function AccountSettings() {
     autoResolveLabel: 'none',
     audioTranscriptions: false,
     autoResolveEnabled: false,
+    maskContactPii: false,
   });
   const [formDataOptions, setFormDataOptions] = useState<FormDataOptions>({
     inboxes: [],
@@ -139,6 +145,7 @@ export default function AccountSettings() {
         autoResolveLabel: settings.auto_resolve_label || 'none',
         audioTranscriptions: settings.audio_transcriptions || false,
         autoResolveEnabled: !!settings.auto_resolve_after,
+        maskContactPii: settings.mask_contact_pii || false,
       });
     } catch (error) {
       console.error('Erro ao carregar dados da conta:', error);
@@ -269,6 +276,31 @@ export default function AccountSettings() {
       );
     } catch (error: unknown) {
       toast.error((error as Error).message || t('messages.error.audioTranscriptionFailed'));
+    }
+  };
+
+  const handleMaskContactPiiToggle = async (enabled: boolean) => {
+    try {
+      const updated = await accountService.updateAccount({
+        settings: {
+          ...(account?.settings ?? {}),
+          mask_contact_pii: enabled,
+        },
+      });
+      setAccount(updated);
+      setFormData(prev => ({ ...prev, maskContactPii: enabled }));
+      try {
+        await useAppDataStore.getState().fetchAccount(true);
+      } catch (cacheError) {
+        console.warn('Failed to refresh appDataStore.account cache:', cacheError);
+      }
+      toast.success(
+        enabled
+          ? t('messages.success.maskPiiEnabled')
+          : t('messages.success.maskPiiDisabled'),
+      );
+    } catch (error: unknown) {
+      toast.error((error as Error).message || t('messages.error.maskPiiFailed'));
     }
   };
 
@@ -507,6 +539,23 @@ export default function AccountSettings() {
                 <Switch
                   checked={formData.audioTranscriptions}
                   onCheckedChange={handleAudioTranscriptionToggle}
+                />
+              }
+            >
+              <></>
+            </SectionLayout>
+          )}
+
+          {/* Mascaramento de PII dos Contatos — admin tiers only (super_admin / account_owner / administrator). */}
+          {isAdmin && (
+            <SectionLayout
+              title={t('sections.maskContactPii.title')}
+              description={t('sections.maskContactPii.description')}
+              withBorder
+              headerActions={
+                <Switch
+                  checked={formData.maskContactPii}
+                  onCheckedChange={handleMaskContactPiiToggle}
                 />
               }
             >

--- a/src/types/contacts/contact.ts
+++ b/src/types/contacts/contact.ts
@@ -23,7 +23,11 @@ export interface ContactableInboxes {
   updated_at: number;
   available?: boolean;
   can_create_conversation?: boolean;
-  source_id: string;
+  // EVO-1551: backend omits source_id (returns null) for PII-derived
+  // channels (WhatsApp/SMS/Email/Twilio) when the contact PII masking flag
+  // is on. The server regenerates it from `contact_id + inbox_id` on
+  // POST /conversations, so callers must NOT echo a null/empty value back.
+  source_id: string | null;
   channel: Channel;
 }
 

--- a/src/types/settings/account.ts
+++ b/src/types/settings/account.ts
@@ -70,6 +70,7 @@ export interface Account {
     auto_resolve_ignore_waiting?: boolean;
     auto_resolve_label?: string;
     audio_transcriptions?: boolean;
+    mask_contact_pii?: boolean;
   };
   custom_attributes?: {
     marked_for_deletion_at?: string;
@@ -111,6 +112,15 @@ export interface UpdateAccount {
   auto_resolve_ignore_waiting?: boolean;
   auto_resolve_label?: string | null;
   audio_transcriptions?: boolean;
+  mask_contact_pii?: boolean;
+  settings?: {
+    auto_resolve_after?: number;
+    auto_resolve_message?: string;
+    auto_resolve_ignore_waiting?: boolean;
+    auto_resolve_label?: string;
+    audio_transcriptions?: boolean;
+    mask_contact_pii?: boolean;
+  };
 }
 
 // Form data options for account forms

--- a/src/utils/contact/maskContactPii.spec.ts
+++ b/src/utils/contact/maskContactPii.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { maskPhone, maskEmail, maskIdentifier } from './maskContactPii';
+
+describe('maskPhone', () => {
+  it('returns null for empty / null / undefined', () => {
+    expect(maskPhone('')).toBeNull();
+    expect(maskPhone(null)).toBeNull();
+    expect(maskPhone(undefined)).toBeNull();
+  });
+
+  it('returns null when input has no digits', () => {
+    expect(maskPhone('abc')).toBeNull();
+  });
+
+  it('masks a Brazilian mobile preserving DDI + DDD + last 4', () => {
+    expect(maskPhone('+55 11 99999-9999')).toBe('+55 11 ****-9999');
+  });
+
+  it('masks a Brazilian landline preserving DDI + DDD + last 4', () => {
+    expect(maskPhone('+55 11 3333-4444')).toBe('+55 11 ****-4444');
+  });
+
+  it('masks a BR number without DDI (parenthesised) preserving DDD + last 4', () => {
+    expect(maskPhone('(11) 99999-9999')).toBe('(11) ****-9999');
+  });
+
+  it('masks an unformatted international number (no dash → last-4 rule)', () => {
+    expect(maskPhone('12155551234')).toBe('*******1234');
+  });
+
+  it('masks international number with leading + (no dash → last-4 rule)', () => {
+    expect(maskPhone('+12155551234')).toBe('+*******1234');
+  });
+
+  it('keeps last 4 digits for short strings without dash', () => {
+    expect(maskPhone('12345')).toBe('*2345');
+  });
+
+  it('masks every digit when fewer than 4', () => {
+    expect(maskPhone('123')).toBe('***');
+    expect(maskPhone('1')).toBe('*');
+  });
+
+  it('preserves non-digit punctuation between masked digits', () => {
+    expect(maskPhone('+1 215 555 1234')).toBe('+* *** *** 1234');
+  });
+
+  it('handles a 4-digit-only input (boundary)', () => {
+    expect(maskPhone('1234')).toBe('1234');
+  });
+});
+
+describe('maskEmail', () => {
+  it('returns null for empty / null / undefined', () => {
+    expect(maskEmail('')).toBeNull();
+    expect(maskEmail(null)).toBeNull();
+    expect(maskEmail(undefined)).toBeNull();
+  });
+
+  it('masks a regular email keeping first letter + domain', () => {
+    expect(maskEmail('marcelo@gmail.com')).toBe('m***@gmail.com');
+  });
+
+  it('hides length even for long local parts (always 3 stars)', () => {
+    expect(maskEmail('marcelogorutubajr@gmail.com')).toBe('m***@gmail.com');
+  });
+
+  it('keeps +alias hidden by masking the entire local body after first char', () => {
+    expect(maskEmail('marcelo+test@gmail.com')).toBe('m***@gmail.com');
+  });
+
+  it('handles 1-char local part with single star', () => {
+    expect(maskEmail('a@gmail.com')).toBe('*@gmail.com');
+  });
+
+  it('preserves short domains', () => {
+    expect(maskEmail('me@a.co')).toBe('m***@a.co');
+  });
+
+  it('returns opaque *** when there is no @', () => {
+    expect(maskEmail('no-arroba')).toBe('***');
+  });
+
+  it('handles missing local part', () => {
+    expect(maskEmail('@noco.com')).toBe('***@noco.com');
+  });
+});
+
+describe('maskIdentifier', () => {
+  it('returns null for empty / null / undefined', () => {
+    expect(maskIdentifier('')).toBeNull();
+    expect(maskIdentifier(null)).toBeNull();
+    expect(maskIdentifier(undefined)).toBeNull();
+  });
+
+  it('masks a WhatsApp JID keeping suffix intact (no dash in prefix → last-4 rule)', () => {
+    expect(maskIdentifier('5511999999999@s.whatsapp.net')).toBe(
+      '*********9999@s.whatsapp.net'
+    );
+  });
+
+  it('masks an international JID', () => {
+    expect(maskIdentifier('12155551234@s.whatsapp.net')).toBe(
+      '*******1234@s.whatsapp.net'
+    );
+  });
+
+  it('returns opaque *** when there are no digits and no @', () => {
+    expect(maskIdentifier('something-random-no-digits')).toBe('***');
+  });
+
+  it('treats input without @ as a phone', () => {
+    expect(maskIdentifier('12345')).toBe('*2345');
+  });
+
+  it('handles empty prefix with suffix', () => {
+    expect(maskIdentifier('@s.whatsapp.net')).toBe('***@s.whatsapp.net');
+  });
+});

--- a/src/utils/contact/maskContactPii.ts
+++ b/src/utils/contact/maskContactPii.ts
@@ -1,0 +1,81 @@
+/**
+ * Visual masking helpers for contact PII (phone, email, WhatsApp identifier).
+ *
+ * Purpose: discourage casual leaks (copy/paste outside the CRM) by hiding the
+ * majority of each PII string while preserving enough to identify the contact.
+ * This is UX friction, NOT real security — the API still returns full values.
+ *
+ * Conventions:
+ * - `null` / `undefined` / `''` → `null` so callers can short-circuit render.
+ * - Phone: when the input is already formatted with a dash (BR pattern from
+ *   `formatContactPhone` or `(DDD) NNNNN-NNNN`), preserve DDI/DDD/last-4 and
+ *   replace the central digit run with literal `****`. For other strings, mask
+ *   all digits except the last 4.
+ * - Email: keeps domain intact, replaces local part with `m***` (fixed length
+ *   so the original length doesn't leak).
+ * - Identifier (JID): splits on `@`, masks prefix as a phone, keeps suffix.
+ */
+
+export function maskPhone(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  const digitsOnly = raw.replace(/\D/g, '');
+  if (!digitsOnly) return null;
+
+  if (digitsOnly.length < 4) {
+    return raw.replace(/\d/g, '*');
+  }
+
+  const lastDashIdx = raw.lastIndexOf('-');
+  if (lastDashIdx > 0) {
+    const before = raw.slice(0, lastDashIdx);
+    const after = raw.slice(lastDashIdx); // includes the dash
+    if (/\d/.test(before) && /\d/.test(after)) {
+      return before.replace(/\d+(?=\D*$)/, '****') + after;
+    }
+  }
+
+  let digitsSeen = 0;
+  const totalDigits = digitsOnly.length;
+  const out: string[] = [];
+  for (const ch of raw) {
+    if (/\d/.test(ch)) {
+      digitsSeen += 1;
+      out.push(digitsSeen > totalDigits - 4 ? ch : '*');
+    } else {
+      out.push(ch);
+    }
+  }
+  return out.join('');
+}
+
+export function maskEmail(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  const atIdx = raw.indexOf('@');
+  if (atIdx === -1) return '***';
+
+  const local = raw.slice(0, atIdx);
+  const domain = raw.slice(atIdx);
+
+  if (!local) return `***${domain}`;
+  if (local.length === 1) return `*${domain}`;
+
+  return `${local[0]}***${domain}`;
+}
+
+export function maskIdentifier(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+
+  const atIdx = raw.indexOf('@');
+  if (atIdx === -1) {
+    return maskPhone(raw) ?? '***';
+  }
+
+  const prefix = raw.slice(0, atIdx);
+  const suffix = raw.slice(atIdx);
+
+  const maskedPrefix = maskPhone(prefix);
+  if (!maskedPrefix) return `***${suffix}`;
+  return `${maskedPrefix}${suffix}`;
+}


### PR DESCRIPTION
## Summary
- Frontend masking of phone/email/identifier in 5 render sites (chat sidebar/header, contact card/table/details)
- Admin tiers (`super_admin` / `account_owner` / `administrator`) always see full data
- Toggle persists via `account.settings.mask_contact_pii`; gated to admins-only (UI + backend)
- Clipboard receives masked value with differentiated toast
- `Lock` icon + tooltip affordance on every masked value
- i18n complete in 6 locales (en, pt-BR, pt, es, fr, it)

## Honest disclaimer
This PR is **frontend** UX. Defence-in-depth at the API layer is in the sibling PR on `evo-ai-crm-community` (`feat: mask_contact_pii`). Webhooks / service tokens / API global continue exposing full data by design.

## Test plan
- [ ] Login as admin → toggle on → phone/email/identifier full in all 5 sites
- [ ] Login as non-admin agent → all 5 sites show masked values + Lock icon
- [ ] Copy from chat sidebar → clipboard has masked string + differentiated toast
- [ ] Toggle hidden in Settings for non-admin users
- [ ] `pnpm vitest run src/utils/contact src/hooks/useContactPiiMasking src/i18n/locales` → 237/237 passing
- [ ] `pnpm tsc --noEmit` → 0 errors

## Linked Issue
- EVO-1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)