### PR TITLE
feat(templates): send message_template_id from template composer (EVO-1235)

### DIFF
--- a/src/components/chat/message-template/MessageTemplateModal.tsx
+++ b/src/components/chat/message-template/MessageTemplateModal.tsx
@@ -22,6 +22,7 @@ interface MessageTemplateModalProps {
   onSend: (payload: {
     message: string;
     templateParams?: {
+      id: string;
       name: string;
       category: string;
       language: string;
@@ -112,6 +113,7 @@ const MessageTemplateModal: React.FC<MessageTemplateModalProps> = ({
   const handleSendMessage = async (payload: {
     message: string;
     templateParams: {
+      id: string;
       name: string;
       category: string;
       language: string;

--- a/src/components/chat/message-template/TemplateParser.tsx
+++ b/src/components/chat/message-template/TemplateParser.tsx
@@ -14,6 +14,7 @@ interface TemplateParserProps {
   onSend: (payload: {
     message: string;
     templateParams: {
+      id: string;
       name: string;
       category: string;
       language: string;
@@ -108,6 +109,7 @@ const TemplateParser: React.FC<TemplateParserProps> = ({ template, channelType, 
     const payload = {
       message: '', // Backend will populate from template
       templateParams: {
+        id: template.id, // EVO-1235: canonical key — backend resolves id-first (global-aware)
         name: template.name,
         category: template.category || 'UTILITY',
         language: template.language,

--- a/src/components/contacts/StartConversationModal.tsx
+++ b/src/components/contacts/StartConversationModal.tsx
@@ -281,6 +281,7 @@ export default function StartConversationModal({
         conversationData.message = {
           content: '', // Backend will populate this from template
           template_params: {
+            id: selectedTemplate.id, // EVO-1235: canonical key — backend resolves id-first (global-aware)
             name: selectedTemplate.name,
             category: selectedTemplate.category || 'UTILITY',
             language: selectedTemplate.language,

--- a/src/types/chat/api.ts
+++ b/src/types/chat/api.ts
@@ -304,6 +304,7 @@ export interface CreateConversationRequest {
     content: string;
     private?: boolean;
     template_params?: {
+      id?: string;
       name: string;
       category: string;
       language: string;
@@ -335,6 +336,7 @@ export interface SendMessageRequest {
   attachments?: File[];
   message_type: MessageTypeValue;
   template_params?: {
+    id?: string;
     name: string;
     category: string;
     language: string;


### PR DESCRIPTION
## Summary

Story 6.6 (frontend half) — include the resolved template `id` in `template_params` when sending, so the backend resolves templates by `message_template_id` (global-aware) instead of by name. The inbox reply, the template modal, and the start-conversation flow all already pick a known template record, so passing its `id` is purely additive.

## Changes

- `message-template/TemplateParser.tsx`: add `id: template.id` to the send payload (+ type).
- `message-template/MessageTemplateModal.tsx`: thread `id` through the `onSend` / `handleSendMessage` payload types.
- `contacts/StartConversationModal.tsx`: add `id: selectedTemplate.id` to `template_params`.
- `types/chat/api.ts`: add optional `id?: string` to the `template_params` shapes.

## Test plan

- `pnpm exec vitest run src/components/chat/message-template` — message-template suite green (9/9).
- Changes are additive optional fields; existing name/language/processed_params payload unchanged.

## Notes

- Pairs with the backend PR (evolution-foundation/evo-ai-crm-community #138). Backend keeps name-based resolution as a fallback, so this is non-breaking on its own.