### PR TITLE
fix(unread-store): reset() neutralizes in-flight GET + trailing re-fetch (EVO-1675)

### DIFF
--- a/src/store/unreadConversationsStore.spec.ts
+++ b/src/store/unreadConversationsStore.spec.ts
@@ -110,6 +110,73 @@ describe('useUnreadConversationsStore.reset', () => {
     expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
     expect(useUnreadConversationsStore.getState().isLoaded).toBe(false);
   });
+
+  it('neutralizes an in-flight GET so it cannot resurrect the badge after reset', async () => {
+    let resolveGet: (v: { unread_count: number }) => void = () => {};
+    mockedGetUnreadCount.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    useUnreadConversationsStore.getState().fetch();
+    await vi.advanceTimersByTimeAsync(401);
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+
+    useUnreadConversationsStore.getState().reset();
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+    expect(useUnreadConversationsStore.getState().isLoaded).toBe(false);
+
+    resolveGet({ unread_count: 42 });
+    await flushMicrotasks();
+
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(0);
+    expect(useUnreadConversationsStore.getState().isLoaded).toBe(false);
+  });
+});
+
+describe('useUnreadConversationsStore.fetch trailing re-fetch', () => {
+  it('re-arms one trailing GET when fetch() is called during an in-flight request', async () => {
+    let resolveFirst: (v: { unread_count: number }) => void = () => {};
+    mockedGetUnreadCount
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValueOnce({ unread_count: 7 });
+
+    useUnreadConversationsStore.getState().fetch();
+    await vi.advanceTimersByTimeAsync(401);
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+
+    useUnreadConversationsStore.getState().fetch();
+    useUnreadConversationsStore.getState().fetch();
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+
+    resolveFirst({ unread_count: 3 });
+    await flushMicrotasks();
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(401);
+    await flushMicrotasks();
+
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(2);
+    expect(useUnreadConversationsStore.getState().totalUnread).toBe(7);
+  });
+
+  it('does not re-arm a trailing GET when no fetch() arrived during the in-flight window', async () => {
+    mockedGetUnreadCount.mockResolvedValueOnce({ unread_count: 4 });
+
+    useUnreadConversationsStore.getState().fetch();
+    await vi.advanceTimersByTimeAsync(450);
+    await flushMicrotasks();
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await flushMicrotasks();
+    expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('useUnreadConversationsStore.setTotal / incrementBy / decrementBy', () => {

--- a/src/store/unreadConversationsStore.ts
+++ b/src/store/unreadConversationsStore.ts
@@ -16,6 +16,7 @@ let latestApplied = 0;
 let inFlight: Promise<void> | null = null;
 let pending: Promise<void> | null = null;
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let trailingRequested = false;
 
 const FETCH_DEBOUNCE_MS = 400;
 
@@ -24,7 +25,10 @@ export const useUnreadConversationsStore = create<UnreadConversationsState>((set
   isLoaded: false,
 
   fetch: async () => {
-    if (inFlight) return inFlight;
+    if (inFlight) {
+      trailingRequested = true;
+      return inFlight;
+    }
     if (pending) return pending;
 
     pending = new Promise<void>((resolve) => {
@@ -42,7 +46,12 @@ export const useUnreadConversationsStore = create<UnreadConversationsState>((set
             console.warn('Failed to fetch total unread count:', error);
           } finally {
             inFlight = null;
+            const shouldTrail = trailingRequested;
+            trailingRequested = false;
             resolve();
+            if (shouldTrail) {
+              useUnreadConversationsStore.getState().fetch();
+            }
           }
         })();
       }, FETCH_DEBOUNCE_MS);
@@ -65,6 +74,8 @@ export const useUnreadConversationsStore = create<UnreadConversationsState>((set
     }
     pending = null;
     inFlight = null;
+    trailingRequested = false;
+    latestApplied = fetchSeq;
     set({ totalUnread: 0, isLoaded: false });
   },
 }));


### PR DESCRIPTION
## Summary

Follow-up de EVO-1550 (frontend #137). Fecha 2 pontos residuais do `unreadConversationsStore`:

- **M1 (MEDIUM)** — `reset()` não avançava `latestApplied`, então um GET `/unread_count` em voo no momento do logout sobrevivia ao reset e re-aplicava o badge na resolução. Em soft-logout (sem reload), os singletons module-level e o Zustand store sobrevivem, e por ~400ms (debounce + RTT) o badge ressuscita. **Pior caso cross-user:** agente A desloga → agente B loga no mesmo browser → badge do A pisca antes do fetch do B sobrescrever (inboxes diferentes via `PermissionFilterService`).
  - **Fix:** `latestApplied = fetchSeq;` dentro do `reset()`. Qualquer `seq` já em voo cai no guard `seq <= latestApplied` e retorna sem `set()`. Próximo fetch pós-reset captura `seq = ++fetchSeq > latestApplied`, intacto.

- **L1 (LOW)** — `if (inFlight) return inFlight` dropava o estado final: se um evento commit'asse server-side durante o round-trip de um GET emitido antes da mutação, a resposta não refletia e o badge ficava stale até o próximo evento WS (sem polling).
  - **Fix:** semântica leading+trailing — flag `trailingRequested` setada quando `fetch()` chega durante in-flight; no `finally`, re-arma 1 GET trailing via `useUnreadConversationsStore.getState().fetch()`. `reset()` limpa a flag pra cancelar trailing pendente.

## Validation

- `evo-ai-frontend-community: pnpm test -- src/store/unreadConversationsStore.spec.ts` → **11 passed (11)**
  - Novo: `reset() neutralizes in-flight GET so it cannot resurrect the badge after reset` (M1)
  - Novo: `re-arms one trailing GET when fetch() is called during an in-flight request` (L1)
  - Novo: `does not re-arm a trailing GET when no fetch() arrived during the in-flight window` (regressão)
- `evo-ai-frontend-community: pnpm exec tsc -b` → sem erros nos arquivos alterados (erros pré-existentes em `TemplateParser.tsx`, alheios ao escopo)

> Frontend-community não roda vitest no CI (Sourcery-only) → validação local.

## Changed Files

- `src/store/unreadConversationsStore.ts`
- `src/store/unreadConversationsStore.spec.ts`

## Linked Issue

- EVO-1675

## Summary by Sourcery

Adjust unread conversations store behavior around in-flight fetches and resets to prevent stale badge states and ensure up-to-date counts.

Bug Fixes:
- Ensure reset() clears sequence state so in-flight unread_count responses cannot reapply unread badges after a reset.
- Trigger a trailing fetch when fetch() is called during an in-flight request so the store reflects server-side changes that happened during the first round-trip.

Tests:
- Add tests covering reset() neutralizing in-flight GETs and the leading+trailing fetch behavior for the unread conversations store.