### PR TITLE
feat(frontend): custom attribute action in automation builder (EVO-1751)

### DIFF
--- a/src/components/automation/ActionRow.spec.tsx
+++ b/src/components/automation/ActionRow.spec.tsx
@@ -21,6 +21,7 @@ const emptyFormData: AutomationFormData = {
   messageTypes: [],
   cannedResponses: [],
   messageTemplates: [],
+  customAttributes: [],
 };
 
 function Wrapper({

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -591,6 +591,7 @@ function CustomAttributeParam({
 
         const pickAttribute = (value: string) => {
           const sep = value.indexOf('::');
+          if (sep === -1) return;
           const model = value.slice(0, sep);
           const key = value.slice(sep + 2);
           field.onChange([{ custom_attribute_key: key, custom_attribute_model: model, custom_attribute_value: '' }]);

--- a/src/components/automation/ActionRow.tsx
+++ b/src/components/automation/ActionRow.tsx
@@ -20,6 +20,16 @@ import {
 import type { AutomationFormData } from '@/hooks/automation/useAutomationFormData';
 import type { AutomationActionType } from '@/types/automation';
 import type { MessageTemplateVariable } from '@/hooks/automation/useAutomationFormData';
+import CustomAttributeValueInput from './CustomAttributeValueInput';
+
+// Custom attribute models that map to a concrete record in automation scope and
+// can therefore be written by the update_custom_attribute action (EVO-1751).
+// pipeline / pipeline_stage attributes are config-level (no per-run record).
+const UPDATABLE_ATTRIBUTE_MODELS: string[] = [
+  'conversation_attribute',
+  'contact_attribute',
+  'pipeline_item_attribute',
+];
 
 interface Props {
   control: Control<AutomationRuleFormData>;
@@ -477,6 +487,9 @@ function ActionParamsRenderer({ control, index, actionName, formData, t }: Param
         />
       );
 
+    case 'update_custom_attribute':
+      return <CustomAttributeParam control={control} index={index} formData={formData} t={t} />;
+
     default:
       return null;
   }
@@ -538,6 +551,82 @@ function SelectParam({ control, index, options, placeholder, coerce = 'single' }
               ))}
             </SelectContent>
           </Select>
+        );
+      }}
+    />
+  );
+}
+
+function CustomAttributeParam({
+  control,
+  index,
+  formData,
+  t,
+}: {
+  control: Control<AutomationRuleFormData>;
+  index: number;
+  formData: AutomationFormData;
+  t: (key: string) => string;
+}) {
+  const options = formData.customAttributes.filter((attr) =>
+    UPDATABLE_ATTRIBUTE_MODELS.includes(attr.attribute_model),
+  );
+
+  return (
+    <Controller
+      control={control}
+      name={`actions.${index}.action_params`}
+      render={({ field }) => {
+        const current = (Array.isArray(field.value) ? field.value[0] : undefined) as
+          | { custom_attribute_key?: string; custom_attribute_model?: string; custom_attribute_value?: string }
+          | undefined;
+        const selectedKey = current?.custom_attribute_key ?? '';
+        const selectedModel = current?.custom_attribute_model ?? '';
+        const selectedAttribute = options.find(
+          (attr) => attr.attribute_key === selectedKey && attr.attribute_model === selectedModel,
+        );
+        const composite = selectedAttribute
+          ? `${selectedAttribute.attribute_model}::${selectedAttribute.attribute_key}`
+          : '';
+
+        const pickAttribute = (value: string) => {
+          const sep = value.indexOf('::');
+          const model = value.slice(0, sep);
+          const key = value.slice(sep + 2);
+          field.onChange([{ custom_attribute_key: key, custom_attribute_model: model, custom_attribute_value: '' }]);
+        };
+        const setValue = (value: string) => {
+          field.onChange([
+            { custom_attribute_key: selectedKey, custom_attribute_model: selectedModel, custom_attribute_value: value },
+          ]);
+        };
+
+        return (
+          <div className="space-y-2">
+            <Select value={composite} onValueChange={pickAttribute}>
+              <SelectTrigger>
+                <SelectValue placeholder={t('form.fields.actionRow.params.update_custom_attribute')} />
+              </SelectTrigger>
+              <SelectContent>
+                {options.map((attr) => (
+                  <SelectItem
+                    key={`${attr.attribute_model}::${attr.attribute_key}`}
+                    value={`${attr.attribute_model}::${attr.attribute_key}`}
+                  >
+                    {`${attr.attribute_display_name} · ${t(`form.fields.customAttributeModels.${attr.attribute_model}`)}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selectedAttribute && (
+              <CustomAttributeValueInput
+                attribute={selectedAttribute}
+                value={current?.custom_attribute_value ?? ''}
+                onChange={setValue}
+                placeholder={t('form.fields.actionRow.params.update_custom_attribute_value')}
+              />
+            )}
+          </div>
         );
       }}
     />

--- a/src/components/automation/ConditionRow.tsx
+++ b/src/components/automation/ConditionRow.tsx
@@ -27,7 +27,10 @@ interface Props {
   onRemove: () => void;
 }
 
-const optionLoaderToData: Record<string, keyof AutomationFormData> = {
+// customAttributes is a value-editor data source (actions side), never a
+// condition option-loader target — exclude it so formData[optionsKey] stays a
+// union of {id,name} option lists.
+const optionLoaderToData: Record<string, Exclude<keyof AutomationFormData, 'customAttributes'>> = {
   pipelines: 'pipelines',
   pipeline_stages: 'pipelineStages',
   agents: 'agents',

--- a/src/components/automation/CustomAttributeValueInput.spec.tsx
+++ b/src/components/automation/CustomAttributeValueInput.spec.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CustomAttributeValueInput from './CustomAttributeValueInput';
+import { actionRegistry } from '@/pages/Customer/Automation/registries/actionRegistry';
+import type { CustomAttributeDefinition } from '@/types/settings';
+
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill as never);
+
+const attr = (overrides: Partial<CustomAttributeDefinition>): CustomAttributeDefinition => ({
+  id: '1',
+  attribute_display_name: 'Attr',
+  attribute_display_type: 'text',
+  attribute_key: 'attr',
+  attribute_model: 'contact_attribute',
+  created_at: '',
+  updated_at: '',
+  ...overrides,
+});
+
+describe('CustomAttributeValueInput', () => {
+  it('renders a text input for text attributes', () => {
+    const { container } = render(
+      <CustomAttributeValueInput attribute={attr({ attribute_display_type: 'text' })} value="hi" onChange={() => {}} />,
+    );
+    const input = container.querySelector('input');
+    expect(input?.type).toBe('text');
+    expect(input?.value).toBe('hi');
+  });
+
+  it('renders a number input for numeric attributes', () => {
+    const { container } = render(
+      <CustomAttributeValueInput attribute={attr({ attribute_display_type: 'currency' })} value="" onChange={() => {}} />,
+    );
+    expect(container.querySelector('input')?.type).toBe('number');
+  });
+
+  it('renders a date input for date attributes', () => {
+    const { container } = render(
+      <CustomAttributeValueInput attribute={attr({ attribute_display_type: 'date' })} value="" onChange={() => {}} />,
+    );
+    expect(container.querySelector('input')?.type).toBe('date');
+  });
+
+  it('renders a checkbox and emits string booleans', () => {
+    const onChange = vi.fn();
+    render(
+      <CustomAttributeValueInput
+        attribute={attr({ attribute_display_type: 'checkbox' })}
+        value="false"
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith('true');
+  });
+});
+
+describe('update_custom_attribute action schema', () => {
+  const schema = actionRegistry.update_custom_attribute.schema;
+
+  it('accepts a key + model with an empty value (empty = set empty)', () => {
+    expect(
+      schema.safeParse([
+        { custom_attribute_key: 'cpf', custom_attribute_model: 'contact_attribute', custom_attribute_value: '' },
+      ]).success,
+    ).toBe(true);
+  });
+
+  it('rejects an empty attribute key', () => {
+    expect(
+      schema.safeParse([
+        { custom_attribute_key: '', custom_attribute_model: 'contact_attribute', custom_attribute_value: 'x' },
+      ]).success,
+    ).toBe(false);
+  });
+});

--- a/src/components/automation/CustomAttributeValueInput.tsx
+++ b/src/components/automation/CustomAttributeValueInput.tsx
@@ -1,0 +1,73 @@
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Checkbox,
+} from '@evoapi/design-system';
+import type { CustomAttributeDefinition } from '@/types/settings';
+
+interface Props {
+  attribute: CustomAttributeDefinition;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+const NUMERIC_TYPES = ['number', 'currency', 'percent'];
+
+// Renders the value editor for a custom attribute based on its display type.
+// The value is always handled as a string (the automation action stores it
+// verbatim; backend casts at read/query time), mirroring the journey panel.
+export default function CustomAttributeValueInput({ attribute, value, onChange, placeholder }: Props) {
+  const type = attribute.attribute_display_type;
+
+  if (type === 'checkbox') {
+    return (
+      <Checkbox
+        checked={value === 'true'}
+        onCheckedChange={(checked) => onChange(checked === true ? 'true' : 'false')}
+        aria-label={attribute.attribute_display_name}
+      />
+    );
+  }
+
+  if (type === 'list') {
+    return (
+      <Select value={value || ''} onValueChange={onChange}>
+        <SelectTrigger>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {(attribute.attribute_values ?? []).map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    );
+  }
+
+  const inputType = NUMERIC_TYPES.includes(type)
+    ? 'number'
+    : type === 'date'
+      ? 'date'
+      : type === 'datetime'
+        ? 'datetime-local'
+        : type === 'link'
+          ? 'url'
+          : 'text';
+
+  return (
+    <Input
+      type={inputType}
+      step={type === 'currency' ? '0.01' : undefined}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+    />
+  );
+}

--- a/src/hooks/automation/useAutomationFormData.ts
+++ b/src/hooks/automation/useAutomationFormData.ts
@@ -3,6 +3,8 @@ import { automationService } from '@/services/automation/automationService';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
 import { cannedResponsesService } from '@/services/cannedResponses/cannedResponsesService';
 import messageTemplatesService from '@/services/channels/messageTemplatesService';
+import { customAttributesService } from '@/services/customAttributes/customAttributesService';
+import type { CustomAttributeDefinition } from '@/types/settings';
 
 export interface MessageTemplateVariable {
   name: string;
@@ -42,6 +44,7 @@ export interface AutomationFormData {
   messageTypes: AutomationFormDataOption[];
   cannedResponses: AutomationFormDataOption[];
   messageTemplates: MessageTemplateOption[];
+  customAttributes: CustomAttributeDefinition[];
 }
 
 const HARDCODED_PRIORITIES: AutomationFormDataOption[] = [
@@ -87,6 +90,7 @@ export function useAutomationFormData(): {
     messageTypes: HARDCODED_MESSAGE_TYPES,
     cannedResponses: [],
     messageTemplates: [],
+    customAttributes: [],
   });
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -96,10 +100,11 @@ export function useAutomationFormData(): {
 
     const load = async () => {
       try {
-        const [formDataResult, pipelinesResult, cannedResult] = await Promise.allSettled([
+        const [formDataResult, pipelinesResult, cannedResult, customAttrsResult] = await Promise.allSettled([
           automationService.getFormData(),
           pipelinesService.getPipelines().catch(() => null),
           cannedResponsesService.getCannedResponses().catch(() => null),
+          customAttributesService.getCustomAttributes().catch(() => null),
         ]);
 
         if (cancelled) return;
@@ -172,6 +177,11 @@ export function useAutomationFormData(): {
             ? (cannedResult.value as { data?: { id: string | number; short_code?: string; content?: string }[] }).data ?? []
             : [];
 
+        const customAttributes =
+          customAttrsResult.status === 'fulfilled' && customAttrsResult.value
+            ? (customAttrsResult.value as { data?: CustomAttributeDefinition[] }).data ?? []
+            : [];
+
         setData({
           inboxes: inboxesArray.map(toOption),
           agents: (formData.agents ?? []).map(toOption),
@@ -187,6 +197,7 @@ export function useAutomationFormData(): {
             name: c.short_code ? `/${c.short_code}` : (c.content ?? String(c.id)).slice(0, 60),
           })),
           messageTemplates: allTemplates,
+          customAttributes,
         });
       } catch (e) {
         if (!cancelled) setError(e as Error);

--- a/src/i18n/locales/en/automation.json
+++ b/src/i18n/locales/en/automation.json
@@ -90,7 +90,8 @@
         "send_email_transcript": "Send email transcript",
         "assign_to_pipeline": "Assign to pipeline",
         "update_pipeline_stage": "Update pipeline stage",
-        "create_pipeline_task": "Create pipeline task"
+        "create_pipeline_task": "Create pipeline task",
+        "update_custom_attribute": "Update custom attribute"
       },
       "conditionRow": {
         "attribute": "Attribute",
@@ -134,8 +135,15 @@
           "create_pipeline_task_assignee": "Assignee user ID (optional)",
           "create_pipeline_task_due_in": "Due in (e.g., 2d, 1w)",
           "send_attachment_ids": "Attachment IDs (comma-separated)",
-          "send_attachment_inbox": "Channel ID (optional)"
+          "send_attachment_inbox": "Channel ID (optional)",
+          "update_custom_attribute": "Pick a custom attribute",
+          "update_custom_attribute_value": "Value"
         }
+      },
+      "customAttributeModels": {
+        "conversation_attribute": "Conversation",
+        "contact_attribute": "Contact",
+        "pipeline_item_attribute": "Pipeline item"
       },
       "operators": {
         "equal_to": "Equals",

--- a/src/i18n/locales/es/automation.json
+++ b/src/i18n/locales/es/automation.json
@@ -90,7 +90,8 @@
         "send_email_transcript": "Enviar transcripción por correo",
         "assign_to_pipeline": "Asignar al pipeline",
         "update_pipeline_stage": "Actualizar etapa del pipeline",
-        "create_pipeline_task": "Crear tarea del pipeline"
+        "create_pipeline_task": "Crear tarea del pipeline",
+        "update_custom_attribute": "Actualizar atributo personalizado"
       },
       "conditionRow": {
         "attribute": "Atributo",
@@ -134,8 +135,15 @@
           "create_pipeline_task_assignee": "ID de usuario asignado (opcional)",
           "create_pipeline_task_due_in": "Vence en (p. ej., 2d, 1w)",
           "send_attachment_ids": "IDs de adjuntos (separados por comas)",
-          "send_attachment_inbox": "ID del canal (opcional)"
+          "send_attachment_inbox": "ID del canal (opcional)",
+          "update_custom_attribute": "Elige un atributo personalizado",
+          "update_custom_attribute_value": "Valor"
         }
+      },
+      "customAttributeModels": {
+        "conversation_attribute": "Conversación",
+        "contact_attribute": "Contacto",
+        "pipeline_item_attribute": "Ítem de pipeline"
       },
       "operators": {
         "equal_to": "Igual a",

--- a/src/i18n/locales/fr/automation.json
+++ b/src/i18n/locales/fr/automation.json
@@ -90,7 +90,8 @@
         "send_email_transcript": "Envoyer la transcription par e-mail",
         "assign_to_pipeline": "Affecter à un pipeline",
         "update_pipeline_stage": "Mettre à jour l'étape du pipeline",
-        "create_pipeline_task": "Créer une tâche de pipeline"
+        "create_pipeline_task": "Créer une tâche de pipeline",
+        "update_custom_attribute": "Mettre à jour l'attribut personnalisé"
       },
       "conditionRow": {
         "attribute": "Attribut",
@@ -134,8 +135,15 @@
           "create_pipeline_task_assignee": "ID de l'utilisateur affecté (facultatif)",
           "create_pipeline_task_due_in": "Échéance dans (ex. 2d, 1w)",
           "send_attachment_ids": "ID des pièces jointes (séparés par des virgules)",
-          "send_attachment_inbox": "ID du canal (facultatif)"
+          "send_attachment_inbox": "ID du canal (facultatif)",
+          "update_custom_attribute": "Choisir un attribut personnalisé",
+          "update_custom_attribute_value": "Valeur"
         }
+      },
+      "customAttributeModels": {
+        "conversation_attribute": "Conversation",
+        "contact_attribute": "Contact",
+        "pipeline_item_attribute": "Élément de pipeline"
       },
       "operators": {
         "equal_to": "Égal à",

--- a/src/i18n/locales/it/automation.json
+++ b/src/i18n/locales/it/automation.json
@@ -90,7 +90,8 @@
         "send_email_transcript": "Invia trascrizione via email",
         "assign_to_pipeline": "Assegna alla pipeline",
         "update_pipeline_stage": "Aggiorna fase della pipeline",
-        "create_pipeline_task": "Crea attività della pipeline"
+        "create_pipeline_task": "Crea attività della pipeline",
+        "update_custom_attribute": "Aggiorna attributo personalizzato"
       },
       "conditionRow": {
         "attribute": "Attributo",
@@ -134,8 +135,15 @@
           "create_pipeline_task_assignee": "ID utente assegnatario (facoltativo)",
           "create_pipeline_task_due_in": "Scadenza tra (es. 2d, 1w)",
           "send_attachment_ids": "ID allegati (separati da virgola)",
-          "send_attachment_inbox": "ID canale (facoltativo)"
+          "send_attachment_inbox": "ID canale (facoltativo)",
+          "update_custom_attribute": "Scegli un attributo personalizzato",
+          "update_custom_attribute_value": "Valore"
         }
+      },
+      "customAttributeModels": {
+        "conversation_attribute": "Conversazione",
+        "contact_attribute": "Contatto",
+        "pipeline_item_attribute": "Elemento pipeline"
       },
       "operators": {
         "equal_to": "Uguale a",

--- a/src/i18n/locales/pt-BR/automation.json
+++ b/src/i18n/locales/pt-BR/automation.json
@@ -90,7 +90,8 @@
         "send_email_transcript": "Enviar transcrição por email",
         "assign_to_pipeline": "Atribuir ao pipeline",
         "update_pipeline_stage": "Atualizar estágio do pipeline",
-        "create_pipeline_task": "Criar tarefa do pipeline"
+        "create_pipeline_task": "Criar tarefa do pipeline",
+        "update_custom_attribute": "Atualizar atributo personalizado"
       },
       "conditionRow": {
         "attribute": "Atributo",
@@ -134,8 +135,15 @@
           "create_pipeline_task_assignee": "ID do responsável (opcional)",
           "create_pipeline_task_due_in": "Vencimento (ex.: 2d, 1w)",
           "send_attachment_ids": "IDs dos anexos separados por vírgula",
-          "send_attachment_inbox": "ID do canal (opcional)"
+          "send_attachment_inbox": "ID do canal (opcional)",
+          "update_custom_attribute": "Escolha um atributo personalizado",
+          "update_custom_attribute_value": "Valor"
         }
+      },
+      "customAttributeModels": {
+        "conversation_attribute": "Conversa",
+        "contact_attribute": "Contato",
+        "pipeline_item_attribute": "Item de pipeline"
       },
       "operators": {
         "equal_to": "Igual a",

--- a/src/i18n/locales/pt/automation.json
+++ b/src/i18n/locales/pt/automation.json
@@ -90,7 +90,8 @@
         "send_email_transcript": "Enviar transcrição por email",
         "assign_to_pipeline": "Atribuir ao pipeline",
         "update_pipeline_stage": "Atualizar estágio do pipeline",
-        "create_pipeline_task": "Criar tarefa do pipeline"
+        "create_pipeline_task": "Criar tarefa do pipeline",
+        "update_custom_attribute": "Atualizar atributo personalizado"
       },
       "conditionRow": {
         "attribute": "Atributo",
@@ -134,8 +135,15 @@
           "create_pipeline_task_assignee": "ID do responsável (opcional)",
           "create_pipeline_task_due_in": "Vencimento (ex.: 2d, 1w)",
           "send_attachment_ids": "IDs dos anexos separados por vírgula",
-          "send_attachment_inbox": "ID do canal (opcional)"
+          "send_attachment_inbox": "ID do canal (opcional)",
+          "update_custom_attribute": "Escolha um atributo personalizado",
+          "update_custom_attribute_value": "Valor"
         }
+      },
+      "customAttributeModels": {
+        "conversation_attribute": "Conversa",
+        "contact_attribute": "Contacto",
+        "pipeline_item_attribute": "Item de pipeline"
       },
       "operators": {
         "equal_to": "Igual a",

--- a/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.spec.ts
@@ -21,6 +21,7 @@ const BACKEND_ACTION_NAMES = [
   'assign_to_pipeline',
   'update_pipeline_stage',
   'create_pipeline_task',
+  'update_custom_attribute',
 ];
 
 describe('actionRegistry', () => {

--- a/src/pages/Customer/Automation/registries/actionRegistry.ts
+++ b/src/pages/Customer/Automation/registries/actionRegistry.ts
@@ -84,6 +84,17 @@ const sendTemplateSchema = z.tuple([
   }),
 ]);
 
+// Custom attribute is unique per (key, model); carry the model so the backend
+// disambiguates the lookup and the write target. Value is a string (empty = set
+// empty), cast at read/query time — consistent with the journey/CRM contract.
+const updateCustomAttributeSchema = z.tuple([
+  z.object({
+    custom_attribute_key: z.string().min(1),
+    custom_attribute_model: z.string().min(1),
+    custom_attribute_value: z.string(),
+  }),
+]);
+
 export interface ActionDescriptor {
   actionName: AutomationActionType;
   schema: z.ZodTypeAny;
@@ -205,6 +216,12 @@ export const actionRegistry: Record<AutomationActionType, ActionDescriptor> = {
     schema: createPipelineTaskSchema,
     defaultParams: [{ title: '' }],
     i18nKey: 'form.fields.actions.create_pipeline_task',
+  },
+  update_custom_attribute: {
+    actionName: 'update_custom_attribute',
+    schema: updateCustomAttributeSchema,
+    defaultParams: [{ custom_attribute_key: '', custom_attribute_model: '', custom_attribute_value: '' }],
+    i18nKey: 'form.fields.actions.update_custom_attribute',
   },
 };
 

--- a/src/pages/Customer/Automation/registries/index.ts
+++ b/src/pages/Customer/Automation/registries/index.ts
@@ -90,6 +90,7 @@ const actionUnionSchema = z.discriminatedUnion('action_name', [
   z.object({ action_name: z.literal('assign_to_pipeline'), action_params: actionRegistry.assign_to_pipeline.schema }),
   z.object({ action_name: z.literal('update_pipeline_stage'), action_params: actionRegistry.update_pipeline_stage.schema }),
   z.object({ action_name: z.literal('create_pipeline_task'), action_params: actionRegistry.create_pipeline_task.schema }),
+  z.object({ action_name: z.literal('update_custom_attribute'), action_params: actionRegistry.update_custom_attribute.schema }),
 ]);
 
 export const automationRuleSchema = z.object({

--- a/src/services/automation/automationService.ts
+++ b/src/services/automation/automationService.ts
@@ -199,7 +199,7 @@ class AutomationService {
         teams: getResultData(teamsRes),
         labels: getResultData(labelsRes),
         campaigns: [],
-        customAttributes: [], // TODO: Implementar busca de custom attributes se necessário
+        customAttributes: [], // fetched in useAutomationFormData via customAttributesService
       };
     } catch (error: any) {
       console.error('Erro ao buscar dados do formulário:', error);

--- a/src/types/automation/automation.ts
+++ b/src/types/automation/automation.ts
@@ -189,7 +189,8 @@ export type AutomationActionType =
   | 'send_email_transcript'
   | 'assign_to_pipeline'
   | 'update_pipeline_stage'
-  | 'create_pipeline_task';
+  | 'create_pipeline_task'
+  | 'update_custom_attribute';
 
 // Flow builder state interface
 export interface AutomationFlowBuilderState {


### PR DESCRIPTION
## Summary
- New **"Update custom attribute"** action in the simple automation rule builder (`ActionRow`): pick a contact/conversation/pipeline-item custom attribute and set its value with a **type-aware input** (text / number / date / datetime / link / list / checkbox).
- Custom attribute definitions are loaded into the automation form data (`useAutomationFormData`); the action is registered in the Zod action union, the `AutomationActionType` type, and the i18n action list across **all 6 locales**.
- New `CustomAttributeValueInput` renders the value editor by `attribute_display_type`. The attribute select stores `attribute_key` + `attribute_model` (composite), matching the backend contract.
- Only the 3 backend-supported models are offered (contact / conversation / pipeline_item).
- `ConditionRow`: narrowed the option-loader key type to exclude `customAttributes` so the new form-data field doesn't widen the condition option union (type fix).

## Security
- No `dangerouslySetInnerHTML`; value handled as a string; reuses the existing `customAttributesService` / `GET /custom_attribute_definitions` endpoint.

## Test plan
- `frontend: pnpm exec tsc -b --noEmit` (clean for changed files; the only remaining errors are 3 pre-existing `StageAutomationRules.tsx` ones, unrelated)
- `frontend: pnpm test -- src/components/automation/CustomAttributeValueInput.spec.tsx src/components/automation/ActionRow.spec.tsx` (10 passing)
- `frontend: pnpm lint` on the changed files (clean)
- Manual smoke: action renders the attribute select (with the model suffix) + a list-type value dropdown; rule saved and fired on `conversation_updated`.

## Changed Files
- `src/components/automation/ActionRow.tsx`
- `src/components/automation/CustomAttributeValueInput.tsx` (new) + `.spec.tsx` (new)
- `src/components/automation/ConditionRow.tsx`
- `src/hooks/automation/useAutomationFormData.ts`
- `src/pages/Customer/Automation/registries/actionRegistry.ts`, `registries/index.ts`
- `src/services/automation/automationService.ts`
- `src/types/automation/automation.ts`
- `src/i18n/locales/{en,pt-BR,es,fr,it,pt}/automation.json`

## QA Notes
- Code-review findings addressed: `ActionRow.spec` `emptyFormData` kept type-complete (`customAttributes: []`); guarded the `model::key` parse against a missing separator.

## Related PRs
- crm (backend handler): https://github.com/evolution-foundation/evo-ai-crm-community/pull/158

## Linked Issue
- EVO-1751