### PR TITLE
feat(frontend): Create Pipeline Task Journey node (EVO-1273)

### DIFF
--- a/src/components/journey/nodes/actions/action-nodes.ts
+++ b/src/components/journey/nodes/actions/action-nodes.ts
@@ -40,6 +40,7 @@ export * from './assign-team';
 export * from './assign-bot';
 export * from './assign-to-pipeline';
 export * from './move-to-pipeline-stage';
+export * from './create-pipeline-task';
 
 // Conversation Management
 export * from './mute-conversation';

--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskNode.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskNode.tsx
@@ -1,0 +1,84 @@
+import { ClipboardList, Settings } from 'lucide-react';
+import { BaseFlowNode } from '@/components/base';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface CreatePipelineTaskAgentOption {
+  id: string | number;
+  name: string;
+  email?: string;
+}
+
+export interface CreatePipelineTaskDueDate {
+  value: number;
+  unit: string;
+}
+
+export interface CreatePipelineTaskNodeData {
+  label?: string;
+  title?: string;
+  description?: string;
+  priority?: string;
+  assigned_to_id?: string;
+  assigned_to_name?: string;
+  due_date?: CreatePipelineTaskDueDate | null;
+  formDataOptions?: { agents: CreatePipelineTaskAgentOption[] };
+}
+
+export interface CreatePipelineTaskNodeType {
+  id: string;
+  type: 'create-pipeline-task-node';
+  position: { x: number; y: number };
+  data: CreatePipelineTaskNodeData;
+}
+
+interface CreatePipelineTaskNodeProps {
+  selected: boolean;
+  data: CreatePipelineTaskNodeData;
+  id: string;
+}
+
+export function CreatePipelineTaskNode({ selected, data, id }: CreatePipelineTaskNodeProps) {
+  const { t } = useLanguage('journey');
+  const hasTitle = !!data.title?.trim();
+
+  return (
+    <BaseFlowNode
+      selected={selected}
+      hasTarget={true}
+      borderColor="amber"
+      isExecuting={false}
+      hasSource={true}
+      nodeId={id}
+      sourceHandleId="create-pipeline-task-output"
+      targetHandleId="create-pipeline-task-input"
+    >
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 w-8 h-8 bg-amber-500 rounded-lg flex items-center justify-center">
+            <ClipboardList className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-medium text-foreground truncate">
+              {t('flowEditor.nodes.createPipelineTask.name')}
+            </h3>
+          </div>
+          <div className="flex-shrink-0">
+            <Settings className="w-3 h-3 text-muted-foreground" />
+          </div>
+        </div>
+
+        <div className="p-2 rounded-md bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-800/30">
+          <p className="text-xs text-amber-800 dark:text-amber-200 leading-relaxed">
+            {hasTitle ? (
+              <>
+                {t('flowEditor.nodes.createPipelineTask.willCreate')} <strong>{data.title}</strong>
+              </>
+            ) : (
+              t('flowEditor.nodes.createPipelineTask.noTitle')
+            )}
+          </p>
+        </div>
+      </div>
+    </BaseFlowNode>
+  );
+}

--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.spec.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CreatePipelineTaskPanel } from './CreatePipelineTaskPanel';
+import { CreatePipelineTaskNodeData } from './CreatePipelineTaskNode';
+import '@/i18n/config';
+
+vi.mock('@/services/automation/automationService', () => ({
+  automationService: { getFormData: vi.fn() },
+}));
+
+import { automationService } from '@/services/automation/automationService';
+
+const mockGetFormData = automationService.getFormData as unknown as ReturnType<typeof vi.fn>;
+
+const AGENTS = [
+  { id: 'u1', name: 'Alice', email: 'alice@example.com' },
+  { id: 'u2', name: 'Bob', email: 'bob@example.com' },
+];
+
+const SAVE_RE = /save|salvar|guardar|salva/i;
+const TITLE_RE = /title|título/i;
+
+function makeData(overrides: Partial<CreatePipelineTaskNodeData> = {}): CreatePipelineTaskNodeData {
+  return { label: 'Create Pipeline Task', ...overrides };
+}
+
+function renderPanel(props: Partial<Parameters<typeof CreatePipelineTaskPanel>[0]> = {}) {
+  return render(
+    <CreatePipelineTaskPanel
+      nodeId="n1"
+      data={makeData()}
+      onUpdate={vi.fn()}
+      onClose={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CreatePipelineTaskPanel', () => {
+  it('keeps Save disabled until a title is entered (title is required)', async () => {
+    mockGetFormData.mockResolvedValueOnce({ agents: AGENTS });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await waitFor(() => expect(mockGetFormData).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: SAVE_RE })).toBeDisabled();
+
+    await user.type(screen.getByRole('textbox', { name: TITLE_RE }), 'Follow up');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: SAVE_RE })).not.toBeDisabled(),
+    );
+  });
+
+  it('emits onUpdate with the title and default priority on save', async () => {
+    mockGetFormData.mockResolvedValueOnce({ agents: AGENTS });
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderPanel({ onUpdate, onClose });
+
+    await waitFor(() => expect(mockGetFormData).toHaveBeenCalled());
+    await user.type(screen.getByRole('textbox', { name: TITLE_RE }), 'Call the lead');
+
+    const saveBtn = screen.getByRole('button', { name: SAVE_RE });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      'n1',
+      expect.objectContaining({
+        title: 'Call the lead',
+        priority: 'medium',
+        due_date: null,
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Label,
+  Input,
+  Textarea,
+} from '@evoapi/design-system';
+import { ClipboardList } from 'lucide-react';
+import {
+  CreatePipelineTaskNodeData,
+  CreatePipelineTaskAgentOption,
+  CreatePipelineTaskDueDate,
+} from './CreatePipelineTaskNode';
+import { automationService } from '@/services/automation/automationService';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { useLanguage } from '@/hooks/useLanguage';
+
+interface CreatePipelineTaskPanelProps {
+  nodeId: string;
+  data: CreatePipelineTaskNodeData;
+  onUpdate: (nodeId: string, newData: CreatePipelineTaskNodeData) => void;
+  onClose: () => void;
+}
+
+const PRIORITIES = ['low', 'medium', 'high', 'urgent'];
+
+const DUE_PRESETS: { key: string; due: CreatePipelineTaskDueDate | null }[] = [
+  { key: 'none', due: null },
+  { key: 'in1h', due: { value: 1, unit: 'hours' } },
+  { key: 'in4h', due: { value: 4, unit: 'hours' } },
+  { key: 'in1d', due: { value: 1, unit: 'days' } },
+  { key: 'in3d', due: { value: 3, unit: 'days' } },
+  { key: 'in1w', due: { value: 7, unit: 'days' } },
+];
+
+const dueKey = (due?: CreatePipelineTaskDueDate | null): string =>
+  DUE_PRESETS.find(p => p.due?.value === due?.value && p.due?.unit === due?.unit)?.key || 'none';
+
+export function CreatePipelineTaskPanel({
+  nodeId,
+  data,
+  onUpdate,
+  onClose,
+}: CreatePipelineTaskPanelProps) {
+  const { t } = useLanguage('journey');
+  const [title, setTitle] = useState<string>(data.title || '');
+  const [description, setDescription] = useState<string>(data.description || '');
+  const [assignedToId, setAssignedToId] = useState<string>(data.assigned_to_id?.toString() || '');
+  const [priority, setPriority] = useState<string>(data.priority || 'medium');
+  const [duePreset, setDuePreset] = useState<string>(dueKey(data.due_date));
+  const [agents, setAgents] = useState<CreatePipelineTaskAgentOption[]>(
+    data.formDataOptions?.agents || [],
+  );
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadFormData = async () => {
+      try {
+        setLoading(true);
+        const formData = await automationService.getFormData();
+        setAgents(formData.agents || []);
+      } catch (error) {
+        console.error(t('panels.createPipelineTask.loadDataError'), error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadFormData();
+  }, []);
+
+  const handleSave = () => {
+    const due = DUE_PRESETS.find(p => p.key === duePreset)?.due ?? null;
+    const selectedAgent = agents.find(a => a.id.toString() === assignedToId);
+
+    const updatedData: CreatePipelineTaskNodeData = {
+      ...data,
+      title: title.trim(),
+      description: description.trim() || undefined,
+      priority,
+      assigned_to_id: assignedToId || undefined,
+      assigned_to_name: selectedAgent?.name || undefined,
+      due_date: due,
+      formDataOptions: { agents },
+    };
+
+    onUpdate(nodeId, updatedData);
+    onClose();
+  };
+
+  const isValid = title.trim().length > 0;
+  const dirty = useMemo(
+    () =>
+      title.trim() !== (data.title || '') ||
+      description.trim() !== (data.description || '') ||
+      assignedToId !== (data.assigned_to_id?.toString() || '') ||
+      priority !== (data.priority || 'medium') ||
+      duePreset !== dueKey(data.due_date),
+    [title, description, assignedToId, priority, duePreset, data],
+  );
+
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.createPipelineTask.title')}
+      icon={<ClipboardList className="h-5 w-5 text-flow-node-action-pipeline-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty && isValid}
+      loading={loading}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+    >
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.createPipelineTask.taskTitle')}
+          </Label>
+          <Input
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            placeholder={t('panels.createPipelineTask.taskTitlePlaceholder')}
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            aria-label={t('panels.createPipelineTask.taskTitle')}
+          />
+          <p className="text-xs text-sidebar-foreground/60">
+            {t('panels.createPipelineTask.variablesHint')}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.createPipelineTask.description')}
+          </Label>
+          <Textarea
+            value={description}
+            onChange={e => setDescription(e.target.value)}
+            placeholder={t('panels.createPipelineTask.descriptionPlaceholder')}
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.createPipelineTask.assignee')}
+          </Label>
+          <Select value={assignedToId} onValueChange={setAssignedToId} disabled={loading}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.createPipelineTask.assignee')}
+            >
+              <SelectValue placeholder={t('panels.createPipelineTask.noAssignee')} />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {agents.map(agent => (
+                <SelectItem
+                  key={agent.id}
+                  value={agent.id.toString()}
+                  className="text-sidebar-foreground"
+                >
+                  {agent.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.createPipelineTask.dueDate')}
+          </Label>
+          <Select value={duePreset} onValueChange={setDuePreset}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.createPipelineTask.dueDate')}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {DUE_PRESETS.map(preset => (
+                <SelectItem
+                  key={preset.key}
+                  value={preset.key}
+                  className="text-sidebar-foreground"
+                >
+                  {t(`panels.createPipelineTask.due.${preset.key}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.createPipelineTask.priority')}
+          </Label>
+          <Select value={priority} onValueChange={setPriority}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.createPipelineTask.priority')}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {PRIORITIES.map(p => (
+                <SelectItem key={p} value={p} className="text-sidebar-foreground">
+                  {t(`panels.createPipelineTask.priorities.${p}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </NodeConfigModal>
+  );
+}

--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.tsx
@@ -9,7 +9,7 @@ import {
   Input,
   Textarea,
 } from '@evoapi/design-system';
-import { ClipboardList } from 'lucide-react';
+import { ClipboardList, AlertCircle } from 'lucide-react';
 import {
   CreatePipelineTaskNodeData,
   CreatePipelineTaskAgentOption,
@@ -17,6 +17,7 @@ import {
 } from './CreatePipelineTaskNode';
 import { automationService } from '@/services/automation/automationService';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
 
 interface CreatePipelineTaskPanelProps {
@@ -56,15 +57,18 @@ export function CreatePipelineTaskPanel({
     data.formDataOptions?.agents || [],
   );
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
 
   useEffect(() => {
     const loadFormData = async () => {
       try {
         setLoading(true);
+        setLoadError(false);
         const formData = await automationService.getFormData();
         setAgents(formData.agents || []);
       } catch (error) {
         console.error(t('panels.createPipelineTask.loadDataError'), error);
+        setLoadError(true);
       } finally {
         setLoading(false);
       }
@@ -117,6 +121,15 @@ export function CreatePipelineTaskPanel({
       cancelLabel={t('panels.actions.cancel')}
     >
       <div className="space-y-4">
+        {loadError && (
+          <FlowFeedbackBanner variant="error">
+            <div className="flex items-center gap-2">
+              <AlertCircle className="w-4 h-4" />
+              <span>{t('panels.createPipelineTask.loadErrorBanner')}</span>
+            </div>
+          </FlowFeedbackBanner>
+        )}
+
         <div className="space-y-2">
           <Label className="text-sidebar-foreground font-medium">
             {t('panels.createPipelineTask.taskTitle')}

--- a/src/components/journey/nodes/actions/create-pipeline-task/index.ts
+++ b/src/components/journey/nodes/actions/create-pipeline-task/index.ts
@@ -1,0 +1,2 @@
+export * from './CreatePipelineTaskNode';
+export * from './CreatePipelineTaskPanel';

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -922,6 +922,7 @@
     "createPipelineTask": {
       "title": "Configure Create Pipeline Task",
       "loadDataError": "Error loading agents:",
+      "loadErrorBanner": "Could not load agents. Check your connection and try reopening this node.",
       "taskTitle": "Title",
       "taskTitlePlaceholder": "e.g. Follow up with {contact.name}",
       "variablesHint": "Supports variables like {contact.name}.",

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -330,6 +330,12 @@
         "moveTo": "Move conversation to",
         "noStageSelected": "No stage selected"
       },
+      "createPipelineTask": {
+        "name": "Create Pipeline Task",
+        "description": "Creates a task on the conversation's pipeline item",
+        "willCreate": "Create task",
+        "noTitle": "No title set"
+      },
       "sendCannedResponse": {
         "name": "Send Canned Response",
         "description": "Sends a pre-written canned response to the conversation",
@@ -912,6 +918,33 @@
       "noStagesFound": "No stages found in this pipeline.",
       "conversationWillMove": "The conversation will move to stage",
       "loadErrorBanner": "Could not load pipelines. Check your connection and try reopening this node."
+    },
+    "createPipelineTask": {
+      "title": "Configure Create Pipeline Task",
+      "loadDataError": "Error loading agents:",
+      "taskTitle": "Title",
+      "taskTitlePlaceholder": "e.g. Follow up with {contact.name}",
+      "variablesHint": "Supports variables like {contact.name}.",
+      "description": "Description",
+      "descriptionPlaceholder": "Optional details",
+      "assignee": "Assignee",
+      "noAssignee": "No assignee",
+      "dueDate": "Due date",
+      "priority": "Priority",
+      "due": {
+        "none": "No due date",
+        "in1h": "In 1 hour",
+        "in4h": "In 4 hours",
+        "in1d": "In 1 day",
+        "in3d": "In 3 days",
+        "in1w": "In 1 week"
+      },
+      "priorities": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "urgent": "Urgent"
+      }
     },
     "sendCannedResponse": {
       "title": "Configure Send Canned Response",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -330,6 +330,12 @@
         "moveTo": "Mover conversa para",
         "noStageSelected": "Nenhum stage selecionado"
       },
+      "createPipelineTask": {
+        "name": "Criar Tarefa no Pipeline",
+        "description": "Cria uma tarefa no pipeline item da conversa",
+        "willCreate": "Criar tarefa",
+        "noTitle": "Sem título definido"
+      },
       "sendCannedResponse": {
         "name": "Enviar Resposta Rápida",
         "description": "Envia uma resposta rápida pré-definida para a conversa",
@@ -912,6 +918,33 @@
       "noStagesFound": "Nenhum stage encontrado neste pipeline.",
       "conversationWillMove": "A conversa será movida para o stage",
       "loadErrorBanner": "Não foi possível carregar os pipelines. Verifique sua conexão e reabra este node."
+    },
+    "createPipelineTask": {
+      "title": "Configurar Criar Tarefa no Pipeline",
+      "loadDataError": "Erro ao carregar agentes:",
+      "taskTitle": "Título",
+      "taskTitlePlaceholder": "ex.: Dar follow-up com {contact.name}",
+      "variablesHint": "Suporta variáveis como {contact.name}.",
+      "description": "Descrição",
+      "descriptionPlaceholder": "Detalhes opcionais",
+      "assignee": "Responsável",
+      "noAssignee": "Sem responsável",
+      "dueDate": "Vencimento",
+      "priority": "Prioridade",
+      "due": {
+        "none": "Sem vencimento",
+        "in1h": "Em 1 hora",
+        "in4h": "Em 4 horas",
+        "in1d": "Em 1 dia",
+        "in3d": "Em 3 dias",
+        "in1w": "Em 1 semana"
+      },
+      "priorities": {
+        "low": "Baixa",
+        "medium": "Média",
+        "high": "Alta",
+        "urgent": "Urgente"
+      }
     },
     "sendCannedResponse": {
       "title": "Configurar Enviar Resposta Rápida",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -922,6 +922,7 @@
     "createPipelineTask": {
       "title": "Configurar Criar Tarefa no Pipeline",
       "loadDataError": "Erro ao carregar agentes:",
+      "loadErrorBanner": "Não foi possível carregar os agentes. Verifique sua conexão e reabra este node.",
       "taskTitle": "Título",
       "taskTitlePlaceholder": "ex.: Dar follow-up com {contact.name}",
       "variablesHint": "Suporta variáveis como {contact.name}.",

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -54,6 +54,7 @@ import {
   AssignBotNode,
   AssignToPipelineNode,
   MoveToPipelineStageNode,
+  CreatePipelineTaskNode,
   SendCannedResponseNode,
   SendEmailTeamNode,
   SendTranscriptNode,
@@ -83,6 +84,7 @@ import {
   AssignBotPanel,
   AssignToPipelinePanel,
   MoveToPipelineStagePanel,
+  CreatePipelineTaskPanel,
   SendCannedResponsePanel,
   SendEmailTeamPanel,
   SendTranscriptPanel,
@@ -117,6 +119,7 @@ import {
   Clock,
   Bot,
   Workflow,
+  ClipboardList,
 } from 'lucide-react';
 
 /**
@@ -181,6 +184,7 @@ function JourneyFlowEditor() {
       'assign-bot-node': AssignBotNode,
       'assign-to-pipeline-node': AssignToPipelineNode,
       'move-to-pipeline-stage-node': MoveToPipelineStageNode,
+      'create-pipeline-task-node': CreatePipelineTaskNode,
       'send-canned-response-node': SendCannedResponseNode,
       'send-email-team-node': SendEmailTeamNode,
       'send-transcript-node': SendTranscriptNode,
@@ -436,6 +440,15 @@ function JourneyFlowEditor() {
         description: t('flowEditor.nodes.moveToPipelineStage.description'),
         searchKeywords: ['pipeline', 'stage', 'move', 'funnel', 'sales', 'crm'],
       },
+      {
+        id: 'create-pipeline-task-node',
+        name: t('flowEditor.nodes.createPipelineTask.name'),
+        icon: ClipboardList,
+        color: 'text-amber-400',
+        category: 'contact',
+        description: t('flowEditor.nodes.createPipelineTask.description'),
+        searchKeywords: ['task', 'todo', 'pipeline', 'follow up', 'crm', 'reminder'],
+      },
     ],
     conversation: [
       {
@@ -506,6 +519,7 @@ function JourneyFlowEditor() {
       'assign-bot-node': flowTokens.node.action.pipeline.border,
       'assign-to-pipeline-node': flowTokens.node.action.pipeline.border,
       'move-to-pipeline-stage-node': flowTokens.node.action.pipeline.border,
+      'create-pipeline-task-node': flowTokens.node.action.pipeline.border,
       'change-priority-node': flowTokens.node.action.pipeline.border,
       'mute-conversation-node': flowTokens.node.action.pipeline.border,
       'defer-conversation-node': flowTokens.node.action.pipeline.border,
@@ -571,6 +585,8 @@ function JourneyFlowEditor() {
           return <AssignToPipelinePanel {...commonProps} />;
         case 'move-to-pipeline-stage-node':
           return <MoveToPipelineStagePanel {...commonProps} />;
+        case 'create-pipeline-task-node':
+          return <CreatePipelineTaskPanel {...commonProps} />;
         case 'send-canned-response-node':
           return <SendCannedResponsePanel {...commonProps} />;
         case 'send-email-team-node':


### PR DESCRIPTION
## Summary
Flow Builder **Create Pipeline Task** action node for the Customer Journey editor (last of the 3 P1 pipeline nodes).

Config panel with 5 fields — title (required, supports `{contact.name}` variables), description, assignee (agents dropdown from `/users`), due date (relative presets), priority — persisted on the node and forwarded by the evo-flow executor to `pipeline_tasks#for_conversation`.

Registered in the palette, node-type map, minimap and panel switch, plus the action-nodes barrel and en / pt-BR i18n. A load failure shows an error banner.

## Test plan
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` — clean
- `evo-ai-frontend-community: pnpm exec vitest run .../CreatePipelineTaskPanel.spec.tsx` — 2 tests (title required gate + onUpdate payload)

## Linked Issue
- EVO-1273

## Related PRs
- evolution-foundation/evo-ai-crm-community#131 (endpoint)
- evolution-foundation/evo-flow#41 (node runtime)