### PR TITLE
fix(frontend): insert canned response correctly (EVO-1685)

### DIFF
--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -36,6 +36,7 @@ import AudioRecorder from '../audio';
 
 import { AIAssistanceButton } from '../ai-assistance';
 import { CannedResponsesList } from '../canned-responses';
+import { buildCannedResponseMessage } from './buildCannedResponseMessage';
 import { RichTextEditor, RichTextEditorRef } from '../rich-text-editor';
 
 import { ReplyMode, Message } from '@/types/chat/api';
@@ -168,13 +169,10 @@ const MessageInput: React.FC<MessageInputProps> = ({
 
   const handleSelectCannedResponse = useCallback(
     async (cannedResponse: CannedResponse) => {
-      const currentMessage = richEditorRef.current?.getContent() || '';
-
-      const slashIndex = currentMessage.lastIndexOf('/');
-      const newMessage =
-        slashIndex >= 0
-          ? currentMessage.substring(0, slashIndex) + cannedResponse.content
-          : cannedResponse.content;
+      const newMessage = buildCannedResponseMessage(
+        richEditorRef.current?.getContent() || '',
+        cannedResponse.content,
+      );
 
       richEditorRef.current?.setContent(newMessage);
       setCurrentEditorMessage(newMessage);

--- a/src/components/chat/message-input/buildCannedResponseMessage.spec.ts
+++ b/src/components/chat/message-input/buildCannedResponseMessage.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { buildCannedResponseMessage } from './buildCannedResponseMessage';
+
+describe('buildCannedResponseMessage (EVO-1685)', () => {
+  it('replaces the trigger slash even though getContent returns HTML', () => {
+    expect(buildCannedResponseMessage('<p>/</p>', 'Hello there')).toBe('Hello there');
+  });
+
+  it('preserves text typed before the slash', () => {
+    expect(buildCannedResponseMessage('<p>oi /</p>', 'tudo bem?')).toBe('oi tudo bem?');
+  });
+
+  it('falls back to the content when there is no slash', () => {
+    expect(buildCannedResponseMessage('<p>plain text</p>', 'X')).toBe('X');
+  });
+
+  it('handles empty editor content', () => {
+    expect(buildCannedResponseMessage('', 'content')).toBe('content');
+  });
+});

--- a/src/components/chat/message-input/buildCannedResponseMessage.ts
+++ b/src/components/chat/message-input/buildCannedResponseMessage.ts
@@ -1,0 +1,13 @@
+// Builds the editor message when a canned response is selected.
+// The editor's getContent() returns HTML (e.g. "<p>/</p>"), so locating the
+// trigger slash with lastIndexOf('/') over the HTML matched the slash in the
+// closing </p> tag and dropped the canned content (EVO-1685). Operate on the
+// plain text so the '/' the user typed is found correctly.
+export function buildCannedResponseMessage(currentHtml: string, content: string): string {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = currentHtml;
+  const text = wrapper.textContent || '';
+
+  const slashIndex = text.lastIndexOf('/');
+  return slashIndex >= 0 ? text.substring(0, slashIndex) + content : content;
+}


### PR DESCRIPTION
## Summary
- Selecting a canned response (typing `/`, then click or Enter) was a silent no-op — the inserted text never reached the message input.
- **Root cause:** `handleSelectCannedResponse` sliced the editor content at `lastIndexOf('/')`, but `getContent()` returns **HTML** (`<p>/</p>`), so the slash matched the closing `</p>` tag — the result was mangled and the canned content dropped.
- **Fix:** extract `buildCannedResponseMessage()` that locates the `/` trigger in the **plain text** (not the HTML) and rebuilds the message.

> Note: the Linear card pointed at `RichTextEditor.setContent()` (updateState vs dispatch) as the cause. That is a real-but-secondary inconsistency, not the blocker — the handler already syncs the value manually, and fixing only `setContent` did not resolve the bug (verified). `RichTextEditor` is left untouched.

## Validation
- `frontend: pnpm test -- src/components/chat/message-input/buildCannedResponseMessage.spec.ts` (4 passing)
- `frontend: pnpm exec tsc -b --noEmit` (clean for changed files; 3 pre-existing `StageAutomationRules` errors are unrelated)
- `frontend: pnpm lint` on changed files (clean; pre-existing warnings only)
- Manual smoke: typing `/`, selecting a canned response by **click** and by **Enter** → text inserted in the input (confirmed).

## Changed Files
- `src/components/chat/message-input/buildCannedResponseMessage.ts` (new)
- `src/components/chat/message-input/buildCannedResponseMessage.spec.ts` (new)
- `src/components/chat/message-input/MessageInput.tsx`

## Linked Issue
- EVO-1685

## Summary by Sourcery

Fix canned response insertion in the chat message input by building the final message from plain text instead of the editor’s HTML content.

Bug Fixes:
- Ensure selecting a canned response correctly replaces the '/' trigger in the message input instead of silently failing when HTML is involved.

Enhancements:
- Extract message-building logic for canned responses into a reusable utility function for the message input.

Tests:
- Add unit tests covering the canned response message-building logic for different input scenarios.