### PR TITLE
feat(frontend): Move to Pipeline Stage Journey node (EVO-1272)

### DIFF
--- a/src/components/journey/nodes/actions/action-nodes.ts
+++ b/src/components/journey/nodes/actions/action-nodes.ts
@@ -39,6 +39,7 @@ export * from './assign-agent';
 export * from './assign-team';
 export * from './assign-bot';
 export * from './assign-to-pipeline';
+export * from './move-to-pipeline-stage';
 
 // Conversation Management
 export * from './mute-conversation';

--- a/src/components/journey/nodes/actions/move-to-pipeline-stage/MoveToPipelineStageNode.tsx
+++ b/src/components/journey/nodes/actions/move-to-pipeline-stage/MoveToPipelineStageNode.tsx
@@ -1,0 +1,90 @@
+import { Workflow, Settings } from 'lucide-react';
+import { BaseFlowNode } from '@/components/base';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface MoveToPipelineStagePipelineOption {
+  id: string;
+  name: string;
+}
+
+export interface MoveToPipelineStageStageOption {
+  id: string;
+  name: string;
+  pipeline_id?: string;
+}
+
+export interface MoveToPipelineStageNodeData {
+  label: string;
+  description?: string;
+  pipeline_id?: string;
+  pipeline_name?: string;
+  stage_id?: string;
+  stage_name?: string;
+  formDataOptions?: {
+    pipelines: MoveToPipelineStagePipelineOption[];
+    stages?: MoveToPipelineStageStageOption[];
+  };
+}
+
+export interface MoveToPipelineStageNodeType {
+  id: string;
+  type: 'move-to-pipeline-stage-node';
+  position: { x: number; y: number };
+  data: MoveToPipelineStageNodeData;
+}
+
+interface MoveToPipelineStageNodeProps {
+  selected: boolean;
+  data: MoveToPipelineStageNodeData;
+  id: string;
+}
+
+export function MoveToPipelineStageNode({ selected, data, id }: MoveToPipelineStageNodeProps) {
+  const { t } = useLanguage('journey');
+
+  const hasStageSelected = !!data.stage_id;
+  const stageLabel = data.stage_name || data.stage_id;
+  const pipelineLabel = data.pipeline_name || data.pipeline_id;
+
+  return (
+    <BaseFlowNode
+      selected={selected}
+      hasTarget={true}
+      borderColor="amber"
+      isExecuting={false}
+      hasSource={true}
+      nodeId={id}
+      sourceHandleId="move-to-pipeline-stage-output"
+      targetHandleId="move-to-pipeline-stage-input"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
+            <Workflow className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-medium text-foreground truncate">
+              {t('flowEditor.nodes.moveToPipelineStage.name')}
+            </h3>
+          </div>
+          <div className="flex-shrink-0">
+            <Settings className="w-3 h-3 text-muted-foreground" />
+          </div>
+        </div>
+
+        <div className="p-2 rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/30">
+          <p className="text-xs text-amber-800 dark:text-amber-200 leading-relaxed">
+            {hasStageSelected ? (
+              <>
+                {t('flowEditor.nodes.moveToPipelineStage.moveTo')} <strong>{stageLabel}</strong>
+                {pipelineLabel ? ` (${pipelineLabel})` : ''}
+              </>
+            ) : (
+              t('flowEditor.nodes.moveToPipelineStage.noStageSelected')
+            )}
+          </p>
+        </div>
+      </div>
+    </BaseFlowNode>
+  );
+}

--- a/src/components/journey/nodes/actions/move-to-pipeline-stage/MoveToPipelineStagePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/move-to-pipeline-stage/MoveToPipelineStagePanel.spec.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MoveToPipelineStagePanel } from './MoveToPipelineStagePanel';
+import { MoveToPipelineStageNodeData } from './MoveToPipelineStageNode';
+import '@/i18n/config';
+
+vi.mock('@/services/pipelines/pipelinesService', () => ({
+  pipelinesService: {
+    getPipelines: vi.fn(),
+    getPipelineStages: vi.fn(),
+  },
+}));
+
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+
+const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
+const mockGetStages = pipelinesService.getPipelineStages as unknown as ReturnType<typeof vi.fn>;
+
+const PIPELINES = [
+  { id: 'pipe-1', name: 'Sales' },
+  { id: 'pipe-2', name: 'Onboarding' },
+];
+const STAGES = [
+  { id: 'stage-1', name: 'Lead' },
+  { id: 'stage-2', name: 'Qualified' },
+];
+
+const SAVE_RE = /save|salvar|guardar|enregistrer|salva/i;
+
+function makeData(overrides: Partial<MoveToPipelineStageNodeData> = {}): MoveToPipelineStageNodeData {
+  return { label: 'Move to Pipeline Stage', ...overrides };
+}
+
+function renderPanel(props: Partial<Parameters<typeof MoveToPipelineStagePanel>[0]> = {}) {
+  return render(
+    <MoveToPipelineStagePanel
+      nodeId="n1"
+      data={makeData()}
+      onUpdate={vi.fn()}
+      onClose={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+async function selectPipeline(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await user.click(screen.getByRole('combobox', { name: /pipeline/i }));
+  await user.click(within(await screen.findByRole('listbox')).getByText(name));
+}
+
+async function selectStage(user: ReturnType<typeof userEvent.setup>, name: string) {
+  await waitFor(() => expect(screen.getByRole('combobox', { name: /stage/i })).not.toBeDisabled());
+  await user.click(screen.getByRole('combobox', { name: /stage/i }));
+  await user.click(within(await screen.findByRole('listbox')).getByText(name));
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MoveToPipelineStagePanel', () => {
+  it('fetches the selected pipeline stages and renders them in the stage select', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: STAGES });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    await selectPipeline(user, 'Sales');
+
+    await waitFor(() => expect(mockGetStages).toHaveBeenCalledWith('pipe-1'));
+    await user.click(screen.getByRole('combobox', { name: /stage/i }));
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getByText('Lead')).toBeTruthy();
+    expect(within(listbox).getByText('Qualified')).toBeTruthy();
+  });
+
+  it('keeps Save disabled until a stage is selected', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: STAGES });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: SAVE_RE })).toBeDisabled();
+
+    await selectPipeline(user, 'Sales');
+    expect(screen.getByRole('button', { name: SAVE_RE })).toBeDisabled();
+
+    await selectStage(user, 'Qualified');
+    await waitFor(() => expect(screen.getByRole('button', { name: SAVE_RE })).not.toBeDisabled());
+  });
+
+  it('emits onUpdate with stage_id + stage_name on save (backend contract)', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: PIPELINES });
+    mockGetStages.mockResolvedValueOnce({ data: STAGES });
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPanel({ onUpdate, onClose });
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    await selectPipeline(user, 'Sales');
+    await selectStage(user, 'Qualified');
+
+    const saveBtn = screen.getByRole('button', { name: SAVE_RE });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    const saveCall = onUpdate.mock.calls.find(([, payload]) => payload?.stage_id === 'stage-2');
+    expect(saveCall).toBeTruthy();
+    expect(saveCall?.[0]).toBe('n1');
+    expect(saveCall?.[1]).toMatchObject({
+      pipeline_id: 'pipe-1',
+      stage_id: 'stage-2',
+      stage_name: 'Qualified',
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/journey/nodes/actions/move-to-pipeline-stage/MoveToPipelineStagePanel.tsx
+++ b/src/components/journey/nodes/actions/move-to-pipeline-stage/MoveToPipelineStagePanel.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Label,
+} from '@evoapi/design-system';
+import { AlertCircle, Workflow } from 'lucide-react';
+import {
+  MoveToPipelineStageNodeData,
+  MoveToPipelineStagePipelineOption,
+  MoveToPipelineStageStageOption,
+} from './MoveToPipelineStageNode';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { useLanguage } from '@/hooks/useLanguage';
+
+interface MoveToPipelineStagePanelProps {
+  nodeId: string;
+  data: MoveToPipelineStageNodeData;
+  onUpdate: (nodeId: string, newData: MoveToPipelineStageNodeData) => void;
+  onClose: () => void;
+}
+
+export function MoveToPipelineStagePanel({
+  nodeId,
+  data,
+  onUpdate,
+  onClose,
+}: MoveToPipelineStagePanelProps) {
+  const { t } = useLanguage('journey');
+  const [pipelineId, setPipelineId] = useState<string>(data.pipeline_id?.toString() || '');
+  const [stageId, setStageId] = useState<string>(data.stage_id?.toString() || '');
+  const [originalStageId] = useState<string>(() => data.stage_id?.toString() || '');
+  const [pipelines, setPipelines] = useState<MoveToPipelineStagePipelineOption[]>([]);
+  const [stages, setStages] = useState<MoveToPipelineStageStageOption[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingStages, setLoadingStages] = useState(false);
+  const [loadError, setLoadError] = useState(false);
+
+  useEffect(() => {
+    const loadPipelines = async () => {
+      try {
+        setLoading(true);
+        setLoadError(false);
+        const response = await pipelinesService.getPipelines();
+        const list = (response?.data || []).map(p => ({ id: p.id.toString(), name: p.name }));
+        setPipelines(list);
+      } catch (error) {
+        console.error(t('panels.moveToPipelineStage.loadDataError'), error);
+        setLoadError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadPipelines();
+  }, []);
+
+  useEffect(() => {
+    if (!pipelineId) {
+      setStages([]);
+      return;
+    }
+
+    const loadStages = async () => {
+      try {
+        setLoadingStages(true);
+        const response = await pipelinesService.getPipelineStages(pipelineId);
+        const list = (response?.data || []).map(s => ({
+          id: s.id.toString(),
+          name: s.name,
+          pipeline_id: pipelineId,
+        }));
+        setStages(list);
+      } catch (error) {
+        console.error(t('panels.moveToPipelineStage.loadStagesError'), error);
+        setStages([]);
+      } finally {
+        setLoadingStages(false);
+      }
+    };
+
+    loadStages();
+  }, [pipelineId]);
+
+  const handlePipelineChange = (value: string) => {
+    setPipelineId(value);
+    setStageId('');
+  };
+
+  const handleSave = () => {
+    const selectedPipeline = pipelines.find(p => p.id === pipelineId);
+    const selectedStage = stages.find(s => s.id === stageId);
+
+    const updatedData: MoveToPipelineStageNodeData = {
+      ...data,
+      pipeline_id: pipelineId || '',
+      pipeline_name: selectedPipeline?.name || '',
+      stage_id: stageId || '',
+      stage_name: selectedStage?.name || '',
+      formDataOptions: { pipelines, stages },
+    };
+
+    onUpdate(nodeId, updatedData);
+    onClose();
+  };
+
+  const dirty = useMemo(() => stageId !== originalStageId, [stageId, originalStageId]);
+  const isValid = Boolean(stageId);
+
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.moveToPipelineStage.title')}
+      icon={<Workflow className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+    >
+      <div className="space-y-4">
+        {loadError && (
+          <FlowFeedbackBanner variant="error">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" />
+              <span>{t('panels.moveToPipelineStage.loadErrorBanner')}</span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.moveToPipelineStage.pipeline')}
+          </Label>
+          <Select value={pipelineId} onValueChange={handlePipelineChange} disabled={loading}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.moveToPipelineStage.pipeline')}
+            >
+              <SelectValue
+                placeholder={
+                  loading
+                    ? t('panels.moveToPipelineStage.loadingPipelines')
+                    : t('panels.moveToPipelineStage.selectPipeline')
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {pipelines.map(pipeline => (
+                <SelectItem
+                  key={pipeline.id}
+                  value={pipeline.id}
+                  className="text-sidebar-foreground"
+                >
+                  {pipeline.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.moveToPipelineStage.stage')}
+          </Label>
+          <Select value={stageId} onValueChange={setStageId} disabled={!pipelineId || loadingStages}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.moveToPipelineStage.stage')}
+            >
+              <SelectValue
+                placeholder={
+                  loadingStages
+                    ? t('panels.moveToPipelineStage.loadingStages')
+                    : t('panels.moveToPipelineStage.selectStage')
+                }
+              />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {stages.map(stage => (
+                <SelectItem key={stage.id} value={stage.id} className="text-sidebar-foreground">
+                  {stage.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {!loadingStages && pipelineId && stages.length === 0 && (
+            <p className="text-sm text-sidebar-foreground/60">
+              {t('panels.moveToPipelineStage.noStagesFound')}
+            </p>
+          )}
+        </div>
+
+        {stageId && (
+          <FlowFeedbackBanner variant="info">
+            <div className="flex items-center gap-2">
+              <Workflow className="w-4 h-4" />
+              <span>
+                {t('panels.moveToPipelineStage.conversationWillMove')}{' '}
+                <strong>{stages.find(s => s.id === stageId)?.name}</strong>
+              </span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
+      </div>
+    </NodeConfigModal>
+  );
+}

--- a/src/components/journey/nodes/actions/move-to-pipeline-stage/index.ts
+++ b/src/components/journey/nodes/actions/move-to-pipeline-stage/index.ts
@@ -1,0 +1,2 @@
+export * from './MoveToPipelineStageNode';
+export * from './MoveToPipelineStagePanel';

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -324,6 +324,12 @@
         "assignTo": "Assign conversation to",
         "noPipelineSelected": "No pipeline selected"
       },
+      "moveToPipelineStage": {
+        "name": "Move to Pipeline Stage",
+        "description": "Moves the conversation to a specific pipeline stage",
+        "moveTo": "Move conversation to",
+        "noStageSelected": "No stage selected"
+      },
       "sendCannedResponse": {
         "name": "Send Canned Response",
         "description": "Sends a pre-written canned response to the conversation",
@@ -891,6 +897,20 @@
       "noPipelinesFound": "No pipelines found in the account.",
       "conversationWillBeAssigned": "The conversation will be assigned to the pipeline",
       "replacesAnyPrevious": "this replaces any previous pipeline assignment",
+      "loadErrorBanner": "Could not load pipelines. Check your connection and try reopening this node."
+    },
+    "moveToPipelineStage": {
+      "title": "Configure Move to Pipeline Stage",
+      "loadDataError": "Error loading pipelines:",
+      "loadStagesError": "Error loading stages:",
+      "pipeline": "Pipeline",
+      "stage": "Stage",
+      "loadingPipelines": "Loading pipelines...",
+      "loadingStages": "Loading stages...",
+      "selectPipeline": "Select a pipeline",
+      "selectStage": "Select a stage",
+      "noStagesFound": "No stages found in this pipeline.",
+      "conversationWillMove": "The conversation will move to stage",
       "loadErrorBanner": "Could not load pipelines. Check your connection and try reopening this node."
     },
     "sendCannedResponse": {

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -324,6 +324,12 @@
         "assignTo": "Atribuir conversa ao",
         "noPipelineSelected": "Nenhum pipeline selecionado"
       },
+      "moveToPipelineStage": {
+        "name": "Mover para Stage do Pipeline",
+        "description": "Move a conversa para um stage específico do pipeline",
+        "moveTo": "Mover conversa para",
+        "noStageSelected": "Nenhum stage selecionado"
+      },
       "sendCannedResponse": {
         "name": "Enviar Resposta Rápida",
         "description": "Envia uma resposta rápida pré-definida para a conversa",
@@ -891,6 +897,20 @@
       "noPipelinesFound": "Nenhum pipeline encontrado na conta.",
       "conversationWillBeAssigned": "A conversa será atribuída ao pipeline",
       "replacesAnyPrevious": "isso substitui qualquer atribuição anterior de pipeline",
+      "loadErrorBanner": "Não foi possível carregar os pipelines. Verifique sua conexão e reabra este node."
+    },
+    "moveToPipelineStage": {
+      "title": "Configurar Mover para Stage do Pipeline",
+      "loadDataError": "Erro ao carregar pipelines:",
+      "loadStagesError": "Erro ao carregar stages:",
+      "pipeline": "Pipeline",
+      "stage": "Stage",
+      "loadingPipelines": "Carregando pipelines...",
+      "loadingStages": "Carregando stages...",
+      "selectPipeline": "Selecione um pipeline",
+      "selectStage": "Selecione um stage",
+      "noStagesFound": "Nenhum stage encontrado neste pipeline.",
+      "conversationWillMove": "A conversa será movida para o stage",
       "loadErrorBanner": "Não foi possível carregar os pipelines. Verifique sua conexão e reabra este node."
     },
     "sendCannedResponse": {

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -53,6 +53,7 @@ import {
   AssignTeamNode,
   AssignBotNode,
   AssignToPipelineNode,
+  MoveToPipelineStageNode,
   SendCannedResponseNode,
   SendEmailTeamNode,
   SendTranscriptNode,
@@ -81,6 +82,7 @@ import {
   AssignTeamPanel,
   AssignBotPanel,
   AssignToPipelinePanel,
+  MoveToPipelineStagePanel,
   SendCannedResponsePanel,
   SendEmailTeamPanel,
   SendTranscriptPanel,
@@ -178,6 +180,7 @@ function JourneyFlowEditor() {
       'assign-team-node': AssignTeamNode,
       'assign-bot-node': AssignBotNode,
       'assign-to-pipeline-node': AssignToPipelineNode,
+      'move-to-pipeline-stage-node': MoveToPipelineStageNode,
       'send-canned-response-node': SendCannedResponseNode,
       'send-email-team-node': SendEmailTeamNode,
       'send-transcript-node': SendTranscriptNode,
@@ -424,6 +427,15 @@ function JourneyFlowEditor() {
         description: t('flowEditor.nodes.assignToPipeline.description'),
         searchKeywords: ['pipeline', 'funnel', 'sales', 'stage', 'crm', 'deal'],
       },
+      {
+        id: 'move-to-pipeline-stage-node',
+        name: t('flowEditor.nodes.moveToPipelineStage.name'),
+        icon: Workflow,
+        color: 'text-amber-400',
+        category: 'contact',
+        description: t('flowEditor.nodes.moveToPipelineStage.description'),
+        searchKeywords: ['pipeline', 'stage', 'move', 'funnel', 'sales', 'crm'],
+      },
     ],
     conversation: [
       {
@@ -493,6 +505,7 @@ function JourneyFlowEditor() {
       'assign-team-node': flowTokens.node.action.pipeline.border,
       'assign-bot-node': flowTokens.node.action.pipeline.border,
       'assign-to-pipeline-node': flowTokens.node.action.pipeline.border,
+      'move-to-pipeline-stage-node': flowTokens.node.action.pipeline.border,
       'change-priority-node': flowTokens.node.action.pipeline.border,
       'mute-conversation-node': flowTokens.node.action.pipeline.border,
       'defer-conversation-node': flowTokens.node.action.pipeline.border,
@@ -556,6 +569,8 @@ function JourneyFlowEditor() {
           return <AssignBotPanel {...commonProps} />;
         case 'assign-to-pipeline-node':
           return <AssignToPipelinePanel {...commonProps} />;
+        case 'move-to-pipeline-stage-node':
+          return <MoveToPipelineStagePanel {...commonProps} />;
         case 'send-canned-response-node':
           return <SendCannedResponsePanel {...commonProps} />;
         case 'send-email-team-node':


### PR DESCRIPTION
## What

Flow Builder **Move to Pipeline Stage** action node for the Customer Journey editor (EVO-1272).

- Config panel with a cascading **pipeline → stage** selector (fetches stages on pipeline change), persisting `pipeline_id` + `stage_id` on the node.
- Registered in the palette, node-type map, minimap and panel switch.
- en / pt-BR i18n.

The evo-flow Temporal executor forwards `pipeline_id` + `stage_id` to the CRM `move_conversation` endpoint.

## Tests

`MoveToPipelineStagePanel` specs (cascading fetch + persistence). `tsc` clean.

Part of EVO-1272 — paired with CRM (`evo-ai-crm-community#129`) and evo-flow (`evo-flow#37`) PRs.