### PR TITLE
fix(frontend): retain label/segment trigger action on save (EVO-1754)

### DIFF
--- a/src/components/journey/nodes/trigger/JourneyTriggerNode.spec.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerNode.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ReactFlowProvider } from '@xyflow/react';
+import { JourneyTriggerNode, type JourneyTriggerNodeData } from './JourneyTriggerNode';
+import '@/i18n/config';
+
+// BaseFlowNode renders @xyflow/react Handles, so the node needs a flow context.
+function renderNode(data: Partial<JourneyTriggerNodeData>) {
+  render(
+    <ReactFlowProvider>
+      <JourneyTriggerNode
+        id="node-1"
+        selected={false}
+        data={{ label: 'Trigger', triggerType: 'manual', ...data } as JourneyTriggerNodeData}
+      />
+    </ReactFlowProvider>,
+  );
+}
+
+// EVO-1754: the canvas card must default an unset action to the SAME value the
+// editor + runtime assume (label → applied, segment → entered), not the opposite.
+describe('JourneyTriggerNode — action defaults on the canvas card (EVO-1754)', () => {
+  it('renders a Label trigger with no labelAction as "applied" (not "removed")', () => {
+    renderNode({ triggerType: 'label', labelId: 'l1', labelName: 'vip' });
+    expect(screen.getByText(/"vip"\s+applied/i)).toBeTruthy();
+    expect(screen.queryByText(/removed/i)).toBeNull();
+  });
+
+  it('renders an explicit labelAction "removed" as "removed"', () => {
+    renderNode({
+      triggerType: 'label',
+      labelId: 'l1',
+      labelName: 'vip',
+      labelAction: 'removed',
+    });
+    expect(screen.getByText(/"vip"\s+removed/i)).toBeTruthy();
+  });
+
+  it('renders a Segment trigger with no segmentAction as "enters" (not "exits")', () => {
+    renderNode({ triggerType: 'segment', segmentId: 's1', segmentName: 'leads' });
+    expect(screen.getByText(/enters\s+"leads"/i)).toBeTruthy();
+    expect(screen.queryByText(/exits/i)).toBeNull();
+  });
+
+  it('renders an explicit segmentAction "exited" as "exits"', () => {
+    renderNode({
+      triggerType: 'segment',
+      segmentId: 's1',
+      segmentName: 'leads',
+      segmentAction: 'exited',
+    });
+    expect(screen.getByText(/exits\s+"leads"/i)).toBeTruthy();
+  });
+});

--- a/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerNode.tsx
@@ -123,13 +123,13 @@ export function JourneyTriggerNode({ selected, data, id }: JourneyTriggerNodePro
       case 'segment':
         if (data.segmentId && data.segmentName) {
           const action =
-            data.segmentAction === 'entered'
+            data.segmentAction !== 'exited'
               ? t('flowEditor.nodes.trigger.descriptions.segmentEnters')
               : t('flowEditor.nodes.trigger.descriptions.segmentExits');
           return `Quando ${action} "${data.segmentName}"`;
         } else if (data.segmentId) {
           const action =
-            data.segmentAction === 'entered'
+            data.segmentAction !== 'exited'
               ? t('flowEditor.nodes.trigger.descriptions.whenEnters')
               : t('flowEditor.nodes.trigger.descriptions.whenExits');
           return `${action} ${t('flowEditor.nodes.trigger.descriptions.segment')}`;
@@ -163,13 +163,13 @@ export function JourneyTriggerNode({ selected, data, id }: JourneyTriggerNodePro
       case 'label':
         if (data.labelId && data.labelName) {
           const action =
-            data.labelAction === 'applied'
+            data.labelAction !== 'removed'
               ? t('flowEditor.nodes.trigger.descriptions.applied')
               : t('flowEditor.nodes.trigger.descriptions.removed');
           return `"${data.labelName}" ${action}`;
         } else if (data.labelId) {
           const action =
-            data.labelAction === 'applied'
+            data.labelAction !== 'removed'
               ? t('flowEditor.nodes.trigger.descriptions.applied')
               : t('flowEditor.nodes.trigger.descriptions.removed');
           return `${t('flowEditor.nodes.trigger.types.label')} ${action}`;

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
@@ -20,6 +20,15 @@ vi.mock('@/hooks/useJourneyVariables', () => ({
   }),
 }));
 
+// Label/Segment config blocks fetch options on mount; stub the services so the
+// label/segment trigger tests don't hit the network (was logging a 401).
+vi.mock('@/services/contacts/labelsService', () => ({
+  labelsService: { getLabels: vi.fn().mockResolvedValue({ data: [] }) },
+}));
+vi.mock('@/services/segments/segmentsService', () => ({
+  segmentsService: { getSegments: vi.fn().mockResolvedValue({ data: [] }) },
+}));
+
 function renderPanel(data: Partial<JourneyTriggerNodeData> = {}) {
   const onUpdate = vi.fn();
   const onClose = vi.fn();
@@ -190,5 +199,59 @@ describe('JourneyTriggerPanel — event trigger tabs (EVO-1276)', () => {
     // Trigger-type selector + Save chrome still present.
     expect(screen.getAllByRole('combobox').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy();
+  });
+});
+
+describe('JourneyTriggerPanel — label/segment action round-trip (EVO-1754)', () => {
+  // Switch the header trigger-type selector (the first combobox), which both
+  // dirties the form (enabling Save) and reveals that type's config — mirroring
+  // a user creating the trigger from the default event type.
+  async function selectTriggerType(
+    user: ReturnType<typeof userEvent.setup>,
+    option: RegExp,
+  ) {
+    await user.click(screen.getAllByRole('combobox')[0]);
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText(option));
+  }
+
+  it('persists labelAction "applied" when a Label trigger is saved without touching the action', async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderPanel();
+
+    await selectTriggerType(user, /^Label$/);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
+    // Regression: the dropdown shows "Applied" by default, so Save must persist
+    // 'applied' — not undefined, which the canvas card rendered as "removed".
+    expect(saved.labelAction).toBe('applied');
+  });
+
+  it('preserves an explicitly chosen labelAction "removed" through Save', async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderPanel();
+
+    await selectTriggerType(user, /^Label$/);
+    // The label-action select is the second combobox; "Removed" is its second
+    // option (after the default "Applied") — picked by index to stay locale-agnostic.
+    await user.click(screen.getAllByRole('combobox')[1]);
+    const actionList = await screen.findByRole('listbox');
+    await user.click(within(actionList).getAllByRole('option')[1]);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
+    expect(saved.labelAction).toBe('removed');
+  });
+
+  it('persists segmentAction "entered" when a Segment trigger is saved without touching the action', async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderPanel();
+
+    await selectTriggerType(user, /^Segment$/);
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
+    expect(saved.segmentAction).toBe('entered');
   });
 });

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -92,11 +92,11 @@ export function JourneyTriggerPanel({
       eventProperties: showEventConfig ? eventProperties : undefined,
       segmentId: showSegmentConfig ? formData.segmentId : undefined,
       segmentName: showSegmentConfig ? formData.segmentName : undefined,
-      segmentAction: showSegmentConfig ? formData.segmentAction : undefined,
+      segmentAction: showSegmentConfig ? (formData.segmentAction ?? 'entered') : undefined,
       contactFields: showContactConfig ? contactFields : undefined,
       labelId: showLabelConfig ? formData.labelId : undefined,
       labelName: showLabelConfig ? formData.labelName : undefined,
-      labelAction: showLabelConfig ? formData.labelAction : undefined,
+      labelAction: showLabelConfig ? (formData.labelAction ?? 'applied') : undefined,
       customAttributeName: showCustomAttributeConfig ? formData.customAttributeName : undefined,
       customAttributeDisplayName: showCustomAttributeConfig
         ? formData.customAttributeDisplayName


### PR DESCRIPTION
## Summary
The Label/Segment journey trigger action `<Select>` received a `|| default` **display** value (`labelAction || 'applied'`, `segmentAction || 'entered'`) that was never committed to `formData`. Leaving the dropdown untouched (its default already shows "Applied"/"Entered") saved `undefined`. The canvas card then used a **different** default for `undefined`, so a node configured as "applied" rendered as **"removed"** (and segment "entered" rendered as "exits").

- `JourneyTriggerPanel.tsx` — `handleSave` persists the effective default: `labelAction ?? 'applied'`, `segmentAction ?? 'entered'`, so the saved value matches the dropdown.
- `JourneyTriggerNode.tsx` — the canvas card aligns its default with the editor/runtime (treat `undefined` as applied/entered via `!== 'removed'` / `!== 'exited'`), which also corrects legacy nodes already saved with `undefined`.

## Behavioral note
Existing journeys saved with no action (`undefined`) now render "applied"/"enters" on the canvas instead of "removed"/"exits". This is a **correction**: the runtime already treated unset as applied/added, and the editor input already defaulted to applied/entered — the canvas card was the only consumer disagreeing.

## Sweep
The card mentioned a possible "Wait node labelAction" — it does not exist in code. The only sibling sharing this exact pattern with a visible canvas mismatch is `segmentAction`, fixed here too. `customAttributeOperator` / `webhookMethod` share the `|| default` input pattern but their canvas rendering already defaults consistently → no visible bug, left out of scope.

## Out of scope — follow-up filed
Code review found that the **evo-flow runtime ignores the action entirely**: `label.trigger.ts` matches both `*.added` and `*.removed` (and `segment.trigger.ts` both `entered`/`exited`) without filtering by the configured action — so a trigger set to "applied" still fires on "removed". That is the backend half and is tracked in **EVO-1763** (High).

## Validation
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` → clean
- `evo-ai-frontend-community: pnpm exec eslint <changed files>` → clean
- `evo-ai-frontend-community: pnpm vitest run JourneyTriggerPanel.spec.tsx JourneyTriggerNode.spec.tsx` → 17/17
- Live smoke (confirmed by Nickolas): Label trigger left at default → canvas shows "applied" (was "removed"). Segment path is identical root cause + unit-covered (segments backend/evo-flow not running locally).

## Changed Files
- `src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx`
- `src/components/journey/nodes/trigger/JourneyTriggerNode.tsx`
- `src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx`
- `src/components/journey/nodes/trigger/JourneyTriggerNode.spec.tsx` (new)

## Linked Issue
- EVO-1754

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align label and segment trigger actions between the editor form and canvas card so that default actions are correctly persisted and displayed.

Bug Fixes:
- Ensure label triggers default to and persist the "applied" action when the action is left unchanged before saving.
- Ensure segment triggers default to and persist the "entered" action when the action is left unchanged before saving.
- Make the trigger canvas card treat missing label/segment actions as applied/entered instead of removed/exited, correcting existing nodes with unset actions.

Tests:
- Add unit tests to verify label and segment actions are saved with the correct defaults and preserve explicit selections in the trigger panel.
- Add unit tests to verify the trigger canvas card renders correct label/segment action text when actions are unset or explicitly configured.
- Stub label and segment services in trigger panel tests to avoid network calls during test runs.