### PR TITLE
docs(message-templates): drop stale channel_id filter mention (EVO-1716)

### DIFF
--- a/src/services/messageTemplates/globalMessageTemplatesService.ts
+++ b/src/services/messageTemplates/globalMessageTemplatesService.ts
@@ -7,8 +7,8 @@ import { extractData, extractResponse } from '@/utils/apiHelpers';
  * Global (channel-independent) message templates — EVO-1233 [6.4].
  *
  * These hit the flat, account-scoped `/message_templates` endpoint (EVO-1716).
- * With NO `inbox_id`/`channel_id` filter the backend lists/creates/updates/
- * deletes channel-less (`channel_id IS NULL`) templates. WhatsApp Cloud is
+ * With NO `inbox_id` filter the backend lists/creates/updates/deletes
+ * channel-less (`channel_id IS NULL`) templates. WhatsApp Cloud is
  * intentionally NOT handled here (channel-bound; stays in the per-channel
  * Message Templates tab).
  */
@@ -76,9 +76,8 @@ export const inferTemplateProvider = (template: MessageTemplate): GlobalTemplate
 const GlobalMessageTemplateService = {
   /**
    * List global (channel-less) templates with pagination + search. With no
-   * `inbox_id`/`channel_id` filter the flat endpoint returns channel-less
-   * templates. Never pass `per_page: -1` — that backend branch hardcodes
-   * `total_pages: 1`.
+   * `inbox_id` filter the flat endpoint returns channel-less templates. Never
+   * pass `per_page: -1` — that backend branch hardcodes `total_pages: 1`.
    */
   async getTemplates(params?: GlobalTemplatesQuery): Promise<MessageTemplateResponse> {
     const response = await api.get(`/message_templates`, { params });


### PR DESCRIPTION
## Summary

Limpeza cosmética de follow-up. O backend removeu o filtro `channel_id` (não usado) do endpoint flat `/message_templates` (ver CRM #141), então os doc-comments do `globalMessageTemplatesService` referenciavam um param que não existe mais.

- Removidas as 2 menções a `inbox_id`/`channel_id` filter nos comentários.
- Mantido o `channel_id IS NULL` (descreve o estado da **coluna** dos templates channel-less, não um filtro de request).

Sem mudança de comportamento — só comentário.

## Test plan

- `eslint` no arquivo: limpo.
- `vitest` nos services de template (`globalMessageTemplatesService` + `channels/messageTemplatesService`): **11/11 green**.

## Notas

- Pareia com CRM #141 (remoção da superfície `channel_id` no backend). Pode mergear independente — é só doc.

## Summary by Sourcery

Documentation:
- Clarify that the flat /message_templates endpoint no longer accepts a channel_id filter and adjust comments to only reference inbox_id where applicable.