### PR TITLE
fix(frontend): unwrap success envelope in journeyService variable + journey reads (EVO-1836)

### DIFF
--- a/src/services/journeys/journeyService.spec.ts
+++ b/src/services/journeys/journeyService.spec.ts
@@ -94,3 +94,45 @@ describe('journeyService session methods — envelope unwrap', () => {
     expect(result.data.deleted).toBe(5);
   });
 });
+
+describe('journeyService variable methods — envelope unwrap (EVO-1836)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getJourneyVariables unwraps the { success, data } envelope into the variables array', async () => {
+    const vars = [{ id: 'var_1', name: 'lead_score', type: 'number', defaultValue: '0' }];
+    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+      data: { success: true, data: vars },
+    } as never);
+
+    const result = await journeyService.getJourneyVariables('journey-1');
+
+    expect(apiEvoFlow.get).toHaveBeenCalledWith('/journeys/journey-1/variables');
+    expect(Array.isArray(result.data)).toBe(true);
+    expect(result.data).toEqual(vars);
+  });
+
+  it('getJourneyVariables returns [] when the unwrapped payload is not an array', async () => {
+    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+      data: { success: true, data: null },
+    } as never);
+
+    const result = await journeyService.getJourneyVariables('journey-1');
+
+    expect(result.data).toEqual([]);
+  });
+
+  it('updateJourneyVariables returns the variables array, not the envelope object (the crash regression)', async () => {
+    const vars = [{ id: 'var_1', name: 'lead_score', type: 'number', defaultValue: '0' }];
+    vi.mocked(apiEvoFlow.post).mockResolvedValue({
+      data: { success: true, data: vars, meta: { timestamp: 'x' } },
+    } as never);
+
+    const result = await journeyService.updateJourneyVariables('journey-1', vars);
+
+    expect(apiEvoFlow.post).toHaveBeenCalledWith('/journeys/journey-1/variables', vars);
+    expect(Array.isArray(result.data)).toBe(true);
+    expect(result.data).toEqual(vars);
+  });
+});

--- a/src/services/journeys/journeyService.ts
+++ b/src/services/journeys/journeyService.ts
@@ -133,7 +133,7 @@ class JourneyService {
         {},
       );
       return {
-        data: response.data,
+        data: extractData<Journey>(response),
       };
     } catch (error: any) {
       console.error('Erro ao duplicar jornada:', error);
@@ -146,8 +146,9 @@ class JourneyService {
   ): Promise<{ data: Journey[] }> {
     try {
       const response = await apiEvoFlow.get(`${this.getBaseUrl()}/trigger-type/${triggerType}`);
+      const data = extractData<Journey[]>(response);
       return {
-        data: response.data || [],
+        data: Array.isArray(data) ? data : [],
       };
     } catch (error: any) {
       console.error('Erro ao buscar jornadas por tipo de trigger:', error);
@@ -161,8 +162,9 @@ class JourneyService {
     try {
       const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${id}/variables`);
 
+      const data = extractData<unknown[]>(response);
       return {
-        data: Array.isArray(response.data) ? response.data : [],
+        data: Array.isArray(data) ? data : [],
       };
     } catch (error: any) {
       console.error('❌ Erro ao buscar variáveis da jornada:', error);
@@ -177,8 +179,9 @@ class JourneyService {
   ): Promise<{ data: any[] }> {
     try {
       const response = await apiEvoFlow.post(`${this.getBaseUrl()}/${id}/variables`, variables);
+      const data = extractData<unknown[]>(response);
       return {
-        data: response.data || [],
+        data: Array.isArray(data) ? data : [],
       };
     } catch (error: any) {
       console.error('Erro ao atualizar variáveis da jornada:', error);


### PR DESCRIPTION
## Summary
Part of **EVO-1836** (cross-repo — journey variables broken). `journeyService` read `response.data` expecting the array, but evo-flow returns the success envelope `{success, data, meta}`. Two user-visible symptoms:
- **Crash on create:** `updateJourneyVariables` returned the envelope object → `setVariables(<object>)` → `TypeError: variables.map is not a function` (VariableSelect.tsx:121).
- **Variables never display:** `getJourneyVariables` guarded `Array.isArray(response.data)` and fell to `[]` (the envelope is an object).

Fix: unwrap via the existing `extractData` helper (the rest of the service already uses it) in `getJourneyVariables`, `updateJourneyVariables`, and — same latent envelope bug surfaced in review — `getJourneysByTriggerType` and `duplicateJourney`.

## Validation
- `pnpm exec tsc -b --noEmit` → clean
- `npx vitest run journeyService.spec` → 9/9 (incl. 3 new variable-unwrap specs: array, crash-regression, [] fallback)
- `npx eslint` → no new errors (the file's pre-existing `no-explicit-any` debt left untouched)
- **Live:** create a journey variable → persists → ENV/trigger dropdown shows it; API `GET /journeys/:id/variables` returns the array.
- Adversarial multi-agent review: confirmed findings fixed; partial-save / race concerns refuted.

## Changed Files
- `src/services/journeys/journeyService.ts`
- `src/services/journeys/journeyService.spec.ts`

## Related PRs
- evo-flow (backend half: cache reconstruction preserves `variables` + refresh on write) — same EVO-1836.

## Linked Issue
- EVO-1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unwrap journey-related API success envelopes so journey data and variables methods consistently return plain arrays or objects instead of the envelope.

Bug Fixes:
- Ensure getJourneyVariables returns the variables array (or an empty array) instead of the success envelope object to prevent frontend crashes and missing variables.
- Ensure updateJourneyVariables returns the updated variables array rather than the envelope payload.
- Ensure duplicateJourney correctly unwraps the response envelope to return a Journey object.
- Ensure getJourneysByTriggerType unwraps the response envelope and safely falls back to an empty array when the payload is not an array.

Tests:
- Add unit tests covering envelope unwrapping for journey variable reads and writes, including regression coverage for the previous crash and non-array payload fallback.