### PR TITLE
feat(frontend): mobile chat polish + contact drawer declutter (EVO-1782)

### DIFF
--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -562,7 +562,7 @@ const ChatHeader = ({
     : t('chatHeader.openContactPanel');
 
   return (
-    <div className="flex-shrink-0 p-4 border-b bg-background/95 backdrop-blur-sm">
+    <div className="flex-shrink-0 p-3 md:p-4 border-b bg-background/95 backdrop-blur-sm">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           {/* Back button for mobile */}
@@ -630,11 +630,11 @@ const ChatHeader = ({
                   size="sm"
                   onClick={onContactSidebarToggle}
                   aria-label={contactPanelLabel}
-                  className={
+                  className={`hidden md:inline-flex ${
                     isContactSidebarOpen
                       ? 'text-primary hover:text-primary/80'
                       : 'text-muted-foreground hover:text-foreground'
-                  }
+                  }`}
                 >
                   {isContactSidebarOpen ? (
                     <PanelRightClose className="h-4 w-4" />

--- a/src/components/chat/contact-sidebar/ContactDetails.tsx
+++ b/src/components/chat/contact-sidebar/ContactDetails.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useState } from 'react';
 
 import { useLanguage } from '@/hooks/useLanguage';
@@ -15,8 +14,6 @@ import {
   Phone,
   Mail,
   // MapPin,
-  Settings,
-  Info,
   Clock,
   Calendar,
   Activity,
@@ -45,13 +42,6 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ contact }) => {
 
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [editingContact, setEditingContact] = useState<FullContact | null>(null);
-
-  const formatCustomAttributeKey = (key: string): string => {
-    return key
-      .split('_')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-  };
 
   const formatDate = (dateString?: string | number): string => {
     if (!dateString) return t('contactSidebar.contactDetails.notInformed');
@@ -184,92 +174,6 @@ const ContactDetails: React.FC<ContactDetailsProps> = ({ contact }) => {
           </Button>
         </CardFooter>
       </Card>
-
-      {/* Custom Attributes */}
-      {contact?.custom_attributes &&
-        Object.keys(contact.custom_attributes).length > 0 &&
-        (() => {
-          // Filtrar atributos com valores válidos
-          const validAttributes = Object.entries(contact.custom_attributes).filter(([_, value]) => {
-            if (!value) return false;
-            const stringValue = String(value);
-            // Ignorar valores vazios, null, undefined, ou "[object Object]"
-            return (
-              stringValue &&
-              stringValue.trim() !== '' &&
-              stringValue !== 'null' &&
-              stringValue !== 'undefined' &&
-              stringValue !== '[object Object]' &&
-              stringValue.toLowerCase() !== 'not informed'
-            );
-          });
-
-          if (validAttributes.length === 0) return null;
-
-          return (
-            <Card className="border-0 shadow-none bg-muted/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <Settings className="h-4 w-4" />
-                  {t('contactSidebar.contactDetails.sections.customAttributes')}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="pt-0 space-y-2">
-                {validAttributes.map(([key, value]) => (
-                  <InfoField
-                    key={key}
-                    label={formatCustomAttributeKey(key)}
-                    value={String(value)}
-                  />
-                ))}
-              </CardContent>
-            </Card>
-          );
-        })()}
-
-      {/* Additional Attributes */}
-      {contact?.additional_attributes &&
-        Object.keys(contact.additional_attributes).length > 0 &&
-        (() => {
-          // Filtrar atributos com valores válidos
-          const validAttributes = Object.entries(contact.additional_attributes).filter(
-            ([_, value]) => {
-              if (!value) return false;
-              const stringValue = String(value);
-              // Ignorar valores vazios, null, undefined, ou "[object Object]"
-              return (
-                stringValue &&
-                stringValue.trim() !== '' &&
-                stringValue !== 'null' &&
-                stringValue !== 'undefined' &&
-                stringValue !== '[object Object]' &&
-                stringValue.toLowerCase() !== 'not informed'
-              );
-            },
-          );
-
-          if (validAttributes.length === 0) return null;
-
-          return (
-            <Card className="border-0 shadow-none bg-muted/20">
-              <CardHeader className="pb-2">
-                <CardTitle className="text-sm flex items-center gap-2">
-                  <Info className="h-4 w-4" />
-                  {t('contactSidebar.contactDetails.sections.additionalInfo')}
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="pt-0 space-y-2">
-                {validAttributes.map(([key, value]) => (
-                  <InfoField
-                    key={key}
-                    label={formatCustomAttributeKey(key)}
-                    value={String(value)}
-                  />
-                ))}
-              </CardContent>
-            </Card>
-          );
-        })()}
 
       {/* Timestamps */}
       <Card className="border-0 shadow-none bg-muted/20">

--- a/src/components/chat/contact-sidebar/ContactHeader.tsx
+++ b/src/components/chat/contact-sidebar/ContactHeader.tsx
@@ -31,7 +31,7 @@ const ContactHeader: React.FC<ContactHeaderProps> = ({ contact, channelType }) =
     : undefined;
 
   return (
-    <div className="p-6 flex-shrink-0">
+    <div className="p-4 md:p-6 flex-shrink-0">
       <div className="flex items-center gap-4">
         {/* Avatar Grande */}
         <ContactAvatar contact={contact} size="lg" />

--- a/src/components/chat/contact-sidebar/ContactSidebar.spec.tsx
+++ b/src/components/chat/contact-sidebar/ContactSidebar.spec.tsx
@@ -105,3 +105,24 @@ describe('ContactSidebar — fetch lifecycle', () => {
     expect(mockGetContact).toHaveBeenCalledWith('1', true);
   });
 });
+
+describe('ContactSidebar — drawer declutter (EVO-1782)', () => {
+  beforeEach(() => {
+    mockGetContact.mockReset();
+    mockGetContact.mockResolvedValue(makeContact('1'));
+  });
+
+  it('drops the dead Contact Notes / Previous Conversations stub sections, keeps Pipeline', async () => {
+    let view!: ReturnType<typeof render>;
+    await act(async () => {
+      view = render(<ContactSidebar {...defaultProps} />);
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    // Removed stub sections must not render
+    expect(view.queryByText('contactSidebar.sections.contactNotes.title')).toBeNull();
+    expect(view.queryByText('contactSidebar.sections.previousConversations.title')).toBeNull();
+    // A kept section still renders
+    expect(view.queryByText('contactSidebar.sections.pipeline.title')).not.toBeNull();
+  });
+});

--- a/src/components/chat/contact-sidebar/ContactSidebar.tsx
+++ b/src/components/chat/contact-sidebar/ContactSidebar.tsx
@@ -196,24 +196,6 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onFilterReload]);
 
-  // Calcular altura real do header dinamicamente
-  useEffect(() => {
-    const calculateHeaderHeight = () => {
-      // Procurar o AppBar do MainLayout
-      const appBar = document.querySelector(
-        '[class*="flex-shrink-0"][class*="bg-sidebar"][class*="border-b"]',
-      );
-      if (appBar) {
-        const height = appBar.getBoundingClientRect().height;
-        document.documentElement.style.setProperty('--header-height', `${height}px`);
-      }
-    };
-
-    calculateHeaderHeight();
-    window.addEventListener('resize', calculateHeaderHeight);
-    return () => window.removeEventListener('resize', calculateHeaderHeight);
-  }, []);
-
   // No mobile, esconder completamente quando fechado
   // No desktop, manter no DOM para animação
   if (!isOpen && isMobile) return null;
@@ -223,8 +205,7 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
       {/* Mobile Backdrop */}
       {isOpen && isMobile && (
         <div
-          className="fixed left-0 right-0 bottom-0 bg-black/50 z-30"
-          style={{ top: 'var(--header-height, 60px)' }}
+          className="fixed inset-0 bg-black/50 z-30"
           onClick={onClose}
         />
       )}
@@ -232,18 +213,14 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
       {/* Sidebar */}
       <div
         className={`
-        border-l bg-background flex flex-col
-        fixed md:static left-0 md:left-auto right-0 md:right-auto bottom-0 md:bottom-auto z-40 md:z-auto
+        border-l bg-background flex flex-col h-full
+        fixed inset-0 md:static md:inset-auto z-40 md:z-auto
         transform transition-all duration-300 ease-in-out overflow-hidden
         ${isOpen
-            ? 'w-full md:w-96 translate-x-0 md:translate-x-0 md:opacity-100'
+            ? 'w-full md:w-96 translate-x-0 md:opacity-100'
             : 'w-full md:w-0 translate-x-full md:translate-x-0 md:opacity-0'
           }
       `}
-        style={{
-          top: isMobile ? 'var(--header-height, 60px)' : 'auto',
-          height: isMobile ? 'calc(100vh - var(--header-height, 60px))' : '100%',
-        }}
       >
         {/* Header com Avatar e Info Básica + Close Button */}
         <div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 relative">

--- a/src/components/chat/contact-sidebar/ContactSidebar.tsx
+++ b/src/components/chat/contact-sidebar/ContactSidebar.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 import { Button } from '@evoapi/design-system/button';
 import { Card, CardHeader, CardContent } from '@evoapi/design-system/card';
 import { Badge } from '@evoapi/design-system/badge';
-import { X, User, FileText, MessageSquare, Clock, ChevronDown, Zap, GitBranch, Tag, Info } from 'lucide-react';
+import { X, User, Clock, ChevronDown, Zap, GitBranch, Tag, Info } from 'lucide-react';
 
 import ContactHeader from './ContactHeader';
 import ContactDetails from './ContactDetails';
@@ -84,9 +84,7 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
   // Estados para controlar seções expandidas/colapsadas (padrão Agents.tsx)
   const [showContactDetails, setShowContactDetails] = useState(false);
   const [showMacros, setShowMacros] = useState(false);
-  const [showPipeline, setShowPipeline] = useState(false);
-  const [showContactNotes, setShowContactNotes] = useState(false);
-  const [showPreviousConversations, setShowPreviousConversations] = useState(false);
+  const [showPipeline, setShowPipeline] = useState(true);
   const [showConversationInfo, setShowConversationInfo] = useState(false);
   const [showConversationAttributes, setShowConversationAttributes] = useState(false);
   const [showContactAttributes, setShowContactAttributes] = useState(false);
@@ -336,52 +334,6 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
               )}
             </Card>
           )}
-
-          {/* 4. Contact Notes - Notas do contato */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CollapsibleHeader
-                title={t('contactSidebar.sections.contactNotes.title')}
-                description={t('contactSidebar.sections.contactNotes.description')}
-                icon={<FileText className="h-4 w-4 text-orange-500" />}
-                count={0}
-                isOpen={showContactNotes}
-                onToggle={() => setShowContactNotes(!showContactNotes)}
-              />
-            </CardHeader>
-
-            {showContactNotes && (
-              <CardContent className="pt-0 px-3 pb-3">
-                <div className="text-sm text-muted-foreground p-2 rounded bg-muted/30">
-                  {/* TODO: Implementar ContactNotes real */}
-                  {t('contactSidebar.sections.contactNotes.noNotes')}
-                </div>
-              </CardContent>
-            )}
-          </Card>
-
-          {/* 4. Previous Conversations - Conversas anteriores */}
-          <Card>
-            <CardHeader className="pb-2">
-              <CollapsibleHeader
-                title={t('contactSidebar.sections.previousConversations.title')}
-                description={t('contactSidebar.sections.previousConversations.description')}
-                icon={<MessageSquare className="h-4 w-4 text-purple-500" />}
-                count={0}
-                isOpen={showPreviousConversations}
-                onToggle={() => setShowPreviousConversations(!showPreviousConversations)}
-              />
-            </CardHeader>
-
-            {showPreviousConversations && (
-              <CardContent className="pt-0 px-3 pb-3">
-                <div className="text-sm text-muted-foreground p-2 rounded bg-muted/30">
-                  {/* TODO: Implementar ContactConversations real */}
-                  {t('contactSidebar.sections.previousConversations.loading')}
-                </div>
-              </CardContent>
-            )}
-          </Card>
 
           {/* 5. Conversation Info - Informações da conversa */}
           <Card>

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -636,7 +636,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         )}
 
         {/* Input Area */}
-        <CardContent className="p-4 px-4 py-4 relative">
+        <CardContent className="p-3 md:p-4 relative">
           {/* 🎯 CANNED RESPONSES: Dropdown de sugestões */}
           {showCannedResponses && (
             <CannedResponsesList
@@ -815,7 +815,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
                   return false;
                 }}
                 disabled={isDisabled || isSending || (isPendingConversation && replyMode !== ReplyMode.NOTE)}
-                className="min-h-[100px]"
+                className="min-h-[56px] md:min-h-[100px]"
                 showToolbar={!isPendingConversation}
               />
             </div>


### PR DESCRIPTION
## Summary
B3.ux — mobile chat usability + contact-drawer declutter (community layer). Polish only, no backend.

**Drawer declutter**
- Remove the non-functional *Contact Notes* and *Previous Conversations* stub sections (TODO placeholders).
- `ContactDetails`: keep only Basic Info + Timestamps; custom/additional attributes now live solely in the editable attribute sections (single source — no duplication).
- Pipeline section expanded by default; others collapsed.

**Mobile**
- Replace the fragile `--header-height` DOM calc with a self-contained `fixed inset-0` mobile drawer (desktop `md:static` unchanged).
- Responsive message-input min-height (56px mobile / 100px md+) + reduced mobile padding.
- Chat/contact header responsive padding; hide the contact-panel toggle on mobile (drawer opens via avatar tap, closes via its own X).

## Architecture note
Per the SaaS roadmap correction (2026-06-18), UX/declutter/mobile polish belongs to **community** (this repo) and is fixed at the source — the enterprise shell inherits it via the `vendor/crm` bump. The older `ux-conversas-mobile-drawer.md` spec's "shell-only / vendor read-only" framing (AC5) reflects the enterprise build lens and does not apply to a community card.

## Acceptance Criteria
- [x] Card: "chat mobile usável" — overlay + responsive input/padding + de-crowded header (smoke-passed).
- [x] Card: "drawer limpo" — stubs removed + attributes de-duplicated.
- [x] AC1 (mobile list hides + back) — already present in community (`Chat.tsx` mobileView + onBackClick).
- [x] AC2 (contact overlay, conversation not reset) — overlay is separate from the conversation component.
- [x] AC4 (desktop no regression) — all changes gated behind `md:`.

## Deferred (out of scope / follow-up)
- **AC3** (URL-driven 3-panel orchestration + deep-link) → **enterprise-shell** (`evolution-ecosystem-frontend` `CrmScreen`/`WouterUrlSync`); not a community-layer change.
- AC6 (swipe to open/close drawer) — nice-to-have.
- M1 secondary-action overflow menu (Canned/Template) and M2 status-dot-only — cosmetic refinements deferred.
- i18n orphan-key cleanup for the removed sections (harmless; en↔pt-BR parity intact) — trivial follow-up.

## Test plan
- `pnpm exec tsc -b` — 0 errors
- `pnpm exec eslint <changed files>` — 0 errors (1 pre-existing warning in MessageInput unrelated to this change)
- `pnpm exec vitest run src/components/chat/contact-sidebar/ContactSidebar.spec.tsx` — 3 passed (new: stub sections dropped, Pipeline kept)
- Manual smoke (desktop + mobile 375/320): drawer declutter, full-screen mobile overlay, input height, header — confirmed by reporter.

## Changed Files
- `src/components/chat/contact-sidebar/ContactSidebar.tsx`
- `src/components/chat/contact-sidebar/ContactDetails.tsx`
- `src/components/chat/contact-sidebar/ContactHeader.tsx`
- `src/components/chat/chat-header/ChatHeader.tsx`
- `src/components/chat/message-input/MessageInput.tsx`
- `src/components/chat/contact-sidebar/ContactSidebar.spec.tsx`

## Linked Issue
- EVO-1782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Polish the chat contact sidebar and mobile chat experience by decluttering unused sections and improving the mobile overlay and input/header responsiveness.

Enhancements:
- Simplify contact details by removing inline custom/additional attributes sections, keeping only basic info and timestamps in the details panel.
- Declutter the contact sidebar by removing non-functional Contact Notes and Previous Conversations sections and expanding the Pipeline section by default.
- Improve mobile behavior of the contact drawer by using a full-screen fixed overlay independent of header height calculations.
- Adjust chat and contact headers and message input padding for better mobile spacing, and make the message editor height responsive between mobile and desktop.
- Hide the contact-panel toggle button on mobile while preserving it on desktop for a cleaner mobile header.

Tests:
- Add a regression test to ensure the removed stub sections do not render while the Pipeline section remains visible.