### PR TITLE
fix(journey): warn when a flow has no path to an exit-journey-node (EVO-1692)

### DIFF
--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -84,6 +84,10 @@
     },
     "saveSuccess": "Journey saved successfully",
     "saveError": "Unable to save journey",
+    "validation": {
+      "danglingExitWarning": "Journey saved, but these nodes don't reach an Exit Journey node, so it won't complete: {{nodes}}",
+      "danglingExitBanner": "This journey won't complete: these nodes have no path to an Exit Journey node: {{nodes}}"
+    },
     "loadError": "Unable to load journey",
     "status": {
       "active": "Active",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -84,6 +84,10 @@
     },
     "saveSuccess": "Jornada guardada con éxito",
     "saveError": "No fue posible guardar la jornada",
+    "validation": {
+      "danglingExitWarning": "Jornada guardada, pero estos nodos no llegan a un nodo de Salir de la Jornada, así que no se completará: {{nodes}}",
+      "danglingExitBanner": "Esta jornada no se completará: estos nodos no tienen un camino hasta un nodo de Salir de la Jornada: {{nodes}}"
+    },
     "loadError": "No fue posible cargar la jornada",
     "status": {
       "active": "Activa",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -84,6 +84,10 @@
     },
     "saveSuccess": "Parcours enregistré avec succès",
     "saveError": "Impossible d'enregistrer le parcours",
+    "validation": {
+      "danglingExitWarning": "Parcours enregistré, mais ces nœuds n'atteignent pas un nœud de Sortie du parcours, il ne se terminera donc pas : {{nodes}}",
+      "danglingExitBanner": "Ce parcours ne se terminera pas : ces nœuds n'ont pas de chemin vers un nœud de Sortie du parcours : {{nodes}}"
+    },
     "loadError": "Impossible de charger le parcours",
     "status": {
       "active": "Actif",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -84,6 +84,10 @@
     },
     "saveSuccess": "Percorso salvato con successo",
     "saveError": "Impossibile salvare il percorso",
+    "validation": {
+      "danglingExitWarning": "Percorso salvato, ma questi nodi non raggiungono un nodo di Uscita dal percorso, quindi non verrà completato: {{nodes}}",
+      "danglingExitBanner": "Questo percorso non verrà completato: questi nodi non hanno un percorso verso un nodo di Uscita dal percorso: {{nodes}}"
+    },
     "loadError": "Impossibile caricare il percorso",
     "status": {
       "active": "Attivo",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -84,6 +84,10 @@
     },
     "saveSuccess": "Jornada salva com sucesso",
     "saveError": "Não foi possível salvar a jornada",
+    "validation": {
+      "danglingExitWarning": "Jornada salva, mas estes nós não chegam a um nó de Sair da Jornada, então ela não vai concluir: {{nodes}}",
+      "danglingExitBanner": "Esta jornada não vai concluir: estes nós não têm caminho até um nó de Sair da Jornada: {{nodes}}"
+    },
     "loadError": "Não foi possível carregar a jornada",
     "status": {
       "active": "Ativa",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -84,6 +84,10 @@
     },
     "saveSuccess": "Jornada salva com sucesso",
     "saveError": "Não foi possível salvar a jornada",
+    "validation": {
+      "danglingExitWarning": "Jornada salva, mas estes nós não chegam a um nó de Sair da Jornada, então ela não vai concluir: {{nodes}}",
+      "danglingExitBanner": "Esta jornada não vai concluir: estes nós não têm caminho até um nó de Sair da Jornada: {{nodes}}"
+    },
     "loadError": "Não foi possível carregar a jornada",
     "status": {
       "active": "Ativa",

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 import { journeyService } from '@/services';
 import type { Journey } from '@/types/automation';
 import { useLanguage } from '@/hooks/useLanguage';
+import { validateJourneyTerminalPaths } from '@/utils/journeyFlowValidation';
 import { BaseFlowEditor, type NodeType, type NodeCategory } from '@/components/base';
 import { EnvironmentManager } from '@/components/journey/environment-manager';
 import { JourneyEditorHeader } from '@/components/journey/shared/JourneyEditorHeader';
@@ -156,6 +157,16 @@ function JourneyFlowEditor() {
   const recoveryCandidate = useFlowEditorStore((s) => s.recoveryCandidate);
   const recoveryEpoch = useFlowEditorStore((s) => s.recoveryEpoch);
   const currentSnapshot = useFlowEditorStore((s) => s.currentSnapshot);
+  const danglingNodes = useMemo(
+    () =>
+      currentSnapshot
+        ? validateJourneyTerminalPaths(
+            currentSnapshot.nodes,
+            currentSnapshot.edges,
+          ).danglingNodes
+        : [],
+    [currentSnapshot],
+  );
 
   const isSaving = status === 'saving';
   const hasUnsavedChanges = status !== 'idle';
@@ -743,7 +754,19 @@ function JourneyFlowEditor() {
       // requirement of EVO-1258).
       useFlowEditorStore.getState().commitSave(new Date(), snapshot);
       if (!opts?.silent) {
-        toast.success(t('flowEditor.saveSuccess'));
+        const { danglingNodes } = validateJourneyTerminalPaths(
+          snapshot.nodes,
+          snapshot.edges,
+        );
+        if (danglingNodes.length > 0) {
+          toast.warning(
+            t('flowEditor.validation.danglingExitWarning', {
+              nodes: danglingNodes.map((node) => node.label).join(', '),
+            }),
+          );
+        } else {
+          toast.success(t('flowEditor.saveSuccess'));
+        }
       }
     } catch (error) {
       console.error('Erro ao salvar jornada:', error);
@@ -900,6 +923,16 @@ function JourneyFlowEditor() {
                   seconds: Math.round(nextRetryDelayMs / 1000),
                 })
               : t('flowEditor.saveErrorBannerNoRetry', { reason: lastError })}
+          </p>
+        </FlowFeedbackBanner>
+      ) : null}
+
+      {danglingNodes.length > 0 ? (
+        <FlowFeedbackBanner variant="warn" className="mx-4 mt-2">
+          <p>
+            {t('flowEditor.validation.danglingExitBanner', {
+              nodes: danglingNodes.map((node) => node.label).join(', '),
+            })}
           </p>
         </FlowFeedbackBanner>
       ) : null}

--- a/src/utils/journeyFlowValidation.spec.ts
+++ b/src/utils/journeyFlowValidation.spec.ts
@@ -29,6 +29,20 @@ describe('validateJourneyTerminalPaths', () => {
     expect(result.danglingNodes).toEqual([]);
   });
 
+  it('treats a transfer-journey-node as a valid terminal path', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node'),
+      node('a', 'send-message-node'),
+      node('x', 'transfer-journey-node'),
+    ];
+    const result = validateJourneyTerminalPaths(nodes, [
+      edge('t', 'a'),
+      edge('a', 'x'),
+    ]);
+    expect(result.isValid).toBe(true);
+    expect(result.danglingNodes).toEqual([]);
+  });
+
   it('flags a terminal action node with no exit', () => {
     const nodes = [
       node('t', 'journey-trigger-node'),

--- a/src/utils/journeyFlowValidation.spec.ts
+++ b/src/utils/journeyFlowValidation.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+import { validateJourneyTerminalPaths } from './journeyFlowValidation';
+
+const node = (
+  id: string,
+  type: string,
+  data: Record<string, unknown> = {},
+): Node => ({ id, type, position: { x: 0, y: 0 }, data });
+
+const edge = (source: string, target: string): Edge => ({
+  id: `${source}-${target}`,
+  source,
+  target,
+});
+
+describe('validateJourneyTerminalPaths', () => {
+  it('is valid when every terminal path ends in an exit-journey-node', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node'),
+      node('a', 'send-message-node'),
+      node('e', 'exit-journey-node'),
+    ];
+    const result = validateJourneyTerminalPaths(nodes, [
+      edge('t', 'a'),
+      edge('a', 'e'),
+    ]);
+    expect(result.isValid).toBe(true);
+    expect(result.danglingNodes).toEqual([]);
+  });
+
+  it('flags a terminal action node with no exit', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node'),
+      node('a', 'send-message-node', { label: 'Send message' }),
+    ];
+    const result = validateJourneyTerminalPaths(nodes, [edge('t', 'a')]);
+    expect(result.isValid).toBe(false);
+    expect(result.danglingNodes).toEqual([{ id: 'a', label: 'Send message' }]);
+  });
+
+  it('flags only the dangling branch when another branch reaches an exit', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node'),
+      node('c', 'conditional-node'),
+      node('a', 'send-message-node', { label: 'No exit' }),
+      node('e', 'exit-journey-node'),
+    ];
+    const result = validateJourneyTerminalPaths(nodes, [
+      edge('t', 'c'),
+      edge('c', 'a'),
+      edge('c', 'e'),
+    ]);
+    expect(result.isValid).toBe(false);
+    expect(result.danglingNodes.map((n) => n.id)).toEqual(['a']);
+  });
+
+  it('flags a lone trigger with no downstream nodes', () => {
+    const result = validateJourneyTerminalPaths(
+      [node('t', 'journey-trigger-node')],
+      [],
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.danglingNodes.map((n) => n.id)).toEqual(['t']);
+  });
+
+  it('ignores nodes not reachable from a trigger', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node'),
+      node('e', 'exit-journey-node'),
+      node('orphan', 'send-message-node'),
+    ];
+    const result = validateJourneyTerminalPaths(nodes, [edge('t', 'e')]);
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/src/utils/journeyFlowValidation.ts
+++ b/src/utils/journeyFlowValidation.ts
@@ -1,0 +1,66 @@
+import type { Node, Edge } from '@xyflow/react';
+
+const TRIGGER_NODE_TYPE = 'journey-trigger-node';
+const EXIT_NODE_TYPE = 'exit-journey-node';
+
+export interface DanglingNode {
+  id: string;
+  label: string;
+}
+
+export interface JourneyTerminalValidation {
+  isValid: boolean;
+  danglingNodes: DanglingNode[];
+}
+
+function labelFor(node: Node): string {
+  const data = (node.data ?? {}) as { label?: string; name?: string };
+  return data.label || data.name || node.type || node.id;
+}
+
+/**
+ * Walks the flow from each trigger node and reports terminal nodes (reachable,
+ * with no outgoing edge) that are not an `exit-journey-node`. Such nodes leave
+ * the journey "running" for up to 30 days instead of completing (EVO-1691), so
+ * the editor warns about them on save (EVO-1692). A lone trigger (no downstream)
+ * counts as dangling too. Cyclic paths with no exit are not detected.
+ */
+export function validateJourneyTerminalPaths(
+  nodes: Node[],
+  edges: Edge[],
+): JourneyTerminalValidation {
+  const outgoing = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!edge.source || !edge.target) continue;
+    const targets = outgoing.get(edge.source) ?? [];
+    targets.push(edge.target);
+    outgoing.set(edge.source, targets);
+  }
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const visited = new Set<string>();
+  const danglingNodes: DanglingNode[] = [];
+  const queue = nodes
+    .filter((node) => node.type === TRIGGER_NODE_TYPE)
+    .map((node) => node.id);
+
+  while (queue.length > 0) {
+    const id = queue.shift() as string;
+    if (visited.has(id)) continue;
+    visited.add(id);
+
+    const node = nodeById.get(id);
+    if (!node) continue;
+
+    const targets = outgoing.get(id) ?? [];
+    if (targets.length === 0) {
+      if (node.type !== EXIT_NODE_TYPE) {
+        danglingNodes.push({ id: node.id, label: labelFor(node) });
+      }
+      continue;
+    }
+    queue.push(...targets);
+  }
+
+  return { isValid: danglingNodes.length === 0, danglingNodes };
+}

--- a/src/utils/journeyFlowValidation.ts
+++ b/src/utils/journeyFlowValidation.ts
@@ -2,6 +2,12 @@ import type { Node, Edge } from '@xyflow/react';
 
 const TRIGGER_NODE_TYPE = 'journey-trigger-node';
 const EXIT_NODE_TYPE = 'exit-journey-node';
+const TRANSFER_NODE_TYPE = 'transfer-journey-node';
+
+// Nodes that legitimately end a path: the runtime terminates the loop cleanly
+// for both exit and transfer (transfer hands the contact to a target journey),
+// so neither leaves the session dangling.
+const TERMINAL_NODE_TYPES = new Set([EXIT_NODE_TYPE, TRANSFER_NODE_TYPE]);
 
 export interface DanglingNode {
   id: string;
@@ -20,10 +26,11 @@ function labelFor(node: Node): string {
 
 /**
  * Walks the flow from each trigger node and reports terminal nodes (reachable,
- * with no outgoing edge) that are not an `exit-journey-node`. Such nodes leave
- * the journey "running" for up to 30 days instead of completing (EVO-1691), so
- * the editor warns about them on save (EVO-1692). A lone trigger (no downstream)
- * counts as dangling too. Cyclic paths with no exit are not detected.
+ * with no outgoing edge) that are not a terminating node (`exit-journey-node`
+ * or `transfer-journey-node`). Such nodes leave the journey "running" for up to
+ * 30 days instead of completing (EVO-1691), so the editor warns about them on
+ * save (EVO-1692). A lone trigger (no downstream) counts as dangling too.
+ * Cyclic paths with no exit are not detected.
  */
 export function validateJourneyTerminalPaths(
   nodes: Node[],
@@ -54,7 +61,7 @@ export function validateJourneyTerminalPaths(
 
     const targets = outgoing.get(id) ?? [];
     if (targets.length === 0) {
-      if (node.type !== EXIT_NODE_TYPE) {
+      if (!node.type || !TERMINAL_NODE_TYPES.has(node.type)) {
         danglingNodes.push({ id: node.id, label: labelFor(node) });
       }
       continue;


### PR DESCRIPTION
## Summary
The Flow Builder saved/activated journeys whose terminal path never reached an `exit-journey-node`, with no feedback. At runtime such sessions stay `active` for 30 days (EVO-1691). Per the chosen UX (**warn, not block**), this surfaces dangling terminal nodes:

- A **persistent warning banner** in the editor (`FlowFeedbackBanner variant="warn"`), computed reactively from the live snapshot — always visible while the flow is dangling, so it catches the silent 5s autosave path (not just explicit save).
- A **warning toast on explicit save**, naming the dangling node(s), as reinforcement.

## Changes
- `src/utils/journeyFlowValidation.ts` (new): `validateJourneyTerminalPaths(nodes, edges)` — walks the graph from trigger nodes; any reachable leaf that isn't an `exit-journey-node` (incl. a lone trigger) is dangling.
- `src/utils/journeyFlowValidation.spec.ts` (new): 5 cases (valid / dangling action / branch with one good + one dangling / lone trigger / unreachable orphan ignored).
- `src/pages/Customer/Journey/JourneyFlowEditor.tsx`: reactive `useMemo` validation → banner + save-time toast.
- `src/i18n/locales/{en,pt-BR,es,fr,it,pt}/journey.json`: `flowEditor.validation.danglingExitWarning` (toast) + `danglingExitBanner` (banner).

## Validation
- `tsc -b --noEmit` → no errors in changed files
- `vitest src/utils/journeyFlowValidation.spec.ts` → 5/5
- `eslint` (changed files) → clean
- all 6 journey.json parse valid

## Acceptance Criteria
- [x] A dangling terminal path triggers the chosen UX (explicit warning naming the node) — banner + toast.
- [x] A flow ending in an exit-journey-node shows no warning (regression covered in the util spec).
- [x] Spec coverage (util level).

## Notes (from code review)
- **Out of scope:** no guard at the literal *activate* action (list page `Journey.tsx` doesn't carry `flowData`); the editor banner + save toast cover the authoring surface. Per chosen UX (A) warn, not block.
- **Test coverage:** the validation logic is unit-tested at the util level; the editor wiring (banner/toast) is not component-tested (the editor is a large component) — deferred.
- **Pre-existing (not this PR):** `tsc -b` currently reports an unrelated error in `src/components/chat/message-template/TemplateParser.tsx:121` on develop.

## Linked Issue
- EVO-1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Warn journey authors when flow terminal paths do not reach an exit node and surface dangling nodes in the editor and on save.

New Features:
- Add journey flow terminal-path validation utility to detect dangling non-exit terminal nodes reachable from triggers.
- Show a persistent warning banner in the journey flow editor when the current snapshot has dangling terminal nodes.
- Display a warning toast on explicit save listing dangling nodes instead of a success message when issues are detected.

Documentation:
- Add localized copy for dangling terminal path warnings in the journey flow editor across supported languages.

Tests:
- Add unit tests covering valid flows, dangling actions, mixed branches, lone triggers, and unreachable orphan nodes for the journey terminal-path validator.