### PR TITLE
fix(frontend): strip doubled /api/v1 prefix from rbacService paths (EVO-1688)

### DIFF
--- a/src/services/rbac/rbacService.spec.ts
+++ b/src/services/rbac/rbacService.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/core', () => ({
+  apiAuth: {
+    get: vi.fn().mockResolvedValue({ data: { data: [] } }),
+    post: vi.fn().mockResolvedValue({ data: { data: {} } }),
+    put: vi.fn().mockResolvedValue({ data: { data: {} } }),
+    delete: vi.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+import { apiAuth } from '@/services/core';
+import {
+  fetchRoles,
+  fetchRoleActions,
+  fetchRolePermissions,
+  createRole,
+  deleteRolePermission,
+} from './rbacService';
+
+const mockedGet = apiAuth.get as ReturnType<typeof vi.fn>;
+const mockedPost = apiAuth.post as ReturnType<typeof vi.fn>;
+const mockedDelete = apiAuth.delete as ReturnType<typeof vi.fn>;
+
+// EVO-1688 regression guard: apiAuth's baseURL already ends in /api/v1, so the
+// paths passed here must NOT repeat the prefix — doubled prefixes 404 on the
+// auth service (broke the user-creation role dropdown).
+describe('rbacService request paths (EVO-1688)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchRoles targets /roles without the /api/v1 prefix', async () => {
+    await fetchRoles();
+    expect(mockedGet.mock.calls[0][0]).toMatch(/^\/roles\?/);
+  });
+
+  it('fetchRoleActions targets /resource_actions without the prefix', async () => {
+    await fetchRoleActions();
+    expect(mockedGet.mock.calls[0][0]).toMatch(/^\/resource_actions\?/);
+  });
+
+  it('fetchRolePermissions targets /role_permissions without the prefix', async () => {
+    await fetchRolePermissions();
+    expect(mockedGet.mock.calls[0][0]).toMatch(/^\/role_permissions\?/);
+  });
+
+  it('write endpoints (create/delete) are also single-prefix', async () => {
+    await createRole({ name: 'r' } as never);
+    await deleteRolePermission('42');
+
+    expect(mockedPost.mock.calls[0][0]).toBe('/roles');
+    expect(mockedDelete.mock.calls[0][0]).toBe('/role_permissions/42');
+  });
+
+  it('no rbacService path starts with /api/v1 (doubled prefix)', async () => {
+    await fetchRoles();
+    await fetchRoleActions();
+    await fetchRolePermissions();
+    await createRole({ name: 'r' } as never);
+    await deleteRolePermission('42');
+
+    const allPaths = [
+      ...mockedGet.mock.calls,
+      ...mockedPost.mock.calls,
+      ...mockedDelete.mock.calls,
+    ].map((call) => call[0] as string);
+
+    expect(allPaths.length).toBeGreaterThan(0);
+    for (const path of allPaths) {
+      expect(path).not.toMatch(/^\/api\/v1\//);
+    }
+  });
+});

--- a/src/services/rbac/rbacService.ts
+++ b/src/services/rbac/rbacService.ts
@@ -29,13 +29,13 @@ export const fetchRoleActions = async (filters?: {
   if (filters?.page) params.append('page', filters.page.toString());
   if (filters?.per_page) params.append('per_page', filters.per_page.toString());
 
-  const response = await apiAuth.get(`/api/v1/resource_actions?${params.toString()}`);
+  const response = await apiAuth.get(`/resource_actions?${params.toString()}`);
   return extractResponse<RoleAction>(response) as RoleActionsResponse;
 };
 
 
 export const fetchActionsForPermissions = async (): Promise<Record<string, RoleAction[]>> => {
-  const response = await apiAuth.get('/api/v1/resource_actions/for_permissions');
+  const response = await apiAuth.get('/resource_actions/for_permissions');
   return extractData<any>(response);
 };
 
@@ -60,7 +60,7 @@ export const fetchRoles = async (filters?: {
   if (filters?.exclude_with_permissions) params.append('exclude_with_permissions', 'true');
   if (filters?.type) params.append('type', filters.type);
 
-  const response = await apiAuth.get(`/api/v1/roles?${params.toString()}`);
+  const response = await apiAuth.get(`/roles?${params.toString()}`);
   return extractResponse<Role>(response) as RoleResponse;
 };
 
@@ -78,22 +78,22 @@ export const fetchRolesFull = async (filters?: {
 };
 
 export const fetchRolesWithoutPermissions = async (): Promise<Role[]> => {
-  const response = await apiAuth.get('/api/v1/roles?exclude_with_permissions=true');
+  const response = await apiAuth.get('/roles?exclude_with_permissions=true');
   return extractData<any>(response);
 };
 
 export const createRole = async (role: RoleCreate): Promise<Role> => {
-  const response = await apiAuth.post('/api/v1/roles', { role });
+  const response = await apiAuth.post('/roles', { role });
   return extractData<any>(response);
 };
 
 export const updateRole = async (id: string, role: RoleUpdate): Promise<Role> => {
-  const response = await apiAuth.put(`/api/v1/roles/${id}`, { role });
+  const response = await apiAuth.put(`/roles/${id}`, { role });
   return extractData<any>(response);
 };
 
 export const deleteRole = async (id: string): Promise<void> => {
-  await apiAuth.delete(`/api/v1/roles/${id}`);
+  await apiAuth.delete(`/roles/${id}`);
 };
 
 // Role Permissions API
@@ -107,12 +107,12 @@ export const fetchRolePermissions = async (filters?: RolePermissionFilters): Pro
   if (filters?.page) params.append('page', filters.page.toString());
   if (filters?.per_page) params.append('per_page', filters.per_page.toString());
 
-  const response = await apiAuth.get(`/api/v1/role_permissions?${params.toString()}`);
+  const response = await apiAuth.get(`/role_permissions?${params.toString()}`);
   return extractResponse<RolePermission>(response) as RolePermissionsResponse;
 };
 
 export const createRolePermission = async (data: RolePermissionCreate): Promise<RolePermission> => {
-  const response = await apiAuth.post('/api/v1/role_permissions', {
+  const response = await apiAuth.post('/role_permissions', {
     role_permission: {
       role_id: data.role_id,
       permission_keys: data.permission_keys
@@ -122,7 +122,7 @@ export const createRolePermission = async (data: RolePermissionCreate): Promise<
 };
 
 export const updateRolePermission = async (id: string, data: RolePermissionUpdate): Promise<RolePermission> => {
-  const response = await apiAuth.put(`/api/v1/role_permissions/${id}`, {
+  const response = await apiAuth.put(`/role_permissions/${id}`, {
     role_permission: {
       role_id: data.role_id,
       permission_keys: data.permission_keys
@@ -132,5 +132,5 @@ export const updateRolePermission = async (id: string, data: RolePermissionUpdat
 };
 
 export const deleteRolePermission = async (id: string): Promise<void> => {
-  await apiAuth.delete(`/api/v1/role_permissions/${id}`);
+  await apiAuth.delete(`/role_permissions/${id}`);
 };


### PR DESCRIPTION
## Summary

`apiAuth`'s baseURL already ends in `/api/v1` (`src/services/core/apiAuth.ts:10`), but all **11** `rbacService` call sites passed `/api/v1`-prefixed paths — every RBAC request went out as `/api/v1/api/v1/...` and 404'd on the auth service.

**Live casualty:** the role dropdown in the add/edit user modal (`/settings/users` → `UserFormModal` → `useRoles()` → `fetchRoles`) came up empty, blocking user creation via the UI (the EVO-1040-style symptom). This PR repairs that path.

Fix: removed the redundant `/api/v1` from the 11 paths (the client keeps the prefix in its baseURL, matching the working siblings — `fetchRolesFull`'s `'/roles/full'` and the newer `rolesService`).

## Known limitation (verified against auth `routes.rb`, documented — out of scope)

5 of the 11 functions (`role_permissions` CRUD ×4, `resource_actions/for_permissions`) target routes the auth service **never exposed** — permissions are managed via `roles#bulk_update_permissions`, which the Admin Roles pages already consume through the newer `rolesService`. The only code referencing these 5 is dead (`hooks/rbac/usePermissions` has zero importers; 3 functions have no importers at all), so no live behavior depends on them. They stay as cleanup candidates.

## Validation

- `evo-ai-frontend-community: pnpm exec vitest run src/services/rbac/rbacService.spec.ts` — 5/5 (representative paths + sweep asserting no path starts with `/api/v1`)
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` — clean
- `evo-ai-frontend-community: pnpm exec eslint` — no new findings (7 pre-existing `extractData<any>` = develop baseline)
- AC3 sweep: no other `apiAuth` consumer passes `/api/v1` literals (flagged matches were comments / another client's baseURL)
- Manual smoke (`/settings/users` → add user → populated role dropdown) pending environment — proxy :3030 was down during the fix; covered by the request-path spec meanwhile

## Changed Files

- `src/services/rbac/rbacService.ts`
- `src/services/rbac/rbacService.spec.ts` (new)

## Linked Issue

- EVO-1688 (related: EVO-1040)

## Summary by Sourcery

Fix RBAC API client paths to align with the apiAuth base URL and prevent doubled /api/v1 prefixes that caused RBAC requests to 404.

Bug Fixes:
- Correct RBAC service endpoints to use paths without the redundant /api/v1 prefix so role- and permission-related requests reach the auth service successfully.

Tests:
- Add vitest coverage to ensure rbacService calls use unprefixed paths and guard against reintroducing /api/v1-prefixed routes.