### PR TITLE
fix(frontend): smooth conversation-list scroll pagination (EVO-1672)

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -59,7 +59,9 @@ vi.mock('@/utils/chat/mediaLabels', () => ({
 }));
 
 vi.mock('../loading-states', () => ({
-  ConversationSkeleton: () => <div data-testid="skeleton" />,
+  ConversationSkeleton: ({ count }: { count?: number }) => (
+    <div data-testid="skeleton" data-count={count} />
+  ),
 }));
 
 vi.mock('../empty-states', () => ({
@@ -498,9 +500,10 @@ describe('ChatSidebar scroll pagination (EVO-1407)', () => {
     await screen.findByText('Test Contact');
 
     const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
-    // clientHeight 600 → threshold = max(600, 900) = 900px. distanceToBottom = 700px:
-    // far beyond the old 120px gate, yet still triggers the prefetch.
-    setScrollDimensions(scrollEl, 5000, 600, 3700);
+    // EVO-1672: clientHeight 600 → threshold = max(1000, 1500) = 1500px.
+    // distanceToBottom = 1400px — beyond the previous 900px threshold, yet
+    // still triggers, pinning the widened lookahead.
+    setScrollDimensions(scrollEl, 5000, 600, 3000);
 
     await act(async () => { fireEvent.scroll(scrollEl); });
 
@@ -514,12 +517,39 @@ describe('ChatSidebar scroll pagination (EVO-1407)', () => {
     await screen.findByText('Test Contact');
 
     const scrollEl = document.querySelector('[data-tour="chat-conversations-list"]')!;
-    // distanceToBottom = 5000 - 0 - 600 = 4400px, well past the 900px threshold.
+    // distanceToBottom = 5000 - 0 - 600 = 4400px, well past the 1500px threshold.
     setScrollDimensions(scrollEl, 5000, 600, 0);
 
     await act(async () => { fireEvent.scroll(scrollEl); });
 
     expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it('keeps the loaded list visible when conversationsLoading flips with items on screen (EVO-1672)', async () => {
+    // loadMore flips the shared conversationsLoading flag; the full-list
+    // skeleton (count=8) must NOT replace an already-populated list — that
+    // loses the scroll position and reads as the whole list vanishing.
+    overrideContext = makePaginatedContext(true);
+    overrideContext.conversations.state.conversationsLoading = true as never;
+    render(<ChatSidebar {...defaultProps} />);
+
+    expect(await screen.findByText('Test Contact')).toBeInTheDocument();
+    expect(screen.queryByTestId('skeleton')).not.toBeInTheDocument();
+  });
+
+  it('renders a multi-row loading cushion during load-more (EVO-1672)', async () => {
+    let resolveFn!: () => void;
+    const loadMore = vi.fn().mockReturnValue(new Promise<void>(res => { resolveFn = res; }));
+    overrideContext = makePaginatedContext(true, loadMore);
+    render(<ChatSidebar {...defaultProps} />);
+    const btn = await screen.findByText('Carregar mais');
+
+    act(() => { fireEvent.click(btn); });
+
+    await waitFor(() => expect(screen.getByTestId('skeleton')).toBeInTheDocument());
+    expect(screen.getByTestId('skeleton').dataset.count).toBe('5');
+
+    await act(async () => { resolveFn(); });
   });
 
   it('does not load more after last page (CA-3)', async () => {

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -105,10 +105,11 @@ interface ChatSidebarProps {
 }
 
 // Prefetch the next page well before the user reaches the end so the loading
-// state is not perceived while scrolling. Anticipated by ~1.5 viewport heights,
-// with a floor for short viewports.
-const PREFETCH_VIEWPORT_FACTOR = 1.5;
-const MIN_PREFETCH_DISTANCE_PX = 600;
+// state is not perceived while scrolling. Anticipated by ~2.5 viewport heights
+// (EVO-1672: 1.5 was outrun by fast scrolling / slow connections), with a
+// floor for short viewports. loadMore stays sequential via loadingMoreRef.
+const PREFETCH_VIEWPORT_FACTOR = 2.5;
+const MIN_PREFETCH_DISTANCE_PX = 1000;
 
 const ChatSidebar = ({
   mobileView,
@@ -580,27 +581,21 @@ const ChatSidebar = ({
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
 
-    const scrollTop = container.scrollTop;
-
     try {
       await conversations.loadMoreConversations();
     } finally {
+      // EVO-1672: no forced scrollTop restore here. It compensated for the
+      // full-list remount (now gone — the list stays mounted during loadMore)
+      // and, with the wider prefetch, it yanked the user back to wherever the
+      // trigger fired if they kept scrolling during the request. Appending
+      // below the viewport does not move scrollTop natively.
       setIsLoadingMoreConversations(false);
-      // Release lock inside RAF so the scroll restoration fires before new events can re-enter
-      requestAnimationFrame(() => {
-        if (sidebarScrollRef.current) {
-          sidebarScrollRef.current.scrollTop = scrollTop;
-        }
-        loadingMoreRef.current = false;
-      });
+      loadingMoreRef.current = false;
     }
   }, [conversations]);
 
   const handleLoadMoreClick = useCallback(async () => {
     if (loadingMoreRef.current || isLoadingMoreConversations || !hasNextPage) return;
-
-    const container = sidebarScrollRef.current;
-    const savedScrollTop = container?.scrollTop ?? 0;
 
     loadingMoreRef.current = true;
     setIsLoadingMoreConversations(true);
@@ -608,12 +603,7 @@ const ChatSidebar = ({
       await conversations.loadMoreConversations();
     } finally {
       setIsLoadingMoreConversations(false);
-      requestAnimationFrame(() => {
-        if (sidebarScrollRef.current) {
-          sidebarScrollRef.current.scrollTop = savedScrollTop;
-        }
-        loadingMoreRef.current = false;
-      });
+      loadingMoreRef.current = false;
     }
   }, [conversations, hasNextPage, isLoadingMoreConversations]);
 
@@ -1068,7 +1058,12 @@ const ChatSidebar = ({
       >
         {!conversations ? (
           <ConversationSkeleton count={8} />
-        ) : conversations.state.conversationsLoading || filters.state.isApplyingFilters ? (
+        ) : (conversations.state.conversationsLoading && visibleConversations.length === 0) ||
+          filters.state.isApplyingFilters ? (
+          // EVO-1672: the full-list skeleton is for the EMPTY/initial load only.
+          // loadMore flips the shared conversationsLoading flag too, and swapping
+          // the whole list mid-scroll loses the user's position (flicker + jump);
+          // with items on screen the bottom cushion is the loading feedback.
           <ConversationSkeleton count={8} />
         ) : conversations.state.conversationsError ? (
           <div className="p-4 text-center">
@@ -1223,9 +1218,12 @@ const ChatSidebar = ({
               );
             })}
 
+            {/* EVO-1672: proportional cushion (~half a viewport) so fast
+                scroll / slow networks read as a deliberate "loading more"
+                affordance instead of a blank gap with pop-in. */}
             {isLoadingMoreConversations && (
               <div className="border-t border-border/40">
-                <ConversationSkeleton count={1} />
+                <ConversationSkeleton count={5} />
               </div>
             )}
 


### PR DESCRIPTION
## Summary

Follow-up to EVO-1617/EVO-1671: load-more on the conversation list was janky — fast scroll outran the prefetch (blank gap + pop-in), and visual testing during this fix surfaced two worse pre-existing behaviors that the wider prefetch made constant:

1. **Prefetch lookahead widened** — `PREFETCH_VIEWPORT_FACTOR` 1.5 → 2.5, `MIN_PREFETCH_DISTANCE_PX` 600 → 1000. Requests stay sequential (existing `loadingMoreRef` guard).
2. **Proportional loading cushion** — bottom placeholder 1 → 5 skeleton rows; slow networks read as a deliberate "loading more" affordance. (Removing the skeleton stays out of scope, per the card.)
3. **Full-list skeleton only on the empty/initial load** — `loadMoreConversations` flips the shared `conversationsLoading` flag, and the sidebar swapped the WHOLE list for 8 skeleton rows mid-scroll: list "vanished", scroll lost, flicker on return. With items on screen the list now stays mounted.
4. **Dropped the forced scrollTop restore after load-more** (scroll + button paths) — it compensated for the now-gone remount and, on slow connections, yanked the user back to wherever the trigger had fired if they kept scrolling during the request.

`DEFAULT_PAGE_SIZE` intentionally untouched (card's optional item) — the above closed the ACs without heavier payloads.

## Validation

- `pnpm exec vitest run .../ChatSidebar.spec.tsx` — **16 passing** (CA-1b re-pinned to the widened threshold; new cushion test count=5; new guard test: populated list + loading flag keeps the list visible)
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec eslint <changed>` — clean
- **Manual smoke (Slow 3G, multi-page account, by the reporter):** no blank gap on fast scroll; continuous cushion; the loaded list never vanishes; scroll position holds while pages load

## Changed Files

- `src/components/chat/chat-sidebar/ChatSidebar.tsx`
- `src/components/chat/chat-sidebar/ChatSidebar.spec.tsx`

## Linked Issue

- EVO-1672 (related: EVO-1617, EVO-1671, EVO-1106)

## Summary by Sourcery

Improve chat sidebar conversation list scroll pagination to avoid janky gaps and scroll jumps during incremental loading.

Bug Fixes:
- Prevent the conversation list from being replaced by a full-list skeleton during load-more when items are already visible, preserving scroll position.
- Remove forced scroll position restoration after loading more conversations so users are not pulled back while scrolling on slow connections.

Enhancements:
- Increase scroll prefetch distance and minimum prefetch threshold so additional conversation pages are requested earlier during fast scrolling or on slow networks.
- Show a multi-row skeleton cushion at the bottom of the list during load-more instead of a single row to provide clearer loading feedback.

Tests:
- Extend chat sidebar pagination tests to cover the widened prefetch threshold, verify that the populated list stays visible while loading, and assert the new multi-row loading cushion behavior.