### PR TITLE
feat(channels): pick a global template for inbox greeting/out-of-office (EVO-1760)

### DIFF
--- a/src/components/channels/settings/BusinessHoursForm.spec.tsx
+++ b/src/components/channels/settings/BusinessHoursForm.spec.tsx
@@ -60,6 +60,12 @@ vi.mock('@evoapi/design-system', async () => {
   };
 });
 
+vi.mock('./GlobalTemplateSelect', () => ({
+  default: ({ value }: { value?: string | null }) => (
+    <div data-testid="global-template-select">{value || 'none'}</div>
+  ),
+}));
+
 describe('BusinessHoursForm', () => {
   const mockOnUpdate = vi.fn().mockResolvedValue(undefined);
   const defaultProps = {
@@ -90,9 +96,22 @@ describe('BusinessHoursForm', () => {
   describe('Button disabled state', () => {
     it('should not disable button when business hours is disabled even if there are validation errors', () => {
       render(<BusinessHoursForm {...defaultProps} workingHoursEnabled={false} />);
-      
+
       const updateButton = screen.getByRole('button', { name: /settings\.businessHours\.buttons\.update/i });
       expect(updateButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Out-of-office template', () => {
+    it('starts in template mode when an out-of-office template id is set', () => {
+      render(
+        <BusinessHoursForm
+          {...defaultProps}
+          workingHoursEnabled={true}
+          outOfOfficeMessageTemplateId="tpl-9"
+        />,
+      );
+      expect(screen.getByTestId('global-template-select')).toHaveTextContent('tpl-9');
     });
   });
 });

--- a/src/components/channels/settings/BusinessHoursForm.tsx
+++ b/src/components/channels/settings/BusinessHoursForm.tsx
@@ -16,6 +16,7 @@ import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
 import BusinessDay from './BusinessDay';
+import GlobalTemplateSelect from './GlobalTemplateSelect';
 import {
   TimeSlot,
   TimeZone,
@@ -32,11 +33,13 @@ interface BusinessHoursFormProps {
   inboxId: string;
   workingHoursEnabled?: boolean;
   outOfOfficeMessage?: string;
+  outOfOfficeMessageTemplateId?: string | null;
   workingHours?: unknown[];
   timezone?: string;
   onUpdate?: (data: {
     working_hours_enabled: boolean;
     out_of_office_message: string;
+    out_of_office_message_template_id: string | null;
     working_hours: unknown[];
     timezone: string;
   }) => Promise<void>;
@@ -45,6 +48,7 @@ interface BusinessHoursFormProps {
 export default function BusinessHoursForm({
   workingHoursEnabled = false,
   outOfOfficeMessage = '',
+  outOfOfficeMessageTemplateId = null,
   workingHours = [],
   timezone,
   onUpdate,
@@ -53,6 +57,8 @@ export default function BusinessHoursForm({
   const defaultTz = getDefaultTimezone();
   const [isBusinessHoursEnabled, setIsBusinessHoursEnabled] = useState(workingHoursEnabled);
   const [unavailableMessage, setUnavailableMessage] = useState(outOfOfficeMessage);
+  const [templateId, setTemplateId] = useState<string | null>(outOfOfficeMessageTemplateId);
+  const [useTemplate, setUseTemplate] = useState(!!outOfOfficeMessageTemplateId);
   const [selectedTimeZone, setSelectedTimeZone] = useState<TimeZone>(defaultTz);
   const [timeSlots, setTimeSlots] = useState<TimeSlot[]>(defaultTimeSlot);
   const [isUpdating, setIsUpdating] = useState(false);
@@ -63,6 +69,8 @@ export default function BusinessHoursForm({
   useEffect(() => {
     setIsBusinessHoursEnabled(workingHoursEnabled);
     setUnavailableMessage(outOfOfficeMessage || '');
+    setTemplateId(outOfOfficeMessageTemplateId ?? null);
+    if (outOfOfficeMessageTemplateId) setUseTemplate(true);
 
     // Parse working hours from API format
     const slots =
@@ -75,7 +83,7 @@ export default function BusinessHoursForm({
     const tzOptions = getTimeZoneOptions();
     const foundTimeZone = tzOptions.find(tz => tz.value === timezone);
     setSelectedTimeZone(foundTimeZone || getDefaultTimezone());
-  }, [workingHoursEnabled, outOfOfficeMessage, workingHours, timezone]);
+  }, [workingHoursEnabled, outOfOfficeMessage, outOfOfficeMessageTemplateId, workingHours, timezone]);
 
   // Check if there are validation errors
   const hasErrors = timeSlots.some(slot => slot.from && slot.to && !slot.valid);
@@ -97,6 +105,7 @@ export default function BusinessHoursForm({
       const updateData = {
         working_hours_enabled: isBusinessHoursEnabled,
         out_of_office_message: unavailableMessage,
+        out_of_office_message_template_id: useTemplate ? templateId : null,
         working_hours: timeSlotTransform(timeSlots),
         timezone: selectedTimeZone.value,
       };
@@ -152,18 +161,55 @@ export default function BusinessHoursForm({
               <div className="space-y-6">
                 {/* Unavailable Message */}
                 <div className="space-y-3">
-                  <label className="text-sm font-medium text-foreground">
-                    {t('settings.businessHours.unavailableMessage.label')}
-                  </label>
-                  <Textarea
-                    value={unavailableMessage}
-                    onChange={e => setUnavailableMessage(e.target.value)}
-                    placeholder={t('settings.businessHours.unavailableMessage.placeholder')}
-                    className="min-h-[100px]"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    {t('settings.businessHours.unavailableMessage.help')}
-                  </p>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <label className="text-sm font-medium text-foreground">
+                        {t('settings.businessHours.useTemplate.label')}
+                      </label>
+                      <p className="text-xs text-muted-foreground">
+                        {t('settings.businessHours.useTemplate.description')}
+                      </p>
+                    </div>
+                    <Switch
+                      checked={useTemplate}
+                      onCheckedChange={checked => {
+                        setUseTemplate(checked);
+                        if (!checked) setTemplateId(null);
+                      }}
+                    />
+                  </div>
+
+                  {useTemplate ? (
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium text-foreground">
+                        {t('settings.businessHours.template.label')}
+                      </label>
+                      <GlobalTemplateSelect
+                        value={templateId}
+                        onChange={setTemplateId}
+                        placeholder={t('settings.businessHours.template.placeholder')}
+                        emptyText={t('settings.businessHours.template.empty')}
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t('settings.businessHours.template.help')}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium text-foreground">
+                        {t('settings.businessHours.unavailableMessage.label')}
+                      </label>
+                      <Textarea
+                        value={unavailableMessage}
+                        onChange={e => setUnavailableMessage(e.target.value)}
+                        placeholder={t('settings.businessHours.unavailableMessage.placeholder')}
+                        className="min-h-[100px]"
+                      />
+                      <p className="text-xs text-muted-foreground">
+                        {t('settings.businessHours.unavailableMessage.help')}
+                      </p>
+                    </div>
+                  )}
                 </div>
 
                 {/* Timezone Selection */}

--- a/src/components/channels/settings/GlobalTemplateSelect.spec.tsx
+++ b/src/components/channels/settings/GlobalTemplateSelect.spec.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+const h = vi.hoisted(() => ({ getTemplates: vi.fn() }));
+
+vi.mock('@/services/messageTemplates/globalMessageTemplatesService', () => ({
+  default: { getTemplates: h.getTemplates },
+}));
+
+// Render the design-system Select as a native <select> so options are assertable.
+vi.mock('@evoapi/design-system', () => ({
+  Select: ({
+    children,
+    value,
+    onValueChange,
+    disabled,
+  }: {
+    children: ReactNode;
+    value?: string | null;
+    onValueChange: (value: string) => void;
+    disabled?: boolean;
+  }) => (
+    <select
+      data-testid="select"
+      disabled={disabled}
+      value={value || ''}
+      onChange={e => onValueChange(e.target.value)}
+    >
+      <option value="" hidden />
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+import GlobalTemplateSelect from './GlobalTemplateSelect';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getTemplates.mockResolvedValue({
+    success: true,
+    data: [
+      { id: 't1', name: 'welcome', language: 'en' },
+      { id: 't2', name: 'goodbye', language: 'pt_BR' },
+    ],
+    meta: {},
+    message: '',
+  });
+});
+
+describe('GlobalTemplateSelect', () => {
+  it('lists global templates from the flat endpoint and emits the selected id', async () => {
+    const onChange = vi.fn();
+    render(<GlobalTemplateSelect value={null} onChange={onChange} placeholder="ph" emptyText="empty" />);
+
+    expect(h.getTemplates).toHaveBeenCalledWith(
+      expect.objectContaining({ per_page: 200, sort_by: 'name' }),
+    );
+
+    // One option per template once the fetch resolves (the hidden empty option
+    // is excluded from the accessibility tree).
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(2));
+
+    fireEvent.change(screen.getByTestId('select'), { target: { value: 't2' } });
+    expect(onChange).toHaveBeenCalledWith('t2');
+  });
+
+  it('is disabled when there are no global templates', async () => {
+    h.getTemplates.mockResolvedValue({ success: true, data: [], meta: {}, message: '' });
+    render(<GlobalTemplateSelect value={null} onChange={vi.fn()} placeholder="ph" emptyText="empty" />);
+    await waitFor(() => expect(screen.getByTestId('select')).toBeDisabled());
+  });
+});

--- a/src/components/channels/settings/GlobalTemplateSelect.tsx
+++ b/src/components/channels/settings/GlobalTemplateSelect.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import GlobalMessageTemplateService from '@/services/messageTemplates/globalMessageTemplatesService';
+import type { MessageTemplate } from '@/types';
+
+interface GlobalTemplateSelectProps {
+  /** Currently selected global template id (or null/undefined for none). */
+  value?: string | null;
+  onChange: (templateId: string) => void;
+  placeholder?: string;
+  /** Shown (disabled) when there are no global templates to pick. */
+  emptyText?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Lists GLOBAL (channel-less) message templates and emits the selected id.
+ *
+ * Consumes the flat `/message_templates` endpoint (no inbox_id) via
+ * GlobalMessageTemplateService, so only channel-less templates appear — the
+ * same catalog managed in Settings → Message Templates. Reusable wherever a
+ * global template needs to be attached (greeting / out-of-office, and later
+ * automation / chat). Fetches once on mount.
+ */
+export default function GlobalTemplateSelect({
+  value,
+  onChange,
+  placeholder,
+  emptyText,
+  disabled = false,
+}: GlobalTemplateSelectProps) {
+  const [templates, setTemplates] = useState<MessageTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    (async () => {
+      try {
+        const response = await GlobalMessageTemplateService.getTemplates({
+          per_page: 200,
+          sort_by: 'name',
+        });
+        if (mounted.current) setTemplates(response.data ?? []);
+      } catch {
+        // No read permission or transient error: degrade to an empty list.
+        if (mounted.current) setTemplates([]);
+      } finally {
+        if (mounted.current) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const isEmpty = !loading && templates.length === 0;
+
+  return (
+    <Select
+      value={value ?? undefined}
+      onValueChange={onChange}
+      disabled={disabled || loading || isEmpty}
+    >
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder={isEmpty ? emptyText : placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {templates.map(template => (
+          <SelectItem key={template.id} value={String(template.id)}>
+            {template.name}
+            {template.language ? ` (${template.language})` : ''}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/channels/settings/GreetingSettingsForm.spec.tsx
+++ b/src/components/channels/settings/GreetingSettingsForm.spec.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+// Stub the picker so the form test stays focused on mode-switching/wiring.
+vi.mock('./GlobalTemplateSelect', () => ({
+  default: ({ value }: { value?: string | null }) => (
+    <div data-testid="global-template-select">{value || 'none'}</div>
+  ),
+}));
+
+// Interactive Switch so the "use template" toggle can be exercised.
+vi.mock('@evoapi/design-system', () => ({
+  Switch: ({ checked, onCheckedChange }: { checked: boolean; onCheckedChange: (v: boolean) => void }) => (
+    <button role="switch" aria-checked={checked} onClick={() => onCheckedChange(!checked)} />
+  ),
+}));
+
+import GreetingSettingsForm from './GreetingSettingsForm';
+
+const base = {
+  greeting_enabled: true,
+  greeting_message: '',
+  greeting_message_template_id: null as string | null,
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('GreetingSettingsForm', () => {
+  it('shows the free-text message by default (no template ref)', () => {
+    render(<GreetingSettingsForm formData={base} onFormChange={vi.fn()} />);
+    expect(
+      screen.getByPlaceholderText('settings.greeting.message.placeholder'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('global-template-select')).not.toBeInTheDocument();
+  });
+
+  it('starts in template mode when a template id is already set', () => {
+    render(
+      <GreetingSettingsForm
+        formData={{ ...base, greeting_message_template_id: 'tpl-1' }}
+        onFormChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('global-template-select')).toHaveTextContent('tpl-1');
+    expect(
+      screen.queryByPlaceholderText('settings.greeting.message.placeholder'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('switches to the template picker when "use template" is toggled on', () => {
+    render(<GreetingSettingsForm formData={base} onFormChange={vi.fn()} />);
+    // switches: [0] greeting_enabled, [1] use-template
+    fireEvent.click(screen.getAllByRole('switch')[1]);
+    expect(screen.getByTestId('global-template-select')).toBeInTheDocument();
+  });
+
+  it('clears the template ref when "use template" is toggled off', () => {
+    const onFormChange = vi.fn();
+    render(
+      <GreetingSettingsForm
+        formData={{ ...base, greeting_message_template_id: 'tpl-1' }}
+        onFormChange={onFormChange}
+      />,
+    );
+    fireEvent.click(screen.getAllByRole('switch')[1]); // ON -> OFF
+    expect(onFormChange).toHaveBeenCalledWith({ greeting_message_template_id: null });
+  });
+});

--- a/src/components/channels/settings/GreetingSettingsForm.tsx
+++ b/src/components/channels/settings/GreetingSettingsForm.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useState } from 'react';
 import { Switch } from '@evoapi/design-system';
 import { useLanguage } from '@/hooks/useLanguage';
+import GlobalTemplateSelect from './GlobalTemplateSelect';
 
 interface GreetingFormData {
   greeting_enabled: boolean;
   greeting_message: string;
+  greeting_message_template_id?: string | null;
 }
 
 interface GreetingSettingsFormProps {
@@ -16,6 +19,19 @@ export default function GreetingSettingsForm({
   onFormChange,
 }: GreetingSettingsFormProps) {
   const { t } = useLanguage('channels');
+  const [useTemplate, setUseTemplate] = useState(!!formData.greeting_message_template_id);
+
+  // Reflect a template id that arrives after the inbox data loads.
+  useEffect(() => {
+    if (formData.greeting_message_template_id) setUseTemplate(true);
+  }, [formData.greeting_message_template_id]);
+
+  const handleUseTemplateChange = (checked: boolean) => {
+    setUseTemplate(checked);
+    // Leaving template mode clears the reference so the free-text message wins.
+    if (!checked) onFormChange({ greeting_message_template_id: null });
+  };
+
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-3 pb-3 border-b border-border">
@@ -48,17 +64,48 @@ export default function GreetingSettingsForm({
       </div>
 
       {formData.greeting_enabled && (
-        <div className="space-y-2">
-          <label className="text-sm font-medium text-foreground">
-            {t('settings.greeting.message.label')}
-          </label>
-          <textarea
-            value={formData.greeting_message}
-            onChange={(e) => onFormChange({ greeting_message: e.target.value })}
-            placeholder={t('settings.greeting.message.placeholder')}
-            rows={3}
-            className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary resize-none"
-          />
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="text-sm font-medium text-foreground">
+                {t('settings.greeting.useTemplate.label')}
+              </label>
+              <p className="text-xs text-muted-foreground">
+                {t('settings.greeting.useTemplate.description')}
+              </p>
+            </div>
+            <Switch checked={useTemplate} onCheckedChange={handleUseTemplateChange} />
+          </div>
+
+          {useTemplate ? (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                {t('settings.greeting.template.label')}
+              </label>
+              <GlobalTemplateSelect
+                value={formData.greeting_message_template_id}
+                onChange={(id) => onFormChange({ greeting_message_template_id: id })}
+                placeholder={t('settings.greeting.template.placeholder')}
+                emptyText={t('settings.greeting.template.empty')}
+              />
+              <p className="text-xs text-muted-foreground">
+                {t('settings.greeting.template.help')}
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-foreground">
+                {t('settings.greeting.message.label')}
+              </label>
+              <textarea
+                value={formData.greeting_message}
+                onChange={(e) => onFormChange({ greeting_message: e.target.value })}
+                placeholder={t('settings.greeting.message.placeholder')}
+                rows={3}
+                className="w-full px-3 py-2 border border-border rounded-md bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary resize-none"
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -434,6 +434,16 @@
         "placeholder": "Sorry, we're outside business hours...",
         "help": "This message will be sent when outside business hours"
       },
+      "useTemplate": {
+        "label": "Use global template",
+        "description": "Send a global message template instead of free text"
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Select a global template",
+        "empty": "No global templates available",
+        "help": "Manage global templates in Settings → Message Templates"
+      },
       "timezone": {
         "label": "Timezone",
         "placeholder": "Select timezone"
@@ -1126,6 +1136,16 @@
       "message": {
         "label": "Greeting Message",
         "placeholder": "Enter your welcome message here..."
+      },
+      "useTemplate": {
+        "label": "Use global template",
+        "description": "Send a global message template instead of free text"
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Select a global template",
+        "empty": "No global templates available",
+        "help": "Manage global templates in Settings → Message Templates"
       }
     },
     "webWidgetAdvanced": {

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -418,6 +418,16 @@
         "placeholder": "Disculpe, estamos fuera del horario de funcionamiento...",
         "help": "Este mensaje será enviado cuando esté fuera del horario"
       },
+      "useTemplate": {
+        "label": "Usar plantilla global",
+        "description": "Enviar una plantilla de mensaje global en lugar de texto libre"
+      },
+      "template": {
+        "label": "Plantilla",
+        "placeholder": "Selecciona una plantilla global",
+        "empty": "No hay plantillas globales disponibles",
+        "help": "Gestiona plantillas globales en Configuración → Plantillas de Mensaje"
+      },
       "timezone": {
         "label": "Zona Horaria",
         "placeholder": "Seleccione la zona horaria"
@@ -1104,6 +1114,16 @@
       "message": {
         "label": "Mensaje de Saludo",
         "placeholder": "Digite aquí el mensaje de bienvenida..."
+      },
+      "useTemplate": {
+        "label": "Usar plantilla global",
+        "description": "Enviar una plantilla de mensaje global en lugar de texto libre"
+      },
+      "template": {
+        "label": "Plantilla",
+        "placeholder": "Selecciona una plantilla global",
+        "empty": "No hay plantillas globales disponibles",
+        "help": "Gestiona plantillas globales en Configuración → Plantillas de Mensaje"
       }
     },
     "webWidgetAdvanced": {

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -417,6 +417,16 @@
         "placeholder": "Désolé, nous sommes en dehors des horaires d'ouverture...",
         "help": "Ce message sera envoyé en dehors des horaires d'ouverture"
       },
+      "useTemplate": {
+        "label": "Utiliser un modèle global",
+        "description": "Envoyer un modèle de message global au lieu d'un texte libre"
+      },
+      "template": {
+        "label": "Modèle",
+        "placeholder": "Sélectionnez un modèle global",
+        "empty": "Aucun modèle global disponible",
+        "help": "Gérez les modèles globaux dans Paramètres → Modèles de message"
+      },
       "timezone": {
         "label": "Fuseau Horaire",
         "placeholder": "Sélectionnez le fuseau horaire"
@@ -1064,6 +1074,16 @@
       "message": {
         "label": "Message d'Accueil",
         "placeholder": "Entrez ici le message de bienvenue..."
+      },
+      "useTemplate": {
+        "label": "Utiliser un modèle global",
+        "description": "Envoyer un modèle de message global au lieu d'un texte libre"
+      },
+      "template": {
+        "label": "Modèle",
+        "placeholder": "Sélectionnez un modèle global",
+        "empty": "Aucun modèle global disponible",
+        "help": "Gérez les modèles globaux dans Paramètres → Modèles de message"
       }
     },
     "webWidgetAdvanced": {

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -417,6 +417,16 @@
         "placeholder": "Siamo spiacenti, siamo al di fuori degli orari di lavoro...",
         "help": "Questo messaggio verrà inviato al di fuori degli orari di lavoro"
       },
+      "useTemplate": {
+        "label": "Usa modello globale",
+        "description": "Invia un modello di messaggio globale invece del testo libero"
+      },
+      "template": {
+        "label": "Modello",
+        "placeholder": "Seleziona un modello globale",
+        "empty": "Nessun modello globale disponibile",
+        "help": "Gestisci i modelli globali in Impostazioni → Modelli di messaggio"
+      },
       "timezone": {
         "label": "Fuso Orario",
         "placeholder": "Seleziona il fuso orario"
@@ -1064,6 +1074,16 @@
       "message": {
         "label": "Messaggio di Saluto",
         "placeholder": "Inserisci qui il messaggio di benvenuto..."
+      },
+      "useTemplate": {
+        "label": "Usa modello globale",
+        "description": "Invia un modello di messaggio globale invece del testo libero"
+      },
+      "template": {
+        "label": "Modello",
+        "placeholder": "Seleziona un modello globale",
+        "empty": "Nessun modello globale disponibile",
+        "help": "Gestisci i modelli globali in Impostazioni → Modelli di messaggio"
       }
     },
     "webWidgetAdvanced": {

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -434,6 +434,16 @@
         "placeholder": "Desculpe, estamos fora do horário de funcionamento...",
         "help": "Esta mensagem será enviada quando estiver fora do horário"
       },
+      "useTemplate": {
+        "label": "Usar template global",
+        "description": "Enviar um template de mensagem global em vez de texto livre"
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Selecione um template global",
+        "empty": "Nenhum template global disponível",
+        "help": "Gerencie templates globais em Configurações → Templates de Mensagem"
+      },
       "timezone": {
         "label": "Fuso Horário",
         "placeholder": "Selecione o fuso horário"
@@ -1126,6 +1136,16 @@
       "message": {
         "label": "Mensagem de Saudação",
         "placeholder": "Digite aqui a mensagem de boas-vindas..."
+      },
+      "useTemplate": {
+        "label": "Usar template global",
+        "description": "Enviar um template de mensagem global em vez de texto livre"
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Selecione um template global",
+        "empty": "Nenhum template global disponível",
+        "help": "Gerencie templates globais em Configurações → Templates de Mensagem"
       }
     },
     "webWidgetAdvanced": {

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -434,6 +434,16 @@
         "placeholder": "Desculpe, estamos fora do horário de funcionamento...",
         "help": "Esta mensagem será enviada quando estiver fora do horário"
       },
+      "useTemplate": {
+        "label": "Usar template global",
+        "description": "Enviar um template de mensagem global em vez de texto livre"
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Selecione um template global",
+        "empty": "Nenhum template global disponível",
+        "help": "Gerencie templates globais em Configurações → Templates de Mensagem"
+      },
       "timezone": {
         "label": "Fuso Horário",
         "placeholder": "Selecione o fuso horário"
@@ -1121,6 +1131,16 @@
       "message": {
         "label": "Mensagem de Saudação",
         "placeholder": "Digite aqui a mensagem de boas-vindas..."
+      },
+      "useTemplate": {
+        "label": "Usar template global",
+        "description": "Enviar um template de mensagem global em vez de texto livre"
+      },
+      "template": {
+        "label": "Template",
+        "placeholder": "Selecione um template global",
+        "empty": "Nenhum template global disponível",
+        "help": "Gerencie templates globais em Configurações → Templates de Mensagem"
       }
     },
     "webWidgetAdvanced": {

--- a/src/pages/Customer/Channels/ChannelSettings.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.tsx
@@ -91,6 +91,7 @@ interface ChannelSettingsData {
   // Communication settings
   greeting_enabled: boolean;
   greeting_message: string;
+  greeting_message_template_id?: string | null;
   enable_email_collect: boolean;
   allow_messages_after_resolved: boolean;
   continuity_via_email: boolean;
@@ -297,6 +298,7 @@ export default function ChannelSettings() {
     display_name: '',
     greeting_enabled: false,
     greeting_message: '',
+    greeting_message_template_id: null,
     enable_email_collect: false,
     allow_messages_after_resolved: true,
     continuity_via_email: true,
@@ -415,6 +417,7 @@ export default function ChannelSettings() {
         locale: data.locale || null,
         greeting_enabled: data.greeting_enabled === true,
         greeting_message: data.greeting_message || '',
+        greeting_message_template_id: data.greeting_message_template_id || null,
         enable_email_collect: data.enable_email_collect === true,
         allow_messages_after_resolved: data.allow_messages_after_resolved !== false,
         continuity_via_email: data.continuity_via_email !== false,
@@ -452,6 +455,7 @@ export default function ChannelSettings() {
         allow_messages_after_resolved: formData.allow_messages_after_resolved,
         greeting_enabled: formData.greeting_enabled,
         greeting_message: formData.greeting_message || '',
+        greeting_message_template_id: formData.greeting_message_template_id || null,
         portal_id: formData.portal_id || null,
         lock_to_single_conversation: formData.lock_to_single_conversation,
         default_conversation_status: formData.default_conversation_status || null,
@@ -771,6 +775,7 @@ export default function ChannelSettings() {
                 inboxId={inboxId}
                 workingHoursEnabled={inbox?.working_hours_enabled === true}
                 outOfOfficeMessage={inbox?.out_of_office_message || ''}
+                outOfOfficeMessageTemplateId={inbox?.out_of_office_message_template_id || null}
                 workingHours={Array.isArray(inbox?.working_hours) ? inbox.working_hours : []}
                 timezone={inbox?.timezone || 'UTC'}
                 onUpdate={async data => {
@@ -779,6 +784,7 @@ export default function ChannelSettings() {
                     id: inboxId,
                     working_hours_enabled: data.working_hours_enabled,
                     out_of_office_message: data.out_of_office_message,
+                    out_of_office_message_template_id: data.out_of_office_message_template_id,
                     working_hours: data.working_hours,
                     timezone: data.timezone,
                   };

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -49,6 +49,7 @@ export interface Inbox {
   // Communication settings
   greeting_enabled?: boolean;
   greeting_message?: string;
+  greeting_message_template_id?: string | null;
   enable_email_collect?: boolean;
   allow_messages_after_resolved?: boolean;
   continuity_via_email?: boolean;
@@ -79,6 +80,7 @@ export interface Inbox {
   // Business hours
   working_hours_enabled?: boolean;
   out_of_office_message?: string;
+  out_of_office_message_template_id?: string | null;
   working_hours?: unknown[];
   timezone?: string;
   // CSAT


### PR DESCRIPTION
## Summary

First UI gap from the EVO-1760 audit: global (channel-less) message templates were already resolvable by the backend send paths, but no screen let a user attach one. This wires the **inbox greeting / out-of-office** path end-to-end.

- New reusable `GlobalTemplateSelect` — lists the global catalog via `globalMessageTemplatesService` (flat `/message_templates`, no `inbox_id`), fetched once on mount.
- `GreetingSettingsForm` + `BusinessHoursForm`: a **"use global template"** toggle swaps the free-text field for the picker, writing `greeting_message_template_id` / `out_of_office_message_template_id` (clearing it returns to free text — the backend prefers the template when the id is set).
- `ChannelSettings` wires both ids into the inbox update payload; `Inbox` type + 6 locales updated.

Depends on the CRM PR (permit + serialize the two ids).

## Test plan

- `GreetingSettingsForm.spec.tsx` — **4/4** (free-text default; starts in template mode when an id is set; toggle on shows the picker; toggle off clears the ref).
- `GlobalTemplateSelect.spec.tsx` — **2/2** (lists globals from the flat endpoint + emits the id; disabled when none).
- `BusinessHoursForm.spec.tsx` — added an out-of-office template-mode test. Note: this spec uses `importActual('@evoapi/design-system')` and does not complete in my local sandbox (pre-existing on develop, not introduced here); it validates in CI.
- `tsc -b` clean; eslint clean on touched files.

## Notas

- WhatsApp Cloud is intentionally out of scope (channel-bound; never in the global catalog).
- Remaining EVO-1760 items (automation dropdown, chat picker, bot auto-reply) stay open on the card.

## Linked issue
- EVO-1760

## Summary by Sourcery

Add support for selecting global message templates for inbox greeting and out-of-office messages and wire the chosen template IDs through channel settings and inbox updates.

New Features:
- Introduce a reusable GlobalTemplateSelect component that lists global (channel-less) message templates from the shared catalog.
- Allow greeting messages to use either free text or a selected global message template in channel settings.
- Allow out-of-office messages in business hours settings to use either free text or a selected global message template, persisting the template ID with the inbox.

Enhancements:
- Extend inbox and channel settings types and payloads to include greeting and out-of-office message template IDs.
- Localize new greeting and business-hours template selection labels and help text across supported locales.

Tests:
- Add focused tests for GreetingSettingsForm to cover default free-text mode, template-initialized mode, toggle behavior, and clearing the template reference.
- Add coverage in BusinessHoursForm tests for initializing in template mode when an out-of-office template ID is present.
- Add unit tests for the GlobalTemplateSelect component to verify listing global templates, emitting selections, and handling an empty catalog.