### PR TITLE
feat(journey): template mode on Send Message node config (EVO-1255)

### DIFF
--- a/src/components/journey/nodes/actions/send-message/SendMessageNode.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessageNode.tsx
@@ -9,6 +9,14 @@ export interface SendMessageNodeData {
   inboxId?: string;
   inboxName?: string;
 
+  // Template mode (EVO-1255): 'text' keeps the free-form message; 'template'
+  // sends a CRM message template (mandatory for WhatsApp Cloud channels).
+  messageMode?: 'text' | 'template';
+  templateId?: string;
+  templateName?: string;
+  templateLanguage?: string;
+  templateParams?: Record<string, string>;
+
   // Opção para usar canal do evento gerado
   useEventChannel?: boolean;
 
@@ -41,7 +49,15 @@ interface SendMessageNodeProps {
 export function SendMessageNode({ selected, data, id }: SendMessageNodeProps) {
   const { t } = useLanguage('journey');
 
+  const isTemplateMode = data.messageMode === 'template';
+
   const getDisplayText = () => {
+    if (isTemplateMode) {
+      return data.templateName
+        ? `${t('flowEditor.nodes.sendMessage.templateLabel')} ${data.templateName}`
+        : t('flowEditor.nodes.sendMessage.templateNotSelected');
+    }
+
     if (!data.message || data.message.trim() === '') {
       return t('flowEditor.nodes.sendMessage.description');
     }

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.spec.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SendMessagePanel } from './SendMessagePanel';
+import MessageTemplateService from '@/services/channels/messageTemplatesService';
+import { automationService } from '@/services/automation/automationService';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+vi.mock('@/services/automation/automationService', () => ({
+  automationService: { getFormData: vi.fn() },
+}));
+
+vi.mock('@/services/channels/messageTemplatesService', () => ({
+  default: { getTemplates: vi.fn() },
+}));
+
+vi.mock('@/components/journey/environment-manager', () => ({
+  VariableTextarea: ({ value, onChange, placeholder }: any) => (
+    <textarea value={value} onChange={onChange} placeholder={placeholder} />
+  ),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mockedFormData = vi.mocked(automationService.getFormData);
+const mockedGetTemplates = vi.mocked(MessageTemplateService.getTemplates);
+
+const inboxes = [
+  { id: 'i1', name: 'WA Cloud', channel_type: 'Channel::Whatsapp', provider: 'whatsapp_cloud' },
+  { id: 'i2', name: 'WA Evolution', channel_type: 'Channel::Whatsapp', provider: 'evolution' },
+  { id: 'i3', name: 'Email Box', channel_type: 'Channel::Email' },
+];
+
+const template = {
+  id: 'tpl-1',
+  name: 'welcome',
+  content: 'Olá {{first_name}}!',
+  language: 'pt_BR',
+  category: 'UTILITY' as const,
+  variables: [{ name: 'first_name', label: 'First name', required: true }],
+};
+
+const noop = () => {};
+
+const renderPanel = (data: Record<string, unknown>) =>
+  render(
+    <SendMessagePanel nodeId="n1" data={data as any} onUpdate={noop} onClose={noop} />,
+  );
+
+beforeEach(() => {
+  mockedFormData.mockReset().mockResolvedValue({ inboxes } as any);
+  mockedGetTemplates.mockReset().mockResolvedValue({ success: true, data: [template] } as any);
+});
+
+describe('SendMessagePanel template mode (EVO-1255)', () => {
+  it('AC1: forces template mode for a WhatsApp Cloud inbox and locks free text', async () => {
+    renderPanel({ inboxId: 'i1', message: '' });
+
+    await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalledWith('i1', expect.anything()));
+    expect(screen.getByText('panels.sendMessage.templateRequiredForCloud')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'panels.sendMessage.modeText' }),
+    ).toBeDisabled();
+  });
+
+  it('AC2: keeps free-text mode available for non-Cloud channels', async () => {
+    renderPanel({ inboxId: 'i2', message: 'hello' });
+
+    await waitFor(() => expect(mockedFormData).toHaveBeenCalled());
+    expect(mockedGetTemplates).not.toHaveBeenCalled();
+    expect(screen.getByText('panels.sendMessage.message')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'panels.sendMessage.modeText' }),
+    ).not.toBeDisabled();
+  });
+
+  it('AC3: flags missing template selection in template mode', async () => {
+    renderPanel({ inboxId: 'i2', messageMode: 'template', message: '' });
+
+    await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalled());
+    expect(
+      await screen.findByText('panels.sendMessage.selectTemplateValidation'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders variable inputs and flags empty required variables', async () => {
+    renderPanel({
+      inboxId: 'i2',
+      messageMode: 'template',
+      templateId: 'tpl-1',
+      templateParams: { first_name: '' },
+      message: '',
+    });
+
+    await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalled());
+    expect(await screen.findByText('First name')).toBeInTheDocument();
+    expect(screen.getByText('panels.sendMessage.fillRequiredVariables')).toBeInTheDocument();
+    expect(screen.getByText('Olá {{first_name}}!')).toBeInTheDocument();
+  });
+
+  it('flags a template that no longer exists', async () => {
+    mockedGetTemplates.mockResolvedValue({ success: true, data: [] } as any);
+    renderPanel({ inboxId: 'i2', messageMode: 'template', templateId: 'tpl-gone', message: '' });
+
+    await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalled());
+    expect(
+      await screen.findByText('panels.sendMessage.templateUnavailable'),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the event-channel option and attachments in template mode', async () => {
+    renderPanel({ inboxId: 'i2', messageMode: 'template', message: '' });
+
+    await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalled());
+    expect(screen.queryByText('panels.sendMessage.useEventChannel')).toBeNull();
+    expect(screen.queryByText('panels.sendMessage.attachments')).toBeNull();
+  });
+});

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
@@ -28,8 +28,17 @@ import { SendMessageNodeData } from './SendMessageNode';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { automationService } from '@/services/automation/automationService';
+import MessageTemplateService from '@/services/channels/messageTemplatesService';
+import type { MessageTemplate } from '@/types/channels/inbox';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
+
+// WhatsApp Cloud requires a Meta-approved template for bot-initiated messages
+// outside the 24h window — both STI spellings exist across the codebase.
+const isWhatsappCloudInbox = (inbox: { channel_type?: string; provider?: string } | undefined) =>
+  !!inbox &&
+  (inbox.channel_type === 'Channel::WhatsappCloud' ||
+    (inbox.channel_type === 'Channel::Whatsapp' && inbox.provider === 'whatsapp_cloud'));
 
 interface SendMessagePanelProps {
   nodeId: string;
@@ -126,6 +135,11 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
     message: data.message || '',
     inboxId: data.inboxId || '',
     inboxName: data.inboxName || '',
+    messageMode: data.messageMode || 'text',
+    templateId: data.templateId || '',
+    templateName: data.templateName || '',
+    templateLanguage: data.templateLanguage || '',
+    templateParams: data.templateParams || {},
     useEventChannel: data.useEventChannel || false,
     hasAttachment: data.hasAttachment || false,
     attachment_ids: data.attachment_ids || [],
@@ -141,8 +155,54 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
   }>({});
   const [loading, setLoading] = useState(true);
   const [filteredInboxes, setFilteredInboxes] = useState<any[]>([]);
+  const [templates, setTemplates] = useState<MessageTemplate[]>([]);
+  const [loadingTemplates, setLoadingTemplates] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isTemplateMode = formData.messageMode === 'template';
+  const selectedInbox = filteredInboxes.find(
+    (inbox: { id: string | number }) => String(inbox.id) === String(formData.inboxId),
+  );
+  const isCloudInbox = isWhatsappCloudInbox(selectedInbox);
+  const selectedTemplate = templates.find(
+    template => String(template.id) === String(formData.templateId),
+  );
+
+  // WhatsApp Cloud forces template mode (Meta-approved templates only).
+  useEffect(() => {
+    if (isCloudInbox && formData.messageMode !== 'template') {
+      setFormData(prev => ({ ...prev, messageMode: 'template' }));
+    }
+  }, [isCloudInbox, formData.messageMode]);
+
+  useEffect(() => {
+    if (!isTemplateMode || !formData.inboxId) {
+      setTemplates([]);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingTemplates(true);
+    MessageTemplateService.getTemplates(formData.inboxId, { active: true, per_page: -1 })
+      .then(response => {
+        if (!cancelled) setTemplates(Array.isArray(response.data) ? response.data : []);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTemplates([]);
+          toast.error(t('panels.sendMessage.templatesLoadError'));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingTemplates(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isTemplateMode, formData.inboxId]);
 
   useEffect(() => {
     const loadFormData = async () => {
@@ -251,11 +311,52 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
   };
 
   const handleInboxChange = (inboxId: string) => {
-    const selectedInbox = filteredInboxes.find((inbox: any) => inbox.id === inboxId);
+    const inbox = filteredInboxes.find(
+      (item: { id: string | number }) => String(item.id) === inboxId,
+    );
+    // Templates are channel-scoped: switching inbox invalidates the selection.
     setFormData(prev => ({
       ...prev,
       inboxId,
-      inboxName: selectedInbox?.name || '',
+      inboxName: inbox?.name || '',
+      templateId: '',
+      templateName: '',
+      templateLanguage: '',
+      templateParams: {},
+      messageMode: isWhatsappCloudInbox(inbox) ? 'template' : prev.messageMode,
+    }));
+  };
+
+  const handleModeChange = (mode: 'text' | 'template') => {
+    if (isCloudInbox && mode === 'text') return;
+    setFormData(prev => ({
+      ...prev,
+      messageMode: mode,
+      // Template mode needs an explicit inbox: the event channel is unknown
+      // at config time, so there is no template list to pick from.
+      useEventChannel: mode === 'template' ? false : prev.useEventChannel,
+    }));
+  };
+
+  const handleTemplateChange = (templateId: string) => {
+    const template = templates.find(item => String(item.id) === templateId);
+    const defaults: Record<string, string> = {};
+    (template?.variables ?? []).forEach(variable => {
+      if (variable.name) defaults[variable.name] = variable.default_value || '';
+    });
+    setFormData(prev => ({
+      ...prev,
+      templateId,
+      templateName: template?.name || '',
+      templateLanguage: template?.language || '',
+      templateParams: defaults,
+    }));
+  };
+
+  const handleTemplateParamChange = (name: string, value: string) => {
+    setFormData(prev => ({
+      ...prev,
+      templateParams: { ...(prev.templateParams ?? {}), [name]: value },
     }));
   };
 
@@ -296,12 +397,29 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
 
   const uploadedCount = attachments.filter(att => att.status === 'uploaded').length;
   const hasUploading = attachments.some(att => att.status === 'uploading');
-  const isValid = !!(
-    formData.message?.trim() &&
-    (formData.useEventChannel || formData.inboxId) &&
-    getCharacterCount() <= 1000 &&
-    !hasUploading
-  );
+  const missingRequiredVariables = isTemplateMode
+    ? (selectedTemplate?.variables ?? []).filter(
+        variable =>
+          variable.required &&
+          variable.name &&
+          !(formData.templateParams?.[variable.name] ?? '').trim(),
+      )
+    : [];
+  const isValid = isTemplateMode
+    ? !!(
+        formData.inboxId &&
+        formData.templateId &&
+        !loadingTemplates &&
+        selectedTemplate &&
+        missingRequiredVariables.length === 0 &&
+        !hasUploading
+      )
+    : !!(
+        formData.message?.trim() &&
+        (formData.useEventChannel || formData.inboxId) &&
+        getCharacterCount() <= 1000 &&
+        !hasUploading
+      );
   const dirty = useMemo(
     () =>
       JSON.stringify(formData) !== JSON.stringify(originalData) ||
@@ -327,38 +445,85 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           <FlowFeedbackBanner variant="warn">
             <p className="font-medium">{t('panels.sendMessage.incompleteConfig')}:</p>
             <ul className="text-xs mt-1 list-disc list-inside">
-              {!formData.message?.trim() && <li>{t('panels.sendMessage.enterMessage')}</li>}
-              {!formData.useEventChannel && !formData.inboxId && (
+              {!isTemplateMode && !formData.message?.trim() && (
+                <li>{t('panels.sendMessage.enterMessage')}</li>
+              )}
+              {!isTemplateMode && !formData.useEventChannel && !formData.inboxId && (
                 <li>{t('panels.sendMessage.selectChannelOrEvent')}</li>
               )}
-              {getCharacterCount() > 1000 && <li>{t('panels.sendMessage.messageTooLong')}</li>}
+              {!isTemplateMode && getCharacterCount() > 1000 && (
+                <li>{t('panels.sendMessage.messageTooLong')}</li>
+              )}
+              {isTemplateMode && !formData.inboxId && (
+                <li>{t('panels.sendMessage.selectChannelForTemplate')}</li>
+              )}
+              {isTemplateMode && formData.inboxId && !formData.templateId && !loadingTemplates && (
+                <li>{t('panels.sendMessage.selectTemplateValidation')}</li>
+              )}
+              {isTemplateMode &&
+                !!formData.templateId &&
+                !selectedTemplate &&
+                !loadingTemplates && <li>{t('panels.sendMessage.templateUnavailable')}</li>}
+              {isTemplateMode && missingRequiredVariables.length > 0 && (
+                <li>{t('panels.sendMessage.fillRequiredVariables')}</li>
+              )}
               {hasUploading && <li>{t('panels.sendMessage.waitingUpload')}</li>}
             </ul>
           </FlowFeedbackBanner>
         )}
 
-        <div className="space-y-3">
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="useEventChannel"
-              checked={formData.useEventChannel}
-              onCheckedChange={checked => {
-                setFormData(prev => ({
-                  ...prev,
-                  useEventChannel: !!checked,
-                  inboxId: checked ? '' : prev.inboxId,
-                  inboxName: checked ? '' : prev.inboxName,
-                }));
-              }}
-            />
-            <Label htmlFor="useEventChannel" className="text-sm font-medium cursor-pointer">
-              {t('panels.sendMessage.useEventChannel')}
-            </Label>
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">{t('panels.sendMessage.mode')}</Label>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={isTemplateMode ? 'outline' : 'default'}
+              disabled={isCloudInbox}
+              onClick={() => handleModeChange('text')}
+            >
+              {t('panels.sendMessage.modeText')}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={isTemplateMode ? 'default' : 'outline'}
+              onClick={() => handleModeChange('template')}
+            >
+              {t('panels.sendMessage.modeTemplate')}
+            </Button>
           </div>
-          <p className="text-xs text-muted-foreground">
-            {t('panels.sendMessage.useEventChannelDescription')}
-          </p>
+          {isCloudInbox && (
+            <p className="text-xs text-muted-foreground">
+              {t('panels.sendMessage.templateRequiredForCloud')}
+            </p>
+          )}
         </div>
+
+        {!isTemplateMode && (
+          <div className="space-y-3">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="useEventChannel"
+                checked={formData.useEventChannel}
+                onCheckedChange={checked => {
+                  setFormData(prev => ({
+                    ...prev,
+                    useEventChannel: !!checked,
+                    inboxId: checked ? '' : prev.inboxId,
+                    inboxName: checked ? '' : prev.inboxName,
+                  }));
+                }}
+              />
+              <Label htmlFor="useEventChannel" className="text-sm font-medium cursor-pointer">
+                {t('panels.sendMessage.useEventChannel')}
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t('panels.sendMessage.useEventChannelDescription')}
+            </p>
+          </div>
+        )}
 
         {!formData.useEventChannel && (
           <div className="space-y-2">
@@ -409,25 +574,136 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           </div>
         )}
 
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('panels.sendMessage.message')}</Label>
-          <VariableTextarea
-            value={formData.message || ''}
-            onChange={e => setFormData(prev => ({ ...prev, message: e.target.value }))}
-            placeholder={t('panels.sendMessage.messagePlaceholder')}
-            className="min-h-[120px] resize-none"
-            disabled={loading}
-            onVariableInsert={variable => {
-              console.log('Variable inserted:', variable);
-            }}
-          />
+        {isTemplateMode ? (
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">{t('panels.sendMessage.template')}</Label>
+              {!formData.inboxId ? (
+                <p className="text-xs text-muted-foreground">
+                  {t('panels.sendMessage.selectChannelForTemplate')}
+                </p>
+              ) : loadingTemplates ? (
+                <div className="flex items-center gap-2 p-3 border border-dashed border-border rounded-lg">
+                  <div className="animate-spin w-4 h-4 border-2 border-flow-node-action-message-fg border-t-transparent rounded-full" />
+                  <span className="text-sm text-muted-foreground">
+                    {t('panels.sendMessage.loadingTemplates')}
+                  </span>
+                </div>
+              ) : templates.length === 0 ? (
+                <Card className="p-4 text-center">
+                  <AlertCircle className="w-6 h-6 text-muted-foreground mx-auto mb-2" />
+                  <p className="text-xs text-muted-foreground">
+                    {t('panels.sendMessage.noTemplates')}
+                  </p>
+                </Card>
+              ) : (
+                <Select value={formData.templateId} onValueChange={handleTemplateChange}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t('panels.sendMessage.chooseTemplate')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {templates.map(template => (
+                      <SelectItem key={template.id} value={String(template.id)}>
+                        <div className="flex items-center gap-2">
+                          <span>{template.name}</span>
+                          {template.language && (
+                            <span className="text-xs text-muted-foreground">
+                              ({template.language})
+                            </span>
+                          )}
+                          {template.category && (
+                            <Badge variant="outline" className="text-[10px]">
+                              {template.category}
+                            </Badge>
+                          )}
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
 
-          <div className="flex justify-between items-center text-xs">
-            <span className="text-muted-foreground">{t('panels.sendMessage.useVariables')}</span>
-            <span className={getCharacterCountColor()}>{getCharacterCount()}/1000</span>
+            {selectedTemplate && (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">
+                  {t('panels.sendMessage.templatePreview')}
+                </Label>
+                <Card className="p-3 space-y-2">
+                  {Array.isArray(selectedTemplate.components) &&
+                  selectedTemplate.components.length > 0 ? (
+                    selectedTemplate.components.map((component, index) =>
+                      component?.text ? (
+                        <p
+                          key={index}
+                          className={
+                            component.type === 'BODY'
+                              ? 'text-sm whitespace-pre-wrap'
+                              : 'text-xs text-muted-foreground whitespace-pre-wrap'
+                          }
+                        >
+                          {component.text}
+                        </p>
+                      ) : null,
+                    )
+                  ) : (
+                    <p className="text-sm whitespace-pre-wrap">{selectedTemplate.content}</p>
+                  )}
+                </Card>
+              </div>
+            )}
+
+            {selectedTemplate && (selectedTemplate.variables?.length ?? 0) > 0 && (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium">
+                  {t('panels.sendMessage.templateVariables')}
+                </Label>
+                <div className="space-y-2">
+                  {selectedTemplate.variables!.map(variable =>
+                    variable.name ? (
+                      <div key={variable.name} className="space-y-1">
+                        <Label className="text-xs text-muted-foreground">
+                          {variable.label || variable.name}
+                          {variable.required && <span className="text-flow-feedback-error-fg"> *</span>}
+                        </Label>
+                        <VariableTextarea
+                          value={formData.templateParams?.[variable.name] ?? ''}
+                          onChange={e => handleTemplateParamChange(variable.name!, e.target.value)}
+                          placeholder={variable.example || `{{${variable.name}}}`}
+                          className="min-h-[40px] resize-none"
+                        />
+                      </div>
+                    ) : null,
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t('panels.sendMessage.useVariables')}
+                </p>
+              </div>
+            )}
           </div>
-        </div>
+        ) : (
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">{t('panels.sendMessage.message')}</Label>
+            <VariableTextarea
+              value={formData.message || ''}
+              onChange={e => setFormData(prev => ({ ...prev, message: e.target.value }))}
+              placeholder={t('panels.sendMessage.messagePlaceholder')}
+              className="min-h-[120px] resize-none"
+              disabled={loading}
+              onVariableInsert={variable => {
+                console.log('Variable inserted:', variable);
+              }}
+            />
 
+            <div className="flex justify-between items-center text-xs">
+              <span className="text-muted-foreground">{t('panels.sendMessage.useVariables')}</span>
+              <span className={getCharacterCountColor()}>{getCharacterCount()}/1000</span>
+            </div>
+          </div>
+        )}
+
+        {!isTemplateMode && (
         <div className="space-y-2">
           <Label className="text-sm font-medium">{t('panels.sendMessage.attachments')}</Label>
 
@@ -465,8 +741,9 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
             />
           </div>
         </div>
+        )}
 
-        {attachments.length > 0 && (
+        {!isTemplateMode && attachments.length > 0 && (
           <div className="space-y-2">
             <Label className="text-sm font-medium">
               {t('panels.sendMessage.attachmentsList', { count: attachments.length })}
@@ -518,13 +795,23 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
           </div>
         )}
 
-        {formData.message?.trim() && (
+        {(isTemplateMode ? !!selectedTemplate : !!formData.message?.trim()) && (
           <FlowFeedbackBanner variant="info">
             <div className="flex items-start gap-3">
               <MessageSquare className="w-4 h-4 mt-1 shrink-0" />
               <div className="flex-1">
-                <p className="font-medium">{t('panels.sendMessage.messageConfigured')}</p>
-                <p className="text-sm mt-1">"{formData.message.trim()}"</p>
+                <p className="font-medium">
+                  {isTemplateMode
+                    ? t('panels.sendMessage.templateConfigured')
+                    : t('panels.sendMessage.messageConfigured')}
+                </p>
+                <p className="text-sm mt-1">
+                  {isTemplateMode
+                    ? `${selectedTemplate?.name}${
+                        selectedTemplate?.language ? ` (${selectedTemplate.language})` : ''
+                      }`
+                    : `"${formData.message?.trim()}"`}
+                </p>
 
                 {(formData.useEventChannel || formData.inboxName) && (
                   <Badge variant="outline" className="mt-2">

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
@@ -361,7 +361,11 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
   };
 
   const handleSave = () => {
-    const uploadedAttachments = attachments.filter(att => att.status === 'uploaded');
+    // Attachments belong to free-text mode only; a mode switch must not leak
+    // previously uploaded files into a template send.
+    const uploadedAttachments = isTemplateMode
+      ? []
+      : attachments.filter(att => att.status === 'uploaded');
     const hasAttachments = uploadedAttachments.length > 0;
 
     const updatedData: SendMessageNodeData = {

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -253,7 +253,9 @@
         "eventChannel": "Event Channel",
         "oneAttachment": "+ 1 attachment",
         "multipleAttachments": "+ {{count}} attachments",
-        "channelLabel": "Channel:"
+        "channelLabel": "Channel:",
+        "templateLabel": "Template:",
+        "templateNotSelected": "No template selected"
       },
       "sendWebhook": {
         "name": "Send Webhook",
@@ -683,7 +685,23 @@
       "oneAttachment": "1 attachment",
       "multipleAttachments": "{{count}} attachments",
       "completeConfig": "Complete the Configuration",
-      "waitingUpload": "Wait for the upload of the attachments"
+      "waitingUpload": "Wait for the upload of the attachments",
+      "mode": "Mode",
+      "modeText": "Free text",
+      "modeTemplate": "Message template",
+      "templateRequiredForCloud": "WhatsApp Cloud requires a Meta-approved template — Template mode is mandatory.",
+      "template": "Template",
+      "chooseTemplate": "Choose a template",
+      "loadingTemplates": "Loading templates...",
+      "noTemplates": "No active templates for this channel",
+      "templatePreview": "Preview",
+      "templateVariables": "Template variables",
+      "selectChannelForTemplate": "Select a channel to list templates",
+      "selectTemplateValidation": "Select a template",
+      "templateUnavailable": "The selected template is no longer available",
+      "fillRequiredVariables": "Fill in the required variables",
+      "templatesLoadError": "Failed to load templates",
+      "templateConfigured": "Template configured"
     },
     "sendWebhook": {
       "title": "Configure Webhook",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -253,7 +253,9 @@
         "eventChannel": "Canal del Evento",
         "oneAttachment": "+ 1 adjunto",
         "multipleAttachments": "+ {{count}} adjuntos",
-        "channelLabel": "Canal:"
+        "channelLabel": "Canal:",
+        "templateLabel": "Plantilla:",
+        "templateNotSelected": "Plantilla no seleccionada"
       },
       "sendWebhook": {
         "name": "Enviar Webhook",
@@ -666,7 +668,23 @@
       "oneAttachment": "1 attachment",
       "multipleAttachments": "{{count}} attachments",
       "completeConfig": "Complete the Configuration",
-      "waitingUpload": "Wait for the upload of the attachments"
+      "waitingUpload": "Wait for the upload of the attachments",
+      "mode": "Modo",
+      "modeText": "Texto libre",
+      "modeTemplate": "Plantilla de mensaje",
+      "templateRequiredForCloud": "WhatsApp Cloud exige una plantilla aprobada por Meta — el modo Plantilla es obligatorio.",
+      "template": "Plantilla",
+      "chooseTemplate": "Elige una plantilla",
+      "loadingTemplates": "Cargando plantillas...",
+      "noTemplates": "No hay plantillas activas para este canal",
+      "templatePreview": "Vista previa",
+      "templateVariables": "Variables de la plantilla",
+      "selectChannelForTemplate": "Selecciona un canal para listar las plantillas",
+      "selectTemplateValidation": "Selecciona una plantilla",
+      "templateUnavailable": "La plantilla seleccionada ya no está disponible",
+      "fillRequiredVariables": "Completa las variables obligatorias",
+      "templatesLoadError": "Error al cargar las plantillas",
+      "templateConfigured": "Plantilla configurada"
     },
     "sendWebhook": {
       "title": "Configure Webhook",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -253,7 +253,9 @@
         "eventChannel": "Canal de l'événement",
         "oneAttachment": "+ 1 pièce jointe",
         "multipleAttachments": "+ {{count}} pièces jointes",
-        "channelLabel": "Canal :"
+        "channelLabel": "Canal :",
+        "templateLabel": "Modèle :",
+        "templateNotSelected": "Aucun modèle sélectionné"
       },
       "sendWebhook": {
         "name": "Envoyer un webhook",
@@ -666,7 +668,23 @@
       "oneAttachment": "1 attachment",
       "multipleAttachments": "{{count}} attachments",
       "completeConfig": "Complete the Configuration",
-      "waitingUpload": "Wait for the upload of the attachments"
+      "waitingUpload": "Wait for the upload of the attachments",
+      "mode": "Mode",
+      "modeText": "Texte libre",
+      "modeTemplate": "Modèle de message",
+      "templateRequiredForCloud": "WhatsApp Cloud exige un modèle approuvé par Meta — le mode Modèle est obligatoire.",
+      "template": "Modèle",
+      "chooseTemplate": "Choisissez un modèle",
+      "loadingTemplates": "Chargement des modèles...",
+      "noTemplates": "Aucun modèle actif pour ce canal",
+      "templatePreview": "Aperçu",
+      "templateVariables": "Variables du modèle",
+      "selectChannelForTemplate": "Sélectionnez un canal pour lister les modèles",
+      "selectTemplateValidation": "Sélectionnez un modèle",
+      "templateUnavailable": "Le modèle sélectionné n'est plus disponible",
+      "fillRequiredVariables": "Renseignez les variables obligatoires",
+      "templatesLoadError": "Échec du chargement des modèles",
+      "templateConfigured": "Modèle configuré"
     },
     "sendWebhook": {
       "title": "Configure Webhook",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -265,7 +265,9 @@
         "eventChannel": "Canale dell'Evento",
         "oneAttachment": "+ 1 allegato",
         "multipleAttachments": "+ {{count}} allegati",
-        "channelLabel": "Canale:"
+        "channelLabel": "Canale:",
+        "templateLabel": "Modello:",
+        "templateNotSelected": "Nessun modello selezionato"
       },
       "sendWebhook": {
         "name": "Invia Webhook",
@@ -678,7 +680,23 @@
       "oneAttachment": "1 attachment",
       "multipleAttachments": "{{count}} attachments",
       "completeConfig": "Complete the Configuration",
-      "waitingUpload": "Wait for the upload of the attachments"
+      "waitingUpload": "Wait for the upload of the attachments",
+      "mode": "Modalità",
+      "modeText": "Testo libero",
+      "modeTemplate": "Modello di messaggio",
+      "templateRequiredForCloud": "WhatsApp Cloud richiede un modello approvato da Meta — la modalità Modello è obbligatoria.",
+      "template": "Modello",
+      "chooseTemplate": "Scegli un modello",
+      "loadingTemplates": "Caricamento modelli...",
+      "noTemplates": "Nessun modello attivo per questo canale",
+      "templatePreview": "Anteprima",
+      "templateVariables": "Variabili del modello",
+      "selectChannelForTemplate": "Seleziona un canale per elencare i modelli",
+      "selectTemplateValidation": "Seleziona un modello",
+      "templateUnavailable": "Il modello selezionato non è più disponibile",
+      "fillRequiredVariables": "Compila le variabili obbligatorie",
+      "templatesLoadError": "Errore nel caricamento dei modelli",
+      "templateConfigured": "Modello configurato"
     },
     "sendWebhook": {
       "title": "Configure Webhook",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -253,7 +253,9 @@
         "eventChannel": "Canal do Evento",
         "oneAttachment": "+ 1 anexo",
         "multipleAttachments": "+ {{count}} anexos",
-        "channelLabel": "Canal:"
+        "channelLabel": "Canal:",
+        "templateLabel": "Template:",
+        "templateNotSelected": "Template não selecionado"
       },
       "sendWebhook": {
         "name": "Enviar Webhook",
@@ -683,7 +685,23 @@
       "oneAttachment": "1 anexo",
       "multipleAttachments": "{{count}} anexos",
       "completeConfig": "Conclua a Configuração",
-      "waitingUpload": "Aguarde o upload dos anexos"
+      "waitingUpload": "Aguarde o upload dos anexos",
+      "mode": "Modo",
+      "modeText": "Texto livre",
+      "modeTemplate": "Template de mensagem",
+      "templateRequiredForCloud": "WhatsApp Cloud exige template aprovado pela Meta — o modo Template é obrigatório.",
+      "template": "Template",
+      "chooseTemplate": "Escolha um template",
+      "loadingTemplates": "Carregando templates...",
+      "noTemplates": "Nenhum template ativo para este canal",
+      "templatePreview": "Pré-visualização",
+      "templateVariables": "Variáveis do template",
+      "selectChannelForTemplate": "Selecione um canal para listar os templates",
+      "selectTemplateValidation": "Selecione um template",
+      "templateUnavailable": "O template selecionado não está mais disponível",
+      "fillRequiredVariables": "Preencha as variáveis obrigatórias",
+      "templatesLoadError": "Erro ao carregar os templates",
+      "templateConfigured": "Template configurado"
     },
     "sendWebhook": {
       "title": "Configurar Webhook",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -253,7 +253,9 @@
         "eventChannel": "Canal do Evento",
         "oneAttachment": "+ 1 anexo",
         "multipleAttachments": "+ {{count}} anexos",
-        "channelLabel": "Canal:"
+        "channelLabel": "Canal:",
+        "templateLabel": "Template:",
+        "templateNotSelected": "Template não selecionado"
       },
       "sendWebhook": {
         "name": "Enviar Webhook",
@@ -666,7 +668,23 @@
       "oneAttachment": "1 attachment",
       "multipleAttachments": "{{count}} attachments",
       "completeConfig": "Complete the Configuration",
-      "waitingUpload": "Wait for the upload of the attachments"
+      "waitingUpload": "Wait for the upload of the attachments",
+      "mode": "Modo",
+      "modeText": "Texto livre",
+      "modeTemplate": "Template de mensagem",
+      "templateRequiredForCloud": "O WhatsApp Cloud exige um template aprovado pela Meta — o modo Template é obrigatório.",
+      "template": "Template",
+      "chooseTemplate": "Escolha um template",
+      "loadingTemplates": "A carregar templates...",
+      "noTemplates": "Nenhum template ativo para este canal",
+      "templatePreview": "Pré-visualização",
+      "templateVariables": "Variáveis do template",
+      "selectChannelForTemplate": "Selecione um canal para listar os templates",
+      "selectTemplateValidation": "Selecione um template",
+      "templateUnavailable": "O template selecionado já não está disponível",
+      "fillRequiredVariables": "Preencha as variáveis obrigatórias",
+      "templatesLoadError": "Erro ao carregar os templates",
+      "templateConfigured": "Template configurado"
     },
     "sendWebhook": {
       "title": "Configure Webhook",


### PR DESCRIPTION
## Summary
- Send Message panel gains a Mode toggle (free text / message template). Template mode lists the inbox's active CRM templates via the existing `messageTemplatesService` (no new service — minimal overlap with EVO-1233's templates UI), previews content/components, renders one input per template variable (required ones gate Save via the existing `dirty && isValid` mechanism) and stores `templateId`/`name`/`language`/`params` on the node.
- WhatsApp Cloud inboxes force template mode (Meta-approved templates only) — free-text toggle locked with an explanatory hint. Detection covers both `Channel::WhatsappCloud` and `Channel::Whatsapp` + `provider=whatsapp_cloud`.
- Template mode requires an explicit inbox (event-channel hidden — the channel is unknown at config time) and hides attachments (free-text only; stale uploads are dropped on save). Switching inbox resets the selected template.
- Canvas node shows the configured template name. New i18n keys in all six journey locales.

## Security
- No new endpoints; templates fetched through the authenticated client. Preview renders text only (no dangerouslySetInnerHTML).

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec vitest run src/components/journey/nodes/actions/send-message/SendMessagePanel.spec.tsx` — 6 specs (Cloud enforcement, free-text availability, missing-template validation, required variables, deleted template, event-channel/attachments hidden)

## Changed Files
- `src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx` (+ new spec)
- `src/components/journey/nodes/actions/send-message/SendMessageNode.tsx` — node data fields + canvas display
- `src/i18n/locales/{pt-BR,en,es,fr,it,pt}/journey.json`

## Related PRs
- evo-flow: https://github.com/evolution-foundation/evo-flow/pull/50 (execution-side)
- evo-ai-crm-community: https://github.com/evolution-foundation/evo-ai-crm-community/pull/134 (service-token policy fix — merge first)

## Linked Issue
- EVO-1255