### PR TITLE
feat(frontend): global message template menu (EVO-1233)

### DIFF
--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -13,6 +13,7 @@ import {
   Clock,
   Code,
   MessageCircle,
+  LayoutTemplate,
   Key,
   Tags,
   TestTube,
@@ -224,6 +225,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         href: '/settings/canned-responses',
         icon: MessageCircle,
         resource: 'canned_responses',
+        action: 'read',
+      },
+      {
+        name: t('menu.settings.messageTemplates'),
+        href: '/settings/message-templates',
+        icon: LayoutTemplate,
+        resource: 'message_templates',
         action: 'read',
       },
       {

--- a/src/config/permissions.ts
+++ b/src/config/permissions.ts
@@ -46,6 +46,7 @@ const RESOURCE_DEFINITIONS = [
   { key: 'labels', actions: ['read', 'create', 'update', 'delete'], category: 'settings' as const },
   { key: 'custom_attribute_definitions', actions: ['read', 'create', 'update', 'delete'], category: 'settings' as const },
   { key: 'canned_responses', actions: ['read', 'create', 'update', 'delete'], category: 'settings' as const },
+  { key: 'message_templates', actions: ['read', 'create', 'update', 'delete'], category: 'settings' as const },
   { key: 'macros', actions: ['read', 'create', 'update', 'delete'], category: 'settings' as const },
   { key: 'integrations', actions: ['read', 'update'], category: 'settings' as const },
   { key: 'access_tokens', actions: ['read', 'create', 'update', 'delete'], category: 'settings' as const },

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -24,6 +24,7 @@ import ptBRLayout from './locales/pt-BR/layout.json';
 import ptBRCommon from './locales/pt-BR/common.json';
 import ptBRAccountSettings from './locales/pt-BR/accountSettings.json';
 import ptBRCannedResponses from './locales/pt-BR/cannedResponses.json';
+import ptBRMessageTemplates from './locales/pt-BR/messageTemplates.json';
 import ptBRProducts from './locales/pt-BR/products.json';
 import ptBRTemplates from './locales/pt-BR/templates.json';
 import ptBRCustomAttributes from './locales/pt-BR/customAttributes.json';
@@ -74,6 +75,7 @@ import ptLayout from './locales/pt/layout.json';
 import ptCommon from './locales/pt/common.json';
 import ptAccountSettings from './locales/pt/accountSettings.json';
 import ptCannedResponses from './locales/pt/cannedResponses.json';
+import ptMessageTemplates from './locales/pt/messageTemplates.json';
 import ptProducts from './locales/pt/products.json';
 import ptTemplates from './locales/pt/templates.json';
 import ptCustomAttributes from './locales/pt/customAttributes.json';
@@ -124,6 +126,7 @@ import enLayout from './locales/en/layout.json';
 import enCommon from './locales/en/common.json';
 import enAccountSettings from './locales/en/accountSettings.json';
 import enCannedResponses from './locales/en/cannedResponses.json';
+import enMessageTemplates from './locales/en/messageTemplates.json';
 import enProducts from './locales/en/products.json';
 import enTemplates from './locales/en/templates.json';
 import enCustomAttributes from './locales/en/customAttributes.json';
@@ -174,6 +177,7 @@ import esLayout from './locales/es/layout.json';
 import esCommon from './locales/es/common.json';
 import esAccountSettings from './locales/es/accountSettings.json';
 import esCannedResponses from './locales/es/cannedResponses.json';
+import esMessageTemplates from './locales/es/messageTemplates.json';
 import esProducts from './locales/es/products.json';
 import esTemplates from './locales/es/templates.json';
 import esCustomAttributes from './locales/es/customAttributes.json';
@@ -224,6 +228,7 @@ import frLayout from './locales/fr/layout.json';
 import frCommon from './locales/fr/common.json';
 import frAccountSettings from './locales/fr/accountSettings.json';
 import frCannedResponses from './locales/fr/cannedResponses.json';
+import frMessageTemplates from './locales/fr/messageTemplates.json';
 import frProducts from './locales/fr/products.json';
 import frTemplates from './locales/fr/templates.json';
 import frCustomAttributes from './locales/fr/customAttributes.json';
@@ -274,6 +279,7 @@ import itLayout from './locales/it/layout.json';
 import itCommon from './locales/it/common.json';
 import itAccountSettings from './locales/it/accountSettings.json';
 import itCannedResponses from './locales/it/cannedResponses.json';
+import itMessageTemplates from './locales/it/messageTemplates.json';
 import itProducts from './locales/it/products.json';
 import itTemplates from './locales/it/templates.json';
 import itCustomAttributes from './locales/it/customAttributes.json';
@@ -392,6 +398,7 @@ const resources = {
     common: ptBRCommon,
     accountSettings: ptBRAccountSettings,
     cannedResponses: ptBRCannedResponses,
+    messageTemplates: ptBRMessageTemplates,
     products: ptBRProducts,
     templates: ptBRTemplates,
     customAttributes: ptBRCustomAttributes,
@@ -449,6 +456,7 @@ const resources = {
     common: ptCommon,
     accountSettings: ptAccountSettings,
     cannedResponses: ptCannedResponses,
+    messageTemplates: ptMessageTemplates,
     products: ptProducts,
     templates: ptTemplates,
     customAttributes: ptCustomAttributes,
@@ -506,6 +514,7 @@ const resources = {
     common: enCommon,
     accountSettings: enAccountSettings,
     cannedResponses: enCannedResponses,
+    messageTemplates: enMessageTemplates,
     products: enProducts,
     templates: enTemplates,
     customAttributes: enCustomAttributes,
@@ -563,6 +572,7 @@ const resources = {
     common: esCommon,
     accountSettings: esAccountSettings,
     cannedResponses: esCannedResponses,
+    messageTemplates: esMessageTemplates,
     products: esProducts,
     templates: esTemplates,
     customAttributes: esCustomAttributes,
@@ -620,6 +630,7 @@ const resources = {
     common: frCommon,
     accountSettings: frAccountSettings,
     cannedResponses: frCannedResponses,
+    messageTemplates: frMessageTemplates,
     products: frProducts,
     templates: frTemplates,
     customAttributes: frCustomAttributes,
@@ -677,6 +688,7 @@ const resources = {
     common: itCommon,
     accountSettings: itAccountSettings,
     cannedResponses: itCannedResponses,
+    messageTemplates: itMessageTemplates,
     products: itProducts,
     templates: itTemplates,
     customAttributes: itCustomAttributes,

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -110,6 +110,7 @@
       "labels": "Labels",
       "customAttributes": "Custom Attributes",
       "cannedResponses": "Canned Responses",
+      "messageTemplates": "Message Templates",
       "macros": "Macros",
       "templates": "Templates",
       "integrations": "Integrations",

--- a/src/i18n/locales/en/messageTemplates.json
+++ b/src/i18n/locales/en/messageTemplates.json
@@ -1,0 +1,101 @@
+{
+  "page": {
+    "title": "Message Templates",
+    "description": "Manage global, channel-independent message templates."
+  },
+  "newTemplate": "New Template",
+  "searchPlaceholder": "Search by name...",
+  "table": {
+    "name": "Name",
+    "category": "Category",
+    "status": "Status",
+    "language": "Language",
+    "actions": "Actions"
+  },
+  "status": {
+    "approved": "Approved",
+    "pending": "Pending approval",
+    "rejected": "Rejected",
+    "paused": "Paused",
+    "inactive": "Inactive",
+    "unknown": "Unknown",
+    "active": "Active"
+  },
+  "categories": {
+    "marketing": "Marketing",
+    "utility": "Utility",
+    "authentication": "Authentication",
+    "transactional": "Transactional"
+  },
+  "emptyState": {
+    "title": "No templates yet",
+    "description": "Create your first global message template.",
+    "searchEmpty": "No templates match your search.",
+    "noInboxes": "An inbox is required",
+    "noInboxesDescription": "Global message templates require at least one inbox. Create an inbox first."
+  },
+  "deleteDialog": {
+    "title": "Delete template",
+    "message": "Are you sure you want to delete \"{{name}}\"?",
+    "warning": "This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirm": "Delete"
+  },
+  "messages": {
+    "loadError": "Failed to load templates.",
+    "createSuccess": "Template created successfully.",
+    "createError": "Failed to create template.",
+    "updateSuccess": "Template updated successfully.",
+    "updateError": "Failed to update template.",
+    "deleteSuccess": "Template deleted successfully.",
+    "deleteError": "Failed to delete template.",
+    "permissionDenied": {
+      "read": "You don't have permission to view templates.",
+      "create": "You don't have permission to create templates.",
+      "update": "You don't have permission to edit templates.",
+      "delete": "You don't have permission to delete templates."
+    }
+  },
+  "form": {
+    "createTitle": "New Template",
+    "editTitle": "Edit Template",
+    "provider": "Provider",
+    "providers": {
+      "generic": "Generic",
+      "email": "Email"
+    },
+    "name": "Name",
+    "namePlaceholder": "e.g. welcome_message",
+    "category": "Category",
+    "categories": {
+      "marketing": "Marketing",
+      "utility": "Utility",
+      "authentication": "Authentication",
+      "transactional": "Transactional"
+    },
+    "language": "Language",
+    "subject": "Subject",
+    "subjectPlaceholder": "Email subject",
+    "content": "Content",
+    "contentPlaceholder": "Type the message content.",
+    "variablesHelp": "Use {{variable}} syntax for dynamic values",
+    "variables": "Variables",
+    "variableLabel": "Label",
+    "variableExample": "Example",
+    "variableSource": "Source",
+    "active": "Active",
+    "activeHelp": "Inactive templates are hidden from selection.",
+    "cancel": "Cancel",
+    "create": "Create",
+    "save": "Save",
+    "errors": {
+      "requiredFields": "Name and content are required."
+    },
+    "categoryReset": "Category reset to a value supported by the selected provider."
+  },
+  "pagination": {
+    "previous": "Previous",
+    "next": "Next",
+    "pageOf": "Page {{page}} of {{total}}"
+  }
+}

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etiquetas",
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respuestas Rápidas",
+      "messageTemplates": "Plantillas de Mensaje",
       "macros": "Macros",
       "templates": "Plantillas",
       "integrations": "Integraciones",

--- a/src/i18n/locales/es/messageTemplates.json
+++ b/src/i18n/locales/es/messageTemplates.json
@@ -1,0 +1,101 @@
+{
+  "page": {
+    "title": "Plantillas de Mensaje",
+    "description": "Gestiona plantillas de mensaje globales, independientes del canal."
+  },
+  "newTemplate": "Nueva Plantilla",
+  "searchPlaceholder": "Buscar por nombre...",
+  "table": {
+    "name": "Nombre",
+    "category": "Categoría",
+    "status": "Estado",
+    "language": "Idioma",
+    "actions": "Acciones"
+  },
+  "status": {
+    "approved": "Aprobada",
+    "pending": "Pendiente de aprobación",
+    "rejected": "Rechazada",
+    "paused": "Pausada",
+    "inactive": "Inactiva",
+    "unknown": "Desconocido",
+    "active": "Activa"
+  },
+  "categories": {
+    "marketing": "Marketing",
+    "utility": "Utilidad",
+    "authentication": "Autenticación",
+    "transactional": "Transaccional"
+  },
+  "emptyState": {
+    "title": "Aún no hay plantillas",
+    "description": "Crea tu primera plantilla de mensaje global.",
+    "searchEmpty": "Ninguna plantilla coincide con tu búsqueda.",
+    "noInboxes": "Se requiere una bandeja de entrada",
+    "noInboxesDescription": "Las plantillas de mensaje globales requieren al menos una bandeja de entrada. Crea una bandeja de entrada primero."
+  },
+  "deleteDialog": {
+    "title": "Eliminar plantilla",
+    "message": "¿Seguro que deseas eliminar \"{{name}}\"?",
+    "warning": "Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "messages": {
+    "loadError": "Error al cargar las plantillas.",
+    "createSuccess": "Plantilla creada correctamente.",
+    "createError": "Error al crear la plantilla.",
+    "updateSuccess": "Plantilla actualizada correctamente.",
+    "updateError": "Error al actualizar la plantilla.",
+    "deleteSuccess": "Plantilla eliminada correctamente.",
+    "deleteError": "Error al eliminar la plantilla.",
+    "permissionDenied": {
+      "read": "No tienes permiso para ver plantillas.",
+      "create": "No tienes permiso para crear plantillas.",
+      "update": "No tienes permiso para editar plantillas.",
+      "delete": "No tienes permiso para eliminar plantillas."
+    }
+  },
+  "form": {
+    "createTitle": "Nueva Plantilla",
+    "editTitle": "Editar Plantilla",
+    "provider": "Proveedor",
+    "providers": {
+      "generic": "Genérico",
+      "email": "Correo electrónico"
+    },
+    "name": "Nombre",
+    "namePlaceholder": "ej.: mensaje_bienvenida",
+    "category": "Categoría",
+    "categories": {
+      "marketing": "Marketing",
+      "utility": "Utilidad",
+      "authentication": "Autenticación",
+      "transactional": "Transaccional"
+    },
+    "language": "Idioma",
+    "subject": "Asunto",
+    "subjectPlaceholder": "Asunto del correo",
+    "content": "Contenido",
+    "contentPlaceholder": "Escribe el contenido del mensaje.",
+    "variablesHelp": "Usa la sintaxis {{variable}} para valores dinámicos",
+    "variables": "Variables",
+    "variableLabel": "Etiqueta",
+    "variableExample": "Ejemplo",
+    "variableSource": "Origen",
+    "active": "Activa",
+    "activeHelp": "Las plantillas inactivas se ocultan en la selección.",
+    "cancel": "Cancelar",
+    "create": "Crear",
+    "save": "Guardar",
+    "errors": {
+      "requiredFields": "El nombre y el contenido son obligatorios."
+    },
+    "categoryReset": "Categoría restablecida a un valor compatible con el proveedor seleccionado."
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "pageOf": "Página {{page}} de {{total}}"
+  }
+}

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -110,6 +110,7 @@
       "labels": "Étiquettes",
       "customAttributes": "Attributs Personnalisés",
       "cannedResponses": "Réponses Rapides",
+      "messageTemplates": "Modèles de Message",
       "macros": "Macros",
       "templates": "Modèles",
       "integrations": "Intégrations",

--- a/src/i18n/locales/fr/messageTemplates.json
+++ b/src/i18n/locales/fr/messageTemplates.json
@@ -1,0 +1,101 @@
+{
+  "page": {
+    "title": "Modèles de Message",
+    "description": "Gérez des modèles de message globaux, indépendants du canal."
+  },
+  "newTemplate": "Nouveau Modèle",
+  "searchPlaceholder": "Rechercher par nom...",
+  "table": {
+    "name": "Nom",
+    "category": "Catégorie",
+    "status": "Statut",
+    "language": "Langue",
+    "actions": "Actions"
+  },
+  "status": {
+    "approved": "Approuvé",
+    "pending": "En attente d'approbation",
+    "rejected": "Rejeté",
+    "paused": "En pause",
+    "inactive": "Inactif",
+    "unknown": "Inconnu",
+    "active": "Actif"
+  },
+  "categories": {
+    "marketing": "Marketing",
+    "utility": "Utilitaire",
+    "authentication": "Authentification",
+    "transactional": "Transactionnel"
+  },
+  "emptyState": {
+    "title": "Aucun modèle pour le moment",
+    "description": "Créez votre premier modèle de message global.",
+    "searchEmpty": "Aucun modèle ne correspond à votre recherche.",
+    "noInboxes": "Une boîte de réception est requise",
+    "noInboxesDescription": "Les modèles de message globaux nécessitent au moins une boîte de réception. Créez d'abord une boîte de réception."
+  },
+  "deleteDialog": {
+    "title": "Supprimer le modèle",
+    "message": "Voulez-vous vraiment supprimer « {{name}} » ?",
+    "warning": "Cette action est irréversible.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer"
+  },
+  "messages": {
+    "loadError": "Échec du chargement des modèles.",
+    "createSuccess": "Modèle créé avec succès.",
+    "createError": "Échec de la création du modèle.",
+    "updateSuccess": "Modèle mis à jour avec succès.",
+    "updateError": "Échec de la mise à jour du modèle.",
+    "deleteSuccess": "Modèle supprimé avec succès.",
+    "deleteError": "Échec de la suppression du modèle.",
+    "permissionDenied": {
+      "read": "Vous n'avez pas la permission de voir les modèles.",
+      "create": "Vous n'avez pas la permission de créer des modèles.",
+      "update": "Vous n'avez pas la permission de modifier les modèles.",
+      "delete": "Vous n'avez pas la permission de supprimer les modèles."
+    }
+  },
+  "form": {
+    "createTitle": "Nouveau Modèle",
+    "editTitle": "Modifier le Modèle",
+    "provider": "Fournisseur",
+    "providers": {
+      "generic": "Générique",
+      "email": "E-mail"
+    },
+    "name": "Nom",
+    "namePlaceholder": "ex. : message_bienvenue",
+    "category": "Catégorie",
+    "categories": {
+      "marketing": "Marketing",
+      "utility": "Utilitaire",
+      "authentication": "Authentification",
+      "transactional": "Transactionnel"
+    },
+    "language": "Langue",
+    "subject": "Objet",
+    "subjectPlaceholder": "Objet de l'e-mail",
+    "content": "Contenu",
+    "contentPlaceholder": "Saisissez le contenu du message.",
+    "variablesHelp": "Utilisez la syntaxe {{variable}} pour les valeurs dynamiques",
+    "variables": "Variables",
+    "variableLabel": "Libellé",
+    "variableExample": "Exemple",
+    "variableSource": "Source",
+    "active": "Actif",
+    "activeHelp": "Les modèles inactifs sont masqués de la sélection.",
+    "cancel": "Annuler",
+    "create": "Créer",
+    "save": "Enregistrer",
+    "errors": {
+      "requiredFields": "Le nom et le contenu sont obligatoires."
+    },
+    "categoryReset": "Catégorie réinitialisée vers une valeur prise en charge par le fournisseur sélectionné."
+  },
+  "pagination": {
+    "previous": "Précédent",
+    "next": "Suivant",
+    "pageOf": "Page {{page}} sur {{total}}"
+  }
+}

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etichette",
       "customAttributes": "Attributi Personalizzati",
       "cannedResponses": "Risposte Predefinite",
+      "messageTemplates": "Modelli di Messaggio",
       "macros": "Macro",
       "templates": "Modelli",
       "integrations": "Integrazioni",

--- a/src/i18n/locales/it/messageTemplates.json
+++ b/src/i18n/locales/it/messageTemplates.json
@@ -1,0 +1,101 @@
+{
+  "page": {
+    "title": "Modelli di Messaggio",
+    "description": "Gestisci modelli di messaggio globali, indipendenti dal canale."
+  },
+  "newTemplate": "Nuovo Modello",
+  "searchPlaceholder": "Cerca per nome...",
+  "table": {
+    "name": "Nome",
+    "category": "Categoria",
+    "status": "Stato",
+    "language": "Lingua",
+    "actions": "Azioni"
+  },
+  "status": {
+    "approved": "Approvato",
+    "pending": "In attesa di approvazione",
+    "rejected": "Rifiutato",
+    "paused": "In pausa",
+    "inactive": "Inattivo",
+    "unknown": "Sconosciuto",
+    "active": "Attivo"
+  },
+  "categories": {
+    "marketing": "Marketing",
+    "utility": "Utilità",
+    "authentication": "Autenticazione",
+    "transactional": "Transazionale"
+  },
+  "emptyState": {
+    "title": "Nessun modello ancora",
+    "description": "Crea il tuo primo modello di messaggio globale.",
+    "searchEmpty": "Nessun modello corrisponde alla tua ricerca.",
+    "noInboxes": "È richiesta una casella di posta",
+    "noInboxesDescription": "I modelli di messaggio globali richiedono almeno una casella di posta. Crea prima una casella di posta."
+  },
+  "deleteDialog": {
+    "title": "Elimina modello",
+    "message": "Sei sicuro di voler eliminare \"{{name}}\"?",
+    "warning": "Questa azione non può essere annullata.",
+    "cancel": "Annulla",
+    "confirm": "Elimina"
+  },
+  "messages": {
+    "loadError": "Impossibile caricare i modelli.",
+    "createSuccess": "Modello creato con successo.",
+    "createError": "Impossibile creare il modello.",
+    "updateSuccess": "Modello aggiornato con successo.",
+    "updateError": "Impossibile aggiornare il modello.",
+    "deleteSuccess": "Modello eliminato con successo.",
+    "deleteError": "Impossibile eliminare il modello.",
+    "permissionDenied": {
+      "read": "Non hai il permesso di visualizzare i modelli.",
+      "create": "Non hai il permesso di creare modelli.",
+      "update": "Non hai il permesso di modificare i modelli.",
+      "delete": "Non hai il permesso di eliminare i modelli."
+    }
+  },
+  "form": {
+    "createTitle": "Nuovo Modello",
+    "editTitle": "Modifica Modello",
+    "provider": "Provider",
+    "providers": {
+      "generic": "Generico",
+      "email": "E-mail"
+    },
+    "name": "Nome",
+    "namePlaceholder": "es. messaggio_benvenuto",
+    "category": "Categoria",
+    "categories": {
+      "marketing": "Marketing",
+      "utility": "Utilità",
+      "authentication": "Autenticazione",
+      "transactional": "Transazionale"
+    },
+    "language": "Lingua",
+    "subject": "Oggetto",
+    "subjectPlaceholder": "Oggetto dell'e-mail",
+    "content": "Contenuto",
+    "contentPlaceholder": "Inserisci il contenuto del messaggio.",
+    "variablesHelp": "Usa la sintassi {{variable}} per i valori dinamici",
+    "variables": "Variabili",
+    "variableLabel": "Etichetta",
+    "variableExample": "Esempio",
+    "variableSource": "Origine",
+    "active": "Attivo",
+    "activeHelp": "I modelli inattivi sono nascosti dalla selezione.",
+    "cancel": "Annulla",
+    "create": "Crea",
+    "save": "Salva",
+    "errors": {
+      "requiredFields": "Nome e contenuto sono obbligatori."
+    },
+    "categoryReset": "Categoria reimpostata su un valore supportato dal provider selezionato."
+  },
+  "pagination": {
+    "previous": "Precedente",
+    "next": "Successivo",
+    "pageOf": "Pagina {{page}} di {{total}}"
+  }
+}

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etiquetas",
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respostas Rápidas",
+      "messageTemplates": "Modelos de Mensagem",
       "macros": "Macros",
       "templates": "Templates",
       "integrations": "Integrações",

--- a/src/i18n/locales/pt-BR/messageTemplates.json
+++ b/src/i18n/locales/pt-BR/messageTemplates.json
@@ -1,0 +1,101 @@
+{
+  "page": {
+    "title": "Modelos de Mensagem",
+    "description": "Gerencie modelos de mensagem globais, independentes de canal."
+  },
+  "newTemplate": "Novo Modelo",
+  "searchPlaceholder": "Buscar por nome...",
+  "table": {
+    "name": "Nome",
+    "category": "Categoria",
+    "status": "Status",
+    "language": "Idioma",
+    "actions": "Ações"
+  },
+  "status": {
+    "approved": "Aprovado",
+    "pending": "Aguardando aprovação",
+    "rejected": "Rejeitado",
+    "paused": "Pausado",
+    "inactive": "Inativo",
+    "unknown": "Desconhecido",
+    "active": "Ativo"
+  },
+  "categories": {
+    "marketing": "Marketing",
+    "utility": "Utilitário",
+    "authentication": "Autenticação",
+    "transactional": "Transacional"
+  },
+  "emptyState": {
+    "title": "Nenhum modelo ainda",
+    "description": "Crie seu primeiro modelo de mensagem global.",
+    "searchEmpty": "Nenhum modelo corresponde à sua busca.",
+    "noInboxes": "É necessário uma caixa de entrada",
+    "noInboxesDescription": "Modelos de mensagem globais exigem pelo menos uma caixa de entrada. Crie uma caixa de entrada primeiro."
+  },
+  "deleteDialog": {
+    "title": "Excluir modelo",
+    "message": "Tem certeza de que deseja excluir \"{{name}}\"?",
+    "warning": "Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "messages": {
+    "loadError": "Falha ao carregar os modelos.",
+    "createSuccess": "Modelo criado com sucesso.",
+    "createError": "Falha ao criar o modelo.",
+    "updateSuccess": "Modelo atualizado com sucesso.",
+    "updateError": "Falha ao atualizar o modelo.",
+    "deleteSuccess": "Modelo excluído com sucesso.",
+    "deleteError": "Falha ao excluir o modelo.",
+    "permissionDenied": {
+      "read": "Você não tem permissão para visualizar modelos.",
+      "create": "Você não tem permissão para criar modelos.",
+      "update": "Você não tem permissão para editar modelos.",
+      "delete": "Você não tem permissão para excluir modelos."
+    }
+  },
+  "form": {
+    "createTitle": "Novo Modelo",
+    "editTitle": "Editar Modelo",
+    "provider": "Provedor",
+    "providers": {
+      "generic": "Genérico",
+      "email": "E-mail"
+    },
+    "name": "Nome",
+    "namePlaceholder": "ex.: mensagem_boas_vindas",
+    "category": "Categoria",
+    "categories": {
+      "marketing": "Marketing",
+      "utility": "Utilitário",
+      "authentication": "Autenticação",
+      "transactional": "Transacional"
+    },
+    "language": "Idioma",
+    "subject": "Assunto",
+    "subjectPlaceholder": "Assunto do e-mail",
+    "content": "Conteúdo",
+    "contentPlaceholder": "Digite o conteúdo da mensagem.",
+    "variablesHelp": "Use a sintaxe {{variable}} para valores dinâmicos",
+    "variables": "Variáveis",
+    "variableLabel": "Rótulo",
+    "variableExample": "Exemplo",
+    "variableSource": "Origem",
+    "active": "Ativo",
+    "activeHelp": "Modelos inativos ficam ocultos na seleção.",
+    "cancel": "Cancelar",
+    "create": "Criar",
+    "save": "Salvar",
+    "errors": {
+      "requiredFields": "Nome e conteúdo são obrigatórios."
+    },
+    "categoryReset": "Categoria redefinida para um valor suportado pelo provedor selecionado."
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Próximo",
+    "pageOf": "Página {{page}} de {{total}}"
+  }
+}

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etiquetas",
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respostas Rápidas",
+      "messageTemplates": "Modelos de Mensagem",
       "macros": "Macros",
       "templates": "Templates",
       "integrations": "Integrações",

--- a/src/i18n/locales/pt/messageTemplates.json
+++ b/src/i18n/locales/pt/messageTemplates.json
@@ -1,0 +1,101 @@
+{
+  "page": {
+    "title": "Modelos de Mensagem",
+    "description": "Gerencie modelos de mensagem globais, independentes de canal."
+  },
+  "newTemplate": "Novo Modelo",
+  "searchPlaceholder": "Buscar por nome...",
+  "table": {
+    "name": "Nome",
+    "category": "Categoria",
+    "status": "Status",
+    "language": "Idioma",
+    "actions": "Ações"
+  },
+  "status": {
+    "approved": "Aprovado",
+    "pending": "Aguardando aprovação",
+    "rejected": "Rejeitado",
+    "paused": "Pausado",
+    "inactive": "Inativo",
+    "unknown": "Desconhecido",
+    "active": "Ativo"
+  },
+  "categories": {
+    "marketing": "Marketing",
+    "utility": "Utilitário",
+    "authentication": "Autenticação",
+    "transactional": "Transacional"
+  },
+  "emptyState": {
+    "title": "Nenhum modelo ainda",
+    "description": "Crie seu primeiro modelo de mensagem global.",
+    "searchEmpty": "Nenhum modelo corresponde à sua busca.",
+    "noInboxes": "É necessário uma caixa de entrada",
+    "noInboxesDescription": "Modelos de mensagem globais exigem pelo menos uma caixa de entrada. Crie uma caixa de entrada primeiro."
+  },
+  "deleteDialog": {
+    "title": "Excluir modelo",
+    "message": "Tem certeza de que deseja excluir \"{{name}}\"?",
+    "warning": "Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "messages": {
+    "loadError": "Falha ao carregar os modelos.",
+    "createSuccess": "Modelo criado com sucesso.",
+    "createError": "Falha ao criar o modelo.",
+    "updateSuccess": "Modelo atualizado com sucesso.",
+    "updateError": "Falha ao atualizar o modelo.",
+    "deleteSuccess": "Modelo excluído com sucesso.",
+    "deleteError": "Falha ao excluir o modelo.",
+    "permissionDenied": {
+      "read": "Você não tem permissão para visualizar modelos.",
+      "create": "Você não tem permissão para criar modelos.",
+      "update": "Você não tem permissão para editar modelos.",
+      "delete": "Você não tem permissão para excluir modelos."
+    }
+  },
+  "form": {
+    "createTitle": "Novo Modelo",
+    "editTitle": "Editar Modelo",
+    "provider": "Provedor",
+    "providers": {
+      "generic": "Genérico",
+      "email": "E-mail"
+    },
+    "name": "Nome",
+    "namePlaceholder": "ex.: mensagem_boas_vindas",
+    "category": "Categoria",
+    "categories": {
+      "marketing": "Marketing",
+      "utility": "Utilitário",
+      "authentication": "Autenticação",
+      "transactional": "Transacional"
+    },
+    "language": "Idioma",
+    "subject": "Assunto",
+    "subjectPlaceholder": "Assunto do e-mail",
+    "content": "Conteúdo",
+    "contentPlaceholder": "Digite o conteúdo da mensagem.",
+    "variablesHelp": "Use a sintaxe {{variable}} para valores dinâmicos",
+    "variables": "Variáveis",
+    "variableLabel": "Rótulo",
+    "variableExample": "Exemplo",
+    "variableSource": "Origem",
+    "active": "Ativo",
+    "activeHelp": "Modelos inativos ficam ocultos na seleção.",
+    "cancel": "Cancelar",
+    "create": "Criar",
+    "save": "Salvar",
+    "errors": {
+      "requiredFields": "Nome e conteúdo são obrigatórios."
+    },
+    "categoryReset": "Categoria redefinida para um valor suportado pelo provedor selecionado."
+  },
+  "pagination": {
+    "previous": "Anterior",
+    "next": "Próximo",
+    "pageOf": "Página {{page}} de {{total}}"
+  }
+}

--- a/src/pages/Customer/Settings/MessageTemplates/MessageTemplates.tsx
+++ b/src/pages/Customer/Settings/MessageTemplates/MessageTemplates.tsx
@@ -1,0 +1,345 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@evoapi/design-system';
+import { ChevronLeft, ChevronRight, Edit, LayoutTemplate, Plus, Search, Trash2 } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
+import { useAppDataStore } from '@/store/appDataStore';
+import EmptyState from '@/components/base/EmptyState';
+import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { extractError } from '@/utils/apiHelpers';
+import GlobalMessageTemplateService, {
+  inferTemplateProvider,
+  type GlobalTemplateProvider,
+} from '@/services/messageTemplates/globalMessageTemplatesService';
+import GlobalTemplateFormModal from './components/GlobalTemplateFormModal';
+import type { MessageTemplate, TemplateFormData } from '@/types';
+
+export default function MessageTemplates() {
+  const { t } = useLanguage('messageTemplates');
+  const { can } = useUserPermissions();
+  const inboxes = useAppDataStore(s => s.inboxes);
+  const fetchInboxes = useAppDataStore(s => s.fetchInboxes);
+
+  // The global endpoints are member routes under /inboxes/:id (the inbox is a
+  // routing placeholder, ignored in ?global=true mode), but it must still be a
+  // real, viewable inbox id.
+  const placeholderInboxId = inboxes[0]?.id;
+
+  const [templates, setTemplates] = useState<MessageTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<MessageTemplate | null>(null);
+
+  const [deleteTarget, setDeleteTarget] = useState<MessageTemplate | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    if (inboxes.length === 0) {
+      fetchInboxes().catch(() => undefined);
+    }
+  }, [inboxes.length, fetchInboxes]);
+
+  // Debounce search: server-side filtering is authoritative (no client re-filter).
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebouncedSearch(searchQuery);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(id);
+  }, [searchQuery]);
+
+  const loadTemplates = useCallback(async () => {
+    if (!placeholderInboxId) {
+      setIsLoading(false);
+      return;
+    }
+    if (!can('message_templates', 'read')) {
+      toast.error(t('messages.permissionDenied.read'));
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const response = await GlobalMessageTemplateService.getTemplates(placeholderInboxId, {
+        page,
+        per_page: DEFAULT_PAGE_SIZE,
+        search: debouncedSearch || undefined,
+        sort_by: 'name',
+      });
+      setTemplates(response.data);
+      setTotalPages(Math.max(1, Number(response.meta?.pagination?.total_pages) || 1));
+    } catch (e) {
+      toast.error(extractError(e).message || t('messages.loadError'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [placeholderInboxId, can, t, debouncedSearch, page]);
+
+  useEffect(() => {
+    loadTemplates();
+  }, [loadTemplates]);
+
+  const openCreate = () => {
+    if (!can('message_templates', 'create')) {
+      toast.error(t('messages.permissionDenied.create'));
+      return;
+    }
+    setEditing(null);
+    setFormOpen(true);
+  };
+
+  const openEdit = (template: MessageTemplate) => {
+    if (!can('message_templates', 'update')) {
+      toast.error(t('messages.permissionDenied.update'));
+      return;
+    }
+    setEditing(template);
+    setFormOpen(true);
+  };
+
+  const handleSave = async (formData: TemplateFormData, provider: GlobalTemplateProvider) => {
+    if (!placeholderInboxId) return;
+    try {
+      if (editing?.id) {
+        await GlobalMessageTemplateService.updateTemplate(
+          placeholderInboxId,
+          editing.id,
+          formData,
+          provider,
+        );
+        toast.success(t('messages.updateSuccess'));
+      } else {
+        await GlobalMessageTemplateService.createTemplate(placeholderInboxId, formData, provider);
+        toast.success(t('messages.createSuccess'));
+      }
+      setEditing(null);
+      await loadTemplates();
+    } catch (e) {
+      // Surface backend validation detail (e.g. duplicate name -> 422).
+      toast.error(extractError(e).message || t(editing ? 'messages.updateError' : 'messages.createError'));
+    }
+  };
+
+  const requestDelete = (template: MessageTemplate) => {
+    if (!can('message_templates', 'delete')) {
+      toast.error(t('messages.permissionDenied.delete'));
+      return;
+    }
+    setDeleteTarget(template);
+  };
+
+  const confirmDelete = async () => {
+    if (!placeholderInboxId || !deleteTarget?.id) return;
+    setIsDeleting(true);
+    try {
+      await GlobalMessageTemplateService.deleteTemplate(placeholderInboxId, deleteTarget.id);
+      toast.success(t('messages.deleteSuccess'));
+      setDeleteTarget(null);
+      await loadTemplates();
+    } catch (e) {
+      toast.error(extractError(e).message || t('messages.deleteError'));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // Global (channel-less) templates have no Meta approval flow, so the Meta
+  // `status` is always null — show the local Active/Inactive state instead.
+  const activeBadge = (template: MessageTemplate) => {
+    const isActive = template.active !== false;
+    return (
+      <Badge className={isActive ? 'bg-green-600 text-white' : 'bg-gray-500 text-white'}>
+        {t(`status.${isActive ? 'active' : 'inactive'}`)}
+      </Badge>
+    );
+  };
+
+  // No inbox exists -> the placeholder-inbox routing constraint can't be met.
+  if (!isLoading && !placeholderInboxId) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon={LayoutTemplate}
+          title={t('emptyState.noInboxes')}
+          description={t('emptyState.noInboxesDescription')}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-foreground">{t('page.title')}</h2>
+          <p className="text-sm text-muted-foreground">{t('page.description')}</p>
+        </div>
+        <Button onClick={openCreate}>
+          <Plus className="w-4 h-4 mr-2" />
+          {t('newTemplate')}
+        </Button>
+      </div>
+
+      <div className="relative max-w-md">
+        <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder={t('searchPlaceholder')}
+          className="pl-10"
+        />
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      ) : (
+        <Card>
+          <CardContent className="p-0">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t('table.name')}</TableHead>
+                  <TableHead>{t('table.category')}</TableHead>
+                  <TableHead>{t('table.status')}</TableHead>
+                  <TableHead>{t('table.language')}</TableHead>
+                  <TableHead className="w-28">{t('table.actions')}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {templates.map(template => (
+                  <TableRow key={template.id}>
+                    <TableCell className="font-medium">{template.name}</TableCell>
+                    <TableCell>
+                      {template.category ? (
+                        <Badge variant="secondary">
+                          {t(`categories.${template.category.toLowerCase()}`)}
+                        </Badge>
+                      ) : (
+                        '-'
+                      )}
+                    </TableCell>
+                    <TableCell>{activeBadge(template)}</TableCell>
+                    <TableCell>{template.language}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button variant="outline" size="sm" onClick={() => openEdit(template)}>
+                          <Edit className="w-4 h-4" />
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => requestDelete(template)}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+
+            {templates.length === 0 && (
+              <div className="p-8 text-center">
+                <LayoutTemplate className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+                <h3 className="text-lg font-medium text-foreground mb-2">
+                  {t('emptyState.title')}
+                </h3>
+                <p className="text-muted-foreground">
+                  {debouncedSearch ? t('emptyState.searchEmpty') : t('emptyState.description')}
+                </p>
+              </div>
+            )}
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-end gap-2 p-4 border-t">
+                <span className="text-sm text-muted-foreground">
+                  {t('pagination.pageOf', { page, total: totalPages })}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage(p => Math.max(1, p - 1))}
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                  {t('pagination.previous')}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                >
+                  {t('pagination.next')}
+                  <ChevronRight className="w-4 h-4" />
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <GlobalTemplateFormModal
+        isOpen={formOpen}
+        mode={editing ? 'edit' : 'create'}
+        template={editing || undefined}
+        initialProvider={editing ? inferTemplateProvider(editing) : 'generic'}
+        onClose={() => {
+          setFormOpen(false);
+          setEditing(null);
+        }}
+        onSave={handleSave}
+      />
+
+      <Dialog open={!!deleteTarget} onOpenChange={open => !open && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('deleteDialog.title')}</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <p className="text-muted-foreground">
+              {t('deleteDialog.message', { name: deleteTarget?.name })}
+            </p>
+            <p className="text-sm text-red-600 mt-2">{t('deleteDialog.warning')}</p>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              {t('deleteDialog.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={confirmDelete} loading={isDeleting}>
+              {t('deleteDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Customer/Settings/MessageTemplates/__tests__/MessageTemplates.spec.tsx
+++ b/src/pages/Customer/Settings/MessageTemplates/__tests__/MessageTemplates.spec.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const h = vi.hoisted(() => ({
+  inboxes: [{ id: 'inbox-1', name: 'Main' }] as Array<{ id: string; name: string }>,
+  service: {
+    getTemplates: vi.fn(),
+    createTemplate: vi.fn(),
+    updateTemplate: vi.fn(),
+    deleteTemplate: vi.fn(),
+  },
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    currentLanguage: 'en',
+    changeLanguage: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useUserPermissions', () => ({
+  useUserPermissions: () => ({
+    can: () => true,
+    canAny: () => true,
+    canAll: () => true,
+    isReady: true,
+  }),
+}));
+
+vi.mock('@/store/appDataStore', () => ({
+  useAppDataStore: (selector: (s: unknown) => unknown) =>
+    selector({ inboxes: h.inboxes, fetchInboxes: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock('@/services/messageTemplates/globalMessageTemplatesService', () => ({
+  default: h.service,
+  providerToChannelType: (p: string) => (p === 'email' ? 'Channel::Email' : 'Channel::Api'),
+  inferTemplateProvider: () => 'generic',
+}));
+
+import MessageTemplates from '../MessageTemplates';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.inboxes = [{ id: 'inbox-1', name: 'Main' }];
+  h.service.getTemplates.mockResolvedValue({
+    success: true,
+    data: [{ id: 't1', name: 'welcome', language: 'en_US', category: 'MARKETING' }],
+    meta: {},
+    message: '',
+  });
+});
+
+describe('MessageTemplates page', () => {
+  it('lists global templates using the placeholder inbox id and global query', async () => {
+    render(<MessageTemplates />);
+    expect(await screen.findByText('welcome')).toBeInTheDocument();
+    expect(h.service.getTemplates).toHaveBeenCalledWith(
+      'inbox-1',
+      expect.objectContaining({ sort_by: 'name' }),
+    );
+  });
+
+  it('opens the create modal when "New Template" is clicked', async () => {
+    render(<MessageTemplates />);
+    await screen.findByText('welcome');
+    fireEvent.click(screen.getByText('newTemplate'));
+    expect(await screen.findByText('form.createTitle')).toBeInTheDocument();
+  });
+
+  it('renders the no-inboxes empty state when no inbox exists (placeholder constraint)', async () => {
+    h.inboxes = [];
+    render(<MessageTemplates />);
+    expect(await screen.findByText('emptyState.noInboxes')).toBeInTheDocument();
+    expect(h.service.getTemplates).not.toHaveBeenCalled();
+  });
+
+  it('paginates: shows controls and refetches the next page', async () => {
+    h.service.getTemplates.mockResolvedValue({
+      success: true,
+      data: [{ id: 't1', name: 'welcome', language: 'en_US', category: 'MARKETING' }],
+      meta: { pagination: { total_pages: 2 } },
+      message: '',
+    });
+    render(<MessageTemplates />);
+    fireEvent.click(await screen.findByText('pagination.next'));
+    await waitFor(() =>
+      expect(h.service.getTemplates).toHaveBeenLastCalledWith(
+        'inbox-1',
+        expect.objectContaining({ page: 2 }),
+      ),
+    );
+  });
+});

--- a/src/pages/Customer/Settings/MessageTemplates/components/GlobalTemplateFormModal.tsx
+++ b/src/pages/Customer/Settings/MessageTemplates/components/GlobalTemplateFormModal.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  Textarea,
+} from '@evoapi/design-system';
+import { useLanguage } from '@/hooks/useLanguage';
+import { getChannelTemplateConfig } from '@/services/channels/messageTemplatesService';
+import {
+  providerToChannelType,
+  type GlobalTemplateProvider,
+} from '@/services/messageTemplates/globalMessageTemplatesService';
+import { extractTemplateFormVariables } from '@/utils/templateVariables';
+import type { MessageTemplate, MessageTemplateVariable, TemplateFormData } from '@/types';
+
+interface GlobalTemplateFormModalProps {
+  isOpen: boolean;
+  mode: 'create' | 'edit';
+  /** Existing template (edit mode) + its resolved provider. */
+  template?: MessageTemplate;
+  initialProvider?: GlobalTemplateProvider;
+  onClose: () => void;
+  onSave: (formData: TemplateFormData, provider: GlobalTemplateProvider) => void;
+}
+
+const emptyForm = (category: string, templateType: string): TemplateFormData => ({
+  name: '',
+  content: '',
+  language: 'pt_BR',
+  category: category as TemplateFormData['category'],
+  template_type: templateType as TemplateFormData['template_type'],
+  active: true,
+  variables: [],
+});
+
+const GlobalTemplateFormModal: React.FC<GlobalTemplateFormModalProps> = ({
+  isOpen,
+  mode,
+  template,
+  initialProvider = 'generic',
+  onClose,
+  onSave,
+}) => {
+  const { t } = useLanguage('messageTemplates');
+  const [provider, setProvider] = useState<GlobalTemplateProvider>(initialProvider);
+
+  // Synthetic channel drives the (non-structured) field config for the chosen
+  // provider. generic -> Channel::Api (TRANSACTIONAL only); email -> Channel::Email.
+  const channelConfig = useMemo(
+    () => getChannelTemplateConfig(providerToChannelType(provider)),
+    [provider],
+  );
+
+  const [formData, setFormData] = useState<TemplateFormData>(() =>
+    emptyForm(channelConfig.categories[0], channelConfig.templateTypes[0]),
+  );
+
+  // Detect {{variables}} from the content and keep the editable variable rows in
+  // sync (preserving any label/example/source the user already typed). Depend
+  // only on the scanned content field — depending on the whole formData would
+  // create a setState feedback edge that only avoids looping via referential
+  // bail-out.
+  const detectedVariables = useMemo(
+    () => extractTemplateFormVariables(formData),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [formData.content],
+  );
+
+  useEffect(() => {
+    setFormData(prev => {
+      const byName = new Map((prev.variables ?? []).map(v => [v.name, v]));
+      const next = detectedVariables.map(v => ({ ...v, ...byName.get(v.name) }));
+      const changed =
+        next.length !== (prev.variables ?? []).length ||
+        next.some((v, i) => v.name !== prev.variables?.[i]?.name);
+      return changed ? { ...prev, variables: next } : prev;
+    });
+  }, [detectedVariables]);
+
+  // (Re)initialise the form when the modal opens or the target template changes.
+  useEffect(() => {
+    if (!isOpen) return;
+    if (mode === 'edit' && template) {
+      setProvider(initialProvider);
+      setFormData({
+        name: template.name,
+        content: template.content ?? '',
+        language: template.language,
+        category: template.category,
+        template_type: template.template_type,
+        active: template.active !== false,
+        subject: (template.settings?.subject as string | undefined) ?? undefined,
+        variables: (template.variables as MessageTemplateVariable[] | undefined) ?? [],
+        settings: template.settings,
+        metadata: template.metadata,
+      });
+    } else {
+      setProvider(initialProvider);
+      setFormData(emptyForm(channelConfig.categories[0], channelConfig.templateTypes[0]));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, mode, template, initialProvider]);
+
+  // When the provider changes in create mode, keep the category valid for the
+  // new provider (its allowed list can shrink, e.g. email -> generic).
+  const handleProviderChange = (value: string) => {
+    const next = value as GlobalTemplateProvider;
+    setProvider(next);
+    const cfg = getChannelTemplateConfig(providerToChannelType(next));
+    setFormData(prev => {
+      const stillValid = cfg.categories.includes(prev.category ?? '');
+      if (!stillValid) {
+        // The category list shrinks across providers; let the user know their
+        // selection was reset rather than silently rewriting it.
+        toast.info(t('form.categoryReset'));
+      }
+      return {
+        ...prev,
+        category: stillValid
+          ? prev.category
+          : (cfg.categories[0] as TemplateFormData['category']),
+      };
+    });
+  };
+
+  const updateVariable = (name: string, patch: Partial<MessageTemplateVariable>) => {
+    setFormData(prev => ({
+      ...prev,
+      variables: (prev.variables ?? []).map(v => (v.name === name ? { ...v, ...patch } : v)),
+    }));
+  };
+
+  const isValid = formData.name.trim().length > 0 && formData.content.trim().length > 0;
+
+  const handleSave = () => {
+    if (!isValid) {
+      toast.error(t('form.errors.requiredFields'));
+      return;
+    }
+    onSave(formData, provider);
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {mode === 'create' ? t('form.createTitle') : t('form.editTitle')}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Provider + Name */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-2">{t('form.provider')}</label>
+              <Select
+                value={provider}
+                onValueChange={handleProviderChange}
+                disabled={mode === 'edit'}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="generic">{t('form.providers.generic')}</SelectItem>
+                  <SelectItem value="email">{t('form.providers.email')}</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-2">{t('form.name')}</label>
+              <Input
+                value={formData.name}
+                onChange={e => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                placeholder={t('form.namePlaceholder')}
+              />
+            </div>
+          </div>
+
+          {/* Category + Language */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium mb-2">{t('form.category')}</label>
+              <Select
+                value={formData.category}
+                onValueChange={value =>
+                  setFormData(prev => ({
+                    ...prev,
+                    category: value as TemplateFormData['category'],
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {channelConfig.categories.map((cat: string) => (
+                    <SelectItem key={cat} value={cat}>
+                      {t(`form.categories.${cat.toLowerCase()}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-2">{t('form.language')}</label>
+              <Select
+                value={formData.language}
+                onValueChange={value => setFormData(prev => ({ ...prev, language: value }))}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="pt_BR">Português (BR)</SelectItem>
+                  <SelectItem value="en_US">English (US)</SelectItem>
+                  <SelectItem value="es_ES">Español</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Email subject */}
+          {provider === 'email' && (
+            <div>
+              <label className="block text-sm font-medium mb-2">{t('form.subject')}</label>
+              <Input
+                value={formData.subject || ''}
+                onChange={e => setFormData(prev => ({ ...prev, subject: e.target.value }))}
+                placeholder={t('form.subjectPlaceholder')}
+              />
+            </div>
+          )}
+
+          {/* Content */}
+          <div>
+            <label className="block text-sm font-medium mb-2">{t('form.content')}</label>
+            <Textarea
+              value={formData.content}
+              onChange={e => setFormData(prev => ({ ...prev, content: e.target.value }))}
+              placeholder={t('form.contentPlaceholder')}
+              rows={6}
+            />
+            <p className="text-xs text-muted-foreground mt-1">{t('form.variablesHelp')}</p>
+          </div>
+
+          {/* Detected variables */}
+          {(formData.variables?.length ?? 0) > 0 && (
+            <div className="space-y-3">
+              <label className="block text-sm font-medium">{t('form.variables')}</label>
+              {formData.variables?.map(variable => (
+                <div key={variable.name} className="grid grid-cols-4 gap-2">
+                  <Input value={variable.name} disabled />
+                  <Input
+                    value={variable.label ?? ''}
+                    onChange={e => updateVariable(variable.name, { label: e.target.value })}
+                    placeholder={t('form.variableLabel')}
+                  />
+                  <Input
+                    value={variable.example ?? ''}
+                    onChange={e => updateVariable(variable.name, { example: e.target.value })}
+                    placeholder={t('form.variableExample')}
+                  />
+                  <Input
+                    value={variable.source ?? ''}
+                    onChange={e => updateVariable(variable.name, { source: e.target.value })}
+                    placeholder={t('form.variableSource')}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Active */}
+          <div className="flex items-center justify-between p-3 bg-muted/50 rounded-lg">
+            <div>
+              <label className="block text-sm font-medium">{t('form.active')}</label>
+              <p className="text-xs text-muted-foreground">{t('form.activeHelp')}</p>
+            </div>
+            <Switch
+              checked={formData.active !== false}
+              onCheckedChange={checked => setFormData(prev => ({ ...prev, active: checked }))}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="mt-4">
+          <Button variant="outline" onClick={onClose}>
+            {t('form.cancel')}
+          </Button>
+          <Button onClick={handleSave} disabled={!isValid}>
+            {mode === 'create' ? t('form.create') : t('form.save')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default GlobalTemplateFormModal;

--- a/src/pages/Customer/Settings/MessageTemplates/index.ts
+++ b/src/pages/Customer/Settings/MessageTemplates/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MessageTemplates';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -58,6 +58,7 @@ import JourneyFlowEditor from '@/pages/Customer/Journey/JourneyFlowEditor';
 import Campaigns from '@/pages/Customer/Campaigns/Campaigns';
 import NewCampaign from '@/pages/Customer/Campaigns/NewCampaign/NewCampaign';
 import CannedResponses from '@/pages/Customer/Settings/CannedResponses';
+import MessageTemplates from '@/pages/Customer/Settings/MessageTemplates';
 import { Macros } from '@/pages/Customer/Settings/Macros';
 import Products from '@/pages/Customer/Settings/Products';
 import Templates from '@/pages/Customer/Settings/Templates/Templates';
@@ -732,6 +733,21 @@ const AppRouter = () => {
                   <MainLayout>
                     <PermissionRoute resource="canned_responses" action="read">
                       <CannedResponses />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/settings/message-templates"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="message_templates" action="read">
+                      <MessageTemplates />
                     </PermissionRoute>
                   </MainLayout>
                 </CustomerRoute>

--- a/src/services/messageTemplates/__tests__/globalMessageTemplatesService.spec.ts
+++ b/src/services/messageTemplates/__tests__/globalMessageTemplatesService.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('@/services/core/api', () => ({ default: apiMock }));
+
+vi.mock('@/services/channels/messageTemplatesService', () => ({
+  default: {
+    transformToBackendFormat: (form: { name: string; content: string }) => ({
+      name: form.name,
+      content: form.content,
+    }),
+    transformToFrontendFormat: (t: unknown) => t,
+  },
+}));
+
+import GlobalMessageTemplateService, { inferTemplateProvider } from '../globalMessageTemplatesService';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('inferTemplateProvider', () => {
+  it('prefers the persisted settings.global_provider marker', () => {
+    expect(inferTemplateProvider({ settings: { global_provider: 'email' } } as never)).toBe('email');
+    expect(inferTemplateProvider({ settings: { global_provider: 'generic' } } as never)).toBe(
+      'generic',
+    );
+  });
+
+  it('falls back to the subject heuristic for legacy templates without the marker', () => {
+    expect(inferTemplateProvider({ settings: { subject: 'Hi' } } as never)).toBe('email');
+    expect(inferTemplateProvider({ settings: {} } as never)).toBe('generic');
+    expect(inferTemplateProvider({} as never)).toBe('generic');
+  });
+});
+
+describe('globalMessageTemplatesService', () => {
+  it('lists templates in ?global=true mode', async () => {
+    apiMock.get.mockResolvedValue({ data: { success: true, data: [], meta: {} } });
+    await GlobalMessageTemplateService.getTemplates('inbox-1', { per_page: 20 });
+    expect(apiMock.get).toHaveBeenCalledWith(
+      '/inboxes/inbox-1/message_templates',
+      expect.objectContaining({ params: expect.objectContaining({ global: true, per_page: 20 }) }),
+    );
+  });
+
+  it('creates with provider nested inside message_template (read via params.dig backend-side)', async () => {
+    apiMock.post.mockResolvedValue({ data: { data: { id: 't1' } } });
+    await GlobalMessageTemplateService.createTemplate(
+      'inbox-1',
+      { name: 'x', content: 'y' } as never,
+      'email',
+    );
+    expect(apiMock.post).toHaveBeenCalledWith(
+      '/inboxes/inbox-1/message_templates',
+      {
+        message_template: {
+          name: 'x',
+          content: 'y',
+          provider: 'email',
+          settings: { global_provider: 'email' },
+        },
+      },
+      { params: { global: true } },
+    );
+  });
+
+  it('unwraps the PUT response envelope (data.template)', async () => {
+    apiMock.put.mockResolvedValue({ data: { data: { template: { id: 't1', name: 'z' } } } });
+    const result = await GlobalMessageTemplateService.updateTemplate(
+      'inbox-1',
+      't1',
+      { name: 'z', content: 'c' } as never,
+      'generic',
+    );
+    expect(result).toEqual({ id: 't1', name: 'z' });
+    expect(apiMock.put).toHaveBeenCalledWith(
+      '/inboxes/inbox-1/message_templates/t1',
+      {
+        message_template: {
+          name: 'z',
+          content: 'c',
+          provider: 'generic',
+          settings: { global_provider: 'generic' },
+        },
+      },
+      { params: { global: true } },
+    );
+  });
+
+  it('deletes in ?global=true mode', async () => {
+    apiMock.delete.mockResolvedValue({ data: { success: true } });
+    await GlobalMessageTemplateService.deleteTemplate('inbox-1', 't1');
+    expect(apiMock.delete).toHaveBeenCalledWith('/inboxes/inbox-1/message_templates/t1', {
+      params: { global: true },
+    });
+  });
+});

--- a/src/services/messageTemplates/globalMessageTemplatesService.ts
+++ b/src/services/messageTemplates/globalMessageTemplatesService.ts
@@ -1,0 +1,154 @@
+import api from '@/services/core/api';
+import MessageTemplateService from '@/services/channels/messageTemplatesService';
+import type { MessageTemplate, TemplateFormData, MessageTemplateResponse } from '@/types';
+import { extractData, extractResponse } from '@/utils/apiHelpers';
+
+/**
+ * Global (channel-independent) message templates — EVO-1233 [6.4].
+ *
+ * These hit the SAME per-inbox member routes as the channel-scoped service, but
+ * in `?global=true` mode (EVO-1231): the backend lists/creates/updates/deletes
+ * channel-less (`channel_id IS NULL`) templates and ignores the inbox in the URL.
+ *
+ * ⚠️ The route still requires a VALID, `show?`-able inbox id as a placeholder
+ * (`fetch_inbox` does `Inbox.find(params[:id])`); callers pass one resolved from
+ * the app data store. WhatsApp Cloud is intentionally NOT handled here (channel
+ * -bound; stays in the per-channel Message Templates tab).
+ */
+
+/** Provider options exposed by the global menu (channel-less only). */
+export type GlobalTemplateProvider = 'generic' | 'email';
+
+/**
+ * Map a global provider to the synthetic `channelType` the existing
+ * `transformToBackendFormat` branch logic understands. Both resolve to
+ * non-structured channels, so only the simple `content` (+ email `subject`)
+ * fields are emitted — no WhatsApp `components` builder.
+ */
+export const providerToChannelType = (provider: GlobalTemplateProvider): string =>
+  provider === 'email' ? 'Channel::Email' : 'Channel::Api';
+
+export interface GlobalTemplatesQuery {
+  page?: number;
+  per_page?: number;
+  search?: string;
+  sort_by?: 'name' | 'created_at';
+  category?: string;
+  template_type?: string;
+}
+
+const GLOBAL_PARAM = { global: true } as const;
+
+/**
+ * Build the `message_template` request body for a global template.
+ *
+ * `provider` is sent both as the sibling key the backend reads via
+ * `params.dig(:message_template, :provider)` AND persisted into
+ * `settings.global_provider`. The backend's `intended_provider` is a virtual
+ * attribute that is NOT echoed back in `serialized`, so without the settings
+ * marker an edited email template (especially one with an empty subject) would
+ * be mis-inferred as `generic` on reload. `settings` IS round-tripped.
+ */
+const buildMessageTemplatePayload = (
+  formData: TemplateFormData,
+  provider: GlobalTemplateProvider,
+) => {
+  const backendTemplate = MessageTemplateService.transformToBackendFormat(
+    formData,
+    providerToChannelType(provider),
+  );
+  return {
+    ...backendTemplate,
+    provider,
+    settings: {
+      ...(backendTemplate.settings as Record<string, unknown> | undefined),
+      global_provider: provider,
+    },
+  };
+};
+
+/**
+ * Recover a global template's provider for editing. Prefers the persisted
+ * `settings.global_provider` marker, falling back to the email-subject heuristic
+ * for templates created before the marker existed.
+ */
+export const inferTemplateProvider = (template: MessageTemplate): GlobalTemplateProvider => {
+  const marker = (template.settings as Record<string, unknown> | undefined)?.global_provider;
+  if (marker === 'email' || marker === 'generic') return marker;
+  return (template.settings as Record<string, unknown> | undefined)?.subject ? 'email' : 'generic';
+};
+
+const GlobalMessageTemplateService = {
+  /**
+   * List global (channel-less) templates with pagination + search.
+   * Never pass `per_page: -1` — that backend branch hardcodes `total_pages: 1`.
+   */
+  async getTemplates(
+    placeholderInboxId: string,
+    params?: GlobalTemplatesQuery,
+  ): Promise<MessageTemplateResponse> {
+    const response = await api.get(`/inboxes/${placeholderInboxId}/message_templates`, {
+      params: { ...GLOBAL_PARAM, ...params },
+    });
+    return extractResponse<MessageTemplate>(response) as MessageTemplateResponse;
+  },
+
+  /**
+   * Create a channel-less template. `provider` is sent as a sibling key INSIDE
+   * `message_template` (the backend reads it via `params.dig(:message_template,
+   * :provider)` — it is deliberately outside strong params). Returns the created
+   * template (POST responds with `data` = the serialized template directly).
+   */
+  async createTemplate(
+    placeholderInboxId: string,
+    formData: TemplateFormData,
+    provider: GlobalTemplateProvider,
+  ): Promise<MessageTemplate> {
+    const response = await api.post(
+      `/inboxes/${placeholderInboxId}/message_templates`,
+      { message_template: buildMessageTemplatePayload(formData, provider) },
+      { params: GLOBAL_PARAM },
+    );
+    return extractData<MessageTemplate>(response);
+  },
+
+  /**
+   * Update a channel-less template. PUT responds with `data.template` (a
+   * different envelope from POST), so unwrap the nested `template`.
+   */
+  async updateTemplate(
+    placeholderInboxId: string,
+    templateId: string,
+    formData: TemplateFormData,
+    provider: GlobalTemplateProvider,
+  ): Promise<MessageTemplate> {
+    const response = await api.put(
+      `/inboxes/${placeholderInboxId}/message_templates/${templateId}`,
+      { message_template: buildMessageTemplatePayload(formData, provider) },
+      { params: GLOBAL_PARAM },
+    );
+    const data = extractData<{ template: MessageTemplate } | MessageTemplate>(response);
+    return (data as { template: MessageTemplate }).template ?? (data as MessageTemplate);
+  },
+
+  /** Delete a channel-less template. */
+  async deleteTemplate(placeholderInboxId: string, templateId: string): Promise<void> {
+    await api.delete(`/inboxes/${placeholderInboxId}/message_templates/${templateId}`, {
+      params: GLOBAL_PARAM,
+    });
+  },
+
+  /**
+   * Convert a backend template into the form shape for editing. Reuses the
+   * channel service's transform with the synthetic channel for the template's
+   * provider.
+   */
+  toFormData(template: MessageTemplate, provider: GlobalTemplateProvider): TemplateFormData {
+    return MessageTemplateService.transformToFrontendFormat(
+      template,
+      providerToChannelType(provider),
+    );
+  },
+};
+
+export default GlobalMessageTemplateService;


### PR DESCRIPTION
## Summary
- New `/settings/message-templates` admin page (sibling of Canned Responses) to manage **global, channel-independent** message templates, consuming the backend `?global=true` CRUD (EVO-1231). Providers: **generic + email** (WhatsApp Cloud stays in the per-channel tab — it is channel-bound by design, so it cannot live in the global/channel-less menu).
- Dedicated global service (`globalMessageTemplatesService`): `?global=true` list/create/update/delete; `provider` nested inside `message_template` (backend reads it via `params.dig`); persists `settings.global_provider` so an edited template recovers its provider on reload; never sends `per_page: -1` (that backend branch hardcodes `total_pages: 1`).
- List page: pagination (`meta.pagination.total_pages`), 300ms debounced **server-side** search, **Active/Inactive** status (global/channel-less templates have no Meta approval flow, so Meta status is always null), delete confirmation. Create/edit modal reuses the existing non-structured template fields (name/content, email subject, auto-detected `{{variables}}`) driven by a provider→synthetic-channel mapping.
- Surfaces backend validation errors (e.g. duplicate-name 422) via `extractError`. i18n across all 6 locales; sidebar entry uses a distinct label/icon (not to be confused with the unrelated config-bundle "Templates" page).
- Note: the ticket was written for the upstream Chatwoot/Vue stack; this implements the intent in the actual React stack.

## Security
- No new endpoints; reuses the authenticated CRM API. Route gated by `PermissionRoute resource="message_templates" action="read"`; in-page action guards mirror Canned Responses. No secrets rendered.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean for all new files (3 pre-existing errors on `develop` are unrelated missing-dep modules).
- `pnpm exec vitest run src/services/messageTemplates src/pages/Customer/Settings/MessageTemplates` — **10 tests green** (global query + nested provider, POST/PUT envelope unwrap, delete, provider inference, list render, create modal, zero-inbox empty state, pagination).
- ESLint clean on touched files.
- Manual browser smoke pending against an environment with backend `?global=true` deployed and the `message_templates` permission seeded (see auth PR).

## Changed Files
- `src/services/messageTemplates/globalMessageTemplatesService.ts` (+ spec)
- `src/pages/Customer/Settings/MessageTemplates/` — `MessageTemplates.tsx`, `components/GlobalTemplateFormModal.tsx`, `index.ts` (+ spec)
- `src/routes/index.tsx`, `src/components/layout/config/menuItems.ts`, `src/config/permissions.ts`
- `src/i18n/config.ts`, `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/messageTemplates.json` (new) + `layout.json` (menu key)

## Related PRs
- evo-auth-service-community (RBAC `message_templates` permission — seed required for the route gate): https://github.com/evolution-foundation/evo-auth-service-community/pull/40
- Depends on backend EVO-1231 (`?global=true` CRUD) being deployed on the CRM the frontend targets.

## Linked Issue
- EVO-1233
