### PR TITLE
feat(frontend): channel hub shows real live connectivity per inbox (EVO-1674)

### DIFF
--- a/src/components/channels/ChannelStatusBadge.tsx
+++ b/src/components/channels/ChannelStatusBadge.tsx
@@ -11,6 +11,7 @@ interface ChannelStatusBadgeProps {
 const dotClasses: Record<ChannelHealthStatus, string> = {
   active: 'bg-emerald-500',
   attention: 'bg-amber-500',
+  error: 'bg-red-500',
   available: 'bg-sidebar-foreground/30',
 };
 

--- a/src/components/channels/ChannelTypeCard.tsx
+++ b/src/components/channels/ChannelTypeCard.tsx
@@ -8,25 +8,48 @@ import {
 } from '@evoapi/design-system';
 import { HelpCircle, Plus, Settings } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { ChannelTypeStatus } from '@/utils/channelStatus';
+import { cn } from '@/utils/cn';
+import { ChannelTypeStatus, formatLastSync } from '@/utils/channelStatus';
+import { InboxConnectionState } from '@/types/channels/inbox';
 import ChannelIcon from './ChannelIcon';
 import ChannelStatusBadge from './ChannelStatusBadge';
+
+const MAX_INBOX_ROWS = 3;
+
+const stateDotClasses: Record<InboxConnectionState, string> = {
+  connected: 'bg-emerald-500',
+  pending: 'bg-amber-500',
+  disconnected: 'bg-red-500',
+  error: 'bg-red-500',
+  unknown: 'bg-sidebar-foreground/30',
+};
 
 interface ChannelTypeCardProps {
   typeStatus: ChannelTypeStatus;
   onAdd: (typeStatus: ChannelTypeStatus) => void;
   onManage: (typeStatus: ChannelTypeStatus) => void;
+  /** Inbox ids with a live connectivity probe in flight. */
+  liveLoadingIds?: Set<string>;
+  /** Inbox ids whose live probe failed (stored state shown instead). */
+  liveFailedIds?: Set<string>;
 }
 
-export default function ChannelTypeCard({ typeStatus, onAdd, onManage }: ChannelTypeCardProps) {
-  const { t } = useLanguage('channels');
-  const { type, total, activeCount, attentionCount, status } = typeStatus;
+export default function ChannelTypeCard({
+  typeStatus,
+  onAdd,
+  onManage,
+  liveLoadingIds,
+  liveFailedIds,
+}: ChannelTypeCardProps) {
+  const { t, currentLanguage } = useLanguage('channels');
+  const { type, total, activeCount, attentionCount, errorCount, status, inboxStates } = typeStatus;
   const isConfigured = total > 0;
 
   const summary = isConfigured
     ? [
         activeCount > 0 ? t('overview.summary.active', { count: activeCount }) : null,
         attentionCount > 0 ? t('overview.summary.attention', { count: attentionCount }) : null,
+        errorCount > 0 ? t('overview.summary.error', { count: errorCount }) : null,
       ]
         .filter(Boolean)
         .join(' · ')
@@ -67,6 +90,47 @@ export default function ChannelTypeCard({ typeStatus, onAdd, onManage }: Channel
             <p className="text-xs text-sidebar-foreground/60 line-clamp-2">{type.description}</p>
           </div>
         </div>
+
+        {isConfigured && (
+          <ul className="space-y-1">
+            {inboxStates.slice(0, MAX_INBOX_ROWS).map(({ inbox, state, unmonitored }) => {
+              const id = String(inbox.id);
+              const isLiveLoading = liveLoadingIds?.has(id) ?? false;
+              const liveFailed = liveFailedIds?.has(id) ?? false;
+              const lastSync = formatLastSync(inbox.last_sync, currentLanguage);
+              const stateLabel = unmonitored
+                ? t('overview.inboxState.unmonitored')
+                : t(`overview.inboxState.${state}`);
+
+              return (
+                <li
+                  key={id}
+                  className="flex items-center gap-2 text-xs text-sidebar-foreground/70"
+                  title={liveFailed ? t('overview.liveCheckFailed') : undefined}
+                >
+                  <span
+                    className={cn(
+                      'h-1.5 w-1.5 shrink-0 rounded-full',
+                      stateDotClasses[state],
+                      isLiveLoading && 'animate-pulse',
+                    )}
+                    aria-hidden="true"
+                  />
+                  <span className="truncate flex-1">{inbox.name}</span>
+                  <span className="shrink-0 text-sidebar-foreground/50">
+                    {isLiveLoading ? t('overview.inboxState.checking') : stateLabel}
+                    {lastSync && !isLiveLoading ? ` · ${lastSync}` : ''}
+                  </span>
+                </li>
+              );
+            })}
+            {total > MAX_INBOX_ROWS && (
+              <li className="text-xs text-sidebar-foreground/50">
+                {t('overview.moreInboxes', { count: total - MAX_INBOX_ROWS })}
+              </li>
+            )}
+          </ul>
+        )}
 
         <div className="flex items-center justify-between mt-auto pt-1">
           <ChannelStatusBadge status={status} />

--- a/src/components/channels/ChannelTypeHub.spec.tsx
+++ b/src/components/channels/ChannelTypeHub.spec.tsx
@@ -18,6 +18,16 @@ vi.mock('@/hooks/useLanguage', () => ({
 // Icon rendering depends on brand assets; not relevant to the hub logic under test.
 vi.mock('./ChannelIcon', () => ({ default: () => null }));
 
+// The live overlay has its own spec; the hub tests exercise the stored state.
+const liveStatusMock = vi.fn(() => ({
+  states: {},
+  loadingIds: new Set<string>(),
+  failedIds: new Set<string>(),
+}));
+vi.mock('@/hooks/channels/useLiveChannelStatus', () => ({
+  default: (inboxes: Inbox[]) => liveStatusMock(inboxes),
+}));
+
 const inbox = (overrides: Partial<Inbox>): Inbox =>
   ({ id: 'i', name: 'n', channel_id: 'c', channel_type: 'whatsapp', ...overrides }) as Inbox;
 
@@ -38,10 +48,17 @@ describe('ChannelTypeHub', () => {
     expect(screen.queryByText('overview.actions.manage')).toBeNull();
   });
 
-  it('switches a configured type to the manage action and flags attention', () => {
+  it('switches a configured type to the manage action and shows the real state', () => {
     render(
       <ChannelTypeHub
-        inboxes={[inbox({ channel_type: 'Channel::Whatsapp', reauthorization_required: true })]}
+        inboxes={[
+          inbox({
+            channel_type: 'Channel::Whatsapp',
+            connection_state: 'connected',
+            health_source: 'provider_event',
+            name: 'Main WA',
+          }),
+        ]}
         isLoading={false}
         onAdd={noop}
         onManage={noop}
@@ -49,6 +66,40 @@ describe('ChannelTypeHub', () => {
     );
     expect(screen.getAllByText('overview.actions.add')).toHaveLength(7);
     expect(screen.getAllByText('overview.actions.manage')).toHaveLength(1);
-    expect(screen.getByText('overview.summary.attention')).toBeInTheDocument();
+    expect(screen.getByText('overview.summary.active')).toBeInTheDocument();
+    expect(screen.getByText('Main WA')).toBeInTheDocument();
+    expect(screen.getByText(/overview\.inboxState\.connected/)).toBeInTheDocument();
+  });
+
+  it('flags a disconnected inbox as error', () => {
+    render(
+      <ChannelTypeHub
+        inboxes={[
+          inbox({ channel_type: 'Channel::Whatsapp', connection_state: 'disconnected' }),
+        ]}
+        isLoading={false}
+        onAdd={noop}
+        onManage={noop}
+      />,
+    );
+    expect(screen.getByText('overview.summary.error')).toBeInTheDocument();
+  });
+
+  it('shows the explicit unmonitored label for channels without health support', () => {
+    render(
+      <ChannelTypeHub
+        inboxes={[
+          inbox({
+            channel_type: 'Channel::Api',
+            connection_state: 'unknown',
+            health_source: 'none',
+          }),
+        ]}
+        isLoading={false}
+        onAdd={noop}
+        onManage={noop}
+      />,
+    );
+    expect(screen.getByText(/overview\.inboxState\.unmonitored/)).toBeInTheDocument();
   });
 });

--- a/src/components/channels/ChannelTypeHub.tsx
+++ b/src/components/channels/ChannelTypeHub.tsx
@@ -4,6 +4,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { Inbox } from '@/types/channels/inbox';
 import { getChannelTypes } from '@/constants/channelTypes';
 import { buildChannelTypeStatuses, ChannelTypeStatus } from '@/utils/channelStatus';
+import useLiveChannelStatus from '@/hooks/channels/useLiveChannelStatus';
 import ChannelTypeCard from './ChannelTypeCard';
 
 interface ChannelTypeHubProps {
@@ -15,12 +16,13 @@ interface ChannelTypeHubProps {
 
 export default function ChannelTypeHub({ inboxes, isLoading, onAdd, onManage }: ChannelTypeHubProps) {
   const { t, currentLanguage } = useLanguage('channels');
+  const { states: liveStates, loadingIds, failedIds } = useLiveChannelStatus(inboxes);
 
   // getChannelTypes() reads translated labels, so recompute when language changes.
   const typeStatuses = useMemo(
-    () => buildChannelTypeStatuses(getChannelTypes(), inboxes),
+    () => buildChannelTypeStatuses(getChannelTypes(), inboxes, liveStates),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [inboxes, currentLanguage],
+    [inboxes, liveStates, currentLanguage],
   );
 
   if (isLoading) {
@@ -46,6 +48,8 @@ export default function ChannelTypeHub({ inboxes, isLoading, onAdd, onManage }: 
             typeStatus={typeStatus}
             onAdd={onAdd}
             onManage={onManage}
+            liveLoadingIds={loadingIds}
+            liveFailedIds={failedIds}
           />
         ))}
       </div>

--- a/src/hooks/channels/useLiveChannelStatus.spec.ts
+++ b/src/hooks/channels/useLiveChannelStatus.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import useLiveChannelStatus, { isLiveCheckable } from './useLiveChannelStatus';
+import api from '@/services/core/api';
+import { Inbox } from '@/types/channels/inbox';
+
+vi.mock('@/services/core/api', () => ({
+  default: { get: vi.fn() },
+}));
+
+const mockedGet = vi.mocked(api.get);
+
+const evolutionInbox = (overrides: Partial<Inbox> = {}): Inbox =>
+  ({
+    id: 'w1',
+    name: 'WA',
+    channel_id: 'c1',
+    channel_type: 'Channel::Whatsapp',
+    provider: 'evolution',
+    provider_config: { instance_name: 'inst-1' },
+    ...overrides,
+  }) as Inbox;
+
+beforeEach(() => {
+  mockedGet.mockReset();
+});
+
+describe('isLiveCheckable', () => {
+  it('accepts only evolution whatsapp inboxes with an instance name', () => {
+    expect(isLiveCheckable(evolutionInbox())).toBe(true);
+    expect(isLiveCheckable(evolutionInbox({ provider: 'evolution_go' }))).toBe(false);
+    expect(isLiveCheckable(evolutionInbox({ provider: 'whatsapp_cloud' }))).toBe(false);
+    expect(isLiveCheckable(evolutionInbox({ provider_config: {} }))).toBe(false);
+    expect(isLiveCheckable(evolutionInbox({ channel_type: 'Channel::Email' }))).toBe(false);
+  });
+});
+
+describe('useLiveChannelStatus', () => {
+  it('overlays the live state reported by the instances proxy', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { success: true, data: { instance: { instanceName: 'inst-1', state: 'open' } } },
+    });
+
+    const { result } = renderHook(() => useLiveChannelStatus([evolutionInbox()]));
+
+    expect(result.current.loadingIds.has('w1')).toBe(true);
+    await waitFor(() => expect(result.current.states.w1).toBe('connected'));
+    expect(result.current.loadingIds.has('w1')).toBe(false);
+    expect(result.current.failedIds.has('w1')).toBe(false);
+    expect(mockedGet).toHaveBeenCalledWith('/evolution/instances', {
+      params: { instanceName: 'inst-1' },
+    });
+  });
+
+  it('marks the inbox as failed when the probe errors, keeping the stored state authoritative', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('proxy down'));
+
+    const { result } = renderHook(() => useLiveChannelStatus([evolutionInbox()]));
+
+    await waitFor(() => expect(result.current.failedIds.has('w1')).toBe(true));
+    expect(result.current.states.w1).toBeUndefined();
+    expect(result.current.loadingIds.has('w1')).toBe(false);
+  });
+
+  it('marks the inbox as failed when the proxy falls back to unknown', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { success: true, data: { instance: { instanceName: 'inst-1', status: 'unknown' } } },
+    });
+
+    const { result } = renderHook(() => useLiveChannelStatus([evolutionInbox()]));
+
+    await waitFor(() => expect(result.current.failedIds.has('w1')).toBe(true));
+    expect(result.current.states.w1).toBeUndefined();
+  });
+
+  it('does nothing when no inbox is live-checkable', () => {
+    const { result } = renderHook(() =>
+      useLiveChannelStatus([evolutionInbox({ provider: 'whatsapp_cloud' })]),
+    );
+
+    expect(mockedGet).not.toHaveBeenCalled();
+    expect(result.current.states).toEqual({});
+    expect(result.current.loadingIds.size).toBe(0);
+  });
+});

--- a/src/hooks/channels/useLiveChannelStatus.ts
+++ b/src/hooks/channels/useLiveChannelStatus.ts
@@ -54,7 +54,11 @@ export default function useLiveChannelStatus(inboxes: Inbox[]): LiveChannelStatu
   const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
 
   const targetsKey = useMemo(
-    () => inboxes.filter(isLiveCheckable).map(inbox => String(inbox.id)).join(','),
+    () =>
+      inboxes
+        .filter(isLiveCheckable)
+        .map(inbox => `${inbox.id}:${evolutionInstanceName(inbox)}`)
+        .join(','),
     [inboxes],
   );
 

--- a/src/hooks/channels/useLiveChannelStatus.ts
+++ b/src/hooks/channels/useLiveChannelStatus.ts
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from 'react';
+import api from '@/services/core/api';
+import { Inbox, InboxConnectionState } from '@/types/channels/inbox';
+import { normalizeChannelTypeId, LiveStatusOverlay } from '@/utils/channelStatus';
+
+// connectionState values reported by the Evolution API (v2 uses `state`,
+// older payloads use `status`).
+const EVOLUTION_STATE_MAP: Record<string, InboxConnectionState> = {
+  open: 'connected',
+  connected: 'connected',
+  connecting: 'pending',
+  close: 'disconnected',
+  closed: 'disconnected',
+  disconnected: 'disconnected',
+};
+
+function evolutionInstanceName(inbox: Inbox): string | undefined {
+  const config = inbox.provider_config as Record<string, unknown> | undefined;
+  const name = config?.instance_name ?? config?.instanceName ?? config?.instance;
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
+}
+
+/**
+ * Only WhatsApp inboxes on the `evolution` provider have a CRM-side live
+ * proxy (`GET /evolution/instances?instanceName=...`, credentials resolved
+ * server-side). Every other type renders the stored state from `/inboxes` —
+ * the explicit degrade required by EVO-1674.
+ */
+export function isLiveCheckable(inbox: Inbox): boolean {
+  return (
+    normalizeChannelTypeId(inbox.channel_type) === 'whatsapp' &&
+    inbox.provider === 'evolution' &&
+    evolutionInstanceName(inbox) !== undefined
+  );
+}
+
+export interface LiveChannelStatus {
+  /** Freshly fetched state per inbox id; overlays the stored /inboxes state. */
+  states: LiveStatusOverlay;
+  /** Inboxes with a live check in flight. */
+  loadingIds: Set<string>;
+  /** Inboxes whose live check failed — stored state remains authoritative. */
+  failedIds: Set<string>;
+}
+
+/**
+ * Live connectivity overlay for the channel hub (EVO-1674). Fires one
+ * connection-state probe per live-checkable inbox on mount/refresh; failures
+ * only mark the inbox as not-live-verified, never break the hub.
+ */
+export default function useLiveChannelStatus(inboxes: Inbox[]): LiveChannelStatus {
+  const [states, setStates] = useState<LiveStatusOverlay>({});
+  const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
+  const [failedIds, setFailedIds] = useState<Set<string>>(new Set());
+
+  const targetsKey = useMemo(
+    () => inboxes.filter(isLiveCheckable).map(inbox => String(inbox.id)).join(','),
+    [inboxes],
+  );
+
+  useEffect(() => {
+    const targets = inboxes.filter(isLiveCheckable);
+    if (targets.length === 0) {
+      setStates({});
+      setLoadingIds(new Set());
+      setFailedIds(new Set());
+      return undefined;
+    }
+
+    let cancelled = false;
+    setStates({});
+    setFailedIds(new Set());
+    setLoadingIds(new Set(targets.map(inbox => String(inbox.id))));
+
+    targets.forEach(inbox => {
+      const id = String(inbox.id);
+      api
+        .get('/evolution/instances', { params: { instanceName: evolutionInstanceName(inbox) } })
+        .then(response => {
+          if (cancelled) return;
+          const instance = (response.data?.data?.instance ?? {}) as Record<string, unknown>;
+          const raw = String(instance.state ?? instance.status ?? '').toLowerCase();
+          const mapped = EVOLUTION_STATE_MAP[raw];
+          if (mapped) {
+            setStates(prev => ({ ...prev, [id]: mapped }));
+          } else {
+            // Proxy's own fallback ('unknown') or unexpected payload.
+            setFailedIds(prev => new Set(prev).add(id));
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setFailedIds(prev => new Set(prev).add(id));
+        })
+        .finally(() => {
+          if (cancelled) return;
+          setLoadingIds(prev => {
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+          });
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // targetsKey captures the identity of the live-checkable set.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetsKey]);
+
+  return { states, loadingIds, failedIds };
+}

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1710,13 +1710,26 @@
     "statusLabel": {
       "active": "Active",
       "attention": "Needs attention",
+      "error": "Error",
       "available": "Available"
     },
     "summary": {
       "active": "{{count}} active",
       "attention": "{{count}} need attention",
+      "error": "{{count}} with errors",
       "notConfigured": "Not configured"
     },
+    "inboxState": {
+      "connected": "Connected",
+      "disconnected": "Disconnected",
+      "pending": "Testing",
+      "error": "Error",
+      "unknown": "Unknown",
+      "unmonitored": "Not monitored",
+      "checking": "Checking..."
+    },
+    "liveCheckFailed": "Live check failed — showing the last known state",
+    "moreInboxes": "+{{count}} more inboxes",
     "actions": {
       "add": "Add",
       "manage": "Manage",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1627,13 +1627,26 @@
     "statusLabel": {
       "active": "Activo",
       "attention": "Requiere atención",
+      "error": "Con error",
       "available": "Disponible"
     },
     "summary": {
       "active": "{{count}} activo(s)",
       "attention": "{{count}} con atención",
+      "error": "{{count}} con error",
       "notConfigured": "No configurado"
     },
+    "inboxState": {
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "pending": "En prueba",
+      "error": "Error",
+      "unknown": "Desconocido",
+      "unmonitored": "Sin monitoreo",
+      "checking": "Verificando..."
+    },
+    "liveCheckFailed": "La verificación en vivo falló — mostrando el último estado conocido",
+    "moreInboxes": "+{{count}} bandejas más",
     "actions": {
       "add": "Agregar",
       "manage": "Gestionar",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1646,13 +1646,26 @@
     "statusLabel": {
       "active": "Actif",
       "attention": "Attention requise",
+      "error": "En erreur",
       "available": "Disponible"
     },
     "summary": {
       "active": "{{count}} actif(s)",
       "attention": "{{count}} à vérifier",
+      "error": "{{count}} en erreur",
       "notConfigured": "Non configuré"
     },
+    "inboxState": {
+      "connected": "Connecté",
+      "disconnected": "Déconnecté",
+      "pending": "En test",
+      "error": "Erreur",
+      "unknown": "Inconnu",
+      "unmonitored": "Non surveillé",
+      "checking": "Vérification..."
+    },
+    "liveCheckFailed": "La vérification en direct a échoué — affichage du dernier état connu",
+    "moreInboxes": "+{{count}} autres boîtes de réception",
     "actions": {
       "add": "Ajouter",
       "manage": "Gérer",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1585,13 +1585,26 @@
     "statusLabel": {
       "active": "Attivo",
       "attention": "Richiede attenzione",
+      "error": "Con errore",
       "available": "Disponibile"
     },
     "summary": {
       "active": "{{count}} attivo/i",
       "attention": "{{count}} da verificare",
+      "error": "{{count}} con errore",
       "notConfigured": "Non configurato"
     },
+    "inboxState": {
+      "connected": "Connesso",
+      "disconnected": "Disconnesso",
+      "pending": "In prova",
+      "error": "Errore",
+      "unknown": "Sconosciuto",
+      "unmonitored": "Non monitorato",
+      "checking": "Verifica in corso..."
+    },
+    "liveCheckFailed": "La verifica in tempo reale non è riuscita — viene mostrato l'ultimo stato noto",
+    "moreInboxes": "+{{count}} altre caselle",
     "actions": {
       "add": "Aggiungi",
       "manage": "Gestisci",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1710,13 +1710,26 @@
     "statusLabel": {
       "active": "Ativo",
       "attention": "Requer atenção",
+      "error": "Com erro",
       "available": "Disponível"
     },
     "summary": {
       "active": "{{count}} ativo(s)",
       "attention": "{{count}} com atenção",
+      "error": "{{count}} com erro",
       "notConfigured": "Não configurado"
     },
+    "inboxState": {
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "pending": "Em teste",
+      "error": "Erro",
+      "unknown": "Desconhecido",
+      "unmonitored": "Sem monitoramento",
+      "checking": "Verificando..."
+    },
+    "liveCheckFailed": "A verificação ao vivo falhou — exibindo o último estado conhecido",
+    "moreInboxes": "+{{count}} outras caixas de entrada",
     "actions": {
       "add": "Adicionar",
       "manage": "Gerenciar",

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1644,13 +1644,26 @@
     "statusLabel": {
       "active": "Ativo",
       "attention": "Requer atenção",
+      "error": "Com erro",
       "available": "Disponível"
     },
     "summary": {
       "active": "{{count}} ativo(s)",
       "attention": "{{count}} com atenção",
+      "error": "{{count}} com erro",
       "notConfigured": "Não configurado"
     },
+    "inboxState": {
+      "connected": "Conectado",
+      "disconnected": "Desconectado",
+      "pending": "Em teste",
+      "error": "Erro",
+      "unknown": "Desconhecido",
+      "unmonitored": "Sem monitorização",
+      "checking": "A verificar..."
+    },
+    "liveCheckFailed": "A verificação ao vivo falhou — a mostrar o último estado conhecido",
+    "moreInboxes": "+{{count}} outras caixas de entrada",
     "actions": {
       "add": "Adicionar",
       "manage": "Gerenciar",

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -6,6 +6,15 @@ import type { PaginatedResponse, PaginationMeta, StandardResponse } from '@/type
 // Inbox Types
 // ============================================
 
+/** Live connection state exposed by /inboxes (EVO-1674). */
+export type InboxConnectionState = 'connected' | 'disconnected' | 'pending' | 'error' | 'unknown';
+
+/**
+ * How trustworthy the connection state is: event-fed by the provider,
+ * assumed from stored configuration, or unsupported by the channel type.
+ */
+export type InboxHealthSource = 'provider_event' | 'stored_flag' | 'none';
+
 export interface Channel {
   id: string;
   phone_number: string;
@@ -46,6 +55,11 @@ export interface Inbox {
   lock_to_single_conversation?: boolean;
   // Auth/status
   reauthorization_required?: boolean;
+  // Live channel health (EVO-1674)
+  connection_state?: InboxConnectionState;
+  health_source?: InboxHealthSource;
+  /** Epoch seconds of the last known connectivity change. */
+  last_sync?: number | null;
   // Sender settings
   sender_name_type?: string;
   business_name?: string;

--- a/src/utils/channelStatus.spec.ts
+++ b/src/utils/channelStatus.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   buildChannelTypeStatuses,
   deriveInboxStatus,
+  formatLastSync,
   normalizeChannelTypeId,
+  resolveInboxConnectionState,
 } from './channelStatus';
 import { Inbox } from '@/types/channels/inbox';
 import { ChannelType } from '@/types/channels/providers';
@@ -37,14 +39,32 @@ describe('normalizeChannelTypeId', () => {
   });
 });
 
-describe('deriveInboxStatus', () => {
-  it('flags reauthorization as attention', () => {
-    expect(deriveInboxStatus(inbox({ reauthorization_required: true }))).toBe('attention');
+describe('resolveInboxConnectionState', () => {
+  it('prefers the live overlay over the API state', () => {
+    const target = inbox({ id: 'w1', connection_state: 'disconnected' });
+    expect(resolveInboxConnectionState(target, { w1: 'connected' })).toBe('connected');
   });
 
-  it('treats a configured inbox without reauth as active', () => {
-    expect(deriveInboxStatus(inbox({ reauthorization_required: false }))).toBe('active');
-    expect(deriveInboxStatus(inbox({}))).toBe('active');
+  it('uses the API connection_state when no overlay exists', () => {
+    expect(resolveInboxConnectionState(inbox({ connection_state: 'pending' }))).toBe('pending');
+  });
+
+  it('falls back to the legacy reauthorization flag for pre-EVO-1674 payloads', () => {
+    expect(resolveInboxConnectionState(inbox({ reauthorization_required: true }))).toBe('error');
+    expect(resolveInboxConnectionState(inbox({}))).toBe('unknown');
+  });
+});
+
+describe('deriveInboxStatus', () => {
+  it('maps real connection states to hub statuses', () => {
+    expect(deriveInboxStatus(inbox({ connection_state: 'connected' }))).toBe('active');
+    expect(deriveInboxStatus(inbox({ connection_state: 'pending' }))).toBe('attention');
+    expect(deriveInboxStatus(inbox({ connection_state: 'disconnected' }))).toBe('error');
+    expect(deriveInboxStatus(inbox({ connection_state: 'error' }))).toBe('error');
+  });
+
+  it('treats unmonitored (unknown) channels as active — explicit degrade, not broken', () => {
+    expect(deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'none' }))).toBe('active');
   });
 });
 
@@ -55,19 +75,48 @@ describe('buildChannelTypeStatuses', () => {
     expect(result.every(r => r.total === 0)).toBe(true);
   });
 
-  it('aggregates active and attention counts per type', () => {
+  it('aggregates active, attention and error counts per type', () => {
     const result = buildChannelTypeStatuses(types, [
-      inbox({ id: 'w1', channel_type: 'Channel::Whatsapp' }),
-      inbox({ id: 'w2', channel_type: 'whatsapp', reauthorization_required: true }),
-      inbox({ id: 'e1', channel_type: 'Channel::Email' }),
+      inbox({ id: 'w1', channel_type: 'Channel::Whatsapp', connection_state: 'connected' }),
+      inbox({ id: 'w2', channel_type: 'whatsapp', connection_state: 'disconnected' }),
+      inbox({ id: 'w3', channel_type: 'whatsapp', connection_state: 'pending' }),
+      inbox({ id: 'e1', channel_type: 'Channel::Email', connection_state: 'connected' }),
     ]);
     const whatsapp = result.find(r => r.type.type === 'whatsapp')!;
     const email = result.find(r => r.type.type === 'email')!;
     const sms = result.find(r => r.type.type === 'sms')!;
 
-    expect(whatsapp).toMatchObject({ total: 2, activeCount: 1, attentionCount: 1, status: 'attention' });
-    expect(email).toMatchObject({ total: 1, activeCount: 1, attentionCount: 0, status: 'active' });
+    expect(whatsapp).toMatchObject({
+      total: 3,
+      activeCount: 1,
+      attentionCount: 1,
+      errorCount: 1,
+      status: 'error',
+    });
+    expect(email).toMatchObject({ total: 1, activeCount: 1, errorCount: 0, status: 'active' });
     expect(sms).toMatchObject({ total: 0, status: 'available' });
+  });
+
+  it('applies the live overlay before aggregating', () => {
+    const result = buildChannelTypeStatuses(
+      types,
+      [inbox({ id: 'w1', channel_type: 'Channel::Whatsapp', connection_state: 'connected' })],
+      { w1: 'disconnected' },
+    );
+    const whatsapp = result.find(r => r.type.type === 'whatsapp')!;
+
+    expect(whatsapp.status).toBe('error');
+    expect(whatsapp.inboxStates[0].state).toBe('disconnected');
+  });
+
+  it('flags unmonitored inboxes in inboxStates', () => {
+    const result = buildChannelTypeStatuses(types, [
+      inbox({ id: 's1', channel_type: 'Channel::Sms', connection_state: 'unknown', health_source: 'none' }),
+    ]);
+    const sms = result.find(r => r.type.type === 'sms')!;
+
+    expect(sms.inboxStates[0].unmonitored).toBe(true);
+    expect(sms.status).toBe('active');
   });
 
   it('ignores inboxes whose type is not in the catalog', () => {
@@ -75,5 +124,17 @@ describe('buildChannelTypeStatuses', () => {
       inbox({ id: 't1', channel_type: 'Channel::Twitter' }),
     ]);
     expect(result.reduce((sum, r) => sum + r.total, 0)).toBe(0);
+  });
+});
+
+describe('formatLastSync', () => {
+  it('returns null when there is no timestamp', () => {
+    expect(formatLastSync(null, 'en')).toBeNull();
+    expect(formatLastSync(undefined, 'en')).toBeNull();
+  });
+
+  it('formats a recent timestamp as relative time', () => {
+    const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 5 * 60;
+    expect(formatLastSync(fiveMinutesAgo, 'en')).toMatch(/5 minutes ago/);
   });
 });

--- a/src/utils/channelStatus.ts
+++ b/src/utils/channelStatus.ts
@@ -1,22 +1,36 @@
-import { Inbox } from '@/types/channels/inbox';
+import { Inbox, InboxConnectionState } from '@/types/channels/inbox';
 import { ChannelType, ChannelTypeId } from '@/types/channels/providers';
 
 /**
- * Derived channel health used by the Channels overview hub.
+ * Channel health used by the Channels overview hub.
  *
- * This is a FRONTEND-ONLY derivation: the `/inboxes` API does not expose live
- * connectivity (no last_sync / connection_state / health), only the
- * `reauthorization_required` flag. We therefore derive a coarse status from the
- * client data we already have instead of probing each channel at load time.
+ * Since EVO-1674 the `/inboxes` API exposes the REAL connection state
+ * (`connection_state` / `health_source` / `last_sync`), event-fed per channel
+ * type on the backend. The hub renders that state — optionally overlaid by a
+ * live Evolution instance check (`useLiveChannelStatus`) — instead of deriving
+ * it from `reauthorization_required` alone.
  */
-export type ChannelHealthStatus = 'active' | 'attention' | 'available';
+export type ChannelHealthStatus = 'active' | 'attention' | 'error' | 'available';
+
+/** Live overlay map (inbox id -> freshly fetched state) from useLiveChannelStatus. */
+export type LiveStatusOverlay = Record<string, InboxConnectionState>;
+
+export interface InboxConnectionInfo {
+  inbox: Inbox;
+  state: InboxConnectionState;
+  /** True when the channel type has no health signal at all (explicit degrade). */
+  unmonitored: boolean;
+}
 
 export interface ChannelTypeStatus {
   type: ChannelType;
   inboxes: Inbox[];
+  /** Per-inbox resolved connectivity, in the order of `inboxes`. */
+  inboxStates: InboxConnectionInfo[];
   total: number;
   activeCount: number;
   attentionCount: number;
+  errorCount: number;
   status: ChannelHealthStatus;
 }
 
@@ -47,12 +61,33 @@ export function normalizeChannelTypeId(channelType?: string | null): ChannelType
 }
 
 /**
- * Status of a single configured inbox. A configured inbox is always either
- * `active` or `attention` — `available` only applies to a channel TYPE that has
- * no configured inboxes at all.
+ * The real connection state of an inbox: live overlay wins, then the
+ * API-provided state, then a legacy fallback for payloads predating EVO-1674.
  */
-export function deriveInboxStatus(inbox: Inbox): Exclude<ChannelHealthStatus, 'available'> {
-  return inbox.reauthorization_required ? 'attention' : 'active';
+export function resolveInboxConnectionState(
+  inbox: Inbox,
+  live?: LiveStatusOverlay,
+): InboxConnectionState {
+  const liveState = live?.[String(inbox.id)];
+  if (liveState) return liveState;
+  if (inbox.connection_state) return inbox.connection_state;
+  return inbox.reauthorization_required ? 'error' : 'unknown';
+}
+
+/**
+ * Hub-level status of a single configured inbox. A configured inbox is never
+ * `available` — that only applies to a channel TYPE with no inboxes at all.
+ * `unknown` counts as active: it means the type has no health signal
+ * (explicit degrade), not that the channel is broken.
+ */
+export function deriveInboxStatus(
+  inbox: Inbox,
+  live?: LiveStatusOverlay,
+): Exclude<ChannelHealthStatus, 'available'> {
+  const state = resolveInboxConnectionState(inbox, live);
+  if (state === 'error' || state === 'disconnected') return 'error';
+  if (state === 'pending') return 'attention';
+  return 'active';
 }
 
 /**
@@ -63,24 +98,53 @@ export function deriveInboxStatus(inbox: Inbox): Exclude<ChannelHealthStatus, 'a
 export function buildChannelTypeStatuses(
   channelTypes: ChannelType[],
   inboxes: Inbox[],
+  live?: LiveStatusOverlay,
 ): ChannelTypeStatus[] {
   return channelTypes.map(type => {
     const matched = inboxes.filter(inbox => normalizeChannelTypeId(inbox.channel_type) === type.type);
-    const attentionCount = matched.filter(inbox => deriveInboxStatus(inbox) === 'attention').length;
-    const activeCount = matched.length - attentionCount;
+    const inboxStates: InboxConnectionInfo[] = matched.map(inbox => ({
+      inbox,
+      state: resolveInboxConnectionState(inbox, live),
+      unmonitored: inbox.health_source === 'none',
+    }));
+
+    const errorCount = matched.filter(inbox => deriveInboxStatus(inbox, live) === 'error').length;
+    const attentionCount = matched.filter(inbox => deriveInboxStatus(inbox, live) === 'attention').length;
+    const activeCount = matched.length - errorCount - attentionCount;
 
     let status: ChannelHealthStatus = 'available';
     if (matched.length > 0) {
-      status = attentionCount > 0 ? 'attention' : 'active';
+      if (errorCount > 0) status = 'error';
+      else if (attentionCount > 0) status = 'attention';
+      else status = 'active';
     }
 
     return {
       type,
       inboxes: matched,
+      inboxStates,
       total: matched.length,
       activeCount,
       attentionCount,
+      errorCount,
       status,
     };
   });
+}
+
+/**
+ * Compact relative timestamp for `last_sync` (epoch seconds), localized via
+ * Intl. Returns null when there is nothing to show.
+ */
+export function formatLastSync(epochSeconds: number | null | undefined, locale: string): string | null {
+  if (!epochSeconds) return null;
+
+  const diffMs = epochSeconds * 1000 - Date.now();
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  const absMs = Math.abs(diffMs);
+
+  if (absMs < 60_000) return rtf.format(Math.round(diffMs / 1000), 'second');
+  if (absMs < 3_600_000) return rtf.format(Math.round(diffMs / 60_000), 'minute');
+  if (absMs < 86_400_000) return rtf.format(Math.round(diffMs / 3_600_000), 'hour');
+  return rtf.format(Math.round(diffMs / 86_400_000), 'day');
 }


### PR DESCRIPTION
## Summary
- Replaces the hub's DERIVED status (EVO-1554 / PR #145) with the REAL state from `/inboxes` (`connection_state` / `health_source` / `last_sync` — backend PR below): per-inbox connected/disconnected/testing/error, relative last-connectivity time, and an explicit 'not monitored' label for channel types without health support.
- New `useLiveChannelStatus` hook: one connection-state probe per evolution WhatsApp inbox through the existing CRM proxy (`GET /evolution/instances?instanceName=...`, credentials resolved server-side), overlaying the stored state with per-inbox loading (pulsing dot) and failure (tooltip) handling. Other providers/types keep the stored state — explicit degrade.
- Type badge and summary gain a red `error` level (any disconnected/error inbox); aggregation: error > attention (pending) > active; unknown counts as active (unmonitored ≠ broken).
- i18n: new status keys in all six locales (pt-BR, en, es, fr, it, pt), following the EVO-1554 pattern.
- Legacy fallback kept for payloads predating the backend field (reauthorization_required → error).

## Security
- No new endpoints; probes reuse the authenticated CRM proxy. No secrets rendered.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec vitest run src/utils/channelStatus.spec.ts src/components/channels/ChannelTypeHub.spec.tsx src/hooks/channels/useLiveChannelStatus.spec.ts src/i18n/locales/i18n-parity.spec.ts` — 188 tests green (state mapping, overlay precedence, hook loading/failure paths, hub rendering, locale parity)
- ESLint clean on touched files

## Changed Files
- `src/utils/channelStatus.ts` (+ spec) — real-state mapping, overlay, error aggregation, formatLastSync
- `src/hooks/channels/useLiveChannelStatus.ts` (+ spec) — live evolution probe
- `src/components/channels/ChannelTypeCard.tsx`, `ChannelTypeHub.tsx` (+ spec), `ChannelStatusBadge.tsx`
- `src/types/channels/inbox.ts` — new Inbox fields
- `src/i18n/locales/{pt-BR,en,es,fr,it,pt}/channels.json`

## Related PRs
- evo-ai-crm-community: https://github.com/evolution-foundation/evo-ai-crm-community/pull/133 (exposes the /inboxes fields — merge first or together)

## Linked Issue
- EVO-1674