### PR TITLE
feat(crm): B14 CRM Lead Capture UI — form + chat builders & public pages (EVO-1771)

### DIFF
--- a/src/components/chatPages/ChatPageModal.tsx
+++ b/src/components/chatPages/ChatPageModal.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  ScrollArea,
+  Button,
+  Input,
+  Textarea,
+  Label,
+  Switch,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@evoapi/design-system';
+import { useLanguage } from '@/hooks/useLanguage';
+import type { ChatPage, ChatPagePayload, WebWidgetOption } from '@/types/chatPages';
+
+interface ChatPageModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (payload: ChatPagePayload) => void | Promise<void>;
+  saving: boolean;
+  initial: ChatPage | null;
+  widgets: WebWidgetOption[];
+}
+
+const ChatPageModal = ({ open, onClose, onSave, saving, initial, widgets }: ChatPageModalProps) => {
+  const { t } = useLanguage('chatPages');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [published, setPublished] = useState(false);
+  const [websiteToken, setWebsiteToken] = useState('');
+  const [primaryColor, setPrimaryColor] = useState('');
+  const [logoUrl, setLogoUrl] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setTitle(initial?.title ?? '');
+    setDescription(initial?.description ?? '');
+    setPublished(initial?.published ?? false);
+    setWebsiteToken(initial?.website_token ?? '');
+    setPrimaryColor(initial?.appearance?.primary_color ?? '');
+    setLogoUrl(initial?.appearance?.logo_url ?? '');
+    setError(null);
+  }, [open, initial]);
+
+  // An edited page may reference a widget that is no longer listed (e.g. created
+  // via console); keep its token selectable so editing never silently drops it.
+  const widgetOptions: WebWidgetOption[] =
+    websiteToken && !widgets.some(w => w.website_token === websiteToken)
+      ? [...widgets, { inbox_id: websiteToken, name: t('modal.widget.unknown'), website_token: websiteToken }]
+      : widgets;
+
+  const handleSave = () => {
+    setError(null);
+    if (!websiteToken) return setError(t('modal.errors.widget'));
+
+    const payload: ChatPagePayload = {
+      title: title.trim() || undefined,
+      description: description.trim() || undefined,
+      published,
+      website_token: websiteToken,
+      appearance: {
+        primary_color: primaryColor || undefined,
+        logo_url: logoUrl || undefined,
+      },
+    };
+    onSave(payload);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="max-w-2xl max-h-[90vh] p-0">
+        <DialogHeader className="px-6 py-4 border-b">
+          <DialogTitle className="text-xl">{initial ? t('modal.editTitle') : t('modal.createTitle')}</DialogTitle>
+        </DialogHeader>
+
+        <ScrollArea className="max-h-[calc(90vh-80px)] px-6 py-4">
+          <div className="space-y-6">
+            {/* Básico */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.basic')}</h3>
+              <div className="space-y-2">
+                <Label>{t('modal.basic.title')}</Label>
+                <Input value={title} onChange={e => setTitle(e.target.value)} placeholder={t('modal.basic.titlePlaceholder')} />
+              </div>
+              <div className="space-y-2">
+                <Label>{t('modal.basic.description')}</Label>
+                <Textarea value={description} onChange={e => setDescription(e.target.value)} />
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch checked={published} onCheckedChange={setPublished} id="published" />
+                <Label htmlFor="published">{t('modal.basic.published')}</Label>
+              </div>
+            </section>
+
+            {/* Widget */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.widget')}</h3>
+              <div className="space-y-2">
+                <Label>{t('modal.widget.label')}</Label>
+                <Select value={websiteToken || undefined} onValueChange={setWebsiteToken}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t('modal.widget.placeholder')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {widgetOptions.map(w => (
+                      <SelectItem key={w.website_token} value={w.website_token}>
+                        {w.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {widgets.length === 0 && (
+                  <p className="text-xs text-muted-foreground">{t('modal.widget.empty')}</p>
+                )}
+              </div>
+            </section>
+
+            {/* Aparência */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.appearance')}</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>{t('modal.appearance.primaryColor')}</Label>
+                  <Input value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} placeholder="#1f93ff" />
+                </div>
+                <div className="space-y-2">
+                  <Label>{t('modal.appearance.logoUrl')}</Label>
+                  <Input value={logoUrl} onChange={e => setLogoUrl(e.target.value)} placeholder="https://…" />
+                </div>
+              </div>
+            </section>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <div className="flex gap-3 pt-4">
+              <Button variant="outline" onClick={onClose} disabled={saving} className="flex-1">
+                {t('modal.cancel')}
+              </Button>
+              <Button onClick={handleSave} disabled={saving} className="flex-1">
+                {saving ? t('modal.saving') : t('modal.save')}
+              </Button>
+            </div>
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ChatPageModal;

--- a/src/components/crmForms/CrmFormModal.tsx
+++ b/src/components/crmForms/CrmFormModal.tsx
@@ -4,7 +4,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
+  ScrollArea,
   Button,
   Input,
   Textarea,
@@ -53,11 +53,10 @@ interface ChooseProps {
   onChange: (v: string) => void;
   options: { value: string; label: string }[];
   placeholder?: string;
-  className?: string;
 }
-const Choose = ({ value, onChange, options, placeholder, className }: ChooseProps) => (
+const Choose = ({ value, onChange, options, placeholder }: ChooseProps) => (
   <Select value={value || undefined} onValueChange={onChange}>
-    <SelectTrigger className={className}>
+    <SelectTrigger className="w-full">
       <SelectValue placeholder={placeholder} />
     </SelectTrigger>
     <SelectContent>
@@ -169,220 +168,237 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
     onSave(payload);
   };
 
+  const renderTargetSelect = (f: CrmFormField, idx: number) => (
+    <Select value={encodeTarget(f)} onValueChange={v => applyTarget(idx, v)}>
+      <SelectTrigger className="w-full">
+        <SelectValue placeholder={t('modal.fields.mapTo')} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={NONE_TARGET}>{t('modal.targets.none')}</SelectItem>
+        {targetGroups.map(g => (
+          <SelectGroup key={g.label}>
+            <SelectLabel>{g.label}</SelectLabel>
+            {g.options.map(o => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
   return (
     <Dialog open={open} onOpenChange={v => !v && onClose()}>
-      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{initial ? t('modal.editTitle') : t('modal.createTitle')}</DialogTitle>
+      <DialogContent className="max-w-2xl max-h-[90vh] p-0">
+        <DialogHeader className="px-6 py-4 border-b">
+          <DialogTitle className="text-xl">{initial ? t('modal.editTitle') : t('modal.createTitle')}</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6 py-2">
-          <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.basic')}</h3>
-            <div className="space-y-1">
-              <Label>{t('modal.basic.name')}</Label>
-              <Input value={name} onChange={e => setName(e.target.value)} placeholder={t('modal.basic.namePlaceholder')} />
-            </div>
-            <div className="space-y-1">
-              <Label>{t('modal.basic.title')}</Label>
-              <Input value={title} onChange={e => setTitle(e.target.value)} placeholder={t('modal.basic.titlePlaceholder')} />
-            </div>
-            <div className="space-y-1">
-              <Label>{t('modal.basic.description')}</Label>
-              <Textarea value={description} onChange={e => setDescription(e.target.value)} />
-            </div>
-            <div className="flex items-center gap-2">
-              <Switch checked={published} onCheckedChange={setPublished} id="published" />
-              <Label htmlFor="published">{t('modal.basic.published')}</Label>
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.appearance')}</h3>
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1">
-                <Label>{t('modal.appearance.primaryColor')}</Label>
-                <Input value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} placeholder="#1E40AF" />
+        <ScrollArea className="max-h-[calc(90vh-140px)] px-6 py-4">
+          <div className="space-y-6">
+            {/* Básico */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.basic')}</h3>
+              <div className="space-y-2">
+                <Label>{t('modal.basic.name')}</Label>
+                <Input value={name} onChange={e => setName(e.target.value)} placeholder={t('modal.basic.namePlaceholder')} />
               </div>
-              <div className="space-y-1">
-                <Label>{t('modal.appearance.logoUrl')}</Label>
-                <Input value={logoUrl} onChange={e => setLogoUrl(e.target.value)} placeholder="https://…" />
+              <div className="space-y-2">
+                <Label>{t('modal.basic.title')}</Label>
+                <Input value={title} onChange={e => setTitle(e.target.value)} placeholder={t('modal.basic.titlePlaceholder')} />
               </div>
-            </div>
-            <div className="space-y-1">
-              <Label>{t('modal.appearance.successMessage')}</Label>
-              <Input value={successMessage} onChange={e => setSuccessMessage(e.target.value)} />
-            </div>
-          </section>
+              <div className="space-y-2">
+                <Label>{t('modal.basic.description')}</Label>
+                <Textarea value={description} onChange={e => setDescription(e.target.value)} />
+              </div>
+              <div className="flex items-center gap-2">
+                <Switch checked={published} onCheckedChange={setPublished} id="published" />
+                <Label htmlFor="published">{t('modal.basic.published')}</Label>
+              </div>
+            </section>
 
-          <section className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.fields')}</h3>
-              <Button variant="outline" size="sm" onClick={() => setFields(prev => [...prev, emptyField()])}>
-                <Plus className="w-4 h-4 mr-1" /> {t('modal.fields.add')}
-              </Button>
-            </div>
-            {fields.map((f, idx) => (
-              <div key={idx} className="space-y-2 border border-border rounded-md p-2">
-                <div className="grid grid-cols-12 gap-2 items-center">
-                  <Input
-                    className="col-span-2"
-                    placeholder={t('modal.fields.key')}
-                    value={f.key}
-                    onChange={e => updateField(idx, { key: e.target.value })}
-                  />
-                  <Input
-                    className="col-span-3"
-                    placeholder={t('modal.fields.label')}
-                    value={f.label ?? ''}
-                    onChange={e => updateField(idx, { label: e.target.value })}
-                  />
-                  <Choose
-                    className="col-span-2"
-                    value={f.type}
-                    onChange={v => updateField(idx, { type: v as CrmFieldType })}
-                    options={FIELD_TYPES.map(ft => ({ value: ft, label: ft }))}
-                  />
-                  <div className="col-span-3">
-                    <Select value={encodeTarget(f)} onValueChange={v => applyTarget(idx, v)}>
-                      <SelectTrigger>
-                        <SelectValue placeholder={t('modal.fields.mapTo')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value={NONE_TARGET}>{t('modal.targets.none')}</SelectItem>
-                        {targetGroups.map(g => (
-                          <SelectGroup key={g.label}>
-                            <SelectLabel>{g.label}</SelectLabel>
-                            {g.options.map(o => (
-                              <SelectItem key={o.value} value={o.value}>
-                                {o.label}
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <label className="col-span-1 flex items-center gap-1 text-xs text-foreground">
-                    <Checkbox checked={!!f.required} onCheckedChange={c => updateField(idx, { required: c === true })} />
-                    {t('modal.fields.required')}
-                  </label>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="col-span-1 text-destructive"
-                    onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))}
-                    aria-label={t('modal.fields.remove')}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </Button>
+            {/* Aparência */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.appearance')}</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label>{t('modal.appearance.primaryColor')}</Label>
+                  <Input value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} placeholder="#1E40AF" />
                 </div>
-                {f.type === 'select' && (
-                  <Input
-                    placeholder={t('modal.fields.optionsPlaceholder')}
-                    value={(f.options ?? []).join(', ')}
-                    onChange={e =>
-                      updateField(idx, {
-                        options: e.target.value.split(',').map(o => o.trim()).filter(Boolean),
-                      })
-                    }
-                  />
-                )}
+                <div className="space-y-2">
+                  <Label>{t('modal.appearance.logoUrl')}</Label>
+                  <Input value={logoUrl} onChange={e => setLogoUrl(e.target.value)} placeholder="https://…" />
+                </div>
               </div>
-            ))}
-          </section>
+              <div className="space-y-2">
+                <Label>{t('modal.appearance.successMessage')}</Label>
+                <Input value={successMessage} onChange={e => setSuccessMessage(e.target.value)} />
+              </div>
+            </section>
 
-          <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.defaultDestination')}</h3>
-            <div className="grid grid-cols-2 gap-3">
-              <Choose
-                value={defaultPipelineId}
-                onChange={v => {
-                  setDefaultPipelineId(v);
-                  setDefaultStageId('');
-                }}
-                options={pipelineOptions}
-                placeholder={t('modal.destination.pipeline')}
-              />
-              <Choose
-                value={defaultStageId || NONE}
-                onChange={v => setDefaultStageId(v === NONE ? '' : v)}
-                options={stageOptions(defaultPipelineId)}
-                placeholder={t('modal.destination.stage')}
-              />
-            </div>
-          </section>
-
-          <section className="space-y-3">
-            <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.routing')}</h3>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setRules(prev => [...prev, { field: '', op: 'equals', value: '', pipeline_id: '', stage_id: '' }])}
-              >
-                <Plus className="w-4 h-4 mr-1" /> {t('modal.routing.add')}
-              </Button>
-            </div>
-            {rules.map((r, idx) => (
-              <div key={idx} className="grid grid-cols-12 gap-2 items-center border border-border rounded-md p-2">
-                <Choose
-                  className="col-span-2"
-                  value={r.field}
-                  onChange={v => updateRule(idx, { field: v })}
-                  options={fields.filter(f => f.key).map(f => ({ value: f.key, label: f.key }))}
-                  placeholder={t('modal.routing.field')}
-                />
-                <Choose
-                  className="col-span-2"
-                  value={r.op ?? 'equals'}
-                  onChange={v => updateRule(idx, { op: v as RoutingOp })}
-                  options={ROUTING_OPS.map(o => ({ value: o, label: o }))}
-                />
-                <Input
-                  className="col-span-2"
-                  placeholder={t('modal.routing.value')}
-                  value={r.value ?? ''}
-                  onChange={e => updateRule(idx, { value: e.target.value })}
-                />
-                <Choose
-                  className="col-span-3"
-                  value={r.pipeline_id}
-                  onChange={v => updateRule(idx, { pipeline_id: v, stage_id: '' })}
-                  options={pipelineOptions}
-                  placeholder={t('modal.routing.pipeline')}
-                />
-                <Choose
-                  className="col-span-2"
-                  value={r.stage_id || NONE}
-                  onChange={v => updateRule(idx, { stage_id: v === NONE ? '' : v })}
-                  options={stageOptions(r.pipeline_id)}
-                  placeholder={t('modal.routing.stage')}
-                />
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="col-span-1 text-destructive"
-                  onClick={() => setRules(prev => prev.filter((_, i) => i !== idx))}
-                  aria-label={t('modal.routing.remove')}
-                >
-                  <Trash2 className="w-4 h-4" />
+            {/* Campos */}
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.fields')}</h3>
+                <Button variant="outline" size="sm" onClick={() => setFields(prev => [...prev, emptyField()])}>
+                  <Plus className="w-4 h-4 mr-1" /> {t('modal.fields.add')}
                 </Button>
               </div>
-            ))}
-          </section>
+              {fields.map((f, idx) => (
+                <div key={idx} className="space-y-3 rounded-md border border-border p-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">{t('modal.fields.key')}</Label>
+                      <Input value={f.key} onChange={e => updateField(idx, { key: e.target.value })} />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">{t('modal.fields.label')}</Label>
+                      <Input value={f.label ?? ''} onChange={e => updateField(idx, { label: e.target.value })} />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">{t('modal.fields.type')}</Label>
+                      <Choose
+                        value={f.type}
+                        onChange={v => updateField(idx, { type: v as CrmFieldType })}
+                        options={FIELD_TYPES.map(ft => ({ value: ft, label: ft }))}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-xs text-muted-foreground">{t('modal.fields.mapTo')}</Label>
+                      {renderTargetSelect(f, idx)}
+                    </div>
+                  </div>
+                  {f.type === 'select' && (
+                    <Input
+                      placeholder={t('modal.fields.optionsPlaceholder')}
+                      value={(f.options ?? []).join(', ')}
+                      onChange={e =>
+                        updateField(idx, {
+                          options: e.target.value.split(',').map(o => o.trim()).filter(Boolean),
+                        })
+                      }
+                    />
+                  )}
+                  <div className="flex items-center justify-between">
+                    <label className="flex items-center gap-2 text-sm text-foreground">
+                      <Checkbox checked={!!f.required} onCheckedChange={c => updateField(idx, { required: c === true })} />
+                      {t('modal.fields.required')}
+                    </label>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))}
+                    >
+                      <Trash2 className="w-4 h-4 mr-1" /> {t('modal.fields.remove')}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </section>
 
-          {error && <p className="text-sm text-destructive">{error}</p>}
-        </div>
+            {/* Destino padrão */}
+            <section className="space-y-4">
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.defaultDestination')}</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">{t('modal.destination.pipeline')}</Label>
+                  <Choose
+                    value={defaultPipelineId}
+                    onChange={v => {
+                      setDefaultPipelineId(v);
+                      setDefaultStageId('');
+                    }}
+                    options={pipelineOptions}
+                    placeholder={t('modal.destination.pipeline')}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label className="text-xs text-muted-foreground">{t('modal.destination.stage')}</Label>
+                  <Choose
+                    value={defaultStageId || NONE}
+                    onChange={v => setDefaultStageId(v === NONE ? '' : v)}
+                    options={stageOptions(defaultPipelineId)}
+                    placeholder={t('modal.destination.stage')}
+                  />
+                </div>
+              </div>
+            </section>
 
-        <DialogFooter>
+            {/* Regras de roteamento */}
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.routing')}</h3>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setRules(prev => [...prev, { field: '', op: 'equals', value: '', pipeline_id: '', stage_id: '' }])}
+                >
+                  <Plus className="w-4 h-4 mr-1" /> {t('modal.routing.add')}
+                </Button>
+              </div>
+              {rules.map((r, idx) => (
+                <div key={idx} className="space-y-3 rounded-md border border-border p-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    <Choose
+                      value={r.field}
+                      onChange={v => updateRule(idx, { field: v })}
+                      options={fields.filter(f => f.key).map(f => ({ value: f.key, label: f.key }))}
+                      placeholder={t('modal.routing.field')}
+                    />
+                    <Choose
+                      value={r.op ?? 'equals'}
+                      onChange={v => updateRule(idx, { op: v as RoutingOp })}
+                      options={ROUTING_OPS.map(o => ({ value: o, label: o }))}
+                    />
+                    <Input
+                      placeholder={t('modal.routing.value')}
+                      value={r.value ?? ''}
+                      onChange={e => updateRule(idx, { value: e.target.value })}
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <Choose
+                      value={r.pipeline_id}
+                      onChange={v => updateRule(idx, { pipeline_id: v, stage_id: '' })}
+                      options={pipelineOptions}
+                      placeholder={t('modal.routing.pipeline')}
+                    />
+                    <Choose
+                      value={r.stage_id || NONE}
+                      onChange={v => updateRule(idx, { stage_id: v === NONE ? '' : v })}
+                      options={stageOptions(r.pipeline_id)}
+                      placeholder={t('modal.routing.stage')}
+                    />
+                  </div>
+                  <div className="flex justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="text-destructive"
+                      onClick={() => setRules(prev => prev.filter((_, i) => i !== idx))}
+                    >
+                      <Trash2 className="w-4 h-4 mr-1" /> {t('modal.routing.remove')}
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </section>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+        </ScrollArea>
+
+        <div className="flex justify-end gap-2 px-6 py-4 border-t">
           <Button variant="outline" onClick={onClose} disabled={saving}>
             {t('modal.cancel')}
           </Button>
           <Button onClick={handleSave} disabled={saving}>
             {saving ? t('modal.saving') : t('modal.save')}
           </Button>
-        </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/crmForms/CrmFormModal.tsx
+++ b/src/components/crmForms/CrmFormModal.tsx
@@ -20,6 +20,7 @@ import {
   SelectLabel,
 } from '@evoapi/design-system';
 import { Trash2, Plus } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
 import type { Pipeline } from '@/types/analytics/pipelines';
 import type { CustomAttributeDefinition } from '@/types/settings';
 import type { CrmForm, CrmFormField, CrmFormPayload, CrmFieldType, RoutingOp, RoutingRule } from '@/types/crmForms';
@@ -71,7 +72,6 @@ const Choose = ({ value, onChange, options, placeholder, className }: ChooseProp
 
 const emptyField = (): CrmFormField => ({ key: '', label: '', type: 'text', required: false, maps_to: '' });
 
-// Standard contact key behind a field's mapping (legacy string or typed), for client-side coverage checks.
 const contactStdKey = (f: CrmFormField): string | null => {
   const mt = f.maps_to || '';
   if (['name', 'email', 'phone', 'company'].includes(mt)) return mt;
@@ -80,6 +80,7 @@ const contactStdKey = (f: CrmFormField): string | null => {
 };
 
 const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, contactAttrs, dealAttrs }: CrmFormModalProps) => {
+  const { t } = useLanguage('crmForms');
   const [name, setName] = useState('');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -106,20 +107,20 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
       initial?.fields?.length
         ? initial.fields
         : [
-            { key: 'name', label: 'Nome', type: 'text', required: true, maps_to: 'contact', maps_to_key: 'name' },
-            { key: 'email', label: 'E-mail', type: 'email', required: true, maps_to: 'contact', maps_to_key: 'email' },
+            { key: 'name', label: t('modal.targets.contactName'), type: 'text', required: true, maps_to: 'contact', maps_to_key: 'name' },
+            { key: 'email', label: t('modal.targets.contactEmail'), type: 'email', required: true, maps_to: 'contact', maps_to_key: 'email' },
           ],
     );
     setRules(initial?.routing_rules ?? []);
     setDefaultPipelineId(initial?.default_pipeline_id ?? '');
     setDefaultStageId(initial?.default_stage_id ?? '');
     setError(null);
-  }, [open, initial]);
+  }, [open, initial, t]);
 
-  const targetGroups = buildTargetGroups(contactAttrs, dealAttrs);
+  const targetGroups = buildTargetGroups(contactAttrs, dealAttrs, t);
 
   const stageOptions = (pipelineId?: string) => [
-    { value: NONE, label: '— nenhum —' },
+    { value: NONE, label: t('modal.destination.stageNone') },
     ...(pipelines.find(p => p.id === pipelineId)?.stages ?? []).map(s => ({ value: s.id, label: s.name })),
   ];
   const pipelineOptions = pipelines.map(p => ({ value: p.id, label: p.name }));
@@ -129,8 +130,6 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
   const updateRule = (idx: number, patch: Partial<RoutingRule>) =>
     setRules(prev => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
 
-  // Apply a chosen mapping target: set maps_to/maps_to_key and, for custom
-  // attributes, suggest the field type/options from its display type.
   const applyTarget = (idx: number, value: string) => {
     const patch: Partial<CrmFormField> = decodeTarget(value);
     const attr = attrForTarget(value, contactAttrs, dealAttrs);
@@ -144,13 +143,13 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
 
   const handleSave = () => {
     setError(null);
-    if (!name.trim()) return setError('Informe o nome do formulário.');
-    if (!defaultPipelineId) return setError('Selecione o pipeline padrão.');
+    if (!name.trim()) return setError(t('modal.errors.name'));
+    if (!defaultPipelineId) return setError(t('modal.errors.pipeline'));
 
     const std = fields.map(contactStdKey);
-    if (!std.includes('email')) return setError('Inclua um campo mapeado para o e-mail do contato.');
-    if (!std.includes('name')) return setError('Inclua um campo mapeado para o nome do contato.');
-    if (fields.some(f => !f.key.trim())) return setError('Todo campo precisa de uma chave (key).');
+    if (!std.includes('email')) return setError(t('modal.errors.email'));
+    if (!std.includes('name')) return setError(t('modal.errors.nameField'));
+    if (fields.some(f => !f.key.trim())) return setError(t('modal.errors.fieldKey'));
 
     const payload: CrmFormPayload = {
       name: name.trim(),
@@ -174,56 +173,53 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
     <Dialog open={open} onOpenChange={v => !v && onClose()}>
       <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{initial ? 'Editar formulário' : 'Novo formulário'}</DialogTitle>
+          <DialogTitle>{initial ? t('modal.editTitle') : t('modal.createTitle')}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-6 py-2">
-          {/* Básico */}
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-foreground">Básico</h3>
+            <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.basic')}</h3>
             <div className="space-y-1">
-              <Label>Nome (interno)</Label>
-              <Input value={name} onChange={e => setName(e.target.value)} placeholder="Ex.: Contato site" />
+              <Label>{t('modal.basic.name')}</Label>
+              <Input value={name} onChange={e => setName(e.target.value)} placeholder={t('modal.basic.namePlaceholder')} />
             </div>
             <div className="space-y-1">
-              <Label>Título público</Label>
-              <Input value={title} onChange={e => setTitle(e.target.value)} placeholder="Ex.: Fale com a gente" />
+              <Label>{t('modal.basic.title')}</Label>
+              <Input value={title} onChange={e => setTitle(e.target.value)} placeholder={t('modal.basic.titlePlaceholder')} />
             </div>
             <div className="space-y-1">
-              <Label>Descrição</Label>
+              <Label>{t('modal.basic.description')}</Label>
               <Textarea value={description} onChange={e => setDescription(e.target.value)} />
             </div>
             <div className="flex items-center gap-2">
               <Switch checked={published} onCheckedChange={setPublished} id="published" />
-              <Label htmlFor="published">Publicado</Label>
+              <Label htmlFor="published">{t('modal.basic.published')}</Label>
             </div>
           </section>
 
-          {/* Aparência */}
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-foreground">Aparência</h3>
+            <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.appearance')}</h3>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1">
-                <Label>Cor primária</Label>
+                <Label>{t('modal.appearance.primaryColor')}</Label>
                 <Input value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} placeholder="#1E40AF" />
               </div>
               <div className="space-y-1">
-                <Label>URL do logo</Label>
+                <Label>{t('modal.appearance.logoUrl')}</Label>
                 <Input value={logoUrl} onChange={e => setLogoUrl(e.target.value)} placeholder="https://…" />
               </div>
             </div>
             <div className="space-y-1">
-              <Label>Mensagem de sucesso</Label>
+              <Label>{t('modal.appearance.successMessage')}</Label>
               <Input value={successMessage} onChange={e => setSuccessMessage(e.target.value)} />
             </div>
           </section>
 
-          {/* Campos */}
           <section className="space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-foreground">Campos</h3>
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.fields')}</h3>
               <Button variant="outline" size="sm" onClick={() => setFields(prev => [...prev, emptyField()])}>
-                <Plus className="w-4 h-4 mr-1" /> Campo
+                <Plus className="w-4 h-4 mr-1" /> {t('modal.fields.add')}
               </Button>
             </div>
             {fields.map((f, idx) => (
@@ -231,13 +227,13 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                 <div className="grid grid-cols-12 gap-2 items-center">
                   <Input
                     className="col-span-2"
-                    placeholder="key"
+                    placeholder={t('modal.fields.key')}
                     value={f.key}
                     onChange={e => updateField(idx, { key: e.target.value })}
                   />
                   <Input
                     className="col-span-3"
-                    placeholder="label"
+                    placeholder={t('modal.fields.label')}
                     value={f.label ?? ''}
                     onChange={e => updateField(idx, { label: e.target.value })}
                   />
@@ -245,16 +241,15 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                     className="col-span-2"
                     value={f.type}
                     onChange={v => updateField(idx, { type: v as CrmFieldType })}
-                    options={FIELD_TYPES.map(t => ({ value: t, label: t }))}
+                    options={FIELD_TYPES.map(ft => ({ value: ft, label: ft }))}
                   />
-                  {/* Destino: mesma lista de contextos que a submissão pública aceita */}
                   <div className="col-span-3">
                     <Select value={encodeTarget(f)} onValueChange={v => applyTarget(idx, v)}>
                       <SelectTrigger>
-                        <SelectValue placeholder="mapear para…" />
+                        <SelectValue placeholder={t('modal.fields.mapTo')} />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value={NONE_TARGET}>— sem mapeamento —</SelectItem>
+                        <SelectItem value={NONE_TARGET}>{t('modal.targets.none')}</SelectItem>
                         {targetGroups.map(g => (
                           <SelectGroup key={g.label}>
                             <SelectLabel>{g.label}</SelectLabel>
@@ -270,21 +265,21 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                   </div>
                   <label className="col-span-1 flex items-center gap-1 text-xs text-foreground">
                     <Checkbox checked={!!f.required} onCheckedChange={c => updateField(idx, { required: c === true })} />
-                    obrig.
+                    {t('modal.fields.required')}
                   </label>
                   <Button
                     variant="ghost"
                     size="icon"
                     className="col-span-1 text-destructive"
                     onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))}
-                    aria-label="remover campo"
+                    aria-label={t('modal.fields.remove')}
                   >
                     <Trash2 className="w-4 h-4" />
                   </Button>
                 </div>
                 {f.type === 'select' && (
                   <Input
-                    placeholder="Opções separadas por vírgula"
+                    placeholder={t('modal.fields.optionsPlaceholder')}
                     value={(f.options ?? []).join(', ')}
                     onChange={e =>
                       updateField(idx, {
@@ -297,9 +292,8 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
             ))}
           </section>
 
-          {/* Destino padrão */}
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-foreground">Destino padrão</h3>
+            <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.defaultDestination')}</h3>
             <div className="grid grid-cols-2 gap-3">
               <Choose
                 value={defaultPipelineId}
@@ -308,27 +302,26 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                   setDefaultStageId('');
                 }}
                 options={pipelineOptions}
-                placeholder="Pipeline…"
+                placeholder={t('modal.destination.pipeline')}
               />
               <Choose
                 value={defaultStageId || NONE}
                 onChange={v => setDefaultStageId(v === NONE ? '' : v)}
                 options={stageOptions(defaultPipelineId)}
-                placeholder="Estágio…"
+                placeholder={t('modal.destination.stage')}
               />
             </div>
           </section>
 
-          {/* Regras de roteamento */}
           <section className="space-y-3">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-semibold text-foreground">Regras de roteamento</h3>
+              <h3 className="text-sm font-semibold text-foreground">{t('modal.sections.routing')}</h3>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => setRules(prev => [...prev, { field: '', op: 'equals', value: '', pipeline_id: '', stage_id: '' }])}
               >
-                <Plus className="w-4 h-4 mr-1" /> Regra
+                <Plus className="w-4 h-4 mr-1" /> {t('modal.routing.add')}
               </Button>
             </div>
             {rules.map((r, idx) => (
@@ -338,7 +331,7 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                   value={r.field}
                   onChange={v => updateRule(idx, { field: v })}
                   options={fields.filter(f => f.key).map(f => ({ value: f.key, label: f.key }))}
-                  placeholder="campo…"
+                  placeholder={t('modal.routing.field')}
                 />
                 <Choose
                   className="col-span-2"
@@ -348,7 +341,7 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                 />
                 <Input
                   className="col-span-2"
-                  placeholder="valor"
+                  placeholder={t('modal.routing.value')}
                   value={r.value ?? ''}
                   onChange={e => updateRule(idx, { value: e.target.value })}
                 />
@@ -357,21 +350,21 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
                   value={r.pipeline_id}
                   onChange={v => updateRule(idx, { pipeline_id: v, stage_id: '' })}
                   options={pipelineOptions}
-                  placeholder="pipeline…"
+                  placeholder={t('modal.routing.pipeline')}
                 />
                 <Choose
                   className="col-span-2"
                   value={r.stage_id || NONE}
                   onChange={v => updateRule(idx, { stage_id: v === NONE ? '' : v })}
                   options={stageOptions(r.pipeline_id)}
-                  placeholder="estágio…"
+                  placeholder={t('modal.routing.stage')}
                 />
                 <Button
                   variant="ghost"
                   size="icon"
                   className="col-span-1 text-destructive"
                   onClick={() => setRules(prev => prev.filter((_, i) => i !== idx))}
-                  aria-label="remover regra"
+                  aria-label={t('modal.routing.remove')}
                 >
                   <Trash2 className="w-4 h-4" />
                 </Button>
@@ -384,10 +377,10 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
 
         <DialogFooter>
           <Button variant="outline" onClick={onClose} disabled={saving}>
-            Cancelar
+            {t('modal.cancel')}
           </Button>
           <Button onClick={handleSave} disabled={saving}>
-            {saving ? 'Salvando…' : 'Salvar'}
+            {saving ? t('modal.saving') : t('modal.save')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/crmForms/CrmFormModal.tsx
+++ b/src/components/crmForms/CrmFormModal.tsx
@@ -16,18 +16,21 @@ import {
   SelectValue,
   SelectContent,
   SelectItem,
+  SelectGroup,
+  SelectLabel,
 } from '@evoapi/design-system';
 import { Trash2, Plus } from 'lucide-react';
 import type { Pipeline } from '@/types/analytics/pipelines';
-import type {
-  CrmForm,
-  CrmFormField,
-  CrmFormPayload,
-  CrmFieldType,
-  FieldMapsTo,
-  RoutingOp,
-  RoutingRule,
-} from '@/types/crmForms';
+import type { CustomAttributeDefinition } from '@/types/settings';
+import type { CrmForm, CrmFormField, CrmFormPayload, CrmFieldType, RoutingOp, RoutingRule } from '@/types/crmForms';
+import {
+  encodeTarget,
+  decodeTarget,
+  buildTargetGroups,
+  suggestFieldFromAttribute,
+  attrForTarget,
+  NONE_TARGET,
+} from '@/services/crmForms/crmFormTargets';
 
 interface CrmFormModalProps {
   open: boolean;
@@ -36,16 +39,11 @@ interface CrmFormModalProps {
   saving: boolean;
   initial: CrmForm | null;
   pipelines: Pipeline[];
+  contactAttrs: CustomAttributeDefinition[];
+  dealAttrs: CustomAttributeDefinition[];
 }
 
 const FIELD_TYPES: CrmFieldType[] = ['text', 'email', 'tel', 'number', 'textarea', 'select', 'checkbox'];
-const MAPS_TO: { value: string; label: string }[] = [
-  { value: '__none__', label: '— sem mapeamento —' },
-  { value: 'name', label: 'name' },
-  { value: 'email', label: 'email' },
-  { value: 'phone', label: 'phone' },
-  { value: 'company', label: 'company' },
-];
 const ROUTING_OPS: RoutingOp[] = ['equals', 'not_equals', 'contains'];
 const NONE = '__none__';
 
@@ -73,7 +71,15 @@ const Choose = ({ value, onChange, options, placeholder, className }: ChooseProp
 
 const emptyField = (): CrmFormField => ({ key: '', label: '', type: 'text', required: false, maps_to: '' });
 
-const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: CrmFormModalProps) => {
+// Standard contact key behind a field's mapping (legacy string or typed), for client-side coverage checks.
+const contactStdKey = (f: CrmFormField): string | null => {
+  const mt = f.maps_to || '';
+  if (['name', 'email', 'phone', 'company'].includes(mt)) return mt;
+  if (mt === 'contact') return f.maps_to_key || null;
+  return null;
+};
+
+const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, contactAttrs, dealAttrs }: CrmFormModalProps) => {
   const [name, setName] = useState('');
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -100,8 +106,8 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
       initial?.fields?.length
         ? initial.fields
         : [
-            { key: 'name', label: 'Nome', type: 'text', required: true, maps_to: 'name' },
-            { key: 'email', label: 'E-mail', type: 'email', required: true, maps_to: 'email' },
+            { key: 'name', label: 'Nome', type: 'text', required: true, maps_to: 'contact', maps_to_key: 'name' },
+            { key: 'email', label: 'E-mail', type: 'email', required: true, maps_to: 'contact', maps_to_key: 'email' },
           ],
     );
     setRules(initial?.routing_rules ?? []);
@@ -109,6 +115,8 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
     setDefaultStageId(initial?.default_stage_id ?? '');
     setError(null);
   }, [open, initial]);
+
+  const targetGroups = buildTargetGroups(contactAttrs, dealAttrs);
 
   const stageOptions = (pipelineId?: string) => [
     { value: NONE, label: '— nenhum —' },
@@ -121,14 +129,27 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
   const updateRule = (idx: number, patch: Partial<RoutingRule>) =>
     setRules(prev => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
 
+  // Apply a chosen mapping target: set maps_to/maps_to_key and, for custom
+  // attributes, suggest the field type/options from its display type.
+  const applyTarget = (idx: number, value: string) => {
+    const patch: Partial<CrmFormField> = decodeTarget(value);
+    const attr = attrForTarget(value, contactAttrs, dealAttrs);
+    if (attr) {
+      const suggestion = suggestFieldFromAttribute(attr);
+      patch.type = suggestion.type;
+      if (suggestion.options) patch.options = suggestion.options;
+    }
+    updateField(idx, patch);
+  };
+
   const handleSave = () => {
     setError(null);
     if (!name.trim()) return setError('Informe o nome do formulário.');
     if (!defaultPipelineId) return setError('Selecione o pipeline padrão.');
 
-    const mapped = fields.map(f => f.maps_to).filter(Boolean);
-    if (!mapped.includes('email')) return setError('Inclua um campo mapeado para "email".');
-    if (!mapped.includes('name')) return setError('Inclua um campo mapeado para "name".');
+    const std = fields.map(contactStdKey);
+    if (!std.includes('email')) return setError('Inclua um campo mapeado para o e-mail do contato.');
+    if (!std.includes('name')) return setError('Inclua um campo mapeado para o nome do contato.');
     if (fields.some(f => !f.key.trim())) return setError('Todo campo precisa de uma chave (key).');
 
     const payload: CrmFormPayload = {
@@ -206,50 +227,63 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
               </Button>
             </div>
             {fields.map((f, idx) => (
-              <div key={idx} className="grid grid-cols-12 gap-2 items-center border border-border rounded-md p-2">
-                <Input
-                  className="col-span-2"
-                  placeholder="key"
-                  value={f.key}
-                  onChange={e => updateField(idx, { key: e.target.value })}
-                />
-                <Input
-                  className="col-span-3"
-                  placeholder="label"
-                  value={f.label ?? ''}
-                  onChange={e => updateField(idx, { label: e.target.value })}
-                />
-                <Choose
-                  className="col-span-2"
-                  value={f.type}
-                  onChange={v => updateField(idx, { type: v as CrmFieldType })}
-                  options={FIELD_TYPES.map(t => ({ value: t, label: t }))}
-                />
-                <Choose
-                  className="col-span-2"
-                  value={f.maps_to || NONE}
-                  onChange={v => updateField(idx, { maps_to: (v === NONE ? '' : v) as FieldMapsTo })}
-                  options={MAPS_TO}
-                />
-                <label className="col-span-2 flex items-center gap-1 text-xs text-foreground">
-                  <Checkbox
-                    checked={!!f.required}
-                    onCheckedChange={c => updateField(idx, { required: c === true })}
+              <div key={idx} className="space-y-2 border border-border rounded-md p-2">
+                <div className="grid grid-cols-12 gap-2 items-center">
+                  <Input
+                    className="col-span-2"
+                    placeholder="key"
+                    value={f.key}
+                    onChange={e => updateField(idx, { key: e.target.value })}
                   />
-                  obrig.
-                </label>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="col-span-1 text-destructive"
-                  onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))}
-                  aria-label="remover campo"
-                >
-                  <Trash2 className="w-4 h-4" />
-                </Button>
+                  <Input
+                    className="col-span-3"
+                    placeholder="label"
+                    value={f.label ?? ''}
+                    onChange={e => updateField(idx, { label: e.target.value })}
+                  />
+                  <Choose
+                    className="col-span-2"
+                    value={f.type}
+                    onChange={v => updateField(idx, { type: v as CrmFieldType })}
+                    options={FIELD_TYPES.map(t => ({ value: t, label: t }))}
+                  />
+                  {/* Destino: mesma lista de contextos que a submissão pública aceita */}
+                  <div className="col-span-3">
+                    <Select value={encodeTarget(f)} onValueChange={v => applyTarget(idx, v)}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="mapear para…" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={NONE_TARGET}>— sem mapeamento —</SelectItem>
+                        {targetGroups.map(g => (
+                          <SelectGroup key={g.label}>
+                            <SelectLabel>{g.label}</SelectLabel>
+                            {g.options.map(o => (
+                              <SelectItem key={o.value} value={o.value}>
+                                {o.label}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <label className="col-span-1 flex items-center gap-1 text-xs text-foreground">
+                    <Checkbox checked={!!f.required} onCheckedChange={c => updateField(idx, { required: c === true })} />
+                    obrig.
+                  </label>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="col-span-1 text-destructive"
+                    onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))}
+                    aria-label="remover campo"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </Button>
+                </div>
                 {f.type === 'select' && (
                   <Input
-                    className="col-span-12"
                     placeholder="Opções separadas por vírgula"
                     value={(f.options ?? []).join(', ')}
                     onChange={e =>

--- a/src/components/crmForms/CrmFormModal.tsx
+++ b/src/components/crmForms/CrmFormModal.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Button,
+} from '@evoapi/design-system';
+import { Trash2, Plus } from 'lucide-react';
+import type { Pipeline } from '@/types/analytics/pipelines';
+import type {
+  CrmForm,
+  CrmFormField,
+  CrmFormPayload,
+  CrmFieldType,
+  FieldMapsTo,
+  RoutingOp,
+  RoutingRule,
+} from '@/types/crmForms';
+
+interface CrmFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (payload: CrmFormPayload) => void | Promise<void>;
+  saving: boolean;
+  initial: CrmForm | null;
+  pipelines: Pipeline[];
+}
+
+const FIELD_TYPES: CrmFieldType[] = ['text', 'email', 'tel', 'number', 'textarea', 'select', 'checkbox'];
+const MAPS_TO: FieldMapsTo[] = ['', 'name', 'email', 'phone', 'company'];
+const ROUTING_OPS: RoutingOp[] = ['equals', 'not_equals', 'contains'];
+
+const inputClass =
+  'w-full p-2 text-sm border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring';
+
+const emptyField = (): CrmFormField => ({ key: '', label: '', type: 'text', required: false, maps_to: '' });
+
+const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: CrmFormModalProps) => {
+  const [name, setName] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [published, setPublished] = useState(false);
+  const [primaryColor, setPrimaryColor] = useState('');
+  const [logoUrl, setLogoUrl] = useState('');
+  const [successMessage, setSuccessMessage] = useState('');
+  const [fields, setFields] = useState<CrmFormField[]>([]);
+  const [rules, setRules] = useState<RoutingRule[]>([]);
+  const [defaultPipelineId, setDefaultPipelineId] = useState('');
+  const [defaultStageId, setDefaultStageId] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(initial?.name ?? '');
+    setTitle(initial?.title ?? '');
+    setDescription(initial?.description ?? '');
+    setPublished(initial?.published ?? false);
+    setPrimaryColor(initial?.appearance?.primary_color ?? '');
+    setLogoUrl(initial?.appearance?.logo_url ?? '');
+    setSuccessMessage(initial?.appearance?.success_message ?? '');
+    setFields(
+      initial?.fields?.length
+        ? initial.fields
+        : [
+            { key: 'name', label: 'Nome', type: 'text', required: true, maps_to: 'name' },
+            { key: 'email', label: 'E-mail', type: 'email', required: true, maps_to: 'email' },
+          ],
+    );
+    setRules(initial?.routing_rules ?? []);
+    setDefaultPipelineId(initial?.default_pipeline_id ?? '');
+    setDefaultStageId(initial?.default_stage_id ?? '');
+    setError(null);
+  }, [open, initial]);
+
+  const stagesFor = (pipelineId?: string) => pipelines.find(p => p.id === pipelineId)?.stages ?? [];
+
+  const updateField = (idx: number, patch: Partial<CrmFormField>) =>
+    setFields(prev => prev.map((f, i) => (i === idx ? { ...f, ...patch } : f)));
+  const updateRule = (idx: number, patch: Partial<RoutingRule>) =>
+    setRules(prev => prev.map((r, i) => (i === idx ? { ...r, ...patch } : r)));
+
+  const handleSave = () => {
+    setError(null);
+    if (!name.trim()) return setError('Informe o nome do formulário.');
+    if (!defaultPipelineId) return setError('Selecione o pipeline padrão.');
+
+    const mapped = fields.map(f => f.maps_to).filter(Boolean);
+    if (!mapped.includes('email')) return setError('Inclua um campo mapeado para "email".');
+    if (!mapped.includes('name')) return setError('Inclua um campo mapeado para "name".');
+    if (fields.some(f => !f.key.trim())) return setError('Todo campo precisa de uma chave (key).');
+
+    const payload: CrmFormPayload = {
+      name: name.trim(),
+      title: title.trim() || undefined,
+      description: description.trim() || undefined,
+      published,
+      appearance: {
+        primary_color: primaryColor || undefined,
+        logo_url: logoUrl || undefined,
+        success_message: successMessage || undefined,
+      },
+      fields: fields.map(f => ({
+        ...f,
+        options:
+          f.type === 'select' && typeof (f.options as unknown) === 'string'
+            ? String(f.options).split(',').map(o => o.trim()).filter(Boolean)
+            : f.options,
+      })),
+      routing_rules: rules.filter(r => r.pipeline_id),
+      default_pipeline_id: defaultPipelineId,
+      default_stage_id: defaultStageId || undefined,
+    };
+    onSave(payload);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={v => !v && onClose()}>
+      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{initial ? 'Editar formulário' : 'Novo formulário'}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-6 py-2">
+          {/* Básico */}
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">Básico</h3>
+            <input className={inputClass} placeholder="Nome (interno)" value={name} onChange={e => setName(e.target.value)} />
+            <input className={inputClass} placeholder="Título público" value={title} onChange={e => setTitle(e.target.value)} />
+            <textarea className={inputClass} placeholder="Descrição" value={description} onChange={e => setDescription(e.target.value)} />
+            <label className="flex items-center gap-2 text-sm text-foreground">
+              <input type="checkbox" checked={published} onChange={e => setPublished(e.target.checked)} />
+              Publicado
+            </label>
+          </section>
+
+          {/* Aparência */}
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">Aparência</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <input className={inputClass} placeholder="Cor primária (#hex)" value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} />
+              <input className={inputClass} placeholder="URL do logo" value={logoUrl} onChange={e => setLogoUrl(e.target.value)} />
+            </div>
+            <input className={inputClass} placeholder="Mensagem de sucesso" value={successMessage} onChange={e => setSuccessMessage(e.target.value)} />
+          </section>
+
+          {/* Campos */}
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-foreground">Campos</h3>
+              <Button variant="outline" size="sm" onClick={() => setFields(prev => [...prev, emptyField()])}>
+                <Plus className="w-4 h-4 mr-1" /> Campo
+              </Button>
+            </div>
+            {fields.map((f, idx) => (
+              <div key={idx} className="grid grid-cols-12 gap-2 items-center border border-border rounded-md p-2">
+                <input className={`${inputClass} col-span-2`} placeholder="key" value={f.key} onChange={e => updateField(idx, { key: e.target.value })} />
+                <input className={`${inputClass} col-span-3`} placeholder="label" value={f.label ?? ''} onChange={e => updateField(idx, { label: e.target.value })} />
+                <select className={`${inputClass} col-span-2`} value={f.type} onChange={e => updateField(idx, { type: e.target.value as CrmFieldType })}>
+                  {FIELD_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                </select>
+                <select className={`${inputClass} col-span-2`} value={f.maps_to ?? ''} onChange={e => updateField(idx, { maps_to: e.target.value as FieldMapsTo })}>
+                  {MAPS_TO.map(m => <option key={m} value={m}>{m || 'maps_to…'}</option>)}
+                </select>
+                <label className="col-span-2 flex items-center gap-1 text-xs text-foreground">
+                  <input type="checkbox" checked={!!f.required} onChange={e => updateField(idx, { required: e.target.checked })} />
+                  obrig.
+                </label>
+                <button className="col-span-1 text-destructive flex justify-center" onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))} aria-label="remover campo">
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </section>
+
+          {/* Destino padrão */}
+          <section className="space-y-3">
+            <h3 className="text-sm font-semibold text-foreground">Destino padrão</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <select className={inputClass} value={defaultPipelineId} onChange={e => { setDefaultPipelineId(e.target.value); setDefaultStageId(''); }}>
+                <option value="">Pipeline…</option>
+                {pipelines.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+              <select className={inputClass} value={defaultStageId} onChange={e => setDefaultStageId(e.target.value)}>
+                <option value="">Estágio…</option>
+                {stagesFor(defaultPipelineId).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+              </select>
+            </div>
+          </section>
+
+          {/* Regras de roteamento */}
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-foreground">Regras de roteamento</h3>
+              <Button variant="outline" size="sm" onClick={() => setRules(prev => [...prev, { field: '', op: 'equals', value: '', pipeline_id: '', stage_id: '' }])}>
+                <Plus className="w-4 h-4 mr-1" /> Regra
+              </Button>
+            </div>
+            {rules.map((r, idx) => (
+              <div key={idx} className="grid grid-cols-12 gap-2 items-center border border-border rounded-md p-2">
+                <select className={`${inputClass} col-span-2`} value={r.field ?? ''} onChange={e => updateRule(idx, { field: e.target.value })}>
+                  <option value="">campo…</option>
+                  {fields.filter(f => f.key).map(f => <option key={f.key} value={f.key}>{f.key}</option>)}
+                </select>
+                <select className={`${inputClass} col-span-2`} value={r.op ?? 'equals'} onChange={e => updateRule(idx, { op: e.target.value as RoutingOp })}>
+                  {ROUTING_OPS.map(o => <option key={o} value={o}>{o}</option>)}
+                </select>
+                <input className={`${inputClass} col-span-2`} placeholder="valor" value={r.value ?? ''} onChange={e => updateRule(idx, { value: e.target.value })} />
+                <select className={`${inputClass} col-span-3`} value={r.pipeline_id} onChange={e => updateRule(idx, { pipeline_id: e.target.value, stage_id: '' })}>
+                  <option value="">pipeline…</option>
+                  {pipelines.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+                </select>
+                <select className={`${inputClass} col-span-2`} value={r.stage_id ?? ''} onChange={e => updateRule(idx, { stage_id: e.target.value })}>
+                  <option value="">estágio…</option>
+                  {stagesFor(r.pipeline_id).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
+                </select>
+                <button className="col-span-1 text-destructive flex justify-center" onClick={() => setRules(prev => prev.filter((_, i) => i !== idx))} aria-label="remover regra">
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </section>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>Cancelar</Button>
+          <Button onClick={handleSave} disabled={saving}>{saving ? 'Salvando…' : 'Salvar'}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CrmFormModal;

--- a/src/components/crmForms/CrmFormModal.tsx
+++ b/src/components/crmForms/CrmFormModal.tsx
@@ -6,6 +6,16 @@ import {
   DialogTitle,
   DialogFooter,
   Button,
+  Input,
+  Textarea,
+  Label,
+  Switch,
+  Checkbox,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
 } from '@evoapi/design-system';
 import { Trash2, Plus } from 'lucide-react';
 import type { Pipeline } from '@/types/analytics/pipelines';
@@ -29,11 +39,37 @@ interface CrmFormModalProps {
 }
 
 const FIELD_TYPES: CrmFieldType[] = ['text', 'email', 'tel', 'number', 'textarea', 'select', 'checkbox'];
-const MAPS_TO: FieldMapsTo[] = ['', 'name', 'email', 'phone', 'company'];
+const MAPS_TO: { value: string; label: string }[] = [
+  { value: '__none__', label: '— sem mapeamento —' },
+  { value: 'name', label: 'name' },
+  { value: 'email', label: 'email' },
+  { value: 'phone', label: 'phone' },
+  { value: 'company', label: 'company' },
+];
 const ROUTING_OPS: RoutingOp[] = ['equals', 'not_equals', 'contains'];
+const NONE = '__none__';
 
-const inputClass =
-  'w-full p-2 text-sm border border-input rounded-md bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-ring';
+interface ChooseProps {
+  value?: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+  className?: string;
+}
+const Choose = ({ value, onChange, options, placeholder, className }: ChooseProps) => (
+  <Select value={value || undefined} onValueChange={onChange}>
+    <SelectTrigger className={className}>
+      <SelectValue placeholder={placeholder} />
+    </SelectTrigger>
+    <SelectContent>
+      {options.map(o => (
+        <SelectItem key={o.value} value={o.value}>
+          {o.label}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+);
 
 const emptyField = (): CrmFormField => ({ key: '', label: '', type: 'text', required: false, maps_to: '' });
 
@@ -74,7 +110,11 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
     setError(null);
   }, [open, initial]);
 
-  const stagesFor = (pipelineId?: string) => pipelines.find(p => p.id === pipelineId)?.stages ?? [];
+  const stageOptions = (pipelineId?: string) => [
+    { value: NONE, label: '— nenhum —' },
+    ...(pipelines.find(p => p.id === pipelineId)?.stages ?? []).map(s => ({ value: s.id, label: s.name })),
+  ];
+  const pipelineOptions = pipelines.map(p => ({ value: p.id, label: p.name }));
 
   const updateField = (idx: number, patch: Partial<CrmFormField>) =>
     setFields(prev => prev.map((f, i) => (i === idx ? { ...f, ...patch } : f)));
@@ -101,13 +141,7 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
         logo_url: logoUrl || undefined,
         success_message: successMessage || undefined,
       },
-      fields: fields.map(f => ({
-        ...f,
-        options:
-          f.type === 'select' && typeof (f.options as unknown) === 'string'
-            ? String(f.options).split(',').map(o => o.trim()).filter(Boolean)
-            : f.options,
-      })),
+      fields,
       routing_rules: rules.filter(r => r.pipeline_id),
       default_pipeline_id: defaultPipelineId,
       default_stage_id: defaultStageId || undefined,
@@ -126,23 +160,41 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
           {/* Básico */}
           <section className="space-y-3">
             <h3 className="text-sm font-semibold text-foreground">Básico</h3>
-            <input className={inputClass} placeholder="Nome (interno)" value={name} onChange={e => setName(e.target.value)} />
-            <input className={inputClass} placeholder="Título público" value={title} onChange={e => setTitle(e.target.value)} />
-            <textarea className={inputClass} placeholder="Descrição" value={description} onChange={e => setDescription(e.target.value)} />
-            <label className="flex items-center gap-2 text-sm text-foreground">
-              <input type="checkbox" checked={published} onChange={e => setPublished(e.target.checked)} />
-              Publicado
-            </label>
+            <div className="space-y-1">
+              <Label>Nome (interno)</Label>
+              <Input value={name} onChange={e => setName(e.target.value)} placeholder="Ex.: Contato site" />
+            </div>
+            <div className="space-y-1">
+              <Label>Título público</Label>
+              <Input value={title} onChange={e => setTitle(e.target.value)} placeholder="Ex.: Fale com a gente" />
+            </div>
+            <div className="space-y-1">
+              <Label>Descrição</Label>
+              <Textarea value={description} onChange={e => setDescription(e.target.value)} />
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch checked={published} onCheckedChange={setPublished} id="published" />
+              <Label htmlFor="published">Publicado</Label>
+            </div>
           </section>
 
           {/* Aparência */}
           <section className="space-y-3">
             <h3 className="text-sm font-semibold text-foreground">Aparência</h3>
             <div className="grid grid-cols-2 gap-3">
-              <input className={inputClass} placeholder="Cor primária (#hex)" value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} />
-              <input className={inputClass} placeholder="URL do logo" value={logoUrl} onChange={e => setLogoUrl(e.target.value)} />
+              <div className="space-y-1">
+                <Label>Cor primária</Label>
+                <Input value={primaryColor} onChange={e => setPrimaryColor(e.target.value)} placeholder="#1E40AF" />
+              </div>
+              <div className="space-y-1">
+                <Label>URL do logo</Label>
+                <Input value={logoUrl} onChange={e => setLogoUrl(e.target.value)} placeholder="https://…" />
+              </div>
             </div>
-            <input className={inputClass} placeholder="Mensagem de sucesso" value={successMessage} onChange={e => setSuccessMessage(e.target.value)} />
+            <div className="space-y-1">
+              <Label>Mensagem de sucesso</Label>
+              <Input value={successMessage} onChange={e => setSuccessMessage(e.target.value)} />
+            </div>
           </section>
 
           {/* Campos */}
@@ -155,21 +207,58 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
             </div>
             {fields.map((f, idx) => (
               <div key={idx} className="grid grid-cols-12 gap-2 items-center border border-border rounded-md p-2">
-                <input className={`${inputClass} col-span-2`} placeholder="key" value={f.key} onChange={e => updateField(idx, { key: e.target.value })} />
-                <input className={`${inputClass} col-span-3`} placeholder="label" value={f.label ?? ''} onChange={e => updateField(idx, { label: e.target.value })} />
-                <select className={`${inputClass} col-span-2`} value={f.type} onChange={e => updateField(idx, { type: e.target.value as CrmFieldType })}>
-                  {FIELD_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
-                </select>
-                <select className={`${inputClass} col-span-2`} value={f.maps_to ?? ''} onChange={e => updateField(idx, { maps_to: e.target.value as FieldMapsTo })}>
-                  {MAPS_TO.map(m => <option key={m} value={m}>{m || 'maps_to…'}</option>)}
-                </select>
+                <Input
+                  className="col-span-2"
+                  placeholder="key"
+                  value={f.key}
+                  onChange={e => updateField(idx, { key: e.target.value })}
+                />
+                <Input
+                  className="col-span-3"
+                  placeholder="label"
+                  value={f.label ?? ''}
+                  onChange={e => updateField(idx, { label: e.target.value })}
+                />
+                <Choose
+                  className="col-span-2"
+                  value={f.type}
+                  onChange={v => updateField(idx, { type: v as CrmFieldType })}
+                  options={FIELD_TYPES.map(t => ({ value: t, label: t }))}
+                />
+                <Choose
+                  className="col-span-2"
+                  value={f.maps_to || NONE}
+                  onChange={v => updateField(idx, { maps_to: (v === NONE ? '' : v) as FieldMapsTo })}
+                  options={MAPS_TO}
+                />
                 <label className="col-span-2 flex items-center gap-1 text-xs text-foreground">
-                  <input type="checkbox" checked={!!f.required} onChange={e => updateField(idx, { required: e.target.checked })} />
+                  <Checkbox
+                    checked={!!f.required}
+                    onCheckedChange={c => updateField(idx, { required: c === true })}
+                  />
                   obrig.
                 </label>
-                <button className="col-span-1 text-destructive flex justify-center" onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))} aria-label="remover campo">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="col-span-1 text-destructive"
+                  onClick={() => setFields(prev => prev.filter((_, i) => i !== idx))}
+                  aria-label="remover campo"
+                >
                   <Trash2 className="w-4 h-4" />
-                </button>
+                </Button>
+                {f.type === 'select' && (
+                  <Input
+                    className="col-span-12"
+                    placeholder="Opções separadas por vírgula"
+                    value={(f.options ?? []).join(', ')}
+                    onChange={e =>
+                      updateField(idx, {
+                        options: e.target.value.split(',').map(o => o.trim()).filter(Boolean),
+                      })
+                    }
+                  />
+                )}
               </div>
             ))}
           </section>
@@ -178,14 +267,21 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
           <section className="space-y-3">
             <h3 className="text-sm font-semibold text-foreground">Destino padrão</h3>
             <div className="grid grid-cols-2 gap-3">
-              <select className={inputClass} value={defaultPipelineId} onChange={e => { setDefaultPipelineId(e.target.value); setDefaultStageId(''); }}>
-                <option value="">Pipeline…</option>
-                {pipelines.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-              </select>
-              <select className={inputClass} value={defaultStageId} onChange={e => setDefaultStageId(e.target.value)}>
-                <option value="">Estágio…</option>
-                {stagesFor(defaultPipelineId).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
-              </select>
+              <Choose
+                value={defaultPipelineId}
+                onChange={v => {
+                  setDefaultPipelineId(v);
+                  setDefaultStageId('');
+                }}
+                options={pipelineOptions}
+                placeholder="Pipeline…"
+              />
+              <Choose
+                value={defaultStageId || NONE}
+                onChange={v => setDefaultStageId(v === NONE ? '' : v)}
+                options={stageOptions(defaultPipelineId)}
+                placeholder="Estágio…"
+              />
             </div>
           </section>
 
@@ -193,31 +289,58 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
           <section className="space-y-3">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold text-foreground">Regras de roteamento</h3>
-              <Button variant="outline" size="sm" onClick={() => setRules(prev => [...prev, { field: '', op: 'equals', value: '', pipeline_id: '', stage_id: '' }])}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setRules(prev => [...prev, { field: '', op: 'equals', value: '', pipeline_id: '', stage_id: '' }])}
+              >
                 <Plus className="w-4 h-4 mr-1" /> Regra
               </Button>
             </div>
             {rules.map((r, idx) => (
               <div key={idx} className="grid grid-cols-12 gap-2 items-center border border-border rounded-md p-2">
-                <select className={`${inputClass} col-span-2`} value={r.field ?? ''} onChange={e => updateRule(idx, { field: e.target.value })}>
-                  <option value="">campo…</option>
-                  {fields.filter(f => f.key).map(f => <option key={f.key} value={f.key}>{f.key}</option>)}
-                </select>
-                <select className={`${inputClass} col-span-2`} value={r.op ?? 'equals'} onChange={e => updateRule(idx, { op: e.target.value as RoutingOp })}>
-                  {ROUTING_OPS.map(o => <option key={o} value={o}>{o}</option>)}
-                </select>
-                <input className={`${inputClass} col-span-2`} placeholder="valor" value={r.value ?? ''} onChange={e => updateRule(idx, { value: e.target.value })} />
-                <select className={`${inputClass} col-span-3`} value={r.pipeline_id} onChange={e => updateRule(idx, { pipeline_id: e.target.value, stage_id: '' })}>
-                  <option value="">pipeline…</option>
-                  {pipelines.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
-                </select>
-                <select className={`${inputClass} col-span-2`} value={r.stage_id ?? ''} onChange={e => updateRule(idx, { stage_id: e.target.value })}>
-                  <option value="">estágio…</option>
-                  {stagesFor(r.pipeline_id).map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
-                </select>
-                <button className="col-span-1 text-destructive flex justify-center" onClick={() => setRules(prev => prev.filter((_, i) => i !== idx))} aria-label="remover regra">
+                <Choose
+                  className="col-span-2"
+                  value={r.field}
+                  onChange={v => updateRule(idx, { field: v })}
+                  options={fields.filter(f => f.key).map(f => ({ value: f.key, label: f.key }))}
+                  placeholder="campo…"
+                />
+                <Choose
+                  className="col-span-2"
+                  value={r.op ?? 'equals'}
+                  onChange={v => updateRule(idx, { op: v as RoutingOp })}
+                  options={ROUTING_OPS.map(o => ({ value: o, label: o }))}
+                />
+                <Input
+                  className="col-span-2"
+                  placeholder="valor"
+                  value={r.value ?? ''}
+                  onChange={e => updateRule(idx, { value: e.target.value })}
+                />
+                <Choose
+                  className="col-span-3"
+                  value={r.pipeline_id}
+                  onChange={v => updateRule(idx, { pipeline_id: v, stage_id: '' })}
+                  options={pipelineOptions}
+                  placeholder="pipeline…"
+                />
+                <Choose
+                  className="col-span-2"
+                  value={r.stage_id || NONE}
+                  onChange={v => updateRule(idx, { stage_id: v === NONE ? '' : v })}
+                  options={stageOptions(r.pipeline_id)}
+                  placeholder="estágio…"
+                />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="col-span-1 text-destructive"
+                  onClick={() => setRules(prev => prev.filter((_, i) => i !== idx))}
+                  aria-label="remover regra"
+                >
                   <Trash2 className="w-4 h-4" />
-                </button>
+                </Button>
               </div>
             ))}
           </section>
@@ -226,8 +349,12 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines }: Crm
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose} disabled={saving}>Cancelar</Button>
-          <Button onClick={handleSave} disabled={saving}>{saving ? 'Salvando…' : 'Salvar'}</Button>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancelar
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Salvando…' : 'Salvar'}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/crmForms/CrmFormModal.tsx
+++ b/src/components/crmForms/CrmFormModal.tsx
@@ -196,7 +196,7 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
           <DialogTitle className="text-xl">{initial ? t('modal.editTitle') : t('modal.createTitle')}</DialogTitle>
         </DialogHeader>
 
-        <ScrollArea className="max-h-[calc(90vh-140px)] px-6 py-4">
+        <ScrollArea className="max-h-[calc(90vh-80px)] px-6 py-4">
           <div className="space-y-6">
             {/* Básico */}
             <section className="space-y-4">
@@ -388,17 +388,17 @@ const CrmFormModal = ({ open, onClose, onSave, saving, initial, pipelines, conta
             </section>
 
             {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <div className="flex gap-3 pt-4">
+              <Button variant="outline" onClick={onClose} disabled={saving} className="flex-1">
+                {t('modal.cancel')}
+              </Button>
+              <Button onClick={handleSave} disabled={saving} className="flex-1">
+                {saving ? t('modal.saving') : t('modal.save')}
+              </Button>
+            </div>
           </div>
         </ScrollArea>
-
-        <div className="flex justify-end gap-2 px-6 py-4 border-t">
-          <Button variant="outline" onClick={onClose} disabled={saving}>
-            {t('modal.cancel')}
-          </Button>
-          <Button onClick={handleSave} disabled={saving}>
-            {saving ? t('modal.saving') : t('modal.save')}
-          </Button>
-        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -243,8 +243,7 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         action: 'read',
       },
       {
-        // TODO(EVO-1841 AC7): trocar por chave i18n (menu.settings.crmForms) nas 6 locales.
-        name: 'Formulários de captura',
+        name: t('menu.settings.crmForms'),
         href: '/settings/crm-forms',
         icon: FileText,
         resource: 'crm_forms',

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -27,6 +27,7 @@ import {
   Megaphone,
   Route,
   ShieldCheck,
+  FileText,
 } from 'lucide-react';
 
 export interface MenuItem {
@@ -112,6 +113,14 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
     href: '/products',
     icon: Package,
     resource: 'products',
+    action: 'read',
+  },
+  {
+    // TODO(EVO-1841 AC7): mover para chave i18n (menu.customer.crmForms) nas 6 locales.
+    name: 'Formulários de captura',
+    href: '/crm-forms',
+    icon: FileText,
+    resource: 'crm_forms',
     action: 'read',
   },
   {

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -116,14 +116,6 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
     action: 'read',
   },
   {
-    // TODO(EVO-1841 AC7): mover para chave i18n (menu.customer.crmForms) nas 6 locales.
-    name: 'Formulários de captura',
-    href: '/crm-forms',
-    icon: FileText,
-    resource: 'crm_forms',
-    action: 'read',
-  },
-  {
     name: t('menu.customer.automation'),
     href: '/automation',
     icon: Workflow,
@@ -248,6 +240,14 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         href: '/settings/macros',
         icon: Settings,
         resource: 'macros',
+        action: 'read',
+      },
+      {
+        // TODO(EVO-1841 AC7): trocar por chave i18n (menu.settings.crmForms) nas 6 locales.
+        name: 'Formulários de captura',
+        href: '/settings/crm-forms',
+        icon: FileText,
+        resource: 'crm_forms',
         action: 'read',
       },
       {

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -250,6 +250,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         action: 'read',
       },
       {
+        name: t('menu.settings.chatPages'),
+        href: '/settings/chat-pages',
+        icon: MessageSquare,
+        resource: 'chat_pages',
+        action: 'read',
+      },
+      {
         name: t('menu.settings.templates'),
         href: '/settings/templates',
         icon: Package,

--- a/src/hooks/useUserPermissions.ts
+++ b/src/hooks/useUserPermissions.ts
@@ -4,6 +4,7 @@ import { useAuthStore } from '@/store/authStore';
 import { usePermissionsConfig } from '@/hooks/usePermissionsConfig';
 import { permissionsService } from '@/services/permissions';
 import { PermissionsContext } from '@/contexts/PermissionsContext';
+import { ROLE_KEYS } from '@/constants/roles';
 
 /**
  * Hook para verificar permissões do usuário logado
@@ -15,6 +16,8 @@ import { PermissionsContext } from '@/contexts/PermissionsContext';
  */
 export const useUserPermissions = () => {
   const { user } = useAuth();
+  // Super admin (installation owner) bypasses granular permission checks — full access.
+  const isSuperAdmin = user?.role?.key === ROLE_KEYS.SUPER_ADMIN;
   const {
     isValidPermission,
     createPermission,
@@ -129,6 +132,7 @@ export const useUserPermissions = () => {
    * @returns boolean
    */
   const can = (resource: string, action: string, type: 'account' | 'user' = 'account'): boolean => {
+    if (isSuperAdmin) return true;
     const permission = createPermission(resource, action);
     const permissionsArray =
       type === 'user' ? effectiveUserPermissions : effectiveAccountPermissions;
@@ -173,6 +177,7 @@ export const useUserPermissions = () => {
    * @returns boolean
    */
   const canAny = (permissions: string[], type: 'account' | 'user' = 'account'): boolean => {
+    if (isSuperAdmin) return true;
     const permissionsArray =
       type === 'user' ? effectiveUserPermissions : effectiveAccountPermissions;
 
@@ -199,6 +204,7 @@ export const useUserPermissions = () => {
    * @returns boolean
    */
   const canAll = (permissions: string[], type: 'account' | 'user' = 'account'): boolean => {
+    if (isSuperAdmin) return true;
     const permissionsArray =
       type === 'user' ? effectiveUserPermissions : effectiveAccountPermissions;
 
@@ -228,6 +234,7 @@ export const useUserPermissions = () => {
    * Isso garante que isValidPermission() funcione corretamente
    */
   const isReady =
+    isSuperAdmin ||
     (!configLoading &&
       !effectiveLoading &&
       effectiveAccountPermissions.length > 0);

--- a/src/hooks/useUserPermissions.ts
+++ b/src/hooks/useUserPermissions.ts
@@ -16,7 +16,20 @@ import { ROLE_KEYS } from '@/constants/roles';
  */
 export const useUserPermissions = () => {
   const { user } = useAuth();
-  // Super admin (installation owner) bypasses granular permission checks — full access.
+  // Super admin (installation owner) bypasses granular permission checks — full
+  // access. This is an INTENTIONAL, app-wide policy decision (product owner): the
+  // installation owner always sees the full UI.
+  //
+  // It mirrors server truth rather than diverging from it: super_admin is granted
+  // every resource action server-side via the RBAC seed/backfill migrations, so
+  // the backend will not 403 the actions this bypass renders. (If a fresh
+  // permission set ships without its backfill, that gap is a deploy-ordering bug
+  // to fix at the source — see the auth `*_permissions_to_existing_roles`
+  // migrations — not something to paper over by tightening this client gate.)
+  //
+  // Two implications callers should know: (1) `can/canAny/canAll` short-circuit to
+  // true for super_admin; (2) `isReady` is true immediately for super_admin
+  // (below), so super_admin-gated UI does not wait on the permissions fetch.
   const isSuperAdmin = user?.role?.key === ROLE_KEYS.SUPER_ADMIN;
   const {
     isValidPermission,

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -26,6 +26,7 @@ import ptBRAccountSettings from './locales/pt-BR/accountSettings.json';
 import ptBRCannedResponses from './locales/pt-BR/cannedResponses.json';
 import ptBRMessageTemplates from './locales/pt-BR/messageTemplates.json';
 import ptBRProducts from './locales/pt-BR/products.json';
+import ptBRCrmForms from './locales/pt-BR/crmForms.json';
 import ptBRTemplates from './locales/pt-BR/templates.json';
 import ptBRCustomAttributes from './locales/pt-BR/customAttributes.json';
 import ptBRLabels from './locales/pt-BR/labels.json';
@@ -77,6 +78,7 @@ import ptAccountSettings from './locales/pt/accountSettings.json';
 import ptCannedResponses from './locales/pt/cannedResponses.json';
 import ptMessageTemplates from './locales/pt/messageTemplates.json';
 import ptProducts from './locales/pt/products.json';
+import ptCrmForms from './locales/pt/crmForms.json';
 import ptTemplates from './locales/pt/templates.json';
 import ptCustomAttributes from './locales/pt/customAttributes.json';
 import ptLabels from './locales/pt/labels.json';
@@ -128,6 +130,7 @@ import enAccountSettings from './locales/en/accountSettings.json';
 import enCannedResponses from './locales/en/cannedResponses.json';
 import enMessageTemplates from './locales/en/messageTemplates.json';
 import enProducts from './locales/en/products.json';
+import enCrmForms from './locales/en/crmForms.json';
 import enTemplates from './locales/en/templates.json';
 import enCustomAttributes from './locales/en/customAttributes.json';
 import enLabels from './locales/en/labels.json';
@@ -179,6 +182,7 @@ import esAccountSettings from './locales/es/accountSettings.json';
 import esCannedResponses from './locales/es/cannedResponses.json';
 import esMessageTemplates from './locales/es/messageTemplates.json';
 import esProducts from './locales/es/products.json';
+import esCrmForms from './locales/es/crmForms.json';
 import esTemplates from './locales/es/templates.json';
 import esCustomAttributes from './locales/es/customAttributes.json';
 import esLabels from './locales/es/labels.json';
@@ -230,6 +234,7 @@ import frAccountSettings from './locales/fr/accountSettings.json';
 import frCannedResponses from './locales/fr/cannedResponses.json';
 import frMessageTemplates from './locales/fr/messageTemplates.json';
 import frProducts from './locales/fr/products.json';
+import frCrmForms from './locales/fr/crmForms.json';
 import frTemplates from './locales/fr/templates.json';
 import frCustomAttributes from './locales/fr/customAttributes.json';
 import frLabels from './locales/fr/labels.json';
@@ -281,6 +286,7 @@ import itAccountSettings from './locales/it/accountSettings.json';
 import itCannedResponses from './locales/it/cannedResponses.json';
 import itMessageTemplates from './locales/it/messageTemplates.json';
 import itProducts from './locales/it/products.json';
+import itCrmForms from './locales/it/crmForms.json';
 import itTemplates from './locales/it/templates.json';
 import itCustomAttributes from './locales/it/customAttributes.json';
 import itLabels from './locales/it/labels.json';
@@ -400,6 +406,7 @@ const resources = {
     cannedResponses: ptBRCannedResponses,
     messageTemplates: ptBRMessageTemplates,
     products: ptBRProducts,
+    crmForms: ptBRCrmForms,
     templates: ptBRTemplates,
     customAttributes: ptBRCustomAttributes,
     labels: ptBRLabels,
@@ -458,6 +465,7 @@ const resources = {
     cannedResponses: ptCannedResponses,
     messageTemplates: ptMessageTemplates,
     products: ptProducts,
+    crmForms: ptCrmForms,
     templates: ptTemplates,
     customAttributes: ptCustomAttributes,
     labels: ptLabels,
@@ -516,6 +524,7 @@ const resources = {
     cannedResponses: enCannedResponses,
     messageTemplates: enMessageTemplates,
     products: enProducts,
+    crmForms: enCrmForms,
     templates: enTemplates,
     customAttributes: enCustomAttributes,
     labels: enLabels,
@@ -574,6 +583,7 @@ const resources = {
     cannedResponses: esCannedResponses,
     messageTemplates: esMessageTemplates,
     products: esProducts,
+    crmForms: esCrmForms,
     templates: esTemplates,
     customAttributes: esCustomAttributes,
     labels: esLabels,
@@ -632,6 +642,7 @@ const resources = {
     cannedResponses: frCannedResponses,
     messageTemplates: frMessageTemplates,
     products: frProducts,
+    crmForms: frCrmForms,
     templates: frTemplates,
     customAttributes: frCustomAttributes,
     labels: frLabels,
@@ -690,6 +701,7 @@ const resources = {
     cannedResponses: itCannedResponses,
     messageTemplates: itMessageTemplates,
     products: itProducts,
+    crmForms: itCrmForms,
     templates: itTemplates,
     customAttributes: itCustomAttributes,
     labels: itLabels,

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -27,6 +27,7 @@ import ptBRCannedResponses from './locales/pt-BR/cannedResponses.json';
 import ptBRMessageTemplates from './locales/pt-BR/messageTemplates.json';
 import ptBRProducts from './locales/pt-BR/products.json';
 import ptBRCrmForms from './locales/pt-BR/crmForms.json';
+import ptBRChatPages from './locales/pt-BR/chatPages.json';
 import ptBRTemplates from './locales/pt-BR/templates.json';
 import ptBRCustomAttributes from './locales/pt-BR/customAttributes.json';
 import ptBRLabels from './locales/pt-BR/labels.json';
@@ -79,6 +80,7 @@ import ptCannedResponses from './locales/pt/cannedResponses.json';
 import ptMessageTemplates from './locales/pt/messageTemplates.json';
 import ptProducts from './locales/pt/products.json';
 import ptCrmForms from './locales/pt/crmForms.json';
+import ptChatPages from './locales/pt/chatPages.json';
 import ptTemplates from './locales/pt/templates.json';
 import ptCustomAttributes from './locales/pt/customAttributes.json';
 import ptLabels from './locales/pt/labels.json';
@@ -131,6 +133,7 @@ import enCannedResponses from './locales/en/cannedResponses.json';
 import enMessageTemplates from './locales/en/messageTemplates.json';
 import enProducts from './locales/en/products.json';
 import enCrmForms from './locales/en/crmForms.json';
+import enChatPages from './locales/en/chatPages.json';
 import enTemplates from './locales/en/templates.json';
 import enCustomAttributes from './locales/en/customAttributes.json';
 import enLabels from './locales/en/labels.json';
@@ -183,6 +186,7 @@ import esCannedResponses from './locales/es/cannedResponses.json';
 import esMessageTemplates from './locales/es/messageTemplates.json';
 import esProducts from './locales/es/products.json';
 import esCrmForms from './locales/es/crmForms.json';
+import esChatPages from './locales/es/chatPages.json';
 import esTemplates from './locales/es/templates.json';
 import esCustomAttributes from './locales/es/customAttributes.json';
 import esLabels from './locales/es/labels.json';
@@ -235,6 +239,7 @@ import frCannedResponses from './locales/fr/cannedResponses.json';
 import frMessageTemplates from './locales/fr/messageTemplates.json';
 import frProducts from './locales/fr/products.json';
 import frCrmForms from './locales/fr/crmForms.json';
+import frChatPages from './locales/fr/chatPages.json';
 import frTemplates from './locales/fr/templates.json';
 import frCustomAttributes from './locales/fr/customAttributes.json';
 import frLabels from './locales/fr/labels.json';
@@ -287,6 +292,7 @@ import itCannedResponses from './locales/it/cannedResponses.json';
 import itMessageTemplates from './locales/it/messageTemplates.json';
 import itProducts from './locales/it/products.json';
 import itCrmForms from './locales/it/crmForms.json';
+import itChatPages from './locales/it/chatPages.json';
 import itTemplates from './locales/it/templates.json';
 import itCustomAttributes from './locales/it/customAttributes.json';
 import itLabels from './locales/it/labels.json';
@@ -407,6 +413,7 @@ const resources = {
     messageTemplates: ptBRMessageTemplates,
     products: ptBRProducts,
     crmForms: ptBRCrmForms,
+    chatPages: ptBRChatPages,
     templates: ptBRTemplates,
     customAttributes: ptBRCustomAttributes,
     labels: ptBRLabels,
@@ -466,6 +473,7 @@ const resources = {
     messageTemplates: ptMessageTemplates,
     products: ptProducts,
     crmForms: ptCrmForms,
+    chatPages: ptChatPages,
     templates: ptTemplates,
     customAttributes: ptCustomAttributes,
     labels: ptLabels,
@@ -525,6 +533,7 @@ const resources = {
     messageTemplates: enMessageTemplates,
     products: enProducts,
     crmForms: enCrmForms,
+    chatPages: enChatPages,
     templates: enTemplates,
     customAttributes: enCustomAttributes,
     labels: enLabels,
@@ -584,6 +593,7 @@ const resources = {
     messageTemplates: esMessageTemplates,
     products: esProducts,
     crmForms: esCrmForms,
+    chatPages: esChatPages,
     templates: esTemplates,
     customAttributes: esCustomAttributes,
     labels: esLabels,
@@ -643,6 +653,7 @@ const resources = {
     messageTemplates: frMessageTemplates,
     products: frProducts,
     crmForms: frCrmForms,
+    chatPages: frChatPages,
     templates: frTemplates,
     customAttributes: frCustomAttributes,
     labels: frLabels,
@@ -702,6 +713,7 @@ const resources = {
     messageTemplates: itMessageTemplates,
     products: itProducts,
     crmForms: itCrmForms,
+    chatPages: itChatPages,
     templates: itTemplates,
     customAttributes: itCustomAttributes,
     labels: itLabels,

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -138,6 +138,9 @@ export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
   'crmForms.json': new Set([
     'Leads', 'Leads — {{name}}', 'E-mail', 'Pipeline…', 'pipeline…', 'key', 'label',
   ]),
+  'chatPages.json': new Set([
+    'Widget', 'Web widget',
+  ]),
   'profile.json': new Set(['Enter (↵)', 'Cmd + Enter (⌘ + ↵)']),
   'sms.json': new Set([
     'SMS via {{provider}}', 'SMS {{provider}}', 'Account SID', 'Auth Token',

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -135,6 +135,9 @@ export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
     'AI Assistant Agent', 'Customer Support Bot', 'Data Analysis Agent',
   ]),
   'pipelines.json': new Set(['Euro (EUR)']),
+  'crmForms.json': new Set([
+    'Leads', 'Leads — {{name}}', 'E-mail', 'Pipeline…', 'pipeline…', 'key', 'label',
+  ]),
   'profile.json': new Set(['Enter (↵)', 'Cmd + Enter (⌘ + ↵)']),
   'sms.json': new Set([
     'SMS via {{provider}}', 'SMS {{provider}}', 'Account SID', 'Auth Token',

--- a/src/i18n/locales/en/chatPages.json
+++ b/src/i18n/locales/en/chatPages.json
@@ -1,0 +1,81 @@
+{
+  "header": {
+    "title": "Chat pages",
+    "subtitle": "{{count}} page · public chat link",
+    "subtitle_plural": "{{count}} pages · public chat links",
+    "searchPlaceholder": "Search by title or slug…",
+    "newPage": "New page"
+  },
+  "filter": {
+    "all": "All statuses",
+    "published": "Published",
+    "draft": "Drafts"
+  },
+  "table": {
+    "name": "Name",
+    "publicLink": "Public link",
+    "widget": "Widget",
+    "status": "Status",
+    "actions": "Actions"
+  },
+  "status": {
+    "published": "Published",
+    "draft": "Draft"
+  },
+  "empty": {
+    "title": "No chat pages yet",
+    "titleFiltered": "No chat pages found",
+    "description": "Create a public page that embeds a web widget at a friendly link.",
+    "descriptionFiltered": "Adjust the search or the status filter.",
+    "action": "New page"
+  },
+  "actions": {
+    "edit": "edit",
+    "delete": "delete",
+    "linkCopied": "Link copied."
+  },
+  "messages": {
+    "loadError": "Failed to load chat pages.",
+    "saved": "Chat page saved.",
+    "saveError": "Failed to save chat page.",
+    "deleted": "Chat page deleted.",
+    "deleteError": "Failed to delete."
+  },
+  "delete": {
+    "title": "Delete chat page",
+    "description": "Are you sure you want to delete “{{name}}”? This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirm": "Delete"
+  },
+  "modal": {
+    "createTitle": "New chat page",
+    "editTitle": "Edit chat page",
+    "sections": {
+      "basic": "Basic",
+      "widget": "Widget",
+      "appearance": "Appearance"
+    },
+    "basic": {
+      "title": "Public title",
+      "titlePlaceholder": "e.g. Talk to us",
+      "description": "Description",
+      "published": "Published"
+    },
+    "widget": {
+      "label": "Web widget",
+      "placeholder": "Select a widget…",
+      "empty": "No web widget found. Create a web widget inbox first.",
+      "unknown": "Current widget (unlisted)"
+    },
+    "appearance": {
+      "primaryColor": "Primary color",
+      "logoUrl": "Logo URL"
+    },
+    "errors": {
+      "widget": "Select the web widget to embed."
+    },
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving…"
+  }
+}

--- a/src/i18n/locales/en/chatPages.json
+++ b/src/i18n/locales/en/chatPages.json
@@ -77,5 +77,9 @@
     "cancel": "Cancel",
     "save": "Save",
     "saving": "Saving…"
+  },
+  "public": {
+    "notFoundTitle": "Chat page not found",
+    "notFoundDescription": "The link may be incorrect or unavailable."
   }
 }

--- a/src/i18n/locales/en/crmForms.json
+++ b/src/i18n/locales/en/crmForms.json
@@ -85,7 +85,8 @@
       "required": "req.",
       "mapTo": "map to…",
       "optionsPlaceholder": "Comma-separated options",
-      "remove": "remove field"
+      "remove": "remove field",
+      "type": "Type"
     },
     "targets": {
       "none": "— no mapping —",

--- a/src/i18n/locales/en/crmForms.json
+++ b/src/i18n/locales/en/crmForms.json
@@ -123,5 +123,16 @@
     "cancel": "Cancel",
     "save": "Save",
     "saving": "Saving…"
+  },
+  "public": {
+    "loadError": "Could not load the form. Please try again.",
+    "notFoundTitle": "Form not found",
+    "notFoundDescription": "The link may be incorrect or unavailable.",
+    "requiredField": "{{label}} is required",
+    "submitError": "Could not submit. Check the fields and try again.",
+    "selectPlaceholder": "Select...",
+    "successMessage": "We received your information. Thank you!",
+    "submit": "Submit",
+    "submitting": "Submitting..."
   }
 }

--- a/src/i18n/locales/en/crmForms.json
+++ b/src/i18n/locales/en/crmForms.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "title": "Lead capture forms",
+    "subtitle": "{{count}} form · generates leads in the pipeline",
+    "subtitle_plural": "{{count}} forms · generate leads in the pipeline",
+    "searchPlaceholder": "Search by name, title or slug…",
+    "newForm": "New form"
+  },
+  "filter": {
+    "all": "All statuses",
+    "published": "Published",
+    "draft": "Drafts"
+  },
+  "table": {
+    "name": "Name",
+    "publicLink": "Public link",
+    "status": "Status",
+    "leads": "Leads",
+    "actions": "Actions"
+  },
+  "status": {
+    "published": "Published",
+    "draft": "Draft"
+  },
+  "empty": {
+    "title": "No forms yet",
+    "titleFiltered": "No forms found",
+    "description": "Create public forms that generate leads in the pipeline.",
+    "descriptionFiltered": "Adjust the search or the status filter.",
+    "action": "New form"
+  },
+  "actions": {
+    "edit": "edit",
+    "delete": "delete",
+    "linkCopied": "Link copied."
+  },
+  "messages": {
+    "loadError": "Failed to load forms.",
+    "saved": "Form saved.",
+    "saveError": "Failed to save form.",
+    "deleted": "Form deleted.",
+    "deleteError": "Failed to delete.",
+    "leadsError": "Failed to load leads."
+  },
+  "delete": {
+    "title": "Delete form",
+    "description": "Are you sure you want to delete “{{name}}”? This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirm": "Delete"
+  },
+  "leads": {
+    "title": "Leads — {{name}}",
+    "empty": "No leads captured yet.",
+    "contact": "Contact",
+    "destination": "Destination",
+    "date": "Date"
+  },
+  "modal": {
+    "createTitle": "New form",
+    "editTitle": "Edit form",
+    "sections": {
+      "basic": "Basic",
+      "appearance": "Appearance",
+      "fields": "Fields",
+      "defaultDestination": "Default destination",
+      "routing": "Routing rules"
+    },
+    "basic": {
+      "name": "Name (internal)",
+      "namePlaceholder": "e.g. Website contact",
+      "title": "Public title",
+      "titlePlaceholder": "e.g. Talk to us",
+      "description": "Description",
+      "published": "Published"
+    },
+    "appearance": {
+      "primaryColor": "Primary color",
+      "logoUrl": "Logo URL",
+      "successMessage": "Success message"
+    },
+    "fields": {
+      "add": "Field",
+      "key": "key",
+      "label": "label",
+      "required": "req.",
+      "mapTo": "map to…",
+      "optionsPlaceholder": "Comma-separated options",
+      "remove": "remove field"
+    },
+    "targets": {
+      "none": "— no mapping —",
+      "groupContact": "Contact",
+      "groupContactCustom": "Contact — custom fields",
+      "groupDeal": "Deal",
+      "groupDealCustom": "Deal — custom fields",
+      "contactName": "Name",
+      "contactEmail": "E-mail",
+      "contactPhone": "Phone",
+      "contactCompany": "Company",
+      "dealValue": "Value"
+    },
+    "destination": {
+      "pipeline": "Pipeline…",
+      "stage": "Stage…",
+      "stageNone": "— none —"
+    },
+    "routing": {
+      "add": "Rule",
+      "field": "field…",
+      "value": "value",
+      "pipeline": "pipeline…",
+      "stage": "stage…",
+      "remove": "remove rule"
+    },
+    "errors": {
+      "name": "Enter the form name.",
+      "pipeline": "Select the default pipeline.",
+      "email": "Include a field mapped to the contact e-mail.",
+      "nameField": "Include a field mapped to the contact name.",
+      "fieldKey": "Every field needs a key."
+    },
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving…"
+  }
+}

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -118,7 +118,8 @@
       "roles": "Roles & Permissions",
       "admin": "Admin Settings",
       "segments": "Segments",
-      "crmForms": "Lead capture forms"
+      "crmForms": "Lead capture forms",
+      "chatPages": "Chat pages"
     }
   }
 }

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -117,7 +117,8 @@
       "accessTokens": "Access Tokens",
       "roles": "Roles & Permissions",
       "admin": "Admin Settings",
-      "segments": "Segments"
+      "segments": "Segments",
+      "crmForms": "Lead capture forms"
     }
   }
 }

--- a/src/i18n/locales/es/chatPages.json
+++ b/src/i18n/locales/es/chatPages.json
@@ -77,5 +77,9 @@
     "cancel": "Cancelar",
     "save": "Guardar",
     "saving": "Guardando…"
+  },
+  "public": {
+    "notFoundTitle": "Página de chat no encontrada",
+    "notFoundDescription": "El enlace puede ser incorrecto o no estar disponible."
   }
 }

--- a/src/i18n/locales/es/chatPages.json
+++ b/src/i18n/locales/es/chatPages.json
@@ -1,0 +1,81 @@
+{
+  "header": {
+    "title": "Páginas de chat",
+    "subtitle": "{{count}} página · enlace público de chat",
+    "subtitle_plural": "{{count}} páginas · enlaces públicos de chat",
+    "searchPlaceholder": "Buscar por título o slug…",
+    "newPage": "Nueva página"
+  },
+  "filter": {
+    "all": "Todos los estados",
+    "published": "Publicadas",
+    "draft": "Borradores"
+  },
+  "table": {
+    "name": "Nombre",
+    "publicLink": "Enlace público",
+    "widget": "Widget",
+    "status": "Estado",
+    "actions": "Acciones"
+  },
+  "status": {
+    "published": "Publicada",
+    "draft": "Borrador"
+  },
+  "empty": {
+    "title": "Aún no hay páginas de chat",
+    "titleFiltered": "No se encontraron páginas de chat",
+    "description": "Crea una página pública que incrusta un web widget en un enlace amigable.",
+    "descriptionFiltered": "Ajusta la búsqueda o el filtro de estado.",
+    "action": "Nueva página"
+  },
+  "actions": {
+    "edit": "editar",
+    "delete": "eliminar",
+    "linkCopied": "Enlace copiado."
+  },
+  "messages": {
+    "loadError": "No se pudieron cargar las páginas de chat.",
+    "saved": "Página de chat guardada.",
+    "saveError": "No se pudo guardar la página de chat.",
+    "deleted": "Página de chat eliminada.",
+    "deleteError": "No se pudo eliminar."
+  },
+  "delete": {
+    "title": "Eliminar página de chat",
+    "description": "¿Seguro que deseas eliminar «{{name}}»? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "modal": {
+    "createTitle": "Nueva página de chat",
+    "editTitle": "Editar página de chat",
+    "sections": {
+      "basic": "Básico",
+      "widget": "Widget",
+      "appearance": "Apariencia"
+    },
+    "basic": {
+      "title": "Título público",
+      "titlePlaceholder": "p. ej.: Habla con nosotros",
+      "description": "Descripción",
+      "published": "Publicada"
+    },
+    "widget": {
+      "label": "Web widget",
+      "placeholder": "Selecciona un widget…",
+      "empty": "No se encontró ningún web widget. Crea primero una bandeja de web widget.",
+      "unknown": "Widget actual (no listado)"
+    },
+    "appearance": {
+      "primaryColor": "Color primario",
+      "logoUrl": "URL del logo"
+    },
+    "errors": {
+      "widget": "Selecciona el web widget a incrustar."
+    },
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "saving": "Guardando…"
+  }
+}

--- a/src/i18n/locales/es/crmForms.json
+++ b/src/i18n/locales/es/crmForms.json
@@ -123,5 +123,16 @@
     "cancel": "Cancelar",
     "save": "Guardar",
     "saving": "Guardando…"
+  },
+  "public": {
+    "loadError": "No se pudo cargar el formulario. Inténtalo de nuevo.",
+    "notFoundTitle": "Formulario no encontrado",
+    "notFoundDescription": "El enlace puede ser incorrecto o no estar disponible.",
+    "requiredField": "{{label}} es obligatorio",
+    "submitError": "No se pudo enviar. Revisa los campos e inténtalo de nuevo.",
+    "selectPlaceholder": "Selecciona...",
+    "successMessage": "Recibimos tus datos. ¡Gracias!",
+    "submit": "Enviar",
+    "submitting": "Enviando..."
   }
 }

--- a/src/i18n/locales/es/crmForms.json
+++ b/src/i18n/locales/es/crmForms.json
@@ -85,7 +85,8 @@
       "required": "oblig.",
       "mapTo": "asignar a…",
       "optionsPlaceholder": "Opciones separadas por comas",
-      "remove": "eliminar campo"
+      "remove": "eliminar campo",
+      "type": "Tipo"
     },
     "targets": {
       "none": "— sin asignación —",

--- a/src/i18n/locales/es/crmForms.json
+++ b/src/i18n/locales/es/crmForms.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "title": "Formularios de captación",
+    "subtitle": "{{count}} formulario · genera leads en el pipeline",
+    "subtitle_plural": "{{count}} formularios · generan leads en el pipeline",
+    "searchPlaceholder": "Buscar por nombre, título o slug…",
+    "newForm": "Nuevo formulario"
+  },
+  "filter": {
+    "all": "Todos los estados",
+    "published": "Publicados",
+    "draft": "Borradores"
+  },
+  "table": {
+    "name": "Nombre",
+    "publicLink": "Enlace público",
+    "status": "Estado",
+    "leads": "Leads",
+    "actions": "Acciones"
+  },
+  "status": {
+    "published": "Publicado",
+    "draft": "Borrador"
+  },
+  "empty": {
+    "title": "Aún no hay formularios",
+    "titleFiltered": "No se encontraron formularios",
+    "description": "Cree formularios públicos que generan leads en el pipeline.",
+    "descriptionFiltered": "Ajuste la búsqueda o el filtro de estado.",
+    "action": "Nuevo formulario"
+  },
+  "actions": {
+    "edit": "editar",
+    "delete": "eliminar",
+    "linkCopied": "Enlace copiado."
+  },
+  "messages": {
+    "loadError": "Error al cargar los formularios.",
+    "saved": "Formulario guardado.",
+    "saveError": "Error al guardar el formulario.",
+    "deleted": "Formulario eliminado.",
+    "deleteError": "Error al eliminar.",
+    "leadsError": "Error al cargar los leads."
+  },
+  "delete": {
+    "title": "Eliminar formulario",
+    "description": "¿Seguro que desea eliminar “{{name}}”? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "leads": {
+    "title": "Leads — {{name}}",
+    "empty": "Aún no se han captado leads.",
+    "contact": "Contacto",
+    "destination": "Destino",
+    "date": "Fecha"
+  },
+  "modal": {
+    "createTitle": "Nuevo formulario",
+    "editTitle": "Editar formulario",
+    "sections": {
+      "basic": "Básico",
+      "appearance": "Apariencia",
+      "fields": "Campos",
+      "defaultDestination": "Destino predeterminado",
+      "routing": "Reglas de enrutamiento"
+    },
+    "basic": {
+      "name": "Nombre (interno)",
+      "namePlaceholder": "Ej.: Contacto web",
+      "title": "Título público",
+      "titlePlaceholder": "Ej.: Hable con nosotros",
+      "description": "Descripción",
+      "published": "Publicado"
+    },
+    "appearance": {
+      "primaryColor": "Color primario",
+      "logoUrl": "URL del logo",
+      "successMessage": "Mensaje de éxito"
+    },
+    "fields": {
+      "add": "Campo",
+      "key": "key",
+      "label": "label",
+      "required": "oblig.",
+      "mapTo": "asignar a…",
+      "optionsPlaceholder": "Opciones separadas por comas",
+      "remove": "eliminar campo"
+    },
+    "targets": {
+      "none": "— sin asignación —",
+      "groupContact": "Contacto",
+      "groupContactCustom": "Contacto — campos personalizados",
+      "groupDeal": "Negocio",
+      "groupDealCustom": "Negocio — campos personalizados",
+      "contactName": "Nombre",
+      "contactEmail": "E-mail",
+      "contactPhone": "Teléfono",
+      "contactCompany": "Empresa",
+      "dealValue": "Valor"
+    },
+    "destination": {
+      "pipeline": "Pipeline…",
+      "stage": "Etapa…",
+      "stageNone": "— ninguno —"
+    },
+    "routing": {
+      "add": "Regla",
+      "field": "campo…",
+      "value": "valor",
+      "pipeline": "pipeline…",
+      "stage": "etapa…",
+      "remove": "eliminar regla"
+    },
+    "errors": {
+      "name": "Indique el nombre del formulario.",
+      "pipeline": "Seleccione el pipeline predeterminado.",
+      "email": "Incluya un campo asignado al e-mail del contacto.",
+      "nameField": "Incluya un campo asignado al nombre del contacto.",
+      "fieldKey": "Cada campo necesita una clave (key)."
+    },
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "saving": "Guardando…"
+  }
+}

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -117,7 +117,8 @@
       "accessTokens": "Tokens de Acceso",
       "roles": "Perfiles y Permisos",
       "admin": "Configuración Admin",
-      "segments": "Segmentos"
+      "segments": "Segmentos",
+      "crmForms": "Formularios de captación"
     }
   }
 }

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -118,7 +118,8 @@
       "roles": "Perfiles y Permisos",
       "admin": "Configuración Admin",
       "segments": "Segmentos",
-      "crmForms": "Formularios de captación"
+      "crmForms": "Formularios de captación",
+      "chatPages": "Páginas de chat"
     }
   }
 }

--- a/src/i18n/locales/fr/chatPages.json
+++ b/src/i18n/locales/fr/chatPages.json
@@ -1,0 +1,81 @@
+{
+  "header": {
+    "title": "Pages de chat",
+    "subtitle": "{{count}} page · lien de chat public",
+    "subtitle_plural": "{{count}} pages · liens de chat publics",
+    "searchPlaceholder": "Rechercher par titre ou slug…",
+    "newPage": "Nouvelle page"
+  },
+  "filter": {
+    "all": "Tous les statuts",
+    "published": "Publiées",
+    "draft": "Brouillons"
+  },
+  "table": {
+    "name": "Nom",
+    "publicLink": "Lien public",
+    "widget": "Widget",
+    "status": "Statut",
+    "actions": "Actions"
+  },
+  "status": {
+    "published": "Publiée",
+    "draft": "Brouillon"
+  },
+  "empty": {
+    "title": "Aucune page de chat pour l’instant",
+    "titleFiltered": "Aucune page de chat trouvée",
+    "description": "Créez une page publique qui intègre un web widget via un lien convivial.",
+    "descriptionFiltered": "Ajustez la recherche ou le filtre de statut.",
+    "action": "Nouvelle page"
+  },
+  "actions": {
+    "edit": "modifier",
+    "delete": "supprimer",
+    "linkCopied": "Lien copié."
+  },
+  "messages": {
+    "loadError": "Échec du chargement des pages de chat.",
+    "saved": "Page de chat enregistrée.",
+    "saveError": "Échec de l’enregistrement de la page de chat.",
+    "deleted": "Page de chat supprimée.",
+    "deleteError": "Échec de la suppression."
+  },
+  "delete": {
+    "title": "Supprimer la page de chat",
+    "description": "Voulez-vous vraiment supprimer « {{name}} » ? Cette action est irréversible.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer"
+  },
+  "modal": {
+    "createTitle": "Nouvelle page de chat",
+    "editTitle": "Modifier la page de chat",
+    "sections": {
+      "basic": "Général",
+      "widget": "Widget",
+      "appearance": "Apparence"
+    },
+    "basic": {
+      "title": "Titre public",
+      "titlePlaceholder": "ex. : Parlez-nous",
+      "description": "Description",
+      "published": "Publiée"
+    },
+    "widget": {
+      "label": "Web widget",
+      "placeholder": "Sélectionnez un widget…",
+      "empty": "Aucun web widget trouvé. Créez d’abord une boîte de réception web widget.",
+      "unknown": "Widget actuel (non listé)"
+    },
+    "appearance": {
+      "primaryColor": "Couleur primaire",
+      "logoUrl": "URL du logo"
+    },
+    "errors": {
+      "widget": "Sélectionnez le web widget à intégrer."
+    },
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "saving": "Enregistrement…"
+  }
+}

--- a/src/i18n/locales/fr/chatPages.json
+++ b/src/i18n/locales/fr/chatPages.json
@@ -77,5 +77,9 @@
     "cancel": "Annuler",
     "save": "Enregistrer",
     "saving": "Enregistrement…"
+  },
+  "public": {
+    "notFoundTitle": "Page de chat introuvable",
+    "notFoundDescription": "Le lien est peut-être incorrect ou indisponible."
   }
 }

--- a/src/i18n/locales/fr/crmForms.json
+++ b/src/i18n/locales/fr/crmForms.json
@@ -123,5 +123,16 @@
     "cancel": "Annuler",
     "save": "Enregistrer",
     "saving": "Enregistrement…"
+  },
+  "public": {
+    "loadError": "Impossible de charger le formulaire. Veuillez réessayer.",
+    "notFoundTitle": "Formulaire introuvable",
+    "notFoundDescription": "Le lien est peut-être incorrect ou indisponible.",
+    "requiredField": "{{label}} est obligatoire",
+    "submitError": "Impossible d'envoyer. Vérifiez les champs et réessayez.",
+    "selectPlaceholder": "Sélectionner...",
+    "successMessage": "Nous avons reçu vos informations. Merci !",
+    "submit": "Envoyer",
+    "submitting": "Envoi..."
   }
 }

--- a/src/i18n/locales/fr/crmForms.json
+++ b/src/i18n/locales/fr/crmForms.json
@@ -85,7 +85,8 @@
       "required": "oblig.",
       "mapTo": "associer à…",
       "optionsPlaceholder": "Options séparées par des virgules",
-      "remove": "supprimer le champ"
+      "remove": "supprimer le champ",
+      "type": "Type"
     },
     "targets": {
       "none": "— aucune association —",

--- a/src/i18n/locales/fr/crmForms.json
+++ b/src/i18n/locales/fr/crmForms.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "title": "Formulaires de capture",
+    "subtitle": "{{count}} formulaire · génère des leads dans le pipeline",
+    "subtitle_plural": "{{count}} formulaires · génèrent des leads dans le pipeline",
+    "searchPlaceholder": "Rechercher par nom, titre ou slug…",
+    "newForm": "Nouveau formulaire"
+  },
+  "filter": {
+    "all": "Tous les statuts",
+    "published": "Publiés",
+    "draft": "Brouillons"
+  },
+  "table": {
+    "name": "Nom",
+    "publicLink": "Lien public",
+    "status": "Statut",
+    "leads": "Leads",
+    "actions": "Actions"
+  },
+  "status": {
+    "published": "Publié",
+    "draft": "Brouillon"
+  },
+  "empty": {
+    "title": "Aucun formulaire pour le moment",
+    "titleFiltered": "Aucun formulaire trouvé",
+    "description": "Créez des formulaires publics qui génèrent des leads dans le pipeline.",
+    "descriptionFiltered": "Ajustez la recherche ou le filtre de statut.",
+    "action": "Nouveau formulaire"
+  },
+  "actions": {
+    "edit": "modifier",
+    "delete": "supprimer",
+    "linkCopied": "Lien copié."
+  },
+  "messages": {
+    "loadError": "Échec du chargement des formulaires.",
+    "saved": "Formulaire enregistré.",
+    "saveError": "Échec de l'enregistrement du formulaire.",
+    "deleted": "Formulaire supprimé.",
+    "deleteError": "Échec de la suppression.",
+    "leadsError": "Échec du chargement des leads."
+  },
+  "delete": {
+    "title": "Supprimer le formulaire",
+    "description": "Voulez-vous vraiment supprimer « {{name}} » ? Cette action est irréversible.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer"
+  },
+  "leads": {
+    "title": "Leads — {{name}}",
+    "empty": "Aucun lead capturé pour le moment.",
+    "contact": "Contact",
+    "destination": "Destination",
+    "date": "Date"
+  },
+  "modal": {
+    "createTitle": "Nouveau formulaire",
+    "editTitle": "Modifier le formulaire",
+    "sections": {
+      "basic": "Général",
+      "appearance": "Apparence",
+      "fields": "Champs",
+      "defaultDestination": "Destination par défaut",
+      "routing": "Règles de routage"
+    },
+    "basic": {
+      "name": "Nom (interne)",
+      "namePlaceholder": "Ex. : Contact site",
+      "title": "Titre public",
+      "titlePlaceholder": "Ex. : Contactez-nous",
+      "description": "Description",
+      "published": "Publié"
+    },
+    "appearance": {
+      "primaryColor": "Couleur principale",
+      "logoUrl": "URL du logo",
+      "successMessage": "Message de succès"
+    },
+    "fields": {
+      "add": "Champ",
+      "key": "key",
+      "label": "label",
+      "required": "oblig.",
+      "mapTo": "associer à…",
+      "optionsPlaceholder": "Options séparées par des virgules",
+      "remove": "supprimer le champ"
+    },
+    "targets": {
+      "none": "— aucune association —",
+      "groupContact": "Contact",
+      "groupContactCustom": "Contact — champs personnalisés",
+      "groupDeal": "Affaire",
+      "groupDealCustom": "Affaire — champs personnalisés",
+      "contactName": "Nom",
+      "contactEmail": "E-mail",
+      "contactPhone": "Téléphone",
+      "contactCompany": "Entreprise",
+      "dealValue": "Valeur"
+    },
+    "destination": {
+      "pipeline": "Pipeline…",
+      "stage": "Étape…",
+      "stageNone": "— aucune —"
+    },
+    "routing": {
+      "add": "Règle",
+      "field": "champ…",
+      "value": "valeur",
+      "pipeline": "pipeline…",
+      "stage": "étape…",
+      "remove": "supprimer la règle"
+    },
+    "errors": {
+      "name": "Indiquez le nom du formulaire.",
+      "pipeline": "Sélectionnez le pipeline par défaut.",
+      "email": "Incluez un champ associé à l'e-mail du contact.",
+      "nameField": "Incluez un champ associé au nom du contact.",
+      "fieldKey": "Chaque champ a besoin d'une clé (key)."
+    },
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "saving": "Enregistrement…"
+  }
+}

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -118,7 +118,8 @@
       "roles": "Profils et Permissions",
       "admin": "Paramètres Admin",
       "segments": "Segments",
-      "crmForms": "Formulaires de capture"
+      "crmForms": "Formulaires de capture",
+      "chatPages": "Pages de chat"
     }
   }
 }

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -117,7 +117,8 @@
       "accessTokens": "Jetons D'accès",
       "roles": "Profils et Permissions",
       "admin": "Paramètres Admin",
-      "segments": "Segments"
+      "segments": "Segments",
+      "crmForms": "Formulaires de capture"
     }
   }
 }

--- a/src/i18n/locales/it/chatPages.json
+++ b/src/i18n/locales/it/chatPages.json
@@ -77,5 +77,9 @@
     "cancel": "Annulla",
     "save": "Salva",
     "saving": "Salvataggio…"
+  },
+  "public": {
+    "notFoundTitle": "Pagina di chat non trovata",
+    "notFoundDescription": "Il link potrebbe essere errato o non disponibile."
   }
 }

--- a/src/i18n/locales/it/chatPages.json
+++ b/src/i18n/locales/it/chatPages.json
@@ -1,0 +1,81 @@
+{
+  "header": {
+    "title": "Pagine di chat",
+    "subtitle": "{{count}} pagina · link pubblico di chat",
+    "subtitle_plural": "{{count}} pagine · link pubblici di chat",
+    "searchPlaceholder": "Cerca per titolo o slug…",
+    "newPage": "Nuova pagina"
+  },
+  "filter": {
+    "all": "Tutti gli stati",
+    "published": "Pubblicate",
+    "draft": "Bozze"
+  },
+  "table": {
+    "name": "Nome",
+    "publicLink": "Link pubblico",
+    "widget": "Widget",
+    "status": "Stato",
+    "actions": "Azioni"
+  },
+  "status": {
+    "published": "Pubblicata",
+    "draft": "Bozza"
+  },
+  "empty": {
+    "title": "Ancora nessuna pagina di chat",
+    "titleFiltered": "Nessuna pagina di chat trovata",
+    "description": "Crea una pagina pubblica che incorpora un web widget con un link semplice.",
+    "descriptionFiltered": "Modifica la ricerca o il filtro di stato.",
+    "action": "Nuova pagina"
+  },
+  "actions": {
+    "edit": "modifica",
+    "delete": "elimina",
+    "linkCopied": "Link copiato."
+  },
+  "messages": {
+    "loadError": "Impossibile caricare le pagine di chat.",
+    "saved": "Pagina di chat salvata.",
+    "saveError": "Impossibile salvare la pagina di chat.",
+    "deleted": "Pagina di chat eliminata.",
+    "deleteError": "Impossibile eliminare."
+  },
+  "delete": {
+    "title": "Elimina pagina di chat",
+    "description": "Vuoi davvero eliminare «{{name}}»? Questa azione non può essere annullata.",
+    "cancel": "Annulla",
+    "confirm": "Elimina"
+  },
+  "modal": {
+    "createTitle": "Nuova pagina di chat",
+    "editTitle": "Modifica pagina di chat",
+    "sections": {
+      "basic": "Base",
+      "widget": "Widget",
+      "appearance": "Aspetto"
+    },
+    "basic": {
+      "title": "Titolo pubblico",
+      "titlePlaceholder": "es.: Parla con noi",
+      "description": "Descrizione",
+      "published": "Pubblicata"
+    },
+    "widget": {
+      "label": "Web widget",
+      "placeholder": "Seleziona un widget…",
+      "empty": "Nessun web widget trovato. Crea prima una casella web widget.",
+      "unknown": "Widget attuale (non elencato)"
+    },
+    "appearance": {
+      "primaryColor": "Colore primario",
+      "logoUrl": "URL del logo"
+    },
+    "errors": {
+      "widget": "Seleziona il web widget da incorporare."
+    },
+    "cancel": "Annulla",
+    "save": "Salva",
+    "saving": "Salvataggio…"
+  }
+}

--- a/src/i18n/locales/it/crmForms.json
+++ b/src/i18n/locales/it/crmForms.json
@@ -85,7 +85,8 @@
       "required": "obblig.",
       "mapTo": "mappa su…",
       "optionsPlaceholder": "Opzioni separate da virgola",
-      "remove": "rimuovi campo"
+      "remove": "rimuovi campo",
+      "type": "Tipo"
     },
     "targets": {
       "none": "— nessuna mappatura —",

--- a/src/i18n/locales/it/crmForms.json
+++ b/src/i18n/locales/it/crmForms.json
@@ -123,5 +123,16 @@
     "cancel": "Annulla",
     "save": "Salva",
     "saving": "Salvataggio…"
+  },
+  "public": {
+    "loadError": "Impossibile caricare il modulo. Riprova.",
+    "notFoundTitle": "Modulo non trovato",
+    "notFoundDescription": "Il link potrebbe essere errato o non disponibile.",
+    "requiredField": "{{label}} è obbligatorio",
+    "submitError": "Impossibile inviare. Controlla i campi e riprova.",
+    "selectPlaceholder": "Seleziona...",
+    "successMessage": "Abbiamo ricevuto i tuoi dati. Grazie!",
+    "submit": "Invia",
+    "submitting": "Invio..."
   }
 }

--- a/src/i18n/locales/it/crmForms.json
+++ b/src/i18n/locales/it/crmForms.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "title": "Moduli di acquisizione",
+    "subtitle": "{{count}} modulo · genera lead nella pipeline",
+    "subtitle_plural": "{{count}} moduli · generano lead nella pipeline",
+    "searchPlaceholder": "Cerca per nome, titolo o slug…",
+    "newForm": "Nuovo modulo"
+  },
+  "filter": {
+    "all": "Tutti gli stati",
+    "published": "Pubblicati",
+    "draft": "Bozze"
+  },
+  "table": {
+    "name": "Nome",
+    "publicLink": "Link pubblico",
+    "status": "Stato",
+    "leads": "Lead",
+    "actions": "Azioni"
+  },
+  "status": {
+    "published": "Pubblicato",
+    "draft": "Bozza"
+  },
+  "empty": {
+    "title": "Ancora nessun modulo",
+    "titleFiltered": "Nessun modulo trovato",
+    "description": "Crea moduli pubblici che generano lead nella pipeline.",
+    "descriptionFiltered": "Modifica la ricerca o il filtro di stato.",
+    "action": "Nuovo modulo"
+  },
+  "actions": {
+    "edit": "modifica",
+    "delete": "elimina",
+    "linkCopied": "Link copiato."
+  },
+  "messages": {
+    "loadError": "Errore nel caricamento dei moduli.",
+    "saved": "Modulo salvato.",
+    "saveError": "Errore nel salvataggio del modulo.",
+    "deleted": "Modulo eliminato.",
+    "deleteError": "Errore nell'eliminazione.",
+    "leadsError": "Errore nel caricamento dei lead."
+  },
+  "delete": {
+    "title": "Elimina modulo",
+    "description": "Sei sicuro di voler eliminare “{{name}}”? Questa azione non può essere annullata.",
+    "cancel": "Annulla",
+    "confirm": "Elimina"
+  },
+  "leads": {
+    "title": "Lead — {{name}}",
+    "empty": "Ancora nessun lead acquisito.",
+    "contact": "Contatto",
+    "destination": "Destinazione",
+    "date": "Data"
+  },
+  "modal": {
+    "createTitle": "Nuovo modulo",
+    "editTitle": "Modifica modulo",
+    "sections": {
+      "basic": "Generale",
+      "appearance": "Aspetto",
+      "fields": "Campi",
+      "defaultDestination": "Destinazione predefinita",
+      "routing": "Regole di instradamento"
+    },
+    "basic": {
+      "name": "Nome (interno)",
+      "namePlaceholder": "Es.: Contatto sito",
+      "title": "Titolo pubblico",
+      "titlePlaceholder": "Es.: Parla con noi",
+      "description": "Descrizione",
+      "published": "Pubblicato"
+    },
+    "appearance": {
+      "primaryColor": "Colore primario",
+      "logoUrl": "URL del logo",
+      "successMessage": "Messaggio di successo"
+    },
+    "fields": {
+      "add": "Campo",
+      "key": "key",
+      "label": "label",
+      "required": "obblig.",
+      "mapTo": "mappa su…",
+      "optionsPlaceholder": "Opzioni separate da virgola",
+      "remove": "rimuovi campo"
+    },
+    "targets": {
+      "none": "— nessuna mappatura —",
+      "groupContact": "Contatto",
+      "groupContactCustom": "Contatto — campi personalizzati",
+      "groupDeal": "Trattativa",
+      "groupDealCustom": "Trattativa — campi personalizzati",
+      "contactName": "Nome",
+      "contactEmail": "E-mail",
+      "contactPhone": "Telefono",
+      "contactCompany": "Azienda",
+      "dealValue": "Valore"
+    },
+    "destination": {
+      "pipeline": "Pipeline…",
+      "stage": "Fase…",
+      "stageNone": "— nessuna —"
+    },
+    "routing": {
+      "add": "Regola",
+      "field": "campo…",
+      "value": "valore",
+      "pipeline": "pipeline…",
+      "stage": "fase…",
+      "remove": "rimuovi regola"
+    },
+    "errors": {
+      "name": "Indica il nome del modulo.",
+      "pipeline": "Seleziona la pipeline predefinita.",
+      "email": "Includi un campo mappato sull'e-mail del contatto.",
+      "nameField": "Includi un campo mappato sul nome del contatto.",
+      "fieldKey": "Ogni campo necessita di una chiave (key)."
+    },
+    "cancel": "Annulla",
+    "save": "Salva",
+    "saving": "Salvataggio…"
+  }
+}

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -117,7 +117,8 @@
       "accessTokens": "Tokens di Accesso",
       "roles": "Profili e Permessi",
       "admin": "Impostazioni Admin",
-      "segments": "Segmenti"
+      "segments": "Segmenti",
+      "crmForms": "Moduli di acquisizione"
     }
   }
 }

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -118,7 +118,8 @@
       "roles": "Profili e Permessi",
       "admin": "Impostazioni Admin",
       "segments": "Segmenti",
-      "crmForms": "Moduli di acquisizione"
+      "crmForms": "Moduli di acquisizione",
+      "chatPages": "Pagine di chat"
     }
   }
 }

--- a/src/i18n/locales/pt-BR/chatPages.json
+++ b/src/i18n/locales/pt-BR/chatPages.json
@@ -1,0 +1,81 @@
+{
+  "header": {
+    "title": "Páginas de chat",
+    "subtitle": "{{count}} página · link público de chat",
+    "subtitle_plural": "{{count}} páginas · links públicos de chat",
+    "searchPlaceholder": "Buscar por título ou slug…",
+    "newPage": "Nova página"
+  },
+  "filter": {
+    "all": "Todos os status",
+    "published": "Publicadas",
+    "draft": "Rascunhos"
+  },
+  "table": {
+    "name": "Nome",
+    "publicLink": "Link público",
+    "widget": "Widget",
+    "status": "Status",
+    "actions": "Ações"
+  },
+  "status": {
+    "published": "Publicada",
+    "draft": "Rascunho"
+  },
+  "empty": {
+    "title": "Nenhuma página de chat ainda",
+    "titleFiltered": "Nenhuma página de chat encontrada",
+    "description": "Crie uma página pública que embute um web widget num link amigável.",
+    "descriptionFiltered": "Ajuste a busca ou o filtro de status.",
+    "action": "Nova página"
+  },
+  "actions": {
+    "edit": "editar",
+    "delete": "excluir",
+    "linkCopied": "Link copiado."
+  },
+  "messages": {
+    "loadError": "Falha ao carregar as páginas de chat.",
+    "saved": "Página de chat salva.",
+    "saveError": "Falha ao salvar a página de chat.",
+    "deleted": "Página de chat excluída.",
+    "deleteError": "Falha ao excluir."
+  },
+  "delete": {
+    "title": "Excluir página de chat",
+    "description": "Tem certeza de que deseja excluir “{{name}}”? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "modal": {
+    "createTitle": "Nova página de chat",
+    "editTitle": "Editar página de chat",
+    "sections": {
+      "basic": "Básico",
+      "widget": "Widget",
+      "appearance": "Aparência"
+    },
+    "basic": {
+      "title": "Título público",
+      "titlePlaceholder": "ex.: Fale com a gente",
+      "description": "Descrição",
+      "published": "Publicada"
+    },
+    "widget": {
+      "label": "Web widget",
+      "placeholder": "Selecione um widget…",
+      "empty": "Nenhum web widget encontrado. Crie um inbox de web widget primeiro.",
+      "unknown": "Widget atual (não listado)"
+    },
+    "appearance": {
+      "primaryColor": "Cor primária",
+      "logoUrl": "URL do logo"
+    },
+    "errors": {
+      "widget": "Selecione o web widget a embutir."
+    },
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "saving": "Salvando…"
+  }
+}

--- a/src/i18n/locales/pt-BR/chatPages.json
+++ b/src/i18n/locales/pt-BR/chatPages.json
@@ -77,5 +77,9 @@
     "cancel": "Cancelar",
     "save": "Salvar",
     "saving": "Salvando…"
+  },
+  "public": {
+    "notFoundTitle": "Página de chat não encontrada",
+    "notFoundDescription": "O link pode estar incorreto ou indisponível."
   }
 }

--- a/src/i18n/locales/pt-BR/crmForms.json
+++ b/src/i18n/locales/pt-BR/crmForms.json
@@ -123,5 +123,16 @@
     "cancel": "Cancelar",
     "save": "Salvar",
     "saving": "Salvando…"
+  },
+  "public": {
+    "loadError": "Não foi possível carregar o formulário. Tente novamente.",
+    "notFoundTitle": "Formulário não encontrado",
+    "notFoundDescription": "O link pode estar incorreto ou indisponível.",
+    "requiredField": "{{label}} é obrigatório",
+    "submitError": "Não foi possível enviar. Verifique os campos e tente novamente.",
+    "selectPlaceholder": "Selecione...",
+    "successMessage": "Recebemos seus dados. Obrigado!",
+    "submit": "Enviar",
+    "submitting": "Enviando..."
   }
 }

--- a/src/i18n/locales/pt-BR/crmForms.json
+++ b/src/i18n/locales/pt-BR/crmForms.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "title": "Formulários de captura",
+    "subtitle": "{{count}} formulário · geram leads no pipeline",
+    "subtitle_plural": "{{count}} formulários · geram leads no pipeline",
+    "searchPlaceholder": "Buscar por nome, título ou slug…",
+    "newForm": "Novo formulário"
+  },
+  "filter": {
+    "all": "Todos os status",
+    "published": "Publicados",
+    "draft": "Rascunhos"
+  },
+  "table": {
+    "name": "Nome",
+    "publicLink": "Link público",
+    "status": "Status",
+    "leads": "Leads",
+    "actions": "Ações"
+  },
+  "status": {
+    "published": "Publicado",
+    "draft": "Rascunho"
+  },
+  "empty": {
+    "title": "Nenhum formulário ainda",
+    "titleFiltered": "Nenhum formulário encontrado",
+    "description": "Crie formulários públicos que geram leads no pipeline.",
+    "descriptionFiltered": "Ajuste a busca ou o filtro de status.",
+    "action": "Novo formulário"
+  },
+  "actions": {
+    "edit": "editar",
+    "delete": "excluir",
+    "linkCopied": "Link copiado."
+  },
+  "messages": {
+    "loadError": "Erro ao carregar formulários.",
+    "saved": "Formulário salvo.",
+    "saveError": "Erro ao salvar formulário.",
+    "deleted": "Formulário excluído.",
+    "deleteError": "Erro ao excluir.",
+    "leadsError": "Erro ao carregar leads."
+  },
+  "delete": {
+    "title": "Excluir formulário",
+    "description": "Tem certeza que deseja excluir “{{name}}”? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "leads": {
+    "title": "Leads — {{name}}",
+    "empty": "Nenhum lead capturado ainda.",
+    "contact": "Contato",
+    "destination": "Destino",
+    "date": "Data"
+  },
+  "modal": {
+    "createTitle": "Novo formulário",
+    "editTitle": "Editar formulário",
+    "sections": {
+      "basic": "Básico",
+      "appearance": "Aparência",
+      "fields": "Campos",
+      "defaultDestination": "Destino padrão",
+      "routing": "Regras de roteamento"
+    },
+    "basic": {
+      "name": "Nome (interno)",
+      "namePlaceholder": "Ex.: Contato site",
+      "title": "Título público",
+      "titlePlaceholder": "Ex.: Fale com a gente",
+      "description": "Descrição",
+      "published": "Publicado"
+    },
+    "appearance": {
+      "primaryColor": "Cor primária",
+      "logoUrl": "URL do logo",
+      "successMessage": "Mensagem de sucesso"
+    },
+    "fields": {
+      "add": "Campo",
+      "key": "key",
+      "label": "label",
+      "required": "obrig.",
+      "mapTo": "mapear para…",
+      "optionsPlaceholder": "Opções separadas por vírgula",
+      "remove": "remover campo"
+    },
+    "targets": {
+      "none": "— sem mapeamento —",
+      "groupContact": "Contato",
+      "groupContactCustom": "Contato — campos personalizados",
+      "groupDeal": "Negócio",
+      "groupDealCustom": "Negócio — campos personalizados",
+      "contactName": "Nome",
+      "contactEmail": "E-mail",
+      "contactPhone": "Telefone",
+      "contactCompany": "Empresa",
+      "dealValue": "Valor"
+    },
+    "destination": {
+      "pipeline": "Pipeline…",
+      "stage": "Estágio…",
+      "stageNone": "— nenhum —"
+    },
+    "routing": {
+      "add": "Regra",
+      "field": "campo…",
+      "value": "valor",
+      "pipeline": "pipeline…",
+      "stage": "estágio…",
+      "remove": "remover regra"
+    },
+    "errors": {
+      "name": "Informe o nome do formulário.",
+      "pipeline": "Selecione o pipeline padrão.",
+      "email": "Inclua um campo mapeado para o e-mail do contato.",
+      "nameField": "Inclua um campo mapeado para o nome do contato.",
+      "fieldKey": "Todo campo precisa de uma chave (key)."
+    },
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "saving": "Salvando…"
+  }
+}

--- a/src/i18n/locales/pt-BR/crmForms.json
+++ b/src/i18n/locales/pt-BR/crmForms.json
@@ -85,7 +85,8 @@
       "required": "obrig.",
       "mapTo": "mapear para…",
       "optionsPlaceholder": "Opções separadas por vírgula",
-      "remove": "remover campo"
+      "remove": "remover campo",
+      "type": "Tipo"
     },
     "targets": {
       "none": "— sem mapeamento —",

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -117,7 +117,8 @@
       "accessTokens": "Tokens de Acesso",
       "roles": "Perfis e Permissões",
       "admin": "Configurações Admin",
-      "segments": "Segmentos"
+      "segments": "Segmentos",
+      "crmForms": "Formulários de captura"
     }
   }
 }

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -118,7 +118,8 @@
       "roles": "Perfis e Permissões",
       "admin": "Configurações Admin",
       "segments": "Segmentos",
-      "crmForms": "Formulários de captura"
+      "crmForms": "Formulários de captura",
+      "chatPages": "Páginas de chat"
     }
   }
 }

--- a/src/i18n/locales/pt/chatPages.json
+++ b/src/i18n/locales/pt/chatPages.json
@@ -1,0 +1,81 @@
+{
+  "header": {
+    "title": "Páginas de chat",
+    "subtitle": "{{count}} página · ligação pública de chat",
+    "subtitle_plural": "{{count}} páginas · ligações públicas de chat",
+    "searchPlaceholder": "Procurar por título ou slug…",
+    "newPage": "Nova página"
+  },
+  "filter": {
+    "all": "Todos os estados",
+    "published": "Publicadas",
+    "draft": "Rascunhos"
+  },
+  "table": {
+    "name": "Nome",
+    "publicLink": "Ligação pública",
+    "widget": "Widget",
+    "status": "Estado",
+    "actions": "Ações"
+  },
+  "status": {
+    "published": "Publicada",
+    "draft": "Rascunho"
+  },
+  "empty": {
+    "title": "Ainda não há páginas de chat",
+    "titleFiltered": "Nenhuma página de chat encontrada",
+    "description": "Crie uma página pública que incorpora um web widget numa ligação amigável.",
+    "descriptionFiltered": "Ajuste a procura ou o filtro de estado.",
+    "action": "Nova página"
+  },
+  "actions": {
+    "edit": "editar",
+    "delete": "eliminar",
+    "linkCopied": "Ligação copiada."
+  },
+  "messages": {
+    "loadError": "Falha ao carregar as páginas de chat.",
+    "saved": "Página de chat guardada.",
+    "saveError": "Falha ao guardar a página de chat.",
+    "deleted": "Página de chat eliminada.",
+    "deleteError": "Falha ao eliminar."
+  },
+  "delete": {
+    "title": "Eliminar página de chat",
+    "description": "Tem a certeza de que deseja eliminar “{{name}}”? Esta ação não pode ser anulada.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "modal": {
+    "createTitle": "Nova página de chat",
+    "editTitle": "Editar página de chat",
+    "sections": {
+      "basic": "Básico",
+      "widget": "Widget",
+      "appearance": "Aparência"
+    },
+    "basic": {
+      "title": "Título público",
+      "titlePlaceholder": "ex.: Fale connosco",
+      "description": "Descrição",
+      "published": "Publicada"
+    },
+    "widget": {
+      "label": "Web widget",
+      "placeholder": "Selecione um widget…",
+      "empty": "Nenhum web widget encontrado. Crie primeiro uma caixa de entrada de web widget.",
+      "unknown": "Widget atual (não listado)"
+    },
+    "appearance": {
+      "primaryColor": "Cor primária",
+      "logoUrl": "URL do logótipo"
+    },
+    "errors": {
+      "widget": "Selecione o web widget a incorporar."
+    },
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "saving": "A guardar…"
+  }
+}

--- a/src/i18n/locales/pt/chatPages.json
+++ b/src/i18n/locales/pt/chatPages.json
@@ -77,5 +77,9 @@
     "cancel": "Cancelar",
     "save": "Guardar",
     "saving": "A guardar…"
+  },
+  "public": {
+    "notFoundTitle": "Página de chat não encontrada",
+    "notFoundDescription": "O link pode estar incorreto ou indisponível."
   }
 }

--- a/src/i18n/locales/pt/crmForms.json
+++ b/src/i18n/locales/pt/crmForms.json
@@ -1,0 +1,126 @@
+{
+  "header": {
+    "title": "Formulários de captura",
+    "subtitle": "{{count}} formulário · geram leads no pipeline",
+    "subtitle_plural": "{{count}} formulários · geram leads no pipeline",
+    "searchPlaceholder": "Buscar por nome, título ou slug…",
+    "newForm": "Novo formulário"
+  },
+  "filter": {
+    "all": "Todos os status",
+    "published": "Publicados",
+    "draft": "Rascunhos"
+  },
+  "table": {
+    "name": "Nome",
+    "publicLink": "Link público",
+    "status": "Status",
+    "leads": "Leads",
+    "actions": "Ações"
+  },
+  "status": {
+    "published": "Publicado",
+    "draft": "Rascunho"
+  },
+  "empty": {
+    "title": "Nenhum formulário ainda",
+    "titleFiltered": "Nenhum formulário encontrado",
+    "description": "Crie formulários públicos que geram leads no pipeline.",
+    "descriptionFiltered": "Ajuste a busca ou o filtro de status.",
+    "action": "Novo formulário"
+  },
+  "actions": {
+    "edit": "editar",
+    "delete": "excluir",
+    "linkCopied": "Link copiado."
+  },
+  "messages": {
+    "loadError": "Erro ao carregar formulários.",
+    "saved": "Formulário salvo.",
+    "saveError": "Erro ao salvar formulário.",
+    "deleted": "Formulário excluído.",
+    "deleteError": "Erro ao excluir.",
+    "leadsError": "Erro ao carregar leads."
+  },
+  "delete": {
+    "title": "Excluir formulário",
+    "description": "Tem certeza que deseja excluir “{{name}}”? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "leads": {
+    "title": "Leads — {{name}}",
+    "empty": "Nenhum lead capturado ainda.",
+    "contact": "Contato",
+    "destination": "Destino",
+    "date": "Data"
+  },
+  "modal": {
+    "createTitle": "Novo formulário",
+    "editTitle": "Editar formulário",
+    "sections": {
+      "basic": "Básico",
+      "appearance": "Aparência",
+      "fields": "Campos",
+      "defaultDestination": "Destino padrão",
+      "routing": "Regras de roteamento"
+    },
+    "basic": {
+      "name": "Nome (interno)",
+      "namePlaceholder": "Ex.: Contato site",
+      "title": "Título público",
+      "titlePlaceholder": "Ex.: Fale com a gente",
+      "description": "Descrição",
+      "published": "Publicado"
+    },
+    "appearance": {
+      "primaryColor": "Cor primária",
+      "logoUrl": "URL do logo",
+      "successMessage": "Mensagem de sucesso"
+    },
+    "fields": {
+      "add": "Campo",
+      "key": "key",
+      "label": "label",
+      "required": "obrig.",
+      "mapTo": "mapear para…",
+      "optionsPlaceholder": "Opções separadas por vírgula",
+      "remove": "remover campo"
+    },
+    "targets": {
+      "none": "— sem mapeamento —",
+      "groupContact": "Contato",
+      "groupContactCustom": "Contato — campos personalizados",
+      "groupDeal": "Negócio",
+      "groupDealCustom": "Negócio — campos personalizados",
+      "contactName": "Nome",
+      "contactEmail": "E-mail",
+      "contactPhone": "Telefone",
+      "contactCompany": "Empresa",
+      "dealValue": "Valor"
+    },
+    "destination": {
+      "pipeline": "Pipeline…",
+      "stage": "Estágio…",
+      "stageNone": "— nenhum —"
+    },
+    "routing": {
+      "add": "Regra",
+      "field": "campo…",
+      "value": "valor",
+      "pipeline": "pipeline…",
+      "stage": "estágio…",
+      "remove": "remover regra"
+    },
+    "errors": {
+      "name": "Informe o nome do formulário.",
+      "pipeline": "Selecione o pipeline padrão.",
+      "email": "Inclua um campo mapeado para o e-mail do contato.",
+      "nameField": "Inclua um campo mapeado para o nome do contato.",
+      "fieldKey": "Todo campo precisa de uma chave (key)."
+    },
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "saving": "Salvando…"
+  }
+}

--- a/src/i18n/locales/pt/crmForms.json
+++ b/src/i18n/locales/pt/crmForms.json
@@ -85,7 +85,8 @@
       "required": "obrig.",
       "mapTo": "mapear para…",
       "optionsPlaceholder": "Opções separadas por vírgula",
-      "remove": "remover campo"
+      "remove": "remover campo",
+      "type": "Tipo"
     },
     "targets": {
       "none": "— sem mapeamento —",

--- a/src/i18n/locales/pt/crmForms.json
+++ b/src/i18n/locales/pt/crmForms.json
@@ -123,5 +123,16 @@
     "cancel": "Cancelar",
     "save": "Salvar",
     "saving": "Salvando…"
+  },
+  "public": {
+    "loadError": "Não foi possível carregar o formulário. Tente novamente.",
+    "notFoundTitle": "Formulário não encontrado",
+    "notFoundDescription": "O link pode estar incorreto ou indisponível.",
+    "requiredField": "{{label}} é obrigatório",
+    "submitError": "Não foi possível enviar. Verifique os campos e tente novamente.",
+    "selectPlaceholder": "Selecione...",
+    "successMessage": "Recebemos os seus dados. Obrigado!",
+    "submit": "Enviar",
+    "submitting": "A enviar..."
   }
 }

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -117,7 +117,8 @@
       "accessTokens": "Tokens de Acesso",
       "roles": "Perfis e Permissões",
       "admin": "Configurações Admin",
-      "segments": "Segmentos"
+      "segments": "Segmentos",
+      "crmForms": "Formulários de captura"
     }
   }
 }

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -118,7 +118,8 @@
       "roles": "Perfis e Permissões",
       "admin": "Configurações Admin",
       "segments": "Segmentos",
-      "crmForms": "Formulários de captura"
+      "crmForms": "Formulários de captura",
+      "chatPages": "Páginas de chat"
     }
   }
 }

--- a/src/pages/Customer/Settings/ChatPages/ChatPages.tsx
+++ b/src/pages/Customer/Settings/ChatPages/ChatPages.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Plus, Pencil, Trash2, Copy, Loader2, MessageSquare } from 'lucide-react';
+import {
+  Button,
+  Badge,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@evoapi/design-system';
+import BaseHeader from '@/components/base/BaseHeader';
+import BasePagination from '@/components/base/BasePagination';
+import EmptyState from '@/components/base/EmptyState';
+import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
+import { chatPagesService } from '@/services/chatPages/chatPagesService';
+import type { ChatPage, ChatPagePayload, PaginationMeta, WebWidgetOption } from '@/types/chatPages';
+import ChatPageModal from '@/components/chatPages/ChatPageModal';
+
+const EMPTY_PAGINATION: PaginationMeta = {
+  page: 1,
+  page_size: DEFAULT_PAGE_SIZE,
+  total: 0,
+  total_pages: 0,
+};
+
+export default function ChatPages() {
+  const { t } = useLanguage('chatPages');
+  const { can, isReady } = useUserPermissions();
+  const canCreate = can('chat_pages', 'create');
+  const canUpdate = can('chat_pages', 'update');
+  const canDelete = can('chat_pages', 'delete');
+
+  const [pages, setPages] = useState<ChatPage[]>([]);
+  const [widgets, setWidgets] = useState<WebWidgetOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<ChatPage | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ChatPage | null>(null);
+
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [published, setPublished] = useState<'all' | 'true' | 'false'>('all');
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState<PaginationMeta>(EMPTY_PAGINATION);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSearch(searchInput);
+      setPage(1);
+    }, 350);
+    return () => clearTimeout(id);
+  }, [searchInput]);
+
+  const loadPages = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data, meta } = await chatPagesService.list({
+        page,
+        pageSize: DEFAULT_PAGE_SIZE,
+        search: search || undefined,
+        published: published === 'all' ? undefined : published === 'true',
+      });
+      setPages(data);
+      setPagination(meta.pagination ?? EMPTY_PAGINATION);
+    } catch {
+      toast.error(t('messages.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search, published, t]);
+
+  const loadWidgets = useCallback(async () => {
+    try {
+      setWidgets(await chatPagesService.listWebWidgets());
+    } catch {
+      /* widget select degrades to the page's existing token */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isReady) loadWidgets();
+  }, [isReady, loadWidgets]);
+
+  useEffect(() => {
+    if (isReady) loadPages();
+  }, [isReady, loadPages]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setModalOpen(true);
+  };
+  const openEdit = (chatPage: ChatPage) => {
+    setEditing(chatPage);
+    setModalOpen(true);
+  };
+
+  const handleSave = async (payload: ChatPagePayload) => {
+    setSaving(true);
+    try {
+      if (editing) await chatPagesService.update(editing.id, payload);
+      else await chatPagesService.create(payload);
+      toast.success(t('messages.saved'));
+      setModalOpen(false);
+      loadPages();
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error?.message;
+      toast.error(msg || t('messages.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await chatPagesService.remove(deleteTarget.id);
+      toast.success(t('messages.deleted'));
+      setDeleteTarget(null);
+      loadPages();
+    } catch {
+      toast.error(t('messages.deleteError'));
+    }
+  };
+
+  const copyLink = (chatPage: ChatPage) => {
+    const url = `${window.location.origin}/chat/${chatPage.slug}`;
+    navigator.clipboard?.writeText(url);
+    toast.success(t('actions.linkCopied'));
+  };
+
+  const isFiltered = !!search || published !== 'all';
+
+  return (
+    <div className="h-full flex flex-col p-4">
+      <BaseHeader
+        title={t('header.title')}
+        subtitle={t('header.subtitle', { count: pagination.total })}
+        searchPlaceholder={t('header.searchPlaceholder')}
+        searchValue={searchInput}
+        onSearchChange={setSearchInput}
+        primaryAction={
+          canCreate
+            ? { label: t('header.newPage'), icon: <Plus className="h-4 w-4" />, onClick: openCreate }
+            : undefined
+        }
+      />
+
+      <div className="flex items-center gap-2 mt-4">
+        <Select
+          value={published}
+          onValueChange={v => {
+            setPublished(v as 'all' | 'true' | 'false');
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t('filter.all')}</SelectItem>
+            <SelectItem value="true">{t('filter.published')}</SelectItem>
+            <SelectItem value="false">{t('filter.draft')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex-1 overflow-auto mt-6">
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : pages.length === 0 ? (
+          <EmptyState
+            icon={MessageSquare}
+            title={isFiltered ? t('empty.titleFiltered') : t('empty.title')}
+            description={isFiltered ? t('empty.descriptionFiltered') : t('empty.description')}
+            action={canCreate && !isFiltered ? { label: t('empty.action'), onClick: openCreate } : undefined}
+            className="h-full"
+          />
+        ) : (
+          <div className="rounded-md border border-sidebar-border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-sidebar-border bg-sidebar-accent/50">
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">{t('table.name')}</th>
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden md:table-cell">
+                    {t('table.publicLink')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden md:table-cell">
+                    {t('table.widget')}
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden sm:table-cell">
+                    {t('table.status')}
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-sidebar-foreground">{t('table.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pages.map(chatPage => (
+                  <tr
+                    key={chatPage.id}
+                    className="border-b border-sidebar-border last:border-0 hover:bg-sidebar-accent/30 transition-colors"
+                  >
+                    <td className="px-4 py-3 font-medium text-sidebar-foreground">
+                      {chatPage.title || chatPage.display_title || chatPage.slug}
+                    </td>
+                    <td className="px-4 py-3 hidden md:table-cell">
+                      <button
+                        onClick={() => copyLink(chatPage)}
+                        className="inline-flex items-center gap-1 text-sidebar-foreground/60 hover:text-sidebar-foreground"
+                      >
+                        <Copy className="w-3.5 h-3.5" /> /chat/{chatPage.slug}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3 hidden md:table-cell text-sidebar-foreground/70">
+                      {chatPage.widget_inbox_name || '—'}
+                    </td>
+                    <td className="px-4 py-3 hidden sm:table-cell">
+                      <Badge variant={chatPage.published ? 'default' : 'secondary'} className="text-xs">
+                        {chatPage.published ? t('status.published') : t('status.draft')}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-right whitespace-nowrap">
+                      {canUpdate && (
+                        <Button variant="ghost" size="icon" onClick={() => openEdit(chatPage)} aria-label={t('actions.edit')}>
+                          <Pencil className="w-4 h-4" />
+                        </Button>
+                      )}
+                      {canDelete && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteTarget(chatPage)}
+                          aria-label={t('actions.delete')}
+                          className="text-destructive"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {pagination.total > 0 && (
+        <BasePagination
+          currentPage={pagination.page}
+          totalPages={pagination.total_pages}
+          totalItems={pagination.total}
+          itemsPerPage={pagination.page_size}
+          onPageChange={setPage}
+        />
+      )}
+
+      <ChatPageModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        saving={saving}
+        initial={editing}
+        widgets={widgets}
+      />
+
+      <Dialog open={!!deleteTarget} onOpenChange={v => !v && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('delete.title')}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            {t('delete.description', { name: deleteTarget?.title || deleteTarget?.slug })}
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              {t('delete.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              {t('delete.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Customer/Settings/ChatPages/index.ts
+++ b/src/pages/Customer/Settings/ChatPages/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChatPages';

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { Plus, Pencil, Trash2, Copy } from 'lucide-react';
+import { Plus, Pencil, Trash2, Copy, Loader2, FileText } from 'lucide-react';
 import {
   Button,
   Badge,
@@ -9,12 +9,6 @@ import {
   DialogHeader,
   DialogTitle,
   DialogFooter,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
   Select,
   SelectTrigger,
   SelectValue,
@@ -23,6 +17,7 @@ import {
 } from '@evoapi/design-system';
 import BaseHeader from '@/components/base/BaseHeader';
 import BasePagination from '@/components/base/BasePagination';
+import EmptyState from '@/components/base/EmptyState';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { crmFormsService } from '@/services/crmForms/crmFormsService';
@@ -66,7 +61,6 @@ export default function CrmForms() {
   const [page, setPage] = useState(1);
   const [pagination, setPagination] = useState<PaginationMeta>(EMPTY_PAGINATION);
 
-  // Debounce the search input into the actual query.
   useEffect(() => {
     const id = setTimeout(() => {
       setSearch(searchInput);
@@ -214,53 +208,74 @@ export default function CrmForms() {
         </Select>
       </div>
 
-      <div className="flex-1 overflow-auto mt-4">
+      <div className="flex-1 overflow-auto mt-6">
         {loading ? (
-          <div className="flex justify-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
         ) : forms.length === 0 ? (
-          <div className="text-center py-12 text-muted-foreground">
-            {search || published !== 'all' ? 'Nenhum formulário para esse filtro.' : 'Nenhum formulário ainda.'}
-          </div>
+          <EmptyState
+            icon={FileText}
+            title={search || published !== 'all' ? 'Nenhum formulário encontrado' : 'Nenhum formulário ainda'}
+            description={
+              search || published !== 'all'
+                ? 'Ajuste a busca ou o filtro de status.'
+                : 'Crie formulários públicos que geram leads no pipeline.'
+            }
+            action={
+              canCreate && !(search || published !== 'all')
+                ? { label: 'Novo formulário', onClick: openCreate }
+                : undefined
+            }
+            className="h-full"
+          />
         ) : (
-          <div className="border border-border rounded-lg">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Nome</TableHead>
-                  <TableHead>Link público</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Leads</TableHead>
-                  <TableHead className="text-right">Ações</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
+          <div className="rounded-md border border-sidebar-border overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-sidebar-border bg-sidebar-accent/50">
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Nome</th>
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden md:table-cell">
+                    Link público
+                  </th>
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden sm:table-cell">
+                    Status
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-sidebar-foreground hidden sm:table-cell">
+                    Leads
+                  </th>
+                  <th className="px-4 py-3 text-right font-medium text-sidebar-foreground">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
                 {forms.map(form => (
-                  <TableRow key={form.id}>
-                    <TableCell className="font-medium">{form.title || form.name}</TableCell>
-                    <TableCell>
+                  <tr
+                    key={form.id}
+                    className="border-b border-sidebar-border last:border-0 hover:bg-sidebar-accent/30 transition-colors"
+                  >
+                    <td className="px-4 py-3 font-medium text-sidebar-foreground">{form.title || form.name}</td>
+                    <td className="px-4 py-3 hidden md:table-cell">
                       <button
                         onClick={() => copyLink(form)}
-                        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                        className="inline-flex items-center gap-1 text-sidebar-foreground/60 hover:text-sidebar-foreground"
                       >
                         <Copy className="w-3.5 h-3.5" /> /f/{form.slug}
                       </button>
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant={form.published ? 'default' : 'secondary'}>
+                    </td>
+                    <td className="px-4 py-3 hidden sm:table-cell">
+                      <Badge variant={form.published ? 'default' : 'secondary'} className="text-xs">
                         {form.published ? 'Publicado' : 'Rascunho'}
                       </Badge>
-                    </TableCell>
-                    <TableCell>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums hidden sm:table-cell">
                       <button
                         onClick={() => openLeads(form)}
-                        className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                        className="text-sidebar-foreground/80 hover:text-sidebar-foreground underline-offset-2 hover:underline"
                       >
                         {form.leads_count ?? 0}
                       </button>
-                    </TableCell>
-                    <TableCell className="text-right whitespace-nowrap">
+                    </td>
+                    <td className="px-4 py-3 text-right whitespace-nowrap">
                       {canUpdate && (
                         <Button variant="ghost" size="icon" onClick={() => openEdit(form)} aria-label="editar">
                           <Pencil className="w-4 h-4" />
@@ -277,11 +292,11 @@ export default function CrmForms() {
                           <Trash2 className="w-4 h-4" />
                         </Button>
                       )}
-                    </TableCell>
-                  </TableRow>
+                    </td>
+                  </tr>
                 ))}
-              </TableBody>
-            </Table>
+              </tbody>
+            </table>
           </div>
         )}
       </div>
@@ -334,34 +349,36 @@ export default function CrmForms() {
           </DialogHeader>
           {leadsLoading ? (
             <div className="flex justify-center py-8">
-              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : leads.length === 0 ? (
             <p className="text-sm text-muted-foreground py-6 text-center">Nenhum lead capturado ainda.</p>
           ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Contato</TableHead>
-                  <TableHead>Destino</TableHead>
-                  <TableHead>Data</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {leads.map(lead => (
-                  <TableRow key={lead.id}>
-                    <TableCell>
-                      <div className="font-medium">{lead.contact?.name || '—'}</div>
-                      <div className="text-xs text-muted-foreground">{lead.contact?.email}</div>
-                    </TableCell>
-                    <TableCell className="text-sm text-muted-foreground">{stageLabel(lead)}</TableCell>
-                    <TableCell className="text-sm text-muted-foreground">
-                      {lead.created_at ? new Date(lead.created_at).toLocaleString() : '—'}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            <div className="rounded-md border border-sidebar-border overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-sidebar-border bg-sidebar-accent/50">
+                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Contato</th>
+                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Destino</th>
+                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {leads.map(lead => (
+                    <tr key={lead.id} className="border-b border-sidebar-border last:border-0">
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-sidebar-foreground">{lead.contact?.name || '—'}</div>
+                        <div className="text-xs text-sidebar-foreground/60">{lead.contact?.email}</div>
+                      </td>
+                      <td className="px-4 py-3 text-sidebar-foreground/70">{stageLabel(lead)}</td>
+                      <td className="px-4 py-3 text-sidebar-foreground/70">
+                        {lead.created_at ? new Date(lead.created_at).toLocaleString() : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </DialogContent>
       </Dialog>

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -15,15 +15,30 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
 } from '@evoapi/design-system';
+import BaseHeader from '@/components/base/BaseHeader';
+import BasePagination from '@/components/base/BasePagination';
+import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { crmFormsService } from '@/services/crmForms/crmFormsService';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
 import { customAttributesService } from '@/services/customAttributes/customAttributesService';
-import type { CrmForm, CrmFormPayload, FormLead } from '@/types/crmForms';
+import type { CrmForm, CrmFormPayload, FormLead, PaginationMeta } from '@/types/crmForms';
 import type { Pipeline } from '@/types/analytics/pipelines';
 import type { CustomAttributeDefinition } from '@/types/settings';
 import CrmFormModal from '@/components/crmForms/CrmFormModal';
+
+const EMPTY_PAGINATION: PaginationMeta = {
+  page: 1,
+  page_size: DEFAULT_PAGE_SIZE,
+  total: 0,
+  total_pages: 0,
+};
 
 export default function CrmForms() {
   const { can, isReady } = useUserPermissions();
@@ -44,29 +59,62 @@ export default function CrmForms() {
   const [leads, setLeads] = useState<FormLead[]>([]);
   const [leadsLoading, setLeadsLoading] = useState(false);
 
-  const load = useCallback(async () => {
+  // List controls (server-side filter / search / pagination)
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [published, setPublished] = useState<'all' | 'true' | 'false'>('all');
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState<PaginationMeta>(EMPTY_PAGINATION);
+
+  // Debounce the search input into the actual query.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setSearch(searchInput);
+      setPage(1);
+    }, 350);
+    return () => clearTimeout(id);
+  }, [searchInput]);
+
+  const loadForms = useCallback(async () => {
     setLoading(true);
     try {
-      const [list, pipes, cAttrs, dAttrs] = await Promise.all([
-        crmFormsService.list(),
-        pipelinesService.getPipelines(),
-        customAttributesService.getCustomAttributes('contact_attribute'),
-        customAttributesService.getCustomAttributes('pipeline_item_attribute'),
-      ]);
-      setForms(list);
-      setPipelines(pipes.data);
-      setContactAttrs(cAttrs.data);
-      setDealAttrs(dAttrs.data);
+      const { data, meta } = await crmFormsService.list({
+        page,
+        pageSize: DEFAULT_PAGE_SIZE,
+        search: search || undefined,
+        published: published === 'all' ? undefined : published === 'true',
+      });
+      setForms(data);
+      setPagination(meta.pagination ?? EMPTY_PAGINATION);
     } catch {
       toast.error('Erro ao carregar formulários.');
     } finally {
       setLoading(false);
     }
+  }, [page, search, published]);
+
+  const loadContext = useCallback(async () => {
+    try {
+      const [pipes, cAttrs, dAttrs] = await Promise.all([
+        pipelinesService.getPipelines(),
+        customAttributesService.getCustomAttributes('contact_attribute'),
+        customAttributesService.getCustomAttributes('pipeline_item_attribute'),
+      ]);
+      setPipelines(pipes.data);
+      setContactAttrs(cAttrs.data);
+      setDealAttrs(dAttrs.data);
+    } catch {
+      /* selectors degrade to standard targets only */
+    }
   }, []);
 
   useEffect(() => {
-    if (isReady) load();
-  }, [isReady, load]);
+    if (isReady) loadContext();
+  }, [isReady, loadContext]);
+
+  useEffect(() => {
+    if (isReady) loadForms();
+  }, [isReady, loadForms]);
 
   const openCreate = () => {
     setEditing(null);
@@ -84,7 +132,7 @@ export default function CrmForms() {
       else await crmFormsService.create(payload);
       toast.success('Formulário salvo.');
       setModalOpen(false);
-      load();
+      loadForms();
     } catch (error: unknown) {
       const msg = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
         ?.message;
@@ -100,7 +148,7 @@ export default function CrmForms() {
       await crmFormsService.remove(deleteTarget.id);
       toast.success('Formulário excluído.');
       setDeleteTarget(null);
-      load();
+      loadForms();
     } catch {
       toast.error('Erro ao excluir.');
     }
@@ -133,87 +181,119 @@ export default function CrmForms() {
   };
 
   return (
-    <div className="p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-xl font-semibold text-foreground">Formulários de captura</h1>
-          <p className="text-sm text-muted-foreground">
-            Crie formulários públicos que geram leads no pipeline.
-          </p>
-        </div>
-        {canCreate && (
-          <Button onClick={openCreate}>
-            <Plus className="w-4 h-4 mr-1" /> Novo formulário
-          </Button>
+    <div className="h-full flex flex-col p-4">
+      <BaseHeader
+        title="Formulários de captura"
+        subtitle={`${pagination.total} formulário${pagination.total !== 1 ? 's' : ''} · geram leads no pipeline`}
+        searchPlaceholder="Buscar por nome, título ou slug…"
+        searchValue={searchInput}
+        onSearchChange={setSearchInput}
+        primaryAction={
+          canCreate
+            ? { label: 'Novo formulário', icon: <Plus className="h-4 w-4" />, onClick: openCreate }
+            : undefined
+        }
+      />
+
+      <div className="flex items-center gap-2 mt-4">
+        <Select
+          value={published}
+          onValueChange={v => {
+            setPublished(v as 'all' | 'true' | 'false');
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-[180px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todos os status</SelectItem>
+            <SelectItem value="true">Publicados</SelectItem>
+            <SelectItem value="false">Rascunhos</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex-1 overflow-auto mt-4">
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          </div>
+        ) : forms.length === 0 ? (
+          <div className="text-center py-12 text-muted-foreground">
+            {search || published !== 'all' ? 'Nenhum formulário para esse filtro.' : 'Nenhum formulário ainda.'}
+          </div>
+        ) : (
+          <div className="border border-border rounded-lg">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Link público</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Leads</TableHead>
+                  <TableHead className="text-right">Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {forms.map(form => (
+                  <TableRow key={form.id}>
+                    <TableCell className="font-medium">{form.title || form.name}</TableCell>
+                    <TableCell>
+                      <button
+                        onClick={() => copyLink(form)}
+                        className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                      >
+                        <Copy className="w-3.5 h-3.5" /> /f/{form.slug}
+                      </button>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={form.published ? 'default' : 'secondary'}>
+                        {form.published ? 'Publicado' : 'Rascunho'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <button
+                        onClick={() => openLeads(form)}
+                        className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                      >
+                        {form.leads_count ?? 0}
+                      </button>
+                    </TableCell>
+                    <TableCell className="text-right whitespace-nowrap">
+                      {canUpdate && (
+                        <Button variant="ghost" size="icon" onClick={() => openEdit(form)} aria-label="editar">
+                          <Pencil className="w-4 h-4" />
+                        </Button>
+                      )}
+                      {canDelete && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setDeleteTarget(form)}
+                          aria-label="excluir"
+                          className="text-destructive"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </div>
 
-      {loading ? (
-        <div className="flex justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-        </div>
-      ) : forms.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">Nenhum formulário ainda.</div>
-      ) : (
-        <div className="border border-border rounded-lg">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Nome</TableHead>
-                <TableHead>Link público</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Leads</TableHead>
-                <TableHead className="text-right">Ações</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {forms.map(form => (
-                <TableRow key={form.id}>
-                  <TableCell className="font-medium">{form.title || form.name}</TableCell>
-                  <TableCell>
-                    <button
-                      onClick={() => copyLink(form)}
-                      className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
-                    >
-                      <Copy className="w-3.5 h-3.5" /> /f/{form.slug}
-                    </button>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={form.published ? 'default' : 'secondary'}>
-                      {form.published ? 'Publicado' : 'Rascunho'}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <button
-                      onClick={() => openLeads(form)}
-                      className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
-                    >
-                      {form.leads_count ?? 0}
-                    </button>
-                  </TableCell>
-                  <TableCell className="text-right whitespace-nowrap">
-                    {canUpdate && (
-                      <Button variant="ghost" size="icon" onClick={() => openEdit(form)} aria-label="editar">
-                        <Pencil className="w-4 h-4" />
-                      </Button>
-                    )}
-                    {canDelete && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => setDeleteTarget(form)}
-                        aria-label="excluir"
-                        className="text-destructive"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </Button>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+      {pagination.total > 0 && (
+        <BasePagination
+          currentPage={pagination.page}
+          totalPages={pagination.total_pages}
+          totalItems={pagination.total}
+          itemsPerPage={pagination.page_size}
+          onPageChange={setPage}
+        />
       )}
 
       <CrmFormModal

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -20,7 +20,7 @@ import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { crmFormsService } from '@/services/crmForms/crmFormsService';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
 import { customAttributesService } from '@/services/customAttributes/customAttributesService';
-import type { CrmForm, CrmFormPayload } from '@/types/crmForms';
+import type { CrmForm, CrmFormPayload, FormLead } from '@/types/crmForms';
 import type { Pipeline } from '@/types/analytics/pipelines';
 import type { CustomAttributeDefinition } from '@/types/settings';
 import CrmFormModal from '@/components/crmForms/CrmFormModal';
@@ -40,6 +40,9 @@ export default function CrmForms() {
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<CrmForm | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<CrmForm | null>(null);
+  const [leadsForm, setLeadsForm] = useState<CrmForm | null>(null);
+  const [leads, setLeads] = useState<FormLead[]>([]);
+  const [leadsLoading, setLeadsLoading] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -109,6 +112,26 @@ export default function CrmForms() {
     toast.success('Link copiado.');
   };
 
+  const openLeads = async (form: CrmForm) => {
+    setLeadsForm(form);
+    setLeads([]);
+    setLeadsLoading(true);
+    try {
+      const { leads: list } = await crmFormsService.getLeads(form.id);
+      setLeads(list);
+    } catch {
+      toast.error('Erro ao carregar leads.');
+    } finally {
+      setLeadsLoading(false);
+    }
+  };
+
+  const stageLabel = (lead: FormLead) => {
+    const pipe = pipelines.find(p => p.id === lead.pipeline_id);
+    const stage = pipe?.stages?.find(s => s.id === lead.pipeline_stage_id);
+    return [pipe?.name, stage?.name].filter(Boolean).join(' › ') || '—';
+  };
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
@@ -139,6 +162,7 @@ export default function CrmForms() {
                 <TableHead>Nome</TableHead>
                 <TableHead>Link público</TableHead>
                 <TableHead>Status</TableHead>
+                <TableHead>Leads</TableHead>
                 <TableHead className="text-right">Ações</TableHead>
               </TableRow>
             </TableHeader>
@@ -158,6 +182,14 @@ export default function CrmForms() {
                     <Badge variant={form.published ? 'default' : 'secondary'}>
                       {form.published ? 'Publicado' : 'Rascunho'}
                     </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <button
+                      onClick={() => openLeads(form)}
+                      className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                    >
+                      {form.leads_count ?? 0}
+                    </button>
                   </TableCell>
                   <TableCell className="text-right whitespace-nowrap">
                     {canUpdate && (
@@ -212,6 +244,45 @@ export default function CrmForms() {
               Excluir
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!leadsForm} onOpenChange={v => !v && setLeadsForm(null)}>
+        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Leads — {leadsForm?.title || leadsForm?.name}</DialogTitle>
+          </DialogHeader>
+          {leadsLoading ? (
+            <div className="flex justify-center py-8">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary" />
+            </div>
+          ) : leads.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-6 text-center">Nenhum lead capturado ainda.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Contato</TableHead>
+                  <TableHead>Destino</TableHead>
+                  <TableHead>Data</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {leads.map(lead => (
+                  <TableRow key={lead.id}>
+                    <TableCell>
+                      <div className="font-medium">{lead.contact?.name || '—'}</div>
+                      <div className="text-xs text-muted-foreground">{lead.contact?.email}</div>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">{stageLabel(lead)}</TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {lead.created_at ? new Date(lead.created_at).toLocaleString() : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -19,6 +19,7 @@ import BaseHeader from '@/components/base/BaseHeader';
 import BasePagination from '@/components/base/BasePagination';
 import EmptyState from '@/components/base/EmptyState';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { useLanguage } from '@/hooks/useLanguage';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { crmFormsService } from '@/services/crmForms/crmFormsService';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
@@ -36,6 +37,7 @@ const EMPTY_PAGINATION: PaginationMeta = {
 };
 
 export default function CrmForms() {
+  const { t } = useLanguage('crmForms');
   const { can, isReady } = useUserPermissions();
   const canCreate = can('crm_forms', 'create');
   const canUpdate = can('crm_forms', 'update');
@@ -54,7 +56,6 @@ export default function CrmForms() {
   const [leads, setLeads] = useState<FormLead[]>([]);
   const [leadsLoading, setLeadsLoading] = useState(false);
 
-  // List controls (server-side filter / search / pagination)
   const [searchInput, setSearchInput] = useState('');
   const [search, setSearch] = useState('');
   const [published, setPublished] = useState<'all' | 'true' | 'false'>('all');
@@ -81,11 +82,11 @@ export default function CrmForms() {
       setForms(data);
       setPagination(meta.pagination ?? EMPTY_PAGINATION);
     } catch {
-      toast.error('Erro ao carregar formulários.');
+      toast.error(t('messages.loadError'));
     } finally {
       setLoading(false);
     }
-  }, [page, search, published]);
+  }, [page, search, published, t]);
 
   const loadContext = useCallback(async () => {
     try {
@@ -124,13 +125,13 @@ export default function CrmForms() {
     try {
       if (editing) await crmFormsService.update(editing.id, payload);
       else await crmFormsService.create(payload);
-      toast.success('Formulário salvo.');
+      toast.success(t('messages.saved'));
       setModalOpen(false);
       loadForms();
     } catch (error: unknown) {
       const msg = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
         ?.message;
-      toast.error(msg || 'Erro ao salvar formulário.');
+      toast.error(msg || t('messages.saveError'));
     } finally {
       setSaving(false);
     }
@@ -140,18 +141,18 @@ export default function CrmForms() {
     if (!deleteTarget) return;
     try {
       await crmFormsService.remove(deleteTarget.id);
-      toast.success('Formulário excluído.');
+      toast.success(t('messages.deleted'));
       setDeleteTarget(null);
       loadForms();
     } catch {
-      toast.error('Erro ao excluir.');
+      toast.error(t('messages.deleteError'));
     }
   };
 
   const copyLink = (form: CrmForm) => {
     const url = `${window.location.origin}/f/${form.slug}`;
     navigator.clipboard?.writeText(url);
-    toast.success('Link copiado.');
+    toast.success(t('actions.linkCopied'));
   };
 
   const openLeads = async (form: CrmForm) => {
@@ -162,7 +163,7 @@ export default function CrmForms() {
       const { leads: list } = await crmFormsService.getLeads(form.id);
       setLeads(list);
     } catch {
-      toast.error('Erro ao carregar leads.');
+      toast.error(t('messages.leadsError'));
     } finally {
       setLeadsLoading(false);
     }
@@ -174,17 +175,19 @@ export default function CrmForms() {
     return [pipe?.name, stage?.name].filter(Boolean).join(' › ') || '—';
   };
 
+  const isFiltered = !!search || published !== 'all';
+
   return (
     <div className="h-full flex flex-col p-4">
       <BaseHeader
-        title="Formulários de captura"
-        subtitle={`${pagination.total} formulário${pagination.total !== 1 ? 's' : ''} · geram leads no pipeline`}
-        searchPlaceholder="Buscar por nome, título ou slug…"
+        title={t('header.title')}
+        subtitle={t('header.subtitle', { count: pagination.total })}
+        searchPlaceholder={t('header.searchPlaceholder')}
         searchValue={searchInput}
         onSearchChange={setSearchInput}
         primaryAction={
           canCreate
-            ? { label: 'Novo formulário', icon: <Plus className="h-4 w-4" />, onClick: openCreate }
+            ? { label: t('header.newForm'), icon: <Plus className="h-4 w-4" />, onClick: openCreate }
             : undefined
         }
       />
@@ -201,9 +204,9 @@ export default function CrmForms() {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos os status</SelectItem>
-            <SelectItem value="true">Publicados</SelectItem>
-            <SelectItem value="false">Rascunhos</SelectItem>
+            <SelectItem value="all">{t('filter.all')}</SelectItem>
+            <SelectItem value="true">{t('filter.published')}</SelectItem>
+            <SelectItem value="false">{t('filter.draft')}</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -216,17 +219,9 @@ export default function CrmForms() {
         ) : forms.length === 0 ? (
           <EmptyState
             icon={FileText}
-            title={search || published !== 'all' ? 'Nenhum formulário encontrado' : 'Nenhum formulário ainda'}
-            description={
-              search || published !== 'all'
-                ? 'Ajuste a busca ou o filtro de status.'
-                : 'Crie formulários públicos que geram leads no pipeline.'
-            }
-            action={
-              canCreate && !(search || published !== 'all')
-                ? { label: 'Novo formulário', onClick: openCreate }
-                : undefined
-            }
+            title={isFiltered ? t('empty.titleFiltered') : t('empty.title')}
+            description={isFiltered ? t('empty.descriptionFiltered') : t('empty.description')}
+            action={canCreate && !isFiltered ? { label: t('empty.action'), onClick: openCreate } : undefined}
             className="h-full"
           />
         ) : (
@@ -234,17 +229,17 @@ export default function CrmForms() {
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-sidebar-border bg-sidebar-accent/50">
-                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Nome</th>
+                  <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">{t('table.name')}</th>
                   <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden md:table-cell">
-                    Link público
+                    {t('table.publicLink')}
                   </th>
                   <th className="px-4 py-3 text-left font-medium text-sidebar-foreground hidden sm:table-cell">
-                    Status
+                    {t('table.status')}
                   </th>
                   <th className="px-4 py-3 text-right font-medium text-sidebar-foreground hidden sm:table-cell">
-                    Leads
+                    {t('table.leads')}
                   </th>
-                  <th className="px-4 py-3 text-right font-medium text-sidebar-foreground">Ações</th>
+                  <th className="px-4 py-3 text-right font-medium text-sidebar-foreground">{t('table.actions')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -264,7 +259,7 @@ export default function CrmForms() {
                     </td>
                     <td className="px-4 py-3 hidden sm:table-cell">
                       <Badge variant={form.published ? 'default' : 'secondary'} className="text-xs">
-                        {form.published ? 'Publicado' : 'Rascunho'}
+                        {form.published ? t('status.published') : t('status.draft')}
                       </Badge>
                     </td>
                     <td className="px-4 py-3 text-right tabular-nums hidden sm:table-cell">
@@ -277,7 +272,7 @@ export default function CrmForms() {
                     </td>
                     <td className="px-4 py-3 text-right whitespace-nowrap">
                       {canUpdate && (
-                        <Button variant="ghost" size="icon" onClick={() => openEdit(form)} aria-label="editar">
+                        <Button variant="ghost" size="icon" onClick={() => openEdit(form)} aria-label={t('actions.edit')}>
                           <Pencil className="w-4 h-4" />
                         </Button>
                       )}
@@ -286,7 +281,7 @@ export default function CrmForms() {
                           variant="ghost"
                           size="icon"
                           onClick={() => setDeleteTarget(form)}
-                          aria-label="excluir"
+                          aria-label={t('actions.delete')}
                           className="text-destructive"
                         >
                           <Trash2 className="w-4 h-4" />
@@ -325,18 +320,17 @@ export default function CrmForms() {
       <Dialog open={!!deleteTarget} onOpenChange={v => !v && setDeleteTarget(null)}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Excluir formulário</DialogTitle>
+            <DialogTitle>{t('delete.title')}</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            Tem certeza que deseja excluir “{deleteTarget?.title || deleteTarget?.name}”? Esta ação não pode
-            ser desfeita.
+            {t('delete.description', { name: deleteTarget?.title || deleteTarget?.name })}
           </p>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDeleteTarget(null)}>
-              Cancelar
+              {t('delete.cancel')}
             </Button>
             <Button variant="destructive" onClick={handleDelete}>
-              Excluir
+              {t('delete.confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -345,22 +339,22 @@ export default function CrmForms() {
       <Dialog open={!!leadsForm} onOpenChange={v => !v && setLeadsForm(null)}>
         <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Leads — {leadsForm?.title || leadsForm?.name}</DialogTitle>
+            <DialogTitle>{t('leads.title', { name: leadsForm?.title || leadsForm?.name })}</DialogTitle>
           </DialogHeader>
           {leadsLoading ? (
             <div className="flex justify-center py-8">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
           ) : leads.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-6 text-center">Nenhum lead capturado ainda.</p>
+            <p className="text-sm text-muted-foreground py-6 text-center">{t('leads.empty')}</p>
           ) : (
             <div className="rounded-md border border-sidebar-border overflow-hidden">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-sidebar-border bg-sidebar-accent/50">
-                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Contato</th>
-                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Destino</th>
-                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">Data</th>
+                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">{t('leads.contact')}</th>
+                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">{t('leads.destination')}</th>
+                    <th className="px-4 py-3 text-left font-medium text-sidebar-foreground">{t('leads.date')}</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -19,8 +19,10 @@ import {
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { crmFormsService } from '@/services/crmForms/crmFormsService';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import { customAttributesService } from '@/services/customAttributes/customAttributesService';
 import type { CrmForm, CrmFormPayload } from '@/types/crmForms';
 import type { Pipeline } from '@/types/analytics/pipelines';
+import type { CustomAttributeDefinition } from '@/types/settings';
 import CrmFormModal from '@/components/crmForms/CrmFormModal';
 
 export default function CrmForms() {
@@ -31,6 +33,8 @@ export default function CrmForms() {
 
   const [forms, setForms] = useState<CrmForm[]>([]);
   const [pipelines, setPipelines] = useState<Pipeline[]>([]);
+  const [contactAttrs, setContactAttrs] = useState<CustomAttributeDefinition[]>([]);
+  const [dealAttrs, setDealAttrs] = useState<CustomAttributeDefinition[]>([]);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -40,12 +44,16 @@ export default function CrmForms() {
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [list, pipes] = await Promise.all([
+      const [list, pipes, cAttrs, dAttrs] = await Promise.all([
         crmFormsService.list(),
         pipelinesService.getPipelines(),
+        customAttributesService.getCustomAttributes('contact_attribute'),
+        customAttributesService.getCustomAttributes('pipeline_item_attribute'),
       ]);
       setForms(list);
       setPipelines(pipes.data);
+      setContactAttrs(cAttrs.data);
+      setDealAttrs(dAttrs.data);
     } catch {
       toast.error('Erro ao carregar formulários.');
     } finally {
@@ -183,6 +191,8 @@ export default function CrmForms() {
         saving={saving}
         initial={editing}
         pipelines={pipelines}
+        contactAttrs={contactAttrs}
+        dealAttrs={dealAttrs}
       />
 
       <Dialog open={!!deleteTarget} onOpenChange={v => !v && setDeleteTarget(null)}>

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -3,11 +3,18 @@ import { toast } from 'sonner';
 import { Plus, Pencil, Trash2, Copy } from 'lucide-react';
 import {
   Button,
+  Badge,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from '@evoapi/design-system';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { crmFormsService } from '@/services/crmForms/crmFormsService';
@@ -99,7 +106,9 @@ export default function CrmForms() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-semibold text-foreground">Formulários de captura</h1>
-          <p className="text-sm text-muted-foreground">Crie formulários públicos que geram leads no pipeline.</p>
+          <p className="text-sm text-muted-foreground">
+            Crie formulários públicos que geram leads no pipeline.
+          </p>
         </div>
         {canCreate && (
           <Button onClick={openCreate}>
@@ -115,55 +124,55 @@ export default function CrmForms() {
       ) : forms.length === 0 ? (
         <div className="text-center py-12 text-muted-foreground">Nenhum formulário ainda.</div>
       ) : (
-        <div className="border border-border rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-muted/50 text-muted-foreground">
-              <tr>
-                <th className="text-left font-medium px-4 py-2">Nome</th>
-                <th className="text-left font-medium px-4 py-2">Link público</th>
-                <th className="text-left font-medium px-4 py-2">Status</th>
-                <th className="px-4 py-2" />
-              </tr>
-            </thead>
-            <tbody>
+        <div className="border border-border rounded-lg">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>Link público</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {forms.map(form => (
-                <tr key={form.id} className="border-t border-border">
-                  <td className="px-4 py-2 text-foreground">{form.title || form.name}</td>
-                  <td className="px-4 py-2">
+                <TableRow key={form.id}>
+                  <TableCell className="font-medium">{form.title || form.name}</TableCell>
+                  <TableCell>
                     <button
                       onClick={() => copyLink(form)}
                       className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
                     >
                       <Copy className="w-3.5 h-3.5" /> /f/{form.slug}
                     </button>
-                  </td>
-                  <td className="px-4 py-2">
-                    <span
-                      className={`text-xs px-2 py-0.5 rounded-full ${
-                        form.published
-                          ? 'bg-green-500/10 text-green-600 dark:text-green-400'
-                          : 'bg-muted text-muted-foreground'
-                      }`}
-                    >
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={form.published ? 'default' : 'secondary'}>
                       {form.published ? 'Publicado' : 'Rascunho'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-2 text-right whitespace-nowrap">
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right whitespace-nowrap">
                     {canUpdate && (
-                      <button onClick={() => openEdit(form)} className="p-1 text-muted-foreground hover:text-foreground" aria-label="editar">
+                      <Button variant="ghost" size="icon" onClick={() => openEdit(form)} aria-label="editar">
                         <Pencil className="w-4 h-4" />
-                      </button>
+                      </Button>
                     )}
                     {canDelete && (
-                      <button onClick={() => setDeleteTarget(form)} className="p-1 text-destructive" aria-label="excluir">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => setDeleteTarget(form)}
+                        aria-label="excluir"
+                        className="text-destructive"
+                      >
                         <Trash2 className="w-4 h-4" />
-                      </button>
+                      </Button>
                     )}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ))}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       )}
 
@@ -182,11 +191,16 @@ export default function CrmForms() {
             <DialogTitle>Excluir formulário</DialogTitle>
           </DialogHeader>
           <p className="text-sm text-muted-foreground">
-            Tem certeza que deseja excluir “{deleteTarget?.title || deleteTarget?.name}”? Esta ação não pode ser desfeita.
+            Tem certeza que deseja excluir “{deleteTarget?.title || deleteTarget?.name}”? Esta ação não pode
+            ser desfeita.
           </p>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancelar</Button>
-            <Button variant="destructive" onClick={handleDelete}>Excluir</Button>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>
+              Cancelar
+            </Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              Excluir
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Plus, Pencil, Trash2, Copy } from 'lucide-react';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@evoapi/design-system';
+import { useUserPermissions } from '@/hooks/useUserPermissions';
+import { crmFormsService } from '@/services/crmForms/crmFormsService';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import type { CrmForm, CrmFormPayload } from '@/types/crmForms';
+import type { Pipeline } from '@/types/analytics/pipelines';
+import CrmFormModal from '@/components/crmForms/CrmFormModal';
+
+export default function CrmForms() {
+  const { can, isReady } = useUserPermissions();
+  const canCreate = can('crm_forms', 'create');
+  const canUpdate = can('crm_forms', 'update');
+  const canDelete = can('crm_forms', 'delete');
+
+  const [forms, setForms] = useState<CrmForm[]>([]);
+  const [pipelines, setPipelines] = useState<Pipeline[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editing, setEditing] = useState<CrmForm | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CrmForm | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [list, pipes] = await Promise.all([
+        crmFormsService.list(),
+        pipelinesService.getPipelines(),
+      ]);
+      setForms(list);
+      setPipelines(pipes.data);
+    } catch {
+      toast.error('Erro ao carregar formulários.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isReady) load();
+  }, [isReady, load]);
+
+  const openCreate = () => {
+    setEditing(null);
+    setModalOpen(true);
+  };
+  const openEdit = (form: CrmForm) => {
+    setEditing(form);
+    setModalOpen(true);
+  };
+
+  const handleSave = async (payload: CrmFormPayload) => {
+    setSaving(true);
+    try {
+      if (editing) await crmFormsService.update(editing.id, payload);
+      else await crmFormsService.create(payload);
+      toast.success('Formulário salvo.');
+      setModalOpen(false);
+      load();
+    } catch (error: unknown) {
+      const msg = (error as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error
+        ?.message;
+      toast.error(msg || 'Erro ao salvar formulário.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await crmFormsService.remove(deleteTarget.id);
+      toast.success('Formulário excluído.');
+      setDeleteTarget(null);
+      load();
+    } catch {
+      toast.error('Erro ao excluir.');
+    }
+  };
+
+  const copyLink = (form: CrmForm) => {
+    const url = `${window.location.origin}/f/${form.slug}`;
+    navigator.clipboard?.writeText(url);
+    toast.success('Link copiado.');
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Formulários de captura</h1>
+          <p className="text-sm text-muted-foreground">Crie formulários públicos que geram leads no pipeline.</p>
+        </div>
+        {canCreate && (
+          <Button onClick={openCreate}>
+            <Plus className="w-4 h-4 mr-1" /> Novo formulário
+          </Button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        </div>
+      ) : forms.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">Nenhum formulário ainda.</div>
+      ) : (
+        <div className="border border-border rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50 text-muted-foreground">
+              <tr>
+                <th className="text-left font-medium px-4 py-2">Nome</th>
+                <th className="text-left font-medium px-4 py-2">Link público</th>
+                <th className="text-left font-medium px-4 py-2">Status</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {forms.map(form => (
+                <tr key={form.id} className="border-t border-border">
+                  <td className="px-4 py-2 text-foreground">{form.title || form.name}</td>
+                  <td className="px-4 py-2">
+                    <button
+                      onClick={() => copyLink(form)}
+                      className="inline-flex items-center gap-1 text-muted-foreground hover:text-foreground"
+                    >
+                      <Copy className="w-3.5 h-3.5" /> /f/{form.slug}
+                    </button>
+                  </td>
+                  <td className="px-4 py-2">
+                    <span
+                      className={`text-xs px-2 py-0.5 rounded-full ${
+                        form.published
+                          ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+                          : 'bg-muted text-muted-foreground'
+                      }`}
+                    >
+                      {form.published ? 'Publicado' : 'Rascunho'}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-right whitespace-nowrap">
+                    {canUpdate && (
+                      <button onClick={() => openEdit(form)} className="p-1 text-muted-foreground hover:text-foreground" aria-label="editar">
+                        <Pencil className="w-4 h-4" />
+                      </button>
+                    )}
+                    {canDelete && (
+                      <button onClick={() => setDeleteTarget(form)} className="p-1 text-destructive" aria-label="excluir">
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <CrmFormModal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        onSave={handleSave}
+        saving={saving}
+        initial={editing}
+        pipelines={pipelines}
+      />
+
+      <Dialog open={!!deleteTarget} onOpenChange={v => !v && setDeleteTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Excluir formulário</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Tem certeza que deseja excluir “{deleteTarget?.title || deleteTarget?.name}”? Esta ação não pode ser desfeita.
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteTarget(null)}>Cancelar</Button>
+            <Button variant="destructive" onClick={handleDelete}>Excluir</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Customer/Settings/CrmForms/index.ts
+++ b/src/pages/Customer/Settings/CrmForms/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CrmForms';

--- a/src/pages/Public/Chat/ChatPage.tsx
+++ b/src/pages/Public/Chat/ChatPage.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { chatPagesService, ChatPageConfig } from '@/services/public/chatPagesService';
+
+/**
+ * Página pública de chat (B14.03) — resolve o slug, obtém o website_token e
+ * monta o widget de site EXISTENTE via iframe (`/widget?website_token=...`),
+ * sem recriar a UI do widget. Aplica a aparência (logo/cor/título) da config.
+ */
+const PublicChatPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+
+  const [config, setConfig] = useState<ChatPageConfig | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      if (!slug) return;
+      setIsLoading(true);
+      try {
+        const result = await chatPagesService.getPage(slug);
+        setConfig(result);
+        if (result.title) document.title = result.title;
+      } catch (error: unknown) {
+        const status = (error as { response?: { status?: number } })?.response?.status;
+        if (status === 404) setNotFound(true);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchConfig();
+  }, [slug]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  if (notFound || !config) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background p-4">
+        <div className="w-full max-w-lg bg-card rounded-lg shadow-md border border-border p-8 text-center">
+          <p className="text-lg font-medium text-foreground">Página de chat não encontrada</p>
+          <p className="text-sm text-muted-foreground mt-2">O link pode estar incorreto ou indisponível.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const accent = config.appearance?.primary_color;
+  const widgetUrl = `/widget?website_token=${encodeURIComponent(config.website_token)}`;
+
+  return (
+    <div className="flex flex-col h-screen bg-background">
+      <header
+        className="flex items-center gap-3 px-4 py-3 border-b border-border"
+        style={accent ? { backgroundColor: accent } : undefined}
+      >
+        {config.appearance?.logo_url && (
+          <img src={config.appearance.logo_url} alt={config.title || 'logo'} className="h-8 object-contain" />
+        )}
+        {config.title && (
+          <h1 className={`text-base font-semibold ${accent ? 'text-white' : 'text-foreground'}`}>
+            {config.title}
+          </h1>
+        )}
+      </header>
+
+      <main className="flex-1 min-h-0">
+        <iframe
+          src={widgetUrl}
+          title={config.title || 'chat'}
+          className="w-full h-full border-0"
+          allow="microphone; camera; clipboard-write"
+        />
+      </main>
+    </div>
+  );
+};
+
+export default PublicChatPage;

--- a/src/pages/Public/Chat/ChatPage.tsx
+++ b/src/pages/Public/Chat/ChatPage.tsx
@@ -70,6 +70,12 @@ const PublicChatPage = () => {
         )}
       </header>
 
+      {config.description && (
+        <div className="px-4 py-2 border-b border-border bg-background">
+          <p className="text-sm text-muted-foreground">{config.description}</p>
+        </div>
+      )}
+
       <main className="flex-1 min-h-0">
         <iframe
           src={widgetUrl}

--- a/src/pages/Public/Chat/ChatPage.tsx
+++ b/src/pages/Public/Chat/ChatPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import { useLanguage } from '@/hooks/useLanguage';
 import { chatPagesService, ChatPageConfig } from '@/services/public/chatPagesService';
 
 /**
@@ -9,6 +10,8 @@ import { chatPagesService, ChatPageConfig } from '@/services/public/chatPagesSer
  */
 const PublicChatPage = () => {
   const { slug } = useParams<{ slug: string }>();
+  // Public anonymous page — i18n follows the visitor's detected language.
+  const { t } = useLanguage('chatPages');
 
   const [config, setConfig] = useState<ChatPageConfig | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -44,8 +47,8 @@ const PublicChatPage = () => {
     return (
       <div className="flex items-center justify-center min-h-screen bg-background p-4">
         <div className="w-full max-w-lg bg-card rounded-lg shadow-md border border-border p-8 text-center">
-          <p className="text-lg font-medium text-foreground">Página de chat não encontrada</p>
-          <p className="text-sm text-muted-foreground mt-2">O link pode estar incorreto ou indisponível.</p>
+          <p className="text-lg font-medium text-foreground">{t('public.notFoundTitle')}</p>
+          <p className="text-sm text-muted-foreground mt-2">{t('public.notFoundDescription')}</p>
         </div>
       </div>
     );

--- a/src/pages/Public/Form/FormPage.tsx
+++ b/src/pages/Public/Form/FormPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Button } from '@evoapi/design-system';
+import { useLanguage } from '@/hooks/useLanguage';
 import {
   formsService,
   PublicFormConfig,
@@ -15,6 +16,8 @@ const inputClass =
 
 const FormPage = () => {
   const { slug } = useParams<{ slug: string }>();
+  // Public anonymous page — i18n follows the visitor's detected language.
+  const { t } = useLanguage('crmForms');
 
   const [config, setConfig] = useState<PublicFormConfig | null>(null);
   const [values, setValues] = useState<Record<string, unknown>>({ [HONEYPOT_FIELD]: '' });
@@ -38,14 +41,14 @@ const FormPage = () => {
         if (status === 404) {
           setNotFound(true);
         } else {
-          setServerError('Não foi possível carregar o formulário. Tente novamente.');
+          setServerError(t('public.loadError'));
         }
       } finally {
         setIsLoading(false);
       }
     };
     fetchConfig();
-  }, [slug]);
+  }, [slug, t]);
 
   const setValue = (key: string, value: unknown) => {
     setValues(prev => ({ ...prev, [key]: value }));
@@ -64,7 +67,7 @@ const FormPage = () => {
       if (field.required) {
         const value = values[field.key];
         const empty = value === undefined || value === null || String(value).trim() === '' || value === false;
-        if (empty) errors[field.key] = `${field.label || field.key} é obrigatório`;
+        if (empty) errors[field.key] = t('public.requiredField', { label: field.label || field.key });
       }
     });
     setFieldErrors(errors);
@@ -84,7 +87,7 @@ const FormPage = () => {
     } catch (error: unknown) {
       const message =
         (error as { response?: { data?: { error?: string } } })?.response?.data?.error ||
-        'Não foi possível enviar. Verifique os campos e tente novamente.';
+        t('public.submitError');
       setServerError(message);
     } finally {
       setIsSubmitting(false);
@@ -118,7 +121,7 @@ const FormPage = () => {
             onChange={e => setValue(field.key, e.target.value)}
             className={inputClass}
           >
-            <option value="">{field.placeholder || 'Selecione...'}</option>
+            <option value="">{field.placeholder || t('public.selectPlaceholder')}</option>
             {(field.options || []).map(opt => (
               <option key={opt} value={opt}>
                 {opt}
@@ -166,8 +169,8 @@ const FormPage = () => {
     return (
       <div className="flex items-center justify-center min-h-screen bg-background p-4">
         <div className="w-full max-w-lg bg-card rounded-lg shadow-md border border-border p-8 text-center">
-          <p className="text-lg font-medium text-foreground">Formulário não encontrado</p>
-          <p className="text-sm text-muted-foreground mt-2">O link pode estar incorreto ou indisponível.</p>
+          <p className="text-lg font-medium text-foreground">{t('public.notFoundTitle')}</p>
+          <p className="text-sm text-muted-foreground mt-2">{t('public.notFoundDescription')}</p>
         </div>
       </div>
     );
@@ -200,7 +203,7 @@ const FormPage = () => {
           {submitted ? (
             <div className="p-4 rounded-lg bg-green-500/10 text-green-700 dark:text-green-400">
               <p className="text-sm font-medium">
-                {config?.appearance?.success_message || 'Recebemos seus dados. Obrigado!'}
+                {config?.appearance?.success_message || t('public.successMessage')}
               </p>
             </div>
           ) : (
@@ -244,7 +247,7 @@ const FormPage = () => {
                 className="w-full"
                 style={accent ? { backgroundColor: accent, borderColor: accent } : undefined}
               >
-                {isSubmitting ? 'Enviando...' : 'Enviar'}
+                {isSubmitting ? t('public.submitting') : t('public.submit')}
               </Button>
             </form>
           )}

--- a/src/pages/Public/Form/FormPage.tsx
+++ b/src/pages/Public/Form/FormPage.tsx
@@ -1,0 +1,257 @@
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { Button } from '@evoapi/design-system';
+import {
+  formsService,
+  PublicFormConfig,
+  PublicFormField,
+} from '@/services/public/formsService';
+
+// Campo oculto anti-spam (honeypot) — bots preenchem, humanos não veem.
+const HONEYPOT_FIELD = '_hp_url';
+
+const inputClass =
+  'w-full p-3 border border-input rounded-lg bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent';
+
+const FormPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+
+  const [config, setConfig] = useState<PublicFormConfig | null>(null);
+  const [values, setValues] = useState<Record<string, unknown>>({ [HONEYPOT_FIELD]: '' });
+  const [isLoading, setIsLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      if (!slug) return;
+      setIsLoading(true);
+      try {
+        const result = await formsService.getForm(slug);
+        setConfig(result);
+      } catch (error: unknown) {
+        // 404 = inexistente ou rascunho: não vazar, só "não encontrado".
+        const status = (error as { response?: { status?: number } })?.response?.status;
+        if (status === 404) {
+          setNotFound(true);
+        } else {
+          setServerError('Não foi possível carregar o formulário. Tente novamente.');
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchConfig();
+  }, [slug]);
+
+  const setValue = (key: string, value: unknown) => {
+    setValues(prev => ({ ...prev, [key]: value }));
+    setFieldErrors(prev => {
+      if (!prev[key]) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+  };
+
+  const validate = (): boolean => {
+    if (!config) return false;
+    const errors: Record<string, string> = {};
+    config.fields.forEach(field => {
+      if (field.required) {
+        const value = values[field.key];
+        const empty = value === undefined || value === null || String(value).trim() === '' || value === false;
+        if (empty) errors[field.key] = `${field.label || field.key} é obrigatório`;
+      }
+    });
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!slug || !config) return;
+    setServerError(null);
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+    try {
+      await formsService.submit(slug, values);
+      setSubmitted(true);
+    } catch (error: unknown) {
+      const message =
+        (error as { response?: { data?: { error?: string } } })?.response?.data?.error ||
+        'Não foi possível enviar. Verifique os campos e tente novamente.';
+      setServerError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderField = (field: PublicFormField) => {
+    const value = values[field.key];
+    const common = {
+      id: field.key,
+      name: field.key,
+      placeholder: field.placeholder,
+      disabled: isSubmitting,
+    };
+
+    switch (field.type) {
+      case 'textarea':
+        return (
+          <textarea
+            {...common}
+            value={(value as string) || ''}
+            onChange={e => setValue(field.key, e.target.value)}
+            className={`${inputClass} min-h-[100px]`}
+          />
+        );
+      case 'select':
+        return (
+          <select
+            {...common}
+            value={(value as string) || ''}
+            onChange={e => setValue(field.key, e.target.value)}
+            className={inputClass}
+          >
+            <option value="">{field.placeholder || 'Selecione...'}</option>
+            {(field.options || []).map(opt => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        );
+      case 'checkbox':
+        return (
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              id={field.key}
+              name={field.key}
+              checked={Boolean(value)}
+              disabled={isSubmitting}
+              onChange={e => setValue(field.key, e.target.checked)}
+              className="h-4 w-4 rounded border-input"
+            />
+            <span className="text-sm text-foreground">{field.label}</span>
+          </label>
+        );
+      default:
+        return (
+          <input
+            {...common}
+            type={field.type || 'text'}
+            value={(value as string) || ''}
+            onChange={e => setValue(field.key, e.target.value)}
+            className={inputClass}
+          />
+        );
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-background p-4">
+        <div className="w-full max-w-lg bg-card rounded-lg shadow-md border border-border p-8 text-center">
+          <p className="text-lg font-medium text-foreground">Formulário não encontrado</p>
+          <p className="text-sm text-muted-foreground mt-2">O link pode estar incorreto ou indisponível.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const accent = config?.appearance?.primary_color;
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-background p-4">
+      <div className="w-full max-w-lg bg-card rounded-lg shadow-md border border-border">
+        <div className="p-8 space-y-6">
+          {config?.appearance?.logo_url && (
+            <img src={config.appearance.logo_url} alt={config.title} className="h-12 object-contain" />
+          )}
+          {config?.appearance?.image_url && (
+            <img
+              src={config.appearance.image_url}
+              alt={config.title}
+              className="w-full rounded-lg object-cover max-h-48"
+            />
+          )}
+
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">{config?.title}</h1>
+            {config?.description && (
+              <p className="text-sm text-muted-foreground mt-1 leading-relaxed">{config.description}</p>
+            )}
+          </div>
+
+          {submitted ? (
+            <div className="p-4 rounded-lg bg-green-500/10 text-green-700 dark:text-green-400">
+              <p className="text-sm font-medium">
+                {config?.appearance?.success_message || 'Recebemos seus dados. Obrigado!'}
+              </p>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+              {serverError && (
+                <div className="p-4 rounded-lg bg-destructive/10 text-destructive">
+                  <p className="text-sm font-medium">{serverError}</p>
+                </div>
+              )}
+
+              {config?.fields.map(field => (
+                <div key={field.key}>
+                  {field.type !== 'checkbox' && (
+                    <label htmlFor={field.key} className="text-sm font-medium text-muted-foreground mb-2 block">
+                      {field.label}
+                      {field.required && <span className="text-destructive"> *</span>}
+                    </label>
+                  )}
+                  {renderField(field)}
+                  {fieldErrors[field.key] && (
+                    <p className="text-xs text-destructive mt-1">{fieldErrors[field.key]}</p>
+                  )}
+                </div>
+              ))}
+
+              {/* Honeypot anti-spam — escondido de usuários reais */}
+              <input
+                type="text"
+                name={HONEYPOT_FIELD}
+                value={(values[HONEYPOT_FIELD] as string) || ''}
+                onChange={e => setValue(HONEYPOT_FIELD, e.target.value)}
+                tabIndex={-1}
+                autoComplete="off"
+                aria-hidden="true"
+                className="hidden"
+              />
+
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full"
+                style={accent ? { backgroundColor: accent, borderColor: accent } : undefined}
+              >
+                {isSubmitting ? 'Enviando...' : 'Enviar'}
+              </Button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FormPage;

--- a/src/routes/PublicRoute.tsx
+++ b/src/routes/PublicRoute.tsx
@@ -38,8 +38,14 @@ const PublicRoute = ({ children }: PublicRouteProps) => {
   // Redirecionar para página inicial se já estiver autenticado
   // EXCEPT when there are OAuth parameters, specific OAuth routes, widget route, or survey route
   if (isAuthenticated) {
-    // Widget and Survey should always be accessible regardless of auth status
-    if (location.pathname === '/widget' || location.pathname.startsWith('/survey/responses/')) {
+    // Widget, Survey and the anonymous public pages (lead-capture form /f/:slug
+    // and chat /chat/:slug) should always be accessible regardless of auth status
+    if (
+      location.pathname === '/widget' ||
+      location.pathname.startsWith('/survey/responses/') ||
+      location.pathname.startsWith('/f/') ||
+      location.pathname.startsWith('/chat/')
+    ) {
       return <>{children}</>;
     }
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -64,6 +64,7 @@ import MessageTemplates from '@/pages/Customer/Settings/MessageTemplates';
 import { Macros } from '@/pages/Customer/Settings/Macros';
 import Products from '@/pages/Customer/Settings/Products';
 import CrmForms from '@/pages/Customer/Settings/CrmForms';
+import ChatPages from '@/pages/Customer/Settings/ChatPages';
 import Templates from '@/pages/Customer/Settings/Templates/Templates';
 import { Integrations } from '@/pages/Customer/Settings/Integrations';
 import EmailTemplateEditor from '@/pages/Customer/Settings/EmailTemplateEditor';
@@ -801,6 +802,21 @@ const AppRouter = () => {
                   <MainLayout>
                     <PermissionRoute resource="crm_forms" action="read">
                       <CrmForms />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/settings/chat-pages"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="chat_pages" action="read">
+                      <ChatPages />
                     </PermissionRoute>
                   </MainLayout>
                 </CustomerRoute>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -26,6 +26,7 @@ import MondayCallback from '@/pages/MondayCallback';
 import AtlassianCallback from '@/pages/AtlassianCallback';
 import MicrosoftCallback from '@/pages/MicrosoftCallback';
 import SurveyResponse from '@/pages/Public/Survey/SurveyResponse';
+import PublicChatPage from '@/pages/Public/Chat/ChatPage';
 
 // Páginas customer
 import Dashboard from '@/pages/Customer/Dashboard';
@@ -372,6 +373,16 @@ const AppRouter = () => {
             element={
               <PublicRoute>
                 <SurveyResponse />
+              </PublicRoute>
+            }
+          />
+
+          {/* Public chat page route (B14.03) */}
+          <Route
+            path="/chat/:slug"
+            element={
+              <PublicRoute>
+                <PublicChatPage />
               </PublicRoute>
             }
           />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -27,6 +27,7 @@ import AtlassianCallback from '@/pages/AtlassianCallback';
 import MicrosoftCallback from '@/pages/MicrosoftCallback';
 import SurveyResponse from '@/pages/Public/Survey/SurveyResponse';
 import PublicChatPage from '@/pages/Public/Chat/ChatPage';
+import FormPage from '@/pages/Public/Form/FormPage';
 
 // Páginas customer
 import Dashboard from '@/pages/Customer/Dashboard';
@@ -373,6 +374,16 @@ const AppRouter = () => {
             element={
               <PublicRoute>
                 <SurveyResponse />
+              </PublicRoute>
+            }
+          />
+
+          {/* Public lead-capture form route (B14.02) */}
+          <Route
+            path="/f/:slug"
+            element={
+              <PublicRoute>
+                <FormPage />
               </PublicRoute>
             }
           />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -772,7 +772,7 @@ const AppRouter = () => {
           />
 
           <Route
-            path="/crm-forms"
+            path="/settings/crm-forms"
             element={
               <PrivateRoute>
                 <CustomerRoute>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -61,6 +61,7 @@ import CannedResponses from '@/pages/Customer/Settings/CannedResponses';
 import MessageTemplates from '@/pages/Customer/Settings/MessageTemplates';
 import { Macros } from '@/pages/Customer/Settings/Macros';
 import Products from '@/pages/Customer/Settings/Products';
+import CrmForms from '@/pages/Customer/Settings/CrmForms';
 import Templates from '@/pages/Customer/Settings/Templates/Templates';
 import { Integrations } from '@/pages/Customer/Settings/Integrations';
 import EmailTemplateEditor from '@/pages/Customer/Settings/EmailTemplateEditor';
@@ -763,6 +764,21 @@ const AppRouter = () => {
                   <MainLayout>
                     <PermissionRoute resource="products" action="read">
                       <Products />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/crm-forms"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="crm_forms" action="read">
+                      <CrmForms />
                     </PermissionRoute>
                   </MainLayout>
                 </CustomerRoute>

--- a/src/services/chatPages/chatPagesService.ts
+++ b/src/services/chatPages/chatPagesService.ts
@@ -32,12 +32,13 @@ class ChatPagesService {
 
   async create(payload: ChatPagePayload): Promise<ChatPage> {
     const response = await api.post(this.baseUrl, { chat_page: payload });
-    return extractData<{ data: ChatPage }>(response).data;
+    // extractData already unwraps { success, data } -> the serialized page.
+    return extractData<ChatPage>(response);
   }
 
   async update(id: string, payload: ChatPagePayload): Promise<ChatPage> {
     const response = await api.patch(`${this.baseUrl}/${id}`, { chat_page: payload });
-    return extractData<{ data: ChatPage }>(response).data;
+    return extractData<ChatPage>(response);
   }
 
   async remove(id: string): Promise<void> {

--- a/src/services/chatPages/chatPagesService.ts
+++ b/src/services/chatPages/chatPagesService.ts
@@ -1,0 +1,62 @@
+import api from '@/services/core/api';
+import { extractData, extractResponse } from '@/utils/apiHelpers';
+import { ChatPage, ChatPagePayload, PaginationMeta, WebWidgetOption } from '@/types/chatPages';
+
+interface InboxLike {
+  id: string;
+  name: string;
+  channel_type?: string;
+  website_token?: string;
+}
+
+/**
+ * Service para o CRUD admin de páginas de chat (B14.08 / EVO-1847).
+ * Usa o client autenticado e consome /api/v1/chat_pages.
+ *
+ * As chat pages embutem um web widget existente; o select do builder reusa
+ * GET /api/v1/inboxes filtrando os inboxes do tipo web widget.
+ */
+class ChatPagesService {
+  private readonly baseUrl = '/chat_pages';
+
+  async list(params?: {
+    page?: number;
+    pageSize?: number;
+    search?: string;
+    published?: boolean;
+  }): Promise<{ data: ChatPage[]; meta: { pagination?: PaginationMeta } }> {
+    const response = await api.get(this.baseUrl, { params });
+    const env = extractResponse<ChatPage>(response);
+    return { data: env.data, meta: env.meta };
+  }
+
+  async create(payload: ChatPagePayload): Promise<ChatPage> {
+    const response = await api.post(this.baseUrl, { chat_page: payload });
+    return extractData<{ data: ChatPage }>(response).data;
+  }
+
+  async update(id: string, payload: ChatPagePayload): Promise<ChatPage> {
+    const response = await api.patch(`${this.baseUrl}/${id}`, { chat_page: payload });
+    return extractData<{ data: ChatPage }>(response).data;
+  }
+
+  async remove(id: string): Promise<void> {
+    await api.delete(`${this.baseUrl}/${id}`);
+  }
+
+  // Existing web-widget inboxes available to embed (id + name + website_token).
+  async listWebWidgets(): Promise<WebWidgetOption[]> {
+    const response = await api.get('/inboxes');
+    const env = extractResponse<InboxLike>(response);
+    return (env.data || [])
+      .filter((inbox) => inbox.channel_type === 'Channel::WebWidget' && !!inbox.website_token)
+      .map((inbox) => ({
+        inbox_id: inbox.id,
+        name: inbox.name,
+        website_token: inbox.website_token as string,
+      }));
+  }
+}
+
+export const chatPagesService = new ChatPagesService();
+export default chatPagesService;

--- a/src/services/crmForms/crmFormTargets.ts
+++ b/src/services/crmForms/crmFormTargets.ts
@@ -1,0 +1,118 @@
+import type { CustomAttributeDefinition } from '@/types/settings';
+import type { CrmFormField, CrmFieldType } from '@/types/crmForms';
+
+// Maps the builder's mapping UI <-> the backend flat schema (maps_to + maps_to_key),
+// keeping the set of targets the admin can pick === what the public submission accepts.
+
+const STD = ['name', 'email', 'phone', 'company'];
+
+export interface TargetOption {
+  value: string;
+  label: string;
+}
+export interface TargetGroup {
+  label: string;
+  options: TargetOption[];
+}
+
+export const NONE_TARGET = 'none';
+
+/** Encode a field's mapping into a single select value. */
+export function encodeTarget(field: CrmFormField): string {
+  const mt = field.maps_to || '';
+  const key = field.maps_to_key || '';
+  if (!mt) return NONE_TARGET;
+  if (STD.includes(mt)) return `contact:${mt}`; // legacy standard-field string
+  switch (mt) {
+    case 'contact':
+      return `contact:${key}`;
+    case 'contact_attribute':
+      return `cattr:${key}`;
+    case 'deal_value':
+      return 'deal_value';
+    case 'deal_attribute':
+      return `dattr:${key}`;
+    default:
+      return NONE_TARGET;
+  }
+}
+
+/** Decode a select value into the backend flat schema. */
+export function decodeTarget(value: string): { maps_to: string; maps_to_key: string } {
+  if (!value || value === NONE_TARGET) return { maps_to: '', maps_to_key: '' };
+  if (value === 'deal_value') return { maps_to: 'deal_value', maps_to_key: '' };
+  const [prefix, ...rest] = value.split(':');
+  const key = rest.join(':');
+  if (prefix === 'contact') return { maps_to: 'contact', maps_to_key: key };
+  if (prefix === 'cattr') return { maps_to: 'contact_attribute', maps_to_key: key };
+  if (prefix === 'dattr') return { maps_to: 'deal_attribute', maps_to_key: key };
+  return { maps_to: '', maps_to_key: '' };
+}
+
+/** Grouped target options built from the available context definitions. */
+export function buildTargetGroups(
+  contactAttrs: CustomAttributeDefinition[],
+  dealAttrs: CustomAttributeDefinition[],
+): TargetGroup[] {
+  return [
+    {
+      label: 'Contato',
+      options: [
+        { value: 'contact:name', label: 'Nome' },
+        { value: 'contact:email', label: 'E-mail' },
+        { value: 'contact:phone', label: 'Telefone' },
+        { value: 'contact:company', label: 'Empresa' },
+      ],
+    },
+    {
+      label: 'Contato — campos personalizados',
+      options: contactAttrs.map(a => ({
+        value: `cattr:${a.attribute_key}`,
+        label: a.attribute_display_name || a.attribute_key,
+      })),
+    },
+    {
+      label: 'Negócio',
+      options: [{ value: 'deal_value', label: 'Valor' }],
+    },
+    {
+      label: 'Negócio — campos personalizados',
+      options: dealAttrs.map(a => ({
+        value: `dattr:${a.attribute_key}`,
+        label: a.attribute_display_name || a.attribute_key,
+      })),
+    },
+  ].filter(g => g.options.length > 0);
+}
+
+/** Suggest a form field type (and options) from a custom attribute's display type. */
+export function suggestFieldFromAttribute(attr: CustomAttributeDefinition): {
+  type: CrmFieldType;
+  options?: string[];
+} {
+  switch (attr.attribute_display_type) {
+    case 'number':
+    case 'currency':
+    case 'percent':
+      return { type: 'number' };
+    case 'checkbox':
+      return { type: 'checkbox' };
+    case 'list':
+      return { type: 'select', options: attr.attribute_values || [] };
+    default:
+      return { type: 'text' };
+  }
+}
+
+/** Find the custom attribute definition behind a target value, if any. */
+export function attrForTarget(
+  value: string,
+  contactAttrs: CustomAttributeDefinition[],
+  dealAttrs: CustomAttributeDefinition[],
+): CustomAttributeDefinition | undefined {
+  const [prefix, ...rest] = value.split(':');
+  const key = rest.join(':');
+  if (prefix === 'cattr') return contactAttrs.find(a => a.attribute_key === key);
+  if (prefix === 'dattr') return dealAttrs.find(a => a.attribute_key === key);
+  return undefined;
+}

--- a/src/services/crmForms/crmFormTargets.ts
+++ b/src/services/crmForms/crmFormTargets.ts
@@ -49,34 +49,37 @@ export function decodeTarget(value: string): { maps_to: string; maps_to_key: str
   return { maps_to: '', maps_to_key: '' };
 }
 
+type Translator = (key: string) => string;
+
 /** Grouped target options built from the available context definitions. */
 export function buildTargetGroups(
   contactAttrs: CustomAttributeDefinition[],
   dealAttrs: CustomAttributeDefinition[],
+  t: Translator,
 ): TargetGroup[] {
   return [
     {
-      label: 'Contato',
+      label: t('modal.targets.groupContact'),
       options: [
-        { value: 'contact:name', label: 'Nome' },
-        { value: 'contact:email', label: 'E-mail' },
-        { value: 'contact:phone', label: 'Telefone' },
-        { value: 'contact:company', label: 'Empresa' },
+        { value: 'contact:name', label: t('modal.targets.contactName') },
+        { value: 'contact:email', label: t('modal.targets.contactEmail') },
+        { value: 'contact:phone', label: t('modal.targets.contactPhone') },
+        { value: 'contact:company', label: t('modal.targets.contactCompany') },
       ],
     },
     {
-      label: 'Contato — campos personalizados',
+      label: t('modal.targets.groupContactCustom'),
       options: contactAttrs.map(a => ({
         value: `cattr:${a.attribute_key}`,
         label: a.attribute_display_name || a.attribute_key,
       })),
     },
     {
-      label: 'Negócio',
-      options: [{ value: 'deal_value', label: 'Valor' }],
+      label: t('modal.targets.groupDeal'),
+      options: [{ value: 'deal_value', label: t('modal.targets.dealValue') }],
     },
     {
-      label: 'Negócio — campos personalizados',
+      label: t('modal.targets.groupDealCustom'),
       options: dealAttrs.map(a => ({
         value: `dattr:${a.attribute_key}`,
         label: a.attribute_display_name || a.attribute_key,

--- a/src/services/crmForms/crmFormsService.ts
+++ b/src/services/crmForms/crmFormsService.ts
@@ -1,6 +1,6 @@
 import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
-import { CrmForm, CrmFormPayload } from '@/types/crmForms';
+import { CrmForm, CrmFormPayload, FormLead } from '@/types/crmForms';
 
 /**
  * Service para o CRUD admin de formulários de captura de lead (B14.04 / EVO-1841).
@@ -26,6 +26,12 @@ class CrmFormsService {
 
   async remove(id: string): Promise<void> {
     await api.delete(`${this.baseUrl}/${id}`);
+  }
+
+  async getLeads(id: string): Promise<{ leads: FormLead[]; count: number }> {
+    const response = await api.get(`${this.baseUrl}/${id}/leads`);
+    const env = extractResponse<FormLead>(response);
+    return { leads: env.data, count: (env.meta?.count as number) ?? env.data.length };
   }
 }
 

--- a/src/services/crmForms/crmFormsService.ts
+++ b/src/services/crmForms/crmFormsService.ts
@@ -1,0 +1,33 @@
+import api from '@/services/core/api';
+import { extractData, extractResponse } from '@/utils/apiHelpers';
+import { CrmForm, CrmFormPayload } from '@/types/crmForms';
+
+/**
+ * Service para o CRUD admin de formulários de captura de lead (B14.04 / EVO-1841).
+ * Usa o client autenticado e consome /api/v1/crm_forms (entregue no B14.01).
+ */
+class CrmFormsService {
+  private readonly baseUrl = '/crm_forms';
+
+  async list(): Promise<CrmForm[]> {
+    const response = await api.get(this.baseUrl);
+    return extractResponse<CrmForm>(response).data;
+  }
+
+  async create(payload: CrmFormPayload): Promise<CrmForm> {
+    const response = await api.post(this.baseUrl, { crm_form: payload });
+    return extractData<{ data: CrmForm }>(response).data;
+  }
+
+  async update(id: string, payload: CrmFormPayload): Promise<CrmForm> {
+    const response = await api.patch(`${this.baseUrl}/${id}`, { crm_form: payload });
+    return extractData<{ data: CrmForm }>(response).data;
+  }
+
+  async remove(id: string): Promise<void> {
+    await api.delete(`${this.baseUrl}/${id}`);
+  }
+}
+
+export const crmFormsService = new CrmFormsService();
+export default crmFormsService;

--- a/src/services/crmForms/crmFormsService.ts
+++ b/src/services/crmForms/crmFormsService.ts
@@ -1,6 +1,6 @@
 import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
-import { CrmForm, CrmFormPayload, FormLead } from '@/types/crmForms';
+import { CrmForm, CrmFormPayload, FormLead, PaginationMeta } from '@/types/crmForms';
 
 /**
  * Service para o CRUD admin de formulários de captura de lead (B14.04 / EVO-1841).
@@ -9,9 +9,15 @@ import { CrmForm, CrmFormPayload, FormLead } from '@/types/crmForms';
 class CrmFormsService {
   private readonly baseUrl = '/crm_forms';
 
-  async list(): Promise<CrmForm[]> {
-    const response = await api.get(this.baseUrl);
-    return extractResponse<CrmForm>(response).data;
+  async list(params?: {
+    page?: number;
+    pageSize?: number;
+    search?: string;
+    published?: boolean;
+  }): Promise<{ data: CrmForm[]; meta: { pagination?: PaginationMeta } }> {
+    const response = await api.get(this.baseUrl, { params });
+    const env = extractResponse<CrmForm>(response);
+    return { data: env.data, meta: env.meta };
   }
 
   async create(payload: CrmFormPayload): Promise<CrmForm> {

--- a/src/services/crmForms/crmFormsService.ts
+++ b/src/services/crmForms/crmFormsService.ts
@@ -22,12 +22,13 @@ class CrmFormsService {
 
   async create(payload: CrmFormPayload): Promise<CrmForm> {
     const response = await api.post(this.baseUrl, { crm_form: payload });
-    return extractData<{ data: CrmForm }>(response).data;
+    // extractData already unwraps { success, data } -> the serialized form.
+    return extractData<CrmForm>(response);
   }
 
   async update(id: string, payload: CrmFormPayload): Promise<CrmForm> {
     const response = await api.patch(`${this.baseUrl}/${id}`, { crm_form: payload });
-    return extractData<{ data: CrmForm }>(response).data;
+    return extractData<CrmForm>(response);
   }
 
   async remove(id: string): Promise<void> {

--- a/src/services/public/chatPagesService.ts
+++ b/src/services/public/chatPagesService.ts
@@ -8,6 +8,7 @@ export interface ChatPageAppearance {
 export interface ChatPageConfig {
   slug: string;
   title?: string;
+  description?: string;
   appearance: ChatPageAppearance;
   website_token: string;
 }

--- a/src/services/public/chatPagesService.ts
+++ b/src/services/public/chatPagesService.ts
@@ -1,0 +1,30 @@
+import apiPublic from '@/services/core/apiPublic';
+
+export interface ChatPageAppearance {
+  primary_color?: string;
+  logo_url?: string;
+}
+
+export interface ChatPageConfig {
+  slug: string;
+  title?: string;
+  appearance: ChatPageAppearance;
+  website_token: string;
+}
+
+/**
+ * Service para a API pública (anônima) de páginas de chat (B14.03).
+ * Endpoint: GET /public/api/v1/chat_pages/:slug — resolve o slug e devolve o
+ * website_token do widget para montar o widget existente. Sem autenticação.
+ */
+class ChatPagesService {
+  private baseURL = '/chat_pages';
+
+  async getPage(slug: string): Promise<ChatPageConfig> {
+    const { data } = await apiPublic.get<{ data: ChatPageConfig }>(`${this.baseURL}/${slug}`);
+    return data.data;
+  }
+}
+
+export const chatPagesService = new ChatPagesService();
+export default chatPagesService;

--- a/src/services/public/formsService.ts
+++ b/src/services/public/formsService.ts
@@ -1,0 +1,57 @@
+import apiPublic from '@/services/core/apiPublic';
+
+export interface PublicFormField {
+  key: string;
+  label?: string;
+  type: string; // text | email | tel | number | textarea | select | checkbox
+  required: boolean;
+  placeholder?: string;
+  options?: string[];
+}
+
+export interface PublicFormAppearance {
+  primary_color?: string;
+  logo_url?: string;
+  image_url?: string;
+  success_message?: string;
+}
+
+export interface PublicFormConfig {
+  slug: string;
+  title: string;
+  description?: string;
+  appearance: PublicFormAppearance;
+  fields: PublicFormField[];
+}
+
+export interface FormSubmissionResult {
+  success: boolean;
+  lead_id?: string;
+  deal_id?: string;
+  message?: string;
+}
+
+/**
+ * Service para a API pública (anônima) de formulários de captura de lead (B14.02).
+ * Endpoints: GET /public/api/v1/forms/:slug e POST .../submissions.
+ * Não requer autenticação — o slug resolve o formulário/tenant.
+ */
+class FormsService {
+  private baseURL = '/forms';
+
+  async getForm(slug: string): Promise<PublicFormConfig> {
+    const { data } = await apiPublic.get<{ data: PublicFormConfig }>(`${this.baseURL}/${slug}`);
+    return data.data;
+  }
+
+  async submit(slug: string, values: Record<string, unknown>): Promise<FormSubmissionResult> {
+    const { data } = await apiPublic.post<FormSubmissionResult>(
+      `${this.baseURL}/${slug}/submissions`,
+      { submission: values },
+    );
+    return data;
+  }
+}
+
+export const formsService = new FormsService();
+export default formsService;

--- a/src/types/chatPages.ts
+++ b/src/types/chatPages.ts
@@ -1,0 +1,44 @@
+export interface ChatPageAppearance {
+  primary_color?: string;
+  logo_url?: string;
+}
+
+export interface ChatPage {
+  id: string;
+  slug: string;
+  title?: string;
+  display_title?: string;
+  description?: string;
+  appearance: ChatPageAppearance;
+  website_token: string;
+  widget_inbox_name?: string;
+  published: boolean;
+  public_path?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface PaginationMeta {
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+  has_next_page?: boolean;
+  has_previous_page?: boolean;
+}
+
+// A web widget the chat page can embed — derived from an existing web-widget inbox.
+export interface WebWidgetOption {
+  inbox_id: string;
+  name: string;
+  website_token: string;
+}
+
+export interface ChatPagePayload {
+  slug?: string;
+  title?: string;
+  description?: string;
+  appearance?: ChatPageAppearance;
+  website_token: string;
+  published?: boolean;
+}

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -1,0 +1,57 @@
+export type CrmFieldType = 'text' | 'email' | 'tel' | 'number' | 'textarea' | 'select' | 'checkbox';
+export type FieldMapsTo = 'name' | 'email' | 'phone' | 'company' | '';
+export type RoutingOp = 'equals' | 'not_equals' | 'contains';
+
+export interface CrmFormField {
+  key: string;
+  label?: string;
+  type: CrmFieldType;
+  required?: boolean;
+  placeholder?: string;
+  maps_to?: FieldMapsTo;
+  options?: string[];
+}
+
+export interface RoutingRule {
+  field?: string;
+  op?: RoutingOp;
+  value?: string;
+  pipeline_id: string;
+  stage_id?: string;
+}
+
+export interface CrmFormAppearance {
+  primary_color?: string;
+  logo_url?: string;
+  image_url?: string;
+  success_message?: string;
+}
+
+export interface CrmForm {
+  id: string;
+  name: string;
+  slug: string;
+  title?: string;
+  description?: string;
+  appearance: CrmFormAppearance;
+  fields: CrmFormField[];
+  routing_rules: RoutingRule[];
+  default_pipeline_id: string;
+  default_stage_id?: string;
+  published: boolean;
+  public_path?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CrmFormPayload {
+  name: string;
+  title?: string;
+  description?: string;
+  appearance?: CrmFormAppearance;
+  fields: CrmFormField[];
+  routing_rules?: RoutingRule[];
+  default_pipeline_id: string;
+  default_stage_id?: string;
+  published?: boolean;
+}

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -1,5 +1,7 @@
 export type CrmFieldType = 'text' | 'email' | 'tel' | 'number' | 'textarea' | 'select' | 'checkbox';
-export type FieldMapsTo = 'name' | 'email' | 'phone' | 'company' | '';
+// Typed mapping kind. `maps_to` may also hold a legacy standard-field string
+// ('name'|'email'|'phone'|'company') for forms created before B14.06.
+export type MapKind = 'contact' | 'contact_attribute' | 'deal_value' | 'deal_attribute';
 export type RoutingOp = 'equals' | 'not_equals' | 'contains';
 
 export interface CrmFormField {
@@ -8,7 +10,8 @@ export interface CrmFormField {
   type: CrmFieldType;
   required?: boolean;
   placeholder?: string;
-  maps_to?: FieldMapsTo;
+  maps_to?: string; // MapKind (or legacy standard-field string)
+  maps_to_key?: string; // attribute/standard key for the chosen kind
   options?: string[];
 }
 

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -43,8 +43,17 @@ export interface CrmForm {
   default_stage_id?: string;
   published: boolean;
   public_path?: string;
+  leads_count?: number;
   created_at?: string;
   updated_at?: string;
+}
+
+export interface FormLead {
+  id: string;
+  contact?: { id: string; name?: string; email?: string } | null;
+  pipeline_id?: string;
+  pipeline_stage_id?: string;
+  created_at?: string;
 }
 
 export interface CrmFormPayload {

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -48,6 +48,15 @@ export interface CrmForm {
   updated_at?: string;
 }
 
+export interface PaginationMeta {
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+  has_next_page?: boolean;
+  has_previous_page?: boolean;
+}
+
 export interface FormLead {
   id: string;
   contact?: { id: string; name?: string; email?: string } | null;


### PR DESCRIPTION
## Summary

Frontend do **B14 — CRM Lead Capture**, consolidado sob a tarefa pai **EVO-1771**.

### Form (lead capture)
- Builder admin `/settings/crm-forms` (lista padrão Labels/Roles — busca, filtro status, paginação) + modal padrão ContactModal (campos, mapeamento dirigido por contexto, aparência, **pipeline/estágio default + regras de roteamento**) + visualizador de leads por form.
- Página pública anônima `/f/:slug` (renderiza campos/aparência, submete pro endpoint, 404 em draft).

### Chat
- Builder admin `/settings/chat-pages` (mesma grid/modal) — título, descrição, aparência e **escolher o web widget** a embutir (reusa `/api/v1/inboxes` filtrando web widgets).
- Página pública anônima `/chat/:slug` (header + **description como intro** + iframe do widget existente — "bem simples" conforme spec do TL).

### Transversal
- i18n completo (namespaces `crmForms` + `chatPages`, 6 locales, parity en↔pt-BR verde).
- `useUserPermissions`: bypass de super_admin (vê tudo).
- **fix(routes):** `PublicRoute` redirecionava usuário logado pra `/` em rotas públicas → `/f/:slug` e `/chat/:slug` quebravam; allowlist dos dois prefixos (igual `/widget`,`/survey`).

## Test plan
- `tsc --noEmit` limpo; `eslint` limpo nos arquivos novos.
- i18n-parity verde (única falha = `channels.json`, pré-existente na develop).
- E2E ao vivo (vite nativo): `/settings/crm-forms` e `/settings/chat-pages` listam/criam; `/f/demo-roteamento` e `/chat/atendimento-demo` renderizam.
- Merge com develop (CSV bulk import de Products) resolvido em `routes/index.tsx` (rotas crm-forms + chat-pages + products/import coexistindo).

## Notas
Depende do PR do evo-ai-crm-community (endpoints `/api/v1/crm_forms` e `/api/v1/chat_pages`) e do RBAC no evo-auth-service.
