### PR TITLE
fix(layout): re-expose Journeys, Campaigns and Segments in the community sidebar (EVO-1687)

### DIFF
--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -23,9 +23,9 @@ import {
   List,
   Shield,
   Package,
-  // Filter,
-  // Megaphone,
-  // Route,
+  Filter,
+  Megaphone,
+  Route,
   ShieldCheck,
 } from 'lucide-react';
 
@@ -121,20 +121,20 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
     resource: 'automation_rules',
     action: 'read',
   },
-  // {
-  //   name: t('menu.customer.journeys'),
-  //   href: '/journeys',
-  //   icon: Route,
-  //   resource: 'journeys',
-  //   action: 'read',
-  // },
-  // {
-  //   name: t('menu.customer.campaigns'),
-  //   href: '/campaigns',
-  //   icon: Megaphone,
-  //   resource: 'campaigns',
-  //   action: 'read',
-  // },
+  {
+    name: t('menu.customer.journeys'),
+    href: '/journeys',
+    icon: Route,
+    resource: 'journeys',
+    action: 'read',
+  },
+  {
+    name: t('menu.customer.campaigns'),
+    href: '/campaigns',
+    icon: Megaphone,
+    resource: 'campaigns',
+    action: 'read',
+  },
   {
     id: 'customer-agents',
     name: t('menu.customer.agents'),
@@ -213,13 +213,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         resource: 'custom_attribute_definitions',
         action: 'read',
       },
-      // {
-      //   name: t('menu.settings.segments'),
-      //   href: '/settings/segments',
-      //   icon: Filter,
-      //   resource: 'segments',
-      //   action: 'read',
-      // },
+      {
+        name: t('menu.settings.segments'),
+        href: '/settings/segments',
+        icon: Filter,
+        resource: 'segments',
+        action: 'read',
+      },
       {
         name: t('menu.settings.cannedResponses'),
         href: '/settings/canned-responses',


### PR DESCRIPTION
## Summary
PR #84 commented Journeys, Campaigns and Segments out of the community sidebar. Per Davidson's decision (EVO-1568) they are core open-source/Community features, so this re-exposes them in `menuItems.ts`:
- Uncomment the `Filter` / `Megaphone` / `Route` icon imports.
- Uncomment the **Journeys** (`/journeys`), **Campaigns** (`/campaigns`) and **Segments** (`/settings/segments`) menu entries.
- **Tutoriais** stays out (per Daniel's note on the card — removed on purpose).

## Why this is safe / complete
- `menuItems.ts` is the single sidebar source (Sidebar/MenuItem consume it) — no other menu config to touch.
- Routes already exist (`routes/index.tsx`: `/journeys`, `/campaigns`, `/settings/segments`).
- i18n keys present in all 6 locales (`layout.json`).
- Items are permission-gated by `resource` (journeys/campaigns/segments) — unchanged from before #84.
- No edition/community flag re-hides them.

## Validation
- `tsc -b --noEmit` → no errors in the changed file
- `eslint src/components/layout/config/menuItems.ts` → clean

## Changed Files
- `src/components/layout/config/menuItems.ts`

## Linked Issue
- EVO-1687

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-expose core customer journey, campaign, and segment items in the community sidebar navigation.

New Features:
- Restore Journeys and Campaigns entries to the customer section of the sidebar when the user has appropriate permissions.
- Restore the Segments settings entry under customer settings in the sidebar when the user has appropriate permissions.