### PR TITLE
refactor(message-templates): repoint to dedicated flat endpoint (EVO-1716)

### DIFF
--- a/src/pages/Customer/Settings/MessageTemplates/MessageTemplates.tsx
+++ b/src/pages/Customer/Settings/MessageTemplates/MessageTemplates.tsx
@@ -22,8 +22,6 @@ import {
 import { ChevronLeft, ChevronRight, Edit, LayoutTemplate, Plus, Search, Trash2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
-import { useAppDataStore } from '@/store/appDataStore';
-import EmptyState from '@/components/base/EmptyState';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 import { extractError } from '@/utils/apiHelpers';
 import GlobalMessageTemplateService, {
@@ -36,13 +34,6 @@ import type { MessageTemplate, TemplateFormData } from '@/types';
 export default function MessageTemplates() {
   const { t } = useLanguage('messageTemplates');
   const { can } = useUserPermissions();
-  const inboxes = useAppDataStore(s => s.inboxes);
-  const fetchInboxes = useAppDataStore(s => s.fetchInboxes);
-
-  // The global endpoints are member routes under /inboxes/:id (the inbox is a
-  // routing placeholder, ignored in ?global=true mode), but it must still be a
-  // real, viewable inbox id.
-  const placeholderInboxId = inboxes[0]?.id;
 
   const [templates, setTemplates] = useState<MessageTemplate[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -57,12 +48,6 @@ export default function MessageTemplates() {
   const [deleteTarget, setDeleteTarget] = useState<MessageTemplate | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  useEffect(() => {
-    if (inboxes.length === 0) {
-      fetchInboxes().catch(() => undefined);
-    }
-  }, [inboxes.length, fetchInboxes]);
-
   // Debounce search: server-side filtering is authoritative (no client re-filter).
   useEffect(() => {
     const id = setTimeout(() => {
@@ -73,10 +58,6 @@ export default function MessageTemplates() {
   }, [searchQuery]);
 
   const loadTemplates = useCallback(async () => {
-    if (!placeholderInboxId) {
-      setIsLoading(false);
-      return;
-    }
     if (!can('message_templates', 'read')) {
       toast.error(t('messages.permissionDenied.read'));
       setIsLoading(false);
@@ -84,7 +65,7 @@ export default function MessageTemplates() {
     }
     setIsLoading(true);
     try {
-      const response = await GlobalMessageTemplateService.getTemplates(placeholderInboxId, {
+      const response = await GlobalMessageTemplateService.getTemplates({
         page,
         per_page: DEFAULT_PAGE_SIZE,
         search: debouncedSearch || undefined,
@@ -97,7 +78,7 @@ export default function MessageTemplates() {
     } finally {
       setIsLoading(false);
     }
-  }, [placeholderInboxId, can, t, debouncedSearch, page]);
+  }, [can, t, debouncedSearch, page]);
 
   useEffect(() => {
     loadTemplates();
@@ -122,18 +103,12 @@ export default function MessageTemplates() {
   };
 
   const handleSave = async (formData: TemplateFormData, provider: GlobalTemplateProvider) => {
-    if (!placeholderInboxId) return;
     try {
       if (editing?.id) {
-        await GlobalMessageTemplateService.updateTemplate(
-          placeholderInboxId,
-          editing.id,
-          formData,
-          provider,
-        );
+        await GlobalMessageTemplateService.updateTemplate(editing.id, formData, provider);
         toast.success(t('messages.updateSuccess'));
       } else {
-        await GlobalMessageTemplateService.createTemplate(placeholderInboxId, formData, provider);
+        await GlobalMessageTemplateService.createTemplate(formData, provider);
         toast.success(t('messages.createSuccess'));
       }
       setEditing(null);
@@ -153,10 +128,10 @@ export default function MessageTemplates() {
   };
 
   const confirmDelete = async () => {
-    if (!placeholderInboxId || !deleteTarget?.id) return;
+    if (!deleteTarget?.id) return;
     setIsDeleting(true);
     try {
-      await GlobalMessageTemplateService.deleteTemplate(placeholderInboxId, deleteTarget.id);
+      await GlobalMessageTemplateService.deleteTemplate(deleteTarget.id);
       toast.success(t('messages.deleteSuccess'));
       setDeleteTarget(null);
       await loadTemplates();
@@ -177,19 +152,6 @@ export default function MessageTemplates() {
       </Badge>
     );
   };
-
-  // No inbox exists -> the placeholder-inbox routing constraint can't be met.
-  if (!isLoading && !placeholderInboxId) {
-    return (
-      <div className="p-6">
-        <EmptyState
-          icon={LayoutTemplate}
-          title={t('emptyState.noInboxes')}
-          description={t('emptyState.noInboxesDescription')}
-        />
-      </div>
-    );
-  }
 
   return (
     <div className="p-6 space-y-6">

--- a/src/pages/Customer/Settings/MessageTemplates/__tests__/MessageTemplates.spec.tsx
+++ b/src/pages/Customer/Settings/MessageTemplates/__tests__/MessageTemplates.spec.tsx
@@ -53,11 +53,10 @@ beforeEach(() => {
 });
 
 describe('MessageTemplates page', () => {
-  it('lists global templates using the placeholder inbox id and global query', async () => {
+  it('lists global templates from the flat endpoint (no inbox arg)', async () => {
     render(<MessageTemplates />);
     expect(await screen.findByText('welcome')).toBeInTheDocument();
     expect(h.service.getTemplates).toHaveBeenCalledWith(
-      'inbox-1',
       expect.objectContaining({ sort_by: 'name' }),
     );
   });
@@ -67,13 +66,6 @@ describe('MessageTemplates page', () => {
     await screen.findByText('welcome');
     fireEvent.click(screen.getByText('newTemplate'));
     expect(await screen.findByText('form.createTitle')).toBeInTheDocument();
-  });
-
-  it('renders the no-inboxes empty state when no inbox exists (placeholder constraint)', async () => {
-    h.inboxes = [];
-    render(<MessageTemplates />);
-    expect(await screen.findByText('emptyState.noInboxes')).toBeInTheDocument();
-    expect(h.service.getTemplates).not.toHaveBeenCalled();
   });
 
   it('paginates: shows controls and refetches the next page', async () => {
@@ -87,7 +79,6 @@ describe('MessageTemplates page', () => {
     fireEvent.click(await screen.findByText('pagination.next'));
     await waitFor(() =>
       expect(h.service.getTemplates).toHaveBeenLastCalledWith(
-        'inbox-1',
         expect.objectContaining({ page: 2 }),
       ),
     );

--- a/src/services/channels/__tests__/messageTemplatesService.spec.ts
+++ b/src/services/channels/__tests__/messageTemplatesService.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+}));
+
+vi.mock('@/services/core/api', () => ({ default: apiMock }));
+
+import MessageTemplateService from '../messageTemplatesService';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('channel MessageTemplateService — flat endpoint with inbox_id (EVO-1716)', () => {
+  it('lists from /message_templates passing inbox_id so the backend resolves the channel', async () => {
+    apiMock.get.mockResolvedValue({ data: { success: true, data: [], meta: {} } });
+    await MessageTemplateService.getTemplates('inbox-1', { per_page: 20 });
+    expect(apiMock.get).toHaveBeenCalledWith(
+      '/message_templates',
+      expect.objectContaining({
+        params: expect.objectContaining({ inbox_id: 'inbox-1', per_page: 20 }),
+      }),
+    );
+  });
+
+  it('creates on /message_templates with inbox_id as a top-level sibling param', async () => {
+    apiMock.post.mockResolvedValue({ data: { id: 't1' } });
+    await MessageTemplateService.createTemplate(
+      'inbox-1',
+      { name: 'x', content: 'y' } as never,
+      'Channel::Api',
+    );
+    expect(apiMock.post).toHaveBeenCalledWith(
+      '/message_templates',
+      expect.objectContaining({ inbox_id: 'inbox-1', message_template: expect.any(Object) }),
+    );
+  });
+
+  it('updates on /message_templates/:id with inbox_id as a top-level sibling param', async () => {
+    apiMock.put.mockResolvedValue({ data: { id: 't1' } });
+    await MessageTemplateService.updateTemplate(
+      'inbox-1',
+      't1',
+      { name: 'z', content: 'c' } as never,
+      'Channel::Api',
+    );
+    expect(apiMock.put).toHaveBeenCalledWith(
+      '/message_templates/t1',
+      expect.objectContaining({ inbox_id: 'inbox-1', message_template: expect.any(Object) }),
+    );
+  });
+
+  it('deletes on /message_templates/:id passing inbox_id', async () => {
+    apiMock.delete.mockResolvedValue({ data: {} });
+    await MessageTemplateService.deleteTemplate('inbox-1', 't1');
+    expect(apiMock.delete).toHaveBeenCalledWith('/message_templates/t1', {
+      params: { inbox_id: 'inbox-1' },
+    });
+  });
+
+  it('keeps syncTemplates pointing at the inbox-scoped sync route (unchanged)', async () => {
+    apiMock.post.mockResolvedValue({ data: [] });
+    await MessageTemplateService.syncTemplates('inbox-1');
+    expect(apiMock.post).toHaveBeenCalledWith('/inboxes/inbox-1/message_templates/sync');
+  });
+});

--- a/src/services/channels/messageTemplatesService.ts
+++ b/src/services/channels/messageTemplatesService.ts
@@ -117,7 +117,10 @@ export const getChannelTemplateConfig = (channelType: string) => {
 
 const MessageTemplateService = {
   /**
-   * Get all templates for an inbox with pagination support
+   * Get all templates for an inbox with pagination support. Hits the flat,
+   * account-scoped `/message_templates` endpoint (EVO-1716) and passes
+   * `inbox_id` so the backend resolves the inbox's channel and returns that
+   * channel's templates.
    */
   async getTemplates(
     inboxId: string,
@@ -130,10 +133,9 @@ const MessageTemplateService = {
     },
   ): Promise<MessageTemplateResponse> {
     try {
-      const response = await api.get<MessageTemplateResponse>(
-        `/inboxes/${inboxId}/message_templates`,
-        { params },
-      );
+      const response = await api.get<MessageTemplateResponse>(`/message_templates`, {
+        params: { ...params, inbox_id: inboxId },
+      });
 
       return extractResponse<MessageTemplate>(response) as MessageTemplateResponse;
     } catch (error) {
@@ -166,7 +168,8 @@ const MessageTemplateService = {
     try {
       const backendTemplate = this.transformToBackendFormat(templateData, channelType);
 
-      const { data } = await api.post(`/inboxes/${inboxId}/message_templates`, {
+      const { data } = await api.post(`/message_templates`, {
+        inbox_id: inboxId,
         message_template: backendTemplate,
       });
       return data;
@@ -188,7 +191,8 @@ const MessageTemplateService = {
     try {
       const backendTemplate = this.transformToBackendFormat(templateData, channelType);
 
-      const { data } = await api.put(`/inboxes/${inboxId}/message_templates/${templateId}`, {
+      const { data } = await api.put(`/message_templates/${templateId}`, {
+        inbox_id: inboxId,
         message_template: backendTemplate,
       });
       return data;
@@ -203,7 +207,9 @@ const MessageTemplateService = {
    */
   async deleteTemplate(inboxId: string, templateId: string): Promise<void> {
     try {
-      await api.delete(`/inboxes/${inboxId}/message_templates/${templateId}`);
+      await api.delete(`/message_templates/${templateId}`, {
+        params: { inbox_id: inboxId },
+      });
     } catch (error) {
       console.error('MessageTemplateService.deleteTemplate error:', error);
       throw error;

--- a/src/services/messageTemplates/__tests__/globalMessageTemplatesService.spec.ts
+++ b/src/services/messageTemplates/__tests__/globalMessageTemplatesService.spec.ts
@@ -39,64 +39,52 @@ describe('inferTemplateProvider', () => {
 });
 
 describe('globalMessageTemplatesService', () => {
-  it('lists templates in ?global=true mode', async () => {
+  it('lists templates from the flat endpoint with no inbox/channel filter', async () => {
     apiMock.get.mockResolvedValue({ data: { success: true, data: [], meta: {} } });
-    await GlobalMessageTemplateService.getTemplates('inbox-1', { per_page: 20 });
+    await GlobalMessageTemplateService.getTemplates({ per_page: 20 });
     expect(apiMock.get).toHaveBeenCalledWith(
-      '/inboxes/inbox-1/message_templates',
-      expect.objectContaining({ params: expect.objectContaining({ global: true, per_page: 20 }) }),
+      '/message_templates',
+      expect.objectContaining({ params: expect.objectContaining({ per_page: 20 }) }),
     );
   });
 
   it('creates with provider nested inside message_template (read via params.dig backend-side)', async () => {
     apiMock.post.mockResolvedValue({ data: { data: { id: 't1' } } });
     await GlobalMessageTemplateService.createTemplate(
-      'inbox-1',
       { name: 'x', content: 'y' } as never,
       'email',
     );
-    expect(apiMock.post).toHaveBeenCalledWith(
-      '/inboxes/inbox-1/message_templates',
-      {
-        message_template: {
-          name: 'x',
-          content: 'y',
-          provider: 'email',
-          settings: { global_provider: 'email' },
-        },
+    expect(apiMock.post).toHaveBeenCalledWith('/message_templates', {
+      message_template: {
+        name: 'x',
+        content: 'y',
+        provider: 'email',
+        settings: { global_provider: 'email' },
       },
-      { params: { global: true } },
-    );
+    });
   });
 
   it('unwraps the PUT response envelope (data.template)', async () => {
     apiMock.put.mockResolvedValue({ data: { data: { template: { id: 't1', name: 'z' } } } });
     const result = await GlobalMessageTemplateService.updateTemplate(
-      'inbox-1',
       't1',
       { name: 'z', content: 'c' } as never,
       'generic',
     );
     expect(result).toEqual({ id: 't1', name: 'z' });
-    expect(apiMock.put).toHaveBeenCalledWith(
-      '/inboxes/inbox-1/message_templates/t1',
-      {
-        message_template: {
-          name: 'z',
-          content: 'c',
-          provider: 'generic',
-          settings: { global_provider: 'generic' },
-        },
+    expect(apiMock.put).toHaveBeenCalledWith('/message_templates/t1', {
+      message_template: {
+        name: 'z',
+        content: 'c',
+        provider: 'generic',
+        settings: { global_provider: 'generic' },
       },
-      { params: { global: true } },
-    );
+    });
   });
 
-  it('deletes in ?global=true mode', async () => {
+  it('deletes from the flat endpoint', async () => {
     apiMock.delete.mockResolvedValue({ data: { success: true } });
-    await GlobalMessageTemplateService.deleteTemplate('inbox-1', 't1');
-    expect(apiMock.delete).toHaveBeenCalledWith('/inboxes/inbox-1/message_templates/t1', {
-      params: { global: true },
-    });
+    await GlobalMessageTemplateService.deleteTemplate('t1');
+    expect(apiMock.delete).toHaveBeenCalledWith('/message_templates/t1');
   });
 });

--- a/src/services/messageTemplates/globalMessageTemplatesService.ts
+++ b/src/services/messageTemplates/globalMessageTemplatesService.ts
@@ -6,14 +6,11 @@ import { extractData, extractResponse } from '@/utils/apiHelpers';
 /**
  * Global (channel-independent) message templates — EVO-1233 [6.4].
  *
- * These hit the SAME per-inbox member routes as the channel-scoped service, but
- * in `?global=true` mode (EVO-1231): the backend lists/creates/updates/deletes
- * channel-less (`channel_id IS NULL`) templates and ignores the inbox in the URL.
- *
- * ⚠️ The route still requires a VALID, `show?`-able inbox id as a placeholder
- * (`fetch_inbox` does `Inbox.find(params[:id])`); callers pass one resolved from
- * the app data store. WhatsApp Cloud is intentionally NOT handled here (channel
- * -bound; stays in the per-channel Message Templates tab).
+ * These hit the flat, account-scoped `/message_templates` endpoint (EVO-1716).
+ * With NO `inbox_id`/`channel_id` filter the backend lists/creates/updates/
+ * deletes channel-less (`channel_id IS NULL`) templates. WhatsApp Cloud is
+ * intentionally NOT handled here (channel-bound; stays in the per-channel
+ * Message Templates tab).
  */
 
 /** Provider options exposed by the global menu (channel-less only). */
@@ -36,8 +33,6 @@ export interface GlobalTemplatesQuery {
   category?: string;
   template_type?: string;
 }
-
-const GLOBAL_PARAM = { global: true } as const;
 
 /**
  * Build the `message_template` request body for a global template.
@@ -80,35 +75,30 @@ export const inferTemplateProvider = (template: MessageTemplate): GlobalTemplate
 
 const GlobalMessageTemplateService = {
   /**
-   * List global (channel-less) templates with pagination + search.
-   * Never pass `per_page: -1` — that backend branch hardcodes `total_pages: 1`.
+   * List global (channel-less) templates with pagination + search. With no
+   * `inbox_id`/`channel_id` filter the flat endpoint returns channel-less
+   * templates. Never pass `per_page: -1` — that backend branch hardcodes
+   * `total_pages: 1`.
    */
-  async getTemplates(
-    placeholderInboxId: string,
-    params?: GlobalTemplatesQuery,
-  ): Promise<MessageTemplateResponse> {
-    const response = await api.get(`/inboxes/${placeholderInboxId}/message_templates`, {
-      params: { ...GLOBAL_PARAM, ...params },
-    });
+  async getTemplates(params?: GlobalTemplatesQuery): Promise<MessageTemplateResponse> {
+    const response = await api.get(`/message_templates`, { params });
     return extractResponse<MessageTemplate>(response) as MessageTemplateResponse;
   },
 
   /**
    * Create a channel-less template. `provider` is sent as a sibling key INSIDE
    * `message_template` (the backend reads it via `params.dig(:message_template,
-   * :provider)` — it is deliberately outside strong params). Returns the created
-   * template (POST responds with `data` = the serialized template directly).
+   * :provider)` — it is deliberately outside strong params). No `inbox_id` is
+   * sent, so the backend creates it global. Returns the created template (POST
+   * responds with `data` = the serialized template directly).
    */
   async createTemplate(
-    placeholderInboxId: string,
     formData: TemplateFormData,
     provider: GlobalTemplateProvider,
   ): Promise<MessageTemplate> {
-    const response = await api.post(
-      `/inboxes/${placeholderInboxId}/message_templates`,
-      { message_template: buildMessageTemplatePayload(formData, provider) },
-      { params: GLOBAL_PARAM },
-    );
+    const response = await api.post(`/message_templates`, {
+      message_template: buildMessageTemplatePayload(formData, provider),
+    });
     return extractData<MessageTemplate>(response);
   },
 
@@ -117,25 +107,20 @@ const GlobalMessageTemplateService = {
    * different envelope from POST), so unwrap the nested `template`.
    */
   async updateTemplate(
-    placeholderInboxId: string,
     templateId: string,
     formData: TemplateFormData,
     provider: GlobalTemplateProvider,
   ): Promise<MessageTemplate> {
-    const response = await api.put(
-      `/inboxes/${placeholderInboxId}/message_templates/${templateId}`,
-      { message_template: buildMessageTemplatePayload(formData, provider) },
-      { params: GLOBAL_PARAM },
-    );
+    const response = await api.put(`/message_templates/${templateId}`, {
+      message_template: buildMessageTemplatePayload(formData, provider),
+    });
     const data = extractData<{ template: MessageTemplate } | MessageTemplate>(response);
     return (data as { template: MessageTemplate }).template ?? (data as MessageTemplate);
   },
 
   /** Delete a channel-less template. */
-  async deleteTemplate(placeholderInboxId: string, templateId: string): Promise<void> {
-    await api.delete(`/inboxes/${placeholderInboxId}/message_templates/${templateId}`, {
-      params: GLOBAL_PARAM,
-    });
+  async deleteTemplate(templateId: string): Promise<void> {
+    await api.delete(`/message_templates/${templateId}`);
   },
 
   /**


### PR DESCRIPTION
## Summary

Point the global and channel template services at the new flat `/api/v1/message_templates` endpoint (CRM PR #140).

- **Global service**: drops the `GLOBAL_PARAM` / placeholder-inbox-id workaround — now a plain flat call.
- **Channel service**: CRUD uses the `inbox_id` query filter; **Meta sync calls unchanged**.
- **No UI/UX change** to the Settings template flow — internal wiring only.

## Test plan

- `globalMessageTemplatesService.spec.ts` + new `channels/__tests__/messageTemplatesService.spec.ts` + `MessageTemplates.spec.tsx`: **14/14 green**.
- Lint + typecheck clean.

## Notas

- Depends on CRM #140 (backend endpoint) and the auth-service RBAC PR being deployed.