### PR TITLE
fix(frontend): emit segment trigger action in journey flowTriggers (EVO-1763)

### DIFF
--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -16,6 +16,7 @@ import { journeyService } from '@/services';
 import type { Journey } from '@/types/automation';
 import { useLanguage } from '@/hooks/useLanguage';
 import { validateJourneyTerminalPaths } from '@/utils/journeyFlowValidation';
+import { buildFlowTriggers } from './journeyFlowTriggers';
 import { BaseFlowEditor, type NodeType, type NodeCategory } from '@/components/base';
 import { EnvironmentManager } from '@/components/journey/environment-manager';
 import { JourneyEditorHeader } from '@/components/journey/shared/JourneyEditorHeader';
@@ -690,54 +691,9 @@ function JourneyFlowEditor() {
         edges: snapshot.edges,
       };
 
-      // Extrair triggers dos nodes
-      const nodes = Array.isArray(flowData.nodes) ? flowData.nodes : [];
-      const flowTriggers = nodes
-        .filter((node: any) => node.type === 'journey-trigger-node')
-        .map((triggerNode: any) => ({
-          id: triggerNode.id,
-          type: triggerNode.data.triggerType || 'Manual',
-          name: `${triggerNode.data.triggerType || 'manual'} trigger`,
-          enabled: true,
-          conditions: {
-            eventName: triggerNode.data.eventName,
-            segmentId: triggerNode.data.segmentId,
-            labelId: triggerNode.data.labelId,
-            attributeName: triggerNode.data.customAttributeName,
-            webhookUrl: triggerNode.data.webhookUrl,
-          },
-          metadata: {
-            // Salvar todos os dados específicos no metadata
-            triggerType: triggerNode.data.triggerType,
-            eventName: triggerNode.data.eventName,
-            eventProperties: triggerNode.data.eventProperties,
-            contactFields: triggerNode.data.contactFields,
-            labelId: triggerNode.data.labelId,
-            labelName: triggerNode.data.labelName,
-            labelAction: triggerNode.data.labelAction,
-            customAttributeName: triggerNode.data.customAttributeName,
-            customAttributeDisplayName: triggerNode.data.customAttributeDisplayName,
-            customAttributeOperator: triggerNode.data.customAttributeOperator,
-            customAttributeValue: triggerNode.data.customAttributeValue,
-            scheduleType: triggerNode.data.scheduleType,
-            scheduleDate: triggerNode.data.scheduleDate,
-            scheduleTime: triggerNode.data.scheduleTime,
-            recurringPattern: triggerNode.data.recurringPattern,
-            recurringDays: triggerNode.data.recurringDays,
-            recurringTime: triggerNode.data.recurringTime,
-            recurringInterval: triggerNode.data.recurringInterval,
-            webhookUrl: triggerNode.data.webhookUrl,
-            webhookSecret: triggerNode.data.webhookSecret,
-            webhookMethod: triggerNode.data.webhookMethod,
-            expectedHeaders: triggerNode.data.expectedHeaders,
-            pipelineId: triggerNode.data.pipelineId,
-            pipelineName: triggerNode.data.pipelineName,
-            fromStageId: triggerNode.data.fromStageId,
-            fromStageName: triggerNode.data.fromStageName,
-            toStageId: triggerNode.data.toStageId,
-            toStageName: triggerNode.data.toStageName,
-          },
-        }));
+      // Extrair triggers dos nodes (ver journeyFlowTriggers.ts — o metadata
+      // alimenta os matchers do evo-flow, incl. labelAction/segmentAction).
+      const flowTriggers = buildFlowTriggers(flowData.nodes);
 
       const updatedJourney = {
         ...currentJourney,

--- a/src/pages/Customer/Journey/journeyFlowTriggers.spec.ts
+++ b/src/pages/Customer/Journey/journeyFlowTriggers.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildFlowTriggers } from './journeyFlowTriggers';
+
+describe('buildFlowTriggers (EVO-1763)', () => {
+  it('mirrors segmentAction (+ id/name) into trigger metadata so the runtime can honor it', () => {
+    const [trigger] = buildFlowTriggers([
+      {
+        id: 'n1',
+        type: 'journey-trigger-node',
+        data: {
+          triggerType: 'segment',
+          segmentId: 's1',
+          segmentName: 'Leads',
+          segmentAction: 'exited',
+        },
+      },
+    ]);
+    expect(trigger.metadata.segmentAction).toBe('exited');
+    expect(trigger.metadata.segmentId).toBe('s1');
+    expect(trigger.metadata.segmentName).toBe('Leads');
+  });
+
+  it('mirrors labelAction into trigger metadata', () => {
+    const [trigger] = buildFlowTriggers([
+      {
+        id: 'n1',
+        type: 'journey-trigger-node',
+        data: { triggerType: 'label', labelId: 'l1', labelName: 'VIP', labelAction: 'removed' },
+      },
+    ]);
+    expect(trigger.metadata.labelAction).toBe('removed');
+  });
+
+  it('ignores non-trigger nodes', () => {
+    const result = buildFlowTriggers([
+      { id: 'a', type: 'action-node', data: {} },
+      { id: 'b', type: 'journey-trigger-node', data: { triggerType: 'manual' } },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('b');
+  });
+
+  it('returns [] for a non-array input', () => {
+    expect(buildFlowTriggers(undefined)).toEqual([]);
+    expect(buildFlowTriggers(null)).toEqual([]);
+  });
+});

--- a/src/pages/Customer/Journey/journeyFlowTriggers.ts
+++ b/src/pages/Customer/Journey/journeyFlowTriggers.ts
@@ -1,0 +1,65 @@
+type TriggerNode = {
+  id: string;
+  type?: string;
+  data: Record<string, unknown>;
+};
+
+// Builds the flowTriggers payload persisted alongside the journey and consumed
+// by the evo-flow runtime trigger matchers. Any node field the runtime honors
+// (e.g. labelAction / segmentAction — EVO-1763) MUST be mirrored into metadata
+// here; dropping one silently disables that runtime filter.
+export function buildFlowTriggers(nodes: unknown) {
+  const list = Array.isArray(nodes) ? (nodes as TriggerNode[]) : [];
+  return list
+    .filter(node => node.type === 'journey-trigger-node')
+    .map(triggerNode => {
+      const data = triggerNode.data;
+      const triggerType = (data.triggerType as string) || undefined;
+      return {
+        id: triggerNode.id,
+        type: triggerType || 'Manual',
+        name: `${triggerType || 'manual'} trigger`,
+        enabled: true,
+        conditions: {
+          eventName: data.eventName,
+          segmentId: data.segmentId,
+          labelId: data.labelId,
+          attributeName: data.customAttributeName,
+          webhookUrl: data.webhookUrl,
+        },
+        metadata: {
+          triggerType: data.triggerType,
+          eventName: data.eventName,
+          eventProperties: data.eventProperties,
+          contactFields: data.contactFields,
+          labelId: data.labelId,
+          labelName: data.labelName,
+          labelAction: data.labelAction,
+          segmentId: data.segmentId,
+          segmentName: data.segmentName,
+          segmentAction: data.segmentAction,
+          customAttributeName: data.customAttributeName,
+          customAttributeDisplayName: data.customAttributeDisplayName,
+          customAttributeOperator: data.customAttributeOperator,
+          customAttributeValue: data.customAttributeValue,
+          scheduleType: data.scheduleType,
+          scheduleDate: data.scheduleDate,
+          scheduleTime: data.scheduleTime,
+          recurringPattern: data.recurringPattern,
+          recurringDays: data.recurringDays,
+          recurringTime: data.recurringTime,
+          recurringInterval: data.recurringInterval,
+          webhookUrl: data.webhookUrl,
+          webhookSecret: data.webhookSecret,
+          webhookMethod: data.webhookMethod,
+          expectedHeaders: data.expectedHeaders,
+          pipelineId: data.pipelineId,
+          pipelineName: data.pipelineName,
+          fromStageId: data.fromStageId,
+          fromStageName: data.fromStageName,
+          toStageId: data.toStageId,
+          toStageName: data.toStageName,
+        },
+      };
+    });
+}


### PR DESCRIPTION
## Summary
The journey editor dropped `segmentAction` (and `segmentName`) when building `flowTriggers`, so the evo-flow segment matcher never received it and couldn't honor entered/exited. (`labelAction` was already sent.)

- Extracted the inline builder into `buildFlowTriggers(nodes)` (pure, unit-tested) and mirror `segmentId`/`segmentName`/`segmentAction` into the trigger metadata.
- This is the companion to the evo-flow matcher fix — without it, segment triggers always default to `entered`.

## Migration note (segment journeys)
Segment journeys saved **before** this change have no `segmentAction` persisted, so the runtime defaults them to `entered`. A journey intended as **"exited"** must be **re-opened and saved once** to start matching exited events again. Label journeys are unaffected.

## Validation
- `evo-ai-frontend-community: pnpm exec vitest run journeyFlowTriggers.spec.ts` → 4/4
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` → clean
- `evo-ai-frontend-community: pnpm exec eslint <new files>` → clean
- **No live smoke:** saving a journey + trigger matching is evo-flow-backed end to end; the stack (Kafka/Temporal/evo-flow) was not up locally. Behavior covered by unit tests here + in the evo-flow PR. Live smoke pending in a full environment.

## Changed Files
- `src/pages/Customer/Journey/JourneyFlowEditor.tsx`
- `src/pages/Customer/Journey/journeyFlowTriggers.ts` (new)
- `src/pages/Customer/Journey/journeyFlowTriggers.spec.ts` (new)

## Related PRs
- evo-flow: https://github.com/evolution-foundation/evo-flow/pull/70

## Linked Issue
- EVO-1763

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extract flow trigger construction into a reusable helper and ensure segment trigger metadata is persisted for evo-flow matching.

Bug Fixes:
- Persist segmentId, segmentName, and segmentAction in journey flow trigger metadata so evo-flow can correctly honor segment trigger actions.

Enhancements:
- Extract journey trigger-node processing into a pure buildFlowTriggers utility reused by the journey editor.

Tests:
- Add unit tests for buildFlowTriggers to cover trigger payload and metadata construction.