### PR TITLE
fix(frontend): preserve journey flow when editing metadata via the modal (EVO-1745)

### DIFF
--- a/src/components/journey/JourneyModal.spec.tsx
+++ b/src/components/journey/JourneyModal.spec.tsx
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import JourneyModal from './JourneyModal';
+
+vi.mock('@/services', () => ({
+  journeyService: {
+    createJourney: vi.fn().mockResolvedValue({}),
+    updateJourney: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+    currentLanguage: 'pt-BR',
+    changeLanguage: () => undefined,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { journeyService } from '@/services';
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+const existingJourney = {
+  id: 'j1',
+  name: 'My Journey',
+  description: 'desc',
+  isActive: true,
+  flowData: {
+    nodes: [
+      { id: 'journey-trigger-node', type: 'journey-trigger-node' },
+      { id: 'send-1', type: 'send-message-node' },
+      { id: 'exit-1', type: 'exit-journey-node' },
+    ],
+    edges: [{ id: 't-s', source: 'journey-trigger-node', target: 'send-1' }],
+    variables: [{ name: 'v1' }],
+  },
+} as never;
+
+describe('JourneyModal — EVO-1745 (do not wipe the flow on metadata edit)', () => {
+  it('updates an existing journey WITHOUT resending flowData/flowTriggers', async () => {
+    render(
+      <JourneyModal open journey={existingJourney} onClose={() => undefined} onSave={() => undefined} />,
+    );
+
+    fireEvent.click(screen.getByText('modal.edit.button'));
+
+    await waitFor(() => {
+      expect(journeyService.updateJourney).toHaveBeenCalledTimes(1);
+    });
+    const [id, payload] = vi.mocked(journeyService.updateJourney).mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(id).toBe('j1');
+    expect(payload).toMatchObject({ name: 'My Journey', isActive: true });
+    expect(payload).not.toHaveProperty('flowData');
+    expect(payload).not.toHaveProperty('flowTriggers');
+    expect(journeyService.createJourney).not.toHaveBeenCalled();
+  });
+
+  it('creates a new journey WITH the default trigger-only flowData', async () => {
+    render(
+      <JourneyModal open journey={null} onClose={() => undefined} onSave={() => undefined} />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('modal.fields.name.placeholder'), {
+      target: { value: 'New Journey' },
+    });
+    fireEvent.click(screen.getByText('modal.create.button'));
+
+    await waitFor(() => {
+      expect(journeyService.createJourney).toHaveBeenCalledTimes(1);
+    });
+    const [payload] = vi.mocked(journeyService.createJourney).mock.calls[0] as [
+      { name: string; flowData: { nodes: Array<{ type: string }> } },
+    ];
+    expect(payload).toMatchObject({ name: 'New Journey' });
+    expect(payload.flowData.nodes[0].type).toBe('journey-trigger-node');
+    expect(journeyService.updateJourney).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/journey/JourneyModal.tsx
+++ b/src/components/journey/JourneyModal.tsx
@@ -57,42 +57,48 @@ export default function JourneyModal({ open, onClose, journey, onSave }: Journey
     try {
       setLoading(true);
 
-      const payload = {
+      const basePayload = {
         name: formData.name.trim(),
         description: formData.description.trim() || undefined,
         isActive: formData.isActive,
-        flowData: {
-          nodes: [
-            {
-              id: 'journey-trigger-node',
-              type: 'journey-trigger-node',
-              position: { x: -100, y: 100 },
-              data: {
-                label: t('modal.defaultTrigger.label'),
-                description: t('modal.defaultTrigger.description'),
-                triggerType: 'manual',
-                conditions: [],
-              },
-            },
-          ],
-          edges: [],
-          variables: [],
-        },
-        flowTriggers: [
-          {
-            id: 'default-trigger',
-            type: TriggerType.Manual,
-            name: t('modal.defaultTrigger.name'),
-            enabled: true,
-          },
-        ],
       };
 
       if (journey?.id) {
-        await journeyService.updateJourney(journey.id, payload);
+        // Metadata-only edit: never resend flowData/flowTriggers — the backend
+        // replaces the stored flow wholesale, so a trigger-only payload would
+        // wipe the flow built in the editor (EVO-1745).
+        await journeyService.updateJourney(journey.id, basePayload);
         toast.success(t('modal.messages.updateSuccess'));
       } else {
-        await journeyService.createJourney(payload);
+        const createPayload = {
+          ...basePayload,
+          flowData: {
+            nodes: [
+              {
+                id: 'journey-trigger-node',
+                type: 'journey-trigger-node',
+                position: { x: -100, y: 100 },
+                data: {
+                  label: t('modal.defaultTrigger.label'),
+                  description: t('modal.defaultTrigger.description'),
+                  triggerType: 'manual',
+                  conditions: [],
+                },
+              },
+            ],
+            edges: [],
+            variables: [],
+          },
+          flowTriggers: [
+            {
+              id: 'default-trigger',
+              type: TriggerType.Manual,
+              name: t('modal.defaultTrigger.name'),
+              enabled: true,
+            },
+          ],
+        };
+        await journeyService.createJourney(createPayload);
         toast.success(t('modal.messages.createSuccess'));
       }
 


### PR DESCRIPTION
## Summary
`JourneyModal.handleSave` always built a synthetic **trigger-only** `flowData` (+ default `flowTriggers`) and sent it on **every** save — including updates. Editing an existing journey's name/description/active via the list modal therefore **wiped the flow built in the editor** (the backend replaces `flowData` wholesale on update). Silent data loss, no warning.

Fix (frontend only):
- **Update** now sends only `{ name, description, isActive }` → the backend keeps the stored `flowData`/`flowTriggers`/variables (`updateJourney` PATCHes the partial payload; `UpdateJourneyDto` is PartialType).
- **Create** is unchanged — a new journey still gets the default trigger-only `flowData` + `flowTriggers`.

## Security
None. Frontend payload shaping only; backend was already correct.

## Test plan
- `evo-ai-frontend-community: pnpm vitest run src/components/journey/JourneyModal.spec.tsx` → 2/2 (update sends no flowData/flowTriggers; create sends flowData)
- `pnpm exec tsc -b --noEmit` → clean for changed files (pre-existing unrelated error in TemplateParser.tsx:121)
- `eslint` (changed files) → clean
- **Live smoke:** built a real flow → edited the name via the list modal → reopened the editor → flow intact (was reduced to a lone trigger before).

## Changed Files
- `src/components/journey/JourneyModal.tsx`
- `src/components/journey/JourneyModal.spec.tsx` (new)

## Linked Issue
- EVO-1745

## Summary by Sourcery

Preserve existing journey flows when editing metadata in the modal by sending only metadata fields on update while keeping default flow initialization for creation.

Bug Fixes:
- Prevent existing journey flows from being overwritten with a default trigger-only flow when updating name, description, or active status via the modal.

Tests:
- Add unit tests for JourneyModal to verify that updates omit flowData/flowTriggers and creations include the default trigger-only flow.