### PR TITLE
feat(frontend): polish product create/edit form + catalog stock column (EVO-1783)

### DIFF
--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProductModal from './ProductModal';
+import type { Product } from '@/types/products';
+
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill as never);
+const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+if (!proto.hasPointerCapture) proto.hasPointerCapture = () => false;
+if (!proto.scrollIntoView) proto.scrollIntoView = () => {};
+
+const baseProduct = (overrides: Partial<Product>): Product => ({
+  id: 'p1',
+  name: 'Prod',
+  kind: 'physical',
+  default_price: 10,
+  currency: 'BRL',
+  status: 'active',
+  variants: [],
+  images: [],
+  ...overrides,
+});
+
+const noop = () => {};
+const onSubmit = vi.fn(async () => {});
+
+describe('ProductModal (EVO-1783 Phase 1)', () => {
+  it('hides the stock field for digital products (AC4)', () => {
+    render(
+      <ProductModal open product={baseProduct({ kind: 'digital' })} loading={false} onOpenChange={noop} onSubmit={onSubmit} />,
+    );
+    expect(document.getElementById('p-stock')).toBeNull();
+  });
+
+  it('shows the stock field for physical products (AC4)', () => {
+    render(
+      <ProductModal open product={baseProduct({ kind: 'physical' })} loading={false} onOpenChange={noop} onSubmit={onSubmit} />,
+    );
+    expect(document.getElementById('p-stock')).not.toBeNull();
+  });
+
+  it('disables submit when required fields are empty on create', () => {
+    render(<ProductModal open product={null} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    const button = screen.getByText('actions.create').closest('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('renders a server field error inline (AC4 — SKU uniqueness)', () => {
+    render(
+      <ProductModal
+        open
+        product={baseProduct({})}
+        loading={false}
+        errors={{ sku: 'has already been taken' }}
+        onOpenChange={noop}
+        onSubmit={onSubmit}
+      />,
+    );
+    expect(screen.getByText('has already been taken')).toBeTruthy();
+  });
+});

--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import ProductModal from './ProductModal';
 import type { Product } from '@/types/products';
 
@@ -43,10 +43,15 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(document.getElementById('p-stock')).not.toBeNull();
   });
 
-  it('disables submit when required fields are empty on create', () => {
-    render(<ProductModal open product={null} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+  it('keeps submit clickable and reveals validation instead of a silent disabled button', () => {
+    const submitSpy = vi.fn(async () => {});
+    render(<ProductModal open product={null} loading={false} onOpenChange={noop} onSubmit={submitSpy} />);
     const button = screen.getByText('actions.create').closest('button') as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
+    expect(button.disabled).toBe(false);
+    fireEvent.click(button);
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('validation.nameRequired')).toBeTruthy();
+    expect(screen.getByText('validation.fixErrors')).toBeTruthy();
   });
 
   it('renders a server field error inline (AC4 — SKU uniqueness)', () => {

--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -67,4 +67,15 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     );
     expect(screen.getByText('has already been taken')).toBeTruthy();
   });
+
+  it('keeps an empty price as null (not 0) and blocks submit (AC3)', () => {
+    const submitSpy = vi.fn(async () => {});
+    render(<ProductModal open product={null} loading={false} onOpenChange={noop} onSubmit={submitSpy} />);
+    fireEvent.change(document.getElementById('p-name') as HTMLInputElement, { target: { value: 'X' } });
+    const priceInput = document.getElementById('p-price') as HTMLInputElement;
+    expect(priceInput.value).toBe('');
+    fireEvent.click(screen.getByText('actions.create').closest('button') as HTMLButtonElement);
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(screen.getByText('validation.priceRequired')).toBeTruthy();
+  });
 });

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -21,7 +21,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@evoapi/design-system';
-import { Plus, Trash2, Upload, X } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import type {
   Product,
   ProductFormData,
@@ -82,7 +82,6 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   const [form, setForm] = useState<ProductFormState>(emptyForm());
   const [variants, setVariants] = useState<ProductVariantFormData[]>([]);
   const [labelsText, setLabelsText] = useState('');
-  const [newFiles, setNewFiles] = useState<File[]>([]);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [activeTab, setActiveTab] = useState('general');
@@ -113,7 +112,6 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       setVariants([]);
       setLabelsText('');
     }
-    setNewFiles([]);
     setTouched({});
     setSubmitAttempted(false);
     setActiveTab('general');
@@ -155,15 +153,6 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
     );
   };
 
-  const handleFilesSelected = (files: FileList | null) => {
-    if (!files) return;
-    setNewFiles((prev) => [...prev, ...Array.from(files)]);
-  };
-
-  const handleRemoveNewFile = (index: number) => {
-    setNewFiles((prev) => prev.filter((_, i) => i !== index));
-  };
-
   const handleSubmit = async () => {
     setSubmitAttempted(true);
     if (!canSubmit) {
@@ -188,7 +177,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       })),
     };
 
-    await onSubmit(payload, newFiles.length > 0 ? newFiles : undefined);
+    await onSubmit(payload);
   };
 
   return (
@@ -200,9 +189,17 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
         </DialogHeader>
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex flex-col">
-          <TabsList className="grid grid-cols-4 w-full">
+          {/*
+            Media tab intentionally omitted: product image upload is not wired
+            end-to-end — the backend (products_controller#attach_images) only
+            attaches ActiveStorage signed_ids and explicitly drops raw multipart
+            files, which is all the client currently sends. Re-add a
+            <TabsTrigger value="media"> + <TabsContent value="media"> (file picker
+            + product.images preview, see git history) once a direct-upload /
+            signed_id flow exists.
+          */}
+          <TabsList className="grid grid-cols-3 w-full">
             <TabsTrigger value="general">{t('modal.tabs.general')}</TabsTrigger>
-            <TabsTrigger value="media" disabled>{t('modal.tabs.mediaSoon')}</TabsTrigger>
             <TabsTrigger value="variants">{t('modal.tabs.variants')}</TabsTrigger>
             <TabsTrigger value="labels">{t('modal.tabs.labels')}</TabsTrigger>
           </TabsList>
@@ -227,7 +224,13 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
 
               <div className="space-y-1.5">
                 <Label htmlFor="p-kind">{t('fields.kind')}</Label>
-                <Select value={form.kind} onValueChange={(v) => setForm({ ...form, kind: v as ProductKind })}>
+                <Select
+                  value={form.kind}
+                  onValueChange={(v) => {
+                    const kind = v as ProductKind;
+                    setForm({ ...form, kind, stock_quantity: kind === 'physical' ? form.stock_quantity : null });
+                  }}
+                >
                   <SelectTrigger id="p-kind">
                     <SelectValue />
                   </SelectTrigger>
@@ -357,57 +360,6 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
             </div>
           </TabsContent>
 
-          <TabsContent value="media" className="space-y-3 overflow-y-auto pt-4">
-            <div className="border-2 border-dashed rounded-md p-6 text-center">
-              <Upload className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
-              <p className="text-sm text-muted-foreground mb-2">{t('media.uploadHint')}</p>
-              <label htmlFor="p-media-upload" className="inline-block">
-                <input
-                  id="p-media-upload"
-                  type="file"
-                  multiple
-                  accept="image/*"
-                  className="hidden"
-                  onChange={(e) => handleFilesSelected(e.target.files)}
-                />
-                <span className="inline-flex items-center gap-2 text-sm font-medium text-primary cursor-pointer">
-                  <Plus className="h-4 w-4" />
-                  {t('media.selectFiles')}
-                </span>
-              </label>
-            </div>
-
-            {product?.images && product.images.length > 0 && (
-              <div>
-                <p className="text-sm font-medium mb-2">{t('media.existing')}</p>
-                <div className="grid grid-cols-3 gap-3">
-                  {product.images.map((image) => (
-                    <div key={image.id} className="border rounded overflow-hidden">
-                      <img src={image.url} alt={image.filename} className="w-full h-32 object-cover" />
-                      <div className="px-2 py-1 text-xs truncate">{image.filename}</div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {newFiles.length > 0 && (
-              <div>
-                <p className="text-sm font-medium mb-2">{t('media.pending')}</p>
-                <ul className="space-y-1">
-                  {newFiles.map((file, idx) => (
-                    <li key={idx} className="flex items-center justify-between text-sm border rounded px-2 py-1">
-                      <span className="truncate">{file.name}</span>
-                      <Button variant="ghost" size="icon" onClick={() => handleRemoveNewFile(idx)}>
-                        <X className="h-4 w-4" />
-                      </Button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-          </TabsContent>
-
           <TabsContent value="variants" className="space-y-3 overflow-y-auto pt-4">
             {!isPhysical && (
               <p className="text-xs text-muted-foreground">{t('variants.digitalHint')}</p>
@@ -427,6 +379,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                       <Label htmlFor={`p-variant-${idx}-name`} className="text-xs">{t('variants.name')}</Label>
                       <Input
                         id={`p-variant-${idx}-name`}
+                        aria-required="true"
                         value={variant.name}
                         onChange={(e) => handleVariantChange(idx, { name: e.target.value })}
                         placeholder={t('variants.namePlaceholder')}

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -84,6 +84,8 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   const [labelsText, setLabelsText] = useState('');
   const [newFiles, setNewFiles] = useState<File[]>([]);
   const [touched, setTouched] = useState<Record<string, boolean>>({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+  const [activeTab, setActiveTab] = useState('general');
 
   const isEdit = useMemo(() => Boolean(product?.id), [product]);
   const isPhysical = form.kind === 'physical';
@@ -113,6 +115,8 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
     }
     setNewFiles([]);
     setTouched({});
+    setSubmitAttempted(false);
+    setActiveTab('general');
   }, [open, product]);
 
   const clientErrors = useMemo<Record<string, string>>(() => {
@@ -125,7 +129,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   }, [form.name, form.default_price, form.purchase_url, t]);
 
   const fieldError = (key: string): string | undefined =>
-    errors?.[key] ?? (touched[key] ? clientErrors[key] : undefined);
+    errors?.[key] ?? (submitAttempted || touched[key] ? clientErrors[key] : undefined);
 
   const markTouched = (key: string) => setTouched((prev) => ({ ...prev, [key]: true }));
   const canSubmit = Object.keys(clientErrors).length === 0;
@@ -161,8 +165,11 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   };
 
   const handleSubmit = async () => {
-    setTouched({ name: true, default_price: true, purchase_url: true });
-    if (!canSubmit) return;
+    setSubmitAttempted(true);
+    if (!canSubmit) {
+      setActiveTab('general');
+      return;
+    }
 
     const labels = labelsText
       .split(',')
@@ -192,7 +199,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
           <DialogDescription>{t('modal.subtitle')}</DialogDescription>
         </DialogHeader>
 
-        <Tabs defaultValue="general" className="flex-1 overflow-hidden flex flex-col">
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex flex-col">
           <TabsList className="grid grid-cols-4 w-full">
             <TabsTrigger value="general">{t('modal.tabs.general')}</TabsTrigger>
             <TabsTrigger value="media">{t('modal.tabs.media')}</TabsTrigger>
@@ -500,11 +507,15 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
         </Tabs>
 
         <DialogFooter className="pt-2 items-center">
-          <p className="text-xs text-muted-foreground mr-auto">{t('validation.requiredLegend')}</p>
+          <p
+            className={`text-xs mr-auto ${submitAttempted && !canSubmit ? 'text-destructive' : 'text-muted-foreground'}`}
+          >
+            {submitAttempted && !canSubmit ? t('validation.fixErrors') : t('validation.requiredLegend')}
+          </p>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
             {t('actions.cancel')}
           </Button>
-          <Button onClick={handleSubmit} disabled={loading || !canSubmit}>
+          <Button onClick={handleSubmit} disabled={loading}>
             {loading ? t('actions.saving') : isEdit ? t('actions.update') : t('actions.create')}
           </Button>
         </DialogFooter>

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -31,10 +31,15 @@ import type {
   ProductCurrency,
 } from '@/types/products';
 
+// default_price is nullable in the form so an empty input stays empty (not 0),
+// letting validation require an explicit price. It is coerced on submit.
+type ProductFormState = Omit<ProductFormData, 'default_price'> & { default_price: number | null };
+
 interface Props {
   open: boolean;
   product?: Product | null;
   loading: boolean;
+  errors?: Record<string, string>;
   onOpenChange: (open: boolean) => void;
   onSubmit: (payload: ProductFormData, files?: File[]) => Promise<void>;
 }
@@ -42,14 +47,15 @@ interface Props {
 const KINDS: ProductKind[] = ['physical', 'digital'];
 const STATUSES: ProductStatus[] = ['active', 'inactive', 'draft'];
 const CURRENCIES: ProductCurrency[] = ['BRL', 'USD', 'EUR'];
+const URL_REGEX = /^https?:\/\/.+/i;
 
-function emptyForm(): ProductFormData {
+function emptyForm(): ProductFormState {
   return {
     name: '',
     kind: 'physical',
     description: '',
     sku: '',
-    default_price: 0,
+    default_price: null,
     currency: 'BRL',
     purchase_url: '',
     status: 'active',
@@ -71,14 +77,16 @@ function variantToForm(variant: Product['variants'][number]): ProductVariantForm
   };
 }
 
-export default function ProductModal({ open, product, loading, onOpenChange, onSubmit }: Props) {
+export default function ProductModal({ open, product, loading, errors, onOpenChange, onSubmit }: Props) {
   const { t } = useLanguage('products');
-  const [form, setForm] = useState<ProductFormData>(emptyForm());
+  const [form, setForm] = useState<ProductFormState>(emptyForm());
   const [variants, setVariants] = useState<ProductVariantFormData[]>([]);
   const [labelsText, setLabelsText] = useState('');
   const [newFiles, setNewFiles] = useState<File[]>([]);
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
 
   const isEdit = useMemo(() => Boolean(product?.id), [product]);
+  const isPhysical = form.kind === 'physical';
 
   useEffect(() => {
     if (!open) return;
@@ -104,19 +112,28 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
       setLabelsText('');
     }
     setNewFiles([]);
+    setTouched({});
   }, [open, product]);
+
+  const clientErrors = useMemo<Record<string, string>>(() => {
+    const e: Record<string, string> = {};
+    if (!form.name.trim()) e.name = t('validation.nameRequired');
+    if (form.default_price == null) e.default_price = t('validation.priceRequired');
+    else if (form.default_price < 0) e.default_price = t('validation.priceMin');
+    if (form.purchase_url && !URL_REGEX.test(form.purchase_url)) e.purchase_url = t('validation.urlInvalid');
+    return e;
+  }, [form.name, form.default_price, form.purchase_url, t]);
+
+  const fieldError = (key: string): string | undefined =>
+    errors?.[key] ?? (touched[key] ? clientErrors[key] : undefined);
+
+  const markTouched = (key: string) => setTouched((prev) => ({ ...prev, [key]: true }));
+  const canSubmit = Object.keys(clientErrors).length === 0;
 
   const handleAddVariant = () => {
     setVariants((prev) => [
       ...prev,
-      {
-        name: '',
-        sku: '',
-        price_override: null,
-        stock_quantity: null,
-        position: prev.length,
-        attributes_data: {},
-      },
+      { name: '', sku: '', price_override: null, stock_quantity: null, position: prev.length, attributes_data: {} },
     ]);
   };
 
@@ -144,6 +161,9 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
   };
 
   const handleSubmit = async () => {
+    setTouched({ name: true, default_price: true, purchase_url: true });
+    if (!canSubmit) return;
+
     const labels = labelsText
       .split(',')
       .map((s) => s.trim())
@@ -151,9 +171,12 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
 
     const payload: ProductFormData = {
       ...form,
+      default_price: form.default_price ?? 0,
+      stock_quantity: isPhysical ? form.stock_quantity : null,
       labels,
       variants_attributes: variants.map((v, idx) => ({
         ...v,
+        stock_quantity: isPhysical ? v.stock_quantity : null,
         position: v.position ?? idx,
       })),
     };
@@ -161,11 +184,9 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
     await onSubmit(payload, newFiles.length > 0 ? newFiles : undefined);
   };
 
-  const canSubmit = form.name.trim().length > 0 && form.default_price >= 0;
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-hidden flex flex-col">
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto flex flex-col">
         <DialogHeader>
           <DialogTitle>{isEdit ? t('modal.editTitle') : t('modal.createTitle')}</DialogTitle>
           <DialogDescription>{t('modal.subtitle')}</DialogDescription>
@@ -182,22 +203,25 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
           <TabsContent value="general" className="space-y-4 overflow-y-auto pt-4">
             <div className="grid grid-cols-2 gap-3">
               <div className="col-span-2 space-y-1.5">
-                <Label htmlFor="p-name">{t('fields.name')} *</Label>
+                <Label htmlFor="p-name">
+                  {t('fields.name')} <span aria-hidden="true">*</span>
+                </Label>
                 <Input
                   id="p-name"
+                  aria-required="true"
+                  aria-invalid={Boolean(fieldError('name'))}
                   value={form.name}
                   onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  onBlur={() => markTouched('name')}
                   placeholder={t('fields.namePlaceholder')}
                 />
+                {fieldError('name') && <p className="text-xs text-destructive">{fieldError('name')}</p>}
               </div>
 
               <div className="space-y-1.5">
-                <Label>{t('fields.kind')}</Label>
-                <Select
-                  value={form.kind}
-                  onValueChange={(v) => setForm({ ...form, kind: v as ProductKind })}
-                >
-                  <SelectTrigger>
+                <Label htmlFor="p-kind">{t('fields.kind')}</Label>
+                <Select value={form.kind} onValueChange={(v) => setForm({ ...form, kind: v as ProductKind })}>
+                  <SelectTrigger id="p-kind">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -208,15 +232,15 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
                     ))}
                   </SelectContent>
                 </Select>
+                {!isPhysical && (
+                  <p className="text-xs text-muted-foreground">{t('fields.digitalNoStockHint')}</p>
+                )}
               </div>
 
               <div className="space-y-1.5">
-                <Label>{t('fields.status')}</Label>
-                <Select
-                  value={form.status}
-                  onValueChange={(v) => setForm({ ...form, status: v as ProductStatus })}
-                >
-                  <SelectTrigger>
+                <Label htmlFor="p-status">{t('fields.status')}</Label>
+                <Select value={form.status} onValueChange={(v) => setForm({ ...form, status: v as ProductStatus })}>
+                  <SelectTrigger id="p-status">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -229,72 +253,88 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
                 </Select>
               </div>
 
-              <div className="space-y-1.5">
+              <div className="col-span-2 grid grid-cols-3 gap-3 items-start">
+                <div className="col-span-2 space-y-1.5">
+                  <Label htmlFor="p-price">
+                    {t('fields.defaultPrice')} <span aria-hidden="true">*</span>
+                  </Label>
+                  <Input
+                    id="p-price"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    aria-required="true"
+                    aria-invalid={Boolean(fieldError('default_price'))}
+                    value={form.default_price ?? ''}
+                    placeholder="0,00"
+                    onChange={(e) =>
+                      setForm({ ...form, default_price: e.target.value === '' ? null : Number(e.target.value) })
+                    }
+                    onBlur={() => markTouched('default_price')}
+                  />
+                  {fieldError('default_price') && (
+                    <p className="text-xs text-destructive">{fieldError('default_price')}</p>
+                  )}
+                </div>
+
+                <div className="space-y-1.5">
+                  <Label htmlFor="p-currency">{t('fields.currency')}</Label>
+                  <Select value={form.currency} onValueChange={(v) => setForm({ ...form, currency: v as ProductCurrency })}>
+                    <SelectTrigger id="p-currency">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {CURRENCIES.map((c) => (
+                        <SelectItem key={c} value={c}>
+                          {t(`currency.${c}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className={isPhysical ? 'space-y-1.5' : 'col-span-2 space-y-1.5'}>
                 <Label htmlFor="p-sku">{t('fields.sku')}</Label>
                 <Input
                   id="p-sku"
+                  aria-invalid={Boolean(fieldError('sku'))}
                   value={form.sku ?? ''}
                   onChange={(e) => setForm({ ...form, sku: e.target.value })}
-                  placeholder="SKU-001"
+                  placeholder={t('fields.skuPlaceholder')}
                 />
+                {fieldError('sku') && <p className="text-xs text-destructive">{fieldError('sku')}</p>}
               </div>
 
-              <div className="space-y-1.5">
-                <Label htmlFor="p-stock">{t('fields.stockQuantity')}</Label>
-                <Input
-                  id="p-stock"
-                  type="number"
-                  min={0}
-                  value={form.stock_quantity ?? ''}
-                  onChange={(e) =>
-                    setForm({
-                      ...form,
-                      stock_quantity: e.target.value === '' ? null : Number(e.target.value),
-                    })
-                  }
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="p-price">{t('fields.defaultPrice')} *</Label>
-                <Input
-                  id="p-price"
-                  type="number"
-                  step="0.01"
-                  min={0}
-                  value={form.default_price}
-                  onChange={(e) => setForm({ ...form, default_price: Number(e.target.value) })}
-                />
-              </div>
-
-              <div className="space-y-1.5">
-                <Label>{t('fields.currency')}</Label>
-                <Select
-                  value={form.currency}
-                  onValueChange={(v) => setForm({ ...form, currency: v as ProductCurrency })}
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CURRENCIES.map((c) => (
-                      <SelectItem key={c} value={c}>
-                        {c}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              {isPhysical && (
+                <div className="space-y-1.5">
+                  <Label htmlFor="p-stock">{t('fields.stockQuantity')}</Label>
+                  <Input
+                    id="p-stock"
+                    type="number"
+                    min={0}
+                    value={form.stock_quantity ?? ''}
+                    onChange={(e) =>
+                      setForm({ ...form, stock_quantity: e.target.value === '' ? null : Number(e.target.value) })
+                    }
+                  />
+                </div>
+              )}
 
               <div className="col-span-2 space-y-1.5">
                 <Label htmlFor="p-url">{t('fields.purchaseUrl')}</Label>
                 <Input
                   id="p-url"
                   type="url"
-                  placeholder="https://..."
+                  aria-invalid={Boolean(fieldError('purchase_url'))}
+                  placeholder={t('fields.purchaseUrlPlaceholder')}
                   value={form.purchase_url ?? ''}
                   onChange={(e) => setForm({ ...form, purchase_url: e.target.value })}
+                  onBlur={() => markTouched('purchase_url')}
                 />
+                {fieldError('purchase_url') && (
+                  <p className="text-xs text-destructive">{fieldError('purchase_url')}</p>
+                )}
               </div>
 
               <div className="col-span-2 space-y-1.5">
@@ -314,8 +354,9 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
             <div className="border-2 border-dashed rounded-md p-6 text-center">
               <Upload className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
               <p className="text-sm text-muted-foreground mb-2">{t('media.uploadHint')}</p>
-              <label className="inline-block">
+              <label htmlFor="p-media-upload" className="inline-block">
                 <input
+                  id="p-media-upload"
                   type="file"
                   multiple
                   accept="image/*"
@@ -361,7 +402,7 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
           </TabsContent>
 
           <TabsContent value="variants" className="space-y-3 overflow-y-auto pt-4">
-            {form.kind === 'digital' && (
+            {!isPhysical && (
               <p className="text-xs text-muted-foreground">{t('variants.digitalHint')}</p>
             )}
 
@@ -376,23 +417,26 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
                 return (
                   <div key={variant.id ?? `new-${idx}`} className="grid grid-cols-12 gap-2 items-end border rounded-md p-3">
                     <div className="col-span-4 space-y-1.5">
-                      <Label className="text-xs">{t('variants.name')}</Label>
+                      <Label htmlFor={`p-variant-${idx}-name`} className="text-xs">{t('variants.name')}</Label>
                       <Input
+                        id={`p-variant-${idx}-name`}
                         value={variant.name}
                         onChange={(e) => handleVariantChange(idx, { name: e.target.value })}
-                        placeholder="P / M / G"
+                        placeholder={t('variants.namePlaceholder')}
                       />
                     </div>
-                    <div className="col-span-3 space-y-1.5">
-                      <Label className="text-xs">{t('variants.sku')}</Label>
+                    <div className={isPhysical ? 'col-span-3 space-y-1.5' : 'col-span-5 space-y-1.5'}>
+                      <Label htmlFor={`p-variant-${idx}-sku`} className="text-xs">{t('variants.sku')}</Label>
                       <Input
+                        id={`p-variant-${idx}-sku`}
                         value={variant.sku ?? ''}
                         onChange={(e) => handleVariantChange(idx, { sku: e.target.value })}
                       />
                     </div>
-                    <div className="col-span-2 space-y-1.5">
-                      <Label className="text-xs">{t('variants.priceOverride')}</Label>
+                    <div className={isPhysical ? 'col-span-2 space-y-1.5' : 'col-span-2 space-y-1.5'}>
+                      <Label htmlFor={`p-variant-${idx}-price`} className="text-xs">{t('variants.priceOverride')}</Label>
                       <Input
+                        id={`p-variant-${idx}-price`}
                         type="number"
                         step="0.01"
                         min={0}
@@ -404,25 +448,29 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
                         }
                       />
                     </div>
-                    <div className="col-span-2 space-y-1.5">
-                      <Label className="text-xs">{t('variants.stock')}</Label>
-                      <Input
-                        type="number"
-                        min={0}
-                        value={variant.stock_quantity ?? ''}
-                        onChange={(e) =>
-                          handleVariantChange(idx, {
-                            stock_quantity: e.target.value === '' ? null : Number(e.target.value),
-                          })
-                        }
-                      />
-                    </div>
+                    {isPhysical && (
+                      <div className="col-span-2 space-y-1.5">
+                        <Label htmlFor={`p-variant-${idx}-stock`} className="text-xs">{t('variants.stock')}</Label>
+                        <Input
+                          id={`p-variant-${idx}-stock`}
+                          type="number"
+                          min={0}
+                          value={variant.stock_quantity ?? ''}
+                          onChange={(e) =>
+                            handleVariantChange(idx, {
+                              stock_quantity: e.target.value === '' ? null : Number(e.target.value),
+                            })
+                          }
+                        />
+                      </div>
+                    )}
                     <div className="col-span-1 flex justify-end">
                       <Button
                         variant="ghost"
                         size="icon"
                         onClick={() => handleVariantRemove(idx)}
                         className="text-destructive hover:text-destructive"
+                        aria-label={t('actions.delete')}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
@@ -451,7 +499,8 @@ export default function ProductModal({ open, product, loading, onOpenChange, onS
           </TabsContent>
         </Tabs>
 
-        <DialogFooter className="pt-2">
+        <DialogFooter className="pt-2 items-center">
+          <p className="text-xs text-muted-foreground mr-auto">{t('validation.requiredLegend')}</p>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
             {t('actions.cancel')}
           </Button>

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -202,7 +202,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex flex-col">
           <TabsList className="grid grid-cols-4 w-full">
             <TabsTrigger value="general">{t('modal.tabs.general')}</TabsTrigger>
-            <TabsTrigger value="media">{t('modal.tabs.media')}</TabsTrigger>
+            <TabsTrigger value="media" disabled>{t('modal.tabs.mediaSoon')}</TabsTrigger>
             <TabsTrigger value="variants">{t('modal.tabs.variants')}</TabsTrigger>
             <TabsTrigger value="labels">{t('modal.tabs.labels')}</TabsTrigger>
           </TabsList>

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -49,6 +49,14 @@ const STATUSES: ProductStatus[] = ['active', 'inactive', 'draft'];
 const CURRENCIES: ProductCurrency[] = ['BRL', 'USD', 'EUR'];
 const URL_REGEX = /^https?:\/\/.+/i;
 
+// Empty input → null; non-numeric input (e.g. a pasted string) → null instead of NaN,
+// which would otherwise leak into the payload and bypass form validation.
+function toNumberOrNull(value: string): number | null {
+  if (value.trim() === '') return null;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
 function emptyForm(): ProductFormState {
   return {
     name: '',
@@ -278,7 +286,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                     value={form.default_price ?? ''}
                     placeholder="0,00"
                     onChange={(e) =>
-                      setForm({ ...form, default_price: e.target.value === '' ? null : Number(e.target.value) })
+                      setForm({ ...form, default_price: toNumberOrNull(e.target.value) })
                     }
                     onBlur={() => markTouched('default_price')}
                   />
@@ -325,7 +333,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                     min={0}
                     value={form.stock_quantity ?? ''}
                     onChange={(e) =>
-                      setForm({ ...form, stock_quantity: e.target.value === '' ? null : Number(e.target.value) })
+                      setForm({ ...form, stock_quantity: toNumberOrNull(e.target.value) })
                     }
                   />
                 </div>
@@ -403,7 +411,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                         value={variant.price_override ?? ''}
                         onChange={(e) =>
                           handleVariantChange(idx, {
-                            price_override: e.target.value === '' ? null : Number(e.target.value),
+                            price_override: toNumberOrNull(e.target.value),
                           })
                         }
                       />
@@ -418,7 +426,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                           value={variant.stock_quantity ?? ''}
                           onChange={(e) =>
                             handleVariantChange(idx, {
-                              stock_quantity: e.target.value === '' ? null : Number(e.target.value),
+                              stock_quantity: toNumberOrNull(e.target.value),
                             })
                           }
                         />

--- a/src/components/products/ProductsTable.spec.tsx
+++ b/src/components/products/ProductsTable.spec.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { stockInfo } from './productStock';
+import type { Product, ProductVariant } from '@/types/products';
+
+const product = (o: Partial<Product>): Product => ({
+  id: '1',
+  name: 'n',
+  kind: 'physical',
+  default_price: 0,
+  currency: 'BRL',
+  status: 'active',
+  variants: [],
+  images: [],
+  ...o,
+});
+
+const variant = (stock: number | null): ProductVariant => ({
+  id: `v-${stock}`,
+  product_id: '1',
+  name: 'V',
+  stock_quantity: stock,
+  position: 0,
+});
+
+describe('stockInfo (EVO-1783 stock column)', () => {
+  it('digital products have no stock concept (null)', () => {
+    expect(stockInfo(product({ kind: 'digital', stock_quantity: 5 }))).toBeNull();
+  });
+
+  it('physical simple product returns its stock_quantity', () => {
+    expect(stockInfo(product({ stock_quantity: 7 }))).toBe(7);
+  });
+
+  it('physical with untracked stock is null (not zero)', () => {
+    expect(stockInfo(product({ stock_quantity: null }))).toBeNull();
+  });
+
+  it('physical zero stock returns 0 (out of stock)', () => {
+    expect(stockInfo(product({ stock_quantity: 0 }))).toBe(0);
+  });
+
+  it('physical with variants sums the per-variant stock', () => {
+    expect(stockInfo(product({ stock_quantity: null, variants: [variant(3), variant(4)] }))).toBe(7);
+  });
+
+  it('physical with variants but none tracked is null', () => {
+    expect(stockInfo(product({ variants: [variant(null)] }))).toBeNull();
+  });
+});

--- a/src/components/products/ProductsTable.tsx
+++ b/src/components/products/ProductsTable.tsx
@@ -2,6 +2,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { Button, Badge } from '@evoapi/design-system';
 import { Pencil, Trash2, Package, Cloud } from 'lucide-react';
 import type { Product } from '@/types/products';
+import { stockInfo } from './productStock';
 
 interface Props {
   products: Product[];
@@ -56,6 +57,7 @@ export default function ProductsTable({
             <th className="px-3 py-2">{t('table.columns.sku')}</th>
             <th className="px-3 py-2">{t('table.columns.kind')}</th>
             <th className="px-3 py-2">{t('table.columns.price')}</th>
+            <th className="px-3 py-2">{t('table.columns.stock')}</th>
             <th className="px-3 py-2">{t('table.columns.status')}</th>
             <th className="px-3 py-2">{t('table.columns.variants')}</th>
             <th className="px-3 py-2 text-right">{t('table.columns.actions')}</th>
@@ -64,6 +66,7 @@ export default function ProductsTable({
         <tbody>
           {products.map((product) => {
             const Icon = product.kind === 'digital' ? Cloud : Package;
+            const stock = stockInfo(product);
             return (
               <tr key={product.id} className="border-t hover:bg-muted/30">
                 <td className="px-3 py-2">
@@ -74,6 +77,15 @@ export default function ProductsTable({
                 <td className="px-3 py-2">{t(`kind.${product.kind}`)}</td>
                 <td className="px-3 py-2 font-mono text-xs">
                   {formatPrice(product.default_price, product.currency)}
+                </td>
+                <td className="px-3 py-2">
+                  {stock == null ? (
+                    <span className="text-muted-foreground">—</span>
+                  ) : stock === 0 ? (
+                    <span className="text-destructive font-medium">{t('table.outOfStock')}</span>
+                  ) : (
+                    stock
+                  )}
                 </td>
                 <td className="px-3 py-2">
                   <Badge variant={STATUS_VARIANT[product.status] ?? 'outline'}>

--- a/src/components/products/productStock.ts
+++ b/src/components/products/productStock.ts
@@ -1,0 +1,15 @@
+import type { Product } from '@/types/products';
+
+// Catalog-row stock: null = not applicable (digital) or untracked (no value set);
+// a number (0 = out of stock) otherwise. Physical products with variants sum the
+// per-variant stock, since product-level stock is usually unset in that case.
+export function stockInfo(product: Product): number | null {
+  if (product.kind !== 'physical') return null;
+  const variants = product.variants ?? [];
+  if (variants.length > 0) {
+    const tracked = variants.filter((v) => v.stock_quantity != null);
+    if (tracked.length === 0) return null;
+    return tracked.reduce((sum, v) => sum + (v.stock_quantity ?? 0), 0);
+  }
+  return product.stock_quantity ?? null;
+}

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -232,6 +232,7 @@
     "urlInvalid": "Enter a valid URL (http/https)",
     "requiredLegend": "Fields marked with * are required",
     "skuTaken": "This SKU is already in use",
-    "variantPriceCurrency": "in {{currency}}"
+    "variantPriceCurrency": "in {{currency}}",
+    "fixErrors": "Fill in the required fields to continue."
   }
 }

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -59,7 +59,10 @@
     "descriptionPlaceholder": "Short product description (shown to the AI agent)",
     "labels": "Categories / tags",
     "labelsPlaceholder": "Comma separated, e.g. apparel, summer-collection",
-    "labelsHint": "Categories help filter products and may also be used by automation rules."
+    "labelsHint": "Categories help filter products and may also be used by automation rules.",
+    "skuPlaceholder": "SKU-001",
+    "purchaseUrlPlaceholder": "https://...",
+    "digitalNoStockHint": "Digital products have no stock."
   },
   "media": {
     "uploadHint": "Drag images here or use the button below.",
@@ -74,7 +77,8 @@
     "sku": "SKU",
     "priceOverride": "Price override",
     "stock": "Stock",
-    "digitalHint": "Variants are usually not used for digital products."
+    "digitalHint": "Variants are usually not used for digital products.",
+    "namePlaceholder": "e.g. S / M / L"
   },
   "actions": {
     "cancel": "Cancel",
@@ -215,5 +219,19 @@
     "noVariant": "No variant",
     "quantity": "Quantity",
     "notes": "Notes (optional)"
+  },
+  "currency": {
+    "BRL": "Brazilian Real (BRL)",
+    "USD": "US Dollar (USD)",
+    "EUR": "Euro (EUR)"
+  },
+  "validation": {
+    "nameRequired": "Name is required",
+    "priceRequired": "Price is required",
+    "priceMin": "Price must be 0 or greater",
+    "urlInvalid": "Enter a valid URL (http/https)",
+    "requiredLegend": "Fields marked with * are required",
+    "skuTaken": "This SKU is already in use",
+    "variantPriceCurrency": "in {{currency}}"
   }
 }

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -42,7 +42,8 @@
       "general": "General",
       "media": "Media",
       "variants": "Variants",
-      "labels": "Categories"
+      "labels": "Categories",
+      "mediaSoon": "Media (soon)"
     }
   },
   "fields": {

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -42,8 +42,7 @@
       "general": "General",
       "media": "Media",
       "variants": "Variants",
-      "labels": "Categories",
-      "mediaSoon": "Media (soon)"
+      "labels": "Categories"
     }
   },
   "fields": {

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -31,8 +31,10 @@
       "price": "Price",
       "status": "Status",
       "variants": "Variants",
-      "actions": "Actions"
-    }
+      "actions": "Actions",
+      "stock": "Stock"
+    },
+    "outOfStock": "Out of stock"
   },
   "modal": {
     "createTitle": "Create product",

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -31,8 +31,10 @@
       "price": "Precio",
       "status": "Estado",
       "variants": "Variantes",
-      "actions": "Acciones"
-    }
+      "actions": "Acciones",
+      "stock": "Stock"
+    },
+    "outOfStock": "Agotado"
   },
   "modal": {
     "createTitle": "Crear producto",

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -232,6 +232,7 @@
     "urlInvalid": "Introduce una URL válida (http/https)",
     "requiredLegend": "Los campos marcados con * son obligatorios",
     "skuTaken": "Este SKU ya está en uso",
-    "variantPriceCurrency": "en {{currency}}"
+    "variantPriceCurrency": "en {{currency}}",
+    "fixErrors": "Completa los campos obligatorios para continuar."
   }
 }

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -42,8 +42,7 @@
       "general": "General",
       "media": "Multimedia",
       "variants": "Variantes",
-      "labels": "Categorías",
-      "mediaSoon": "Medios (próximamente)"
+      "labels": "Categorías"
     }
   },
   "fields": {

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -42,7 +42,8 @@
       "general": "General",
       "media": "Multimedia",
       "variants": "Variantes",
-      "labels": "Categorías"
+      "labels": "Categorías",
+      "mediaSoon": "Medios (próximamente)"
     }
   },
   "fields": {

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -59,7 +59,10 @@
     "descriptionPlaceholder": "Descripción corta del producto (también usada por el agente de IA)",
     "labels": "Categorías / etiquetas",
     "labelsPlaceholder": "Separadas por comas, ej.: ropa, coleccion-verano",
-    "labelsHint": "Las categorías ayudan a filtrar productos y pueden ser usadas por reglas de automatización."
+    "labelsHint": "Las categorías ayudan a filtrar productos y pueden ser usadas por reglas de automatización.",
+    "skuPlaceholder": "SKU-001",
+    "purchaseUrlPlaceholder": "https://...",
+    "digitalNoStockHint": "Los productos digitales no tienen stock."
   },
   "media": {
     "uploadHint": "Arrastre imágenes aquí o use el botón de abajo.",
@@ -74,7 +77,8 @@
     "sku": "SKU",
     "priceOverride": "Precio (anula el predeterminado)",
     "stock": "Stock",
-    "digitalHint": "Generalmente no se usan variantes en productos digitales."
+    "digitalHint": "Generalmente no se usan variantes en productos digitales.",
+    "namePlaceholder": "ej.: P / M / G"
   },
   "actions": {
     "cancel": "Cancelar",
@@ -215,5 +219,19 @@
     "noVariant": "Sin variante",
     "quantity": "Cantidad",
     "notes": "Notas (opcional)"
+  },
+  "currency": {
+    "BRL": "Real (BRL)",
+    "USD": "Dólar (USD)",
+    "EUR": "Euro (EUR)"
+  },
+  "validation": {
+    "nameRequired": "El nombre es obligatorio",
+    "priceRequired": "El precio es obligatorio",
+    "priceMin": "El precio debe ser 0 o mayor",
+    "urlInvalid": "Introduce una URL válida (http/https)",
+    "requiredLegend": "Los campos marcados con * son obligatorios",
+    "skuTaken": "Este SKU ya está en uso",
+    "variantPriceCurrency": "en {{currency}}"
   }
 }

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -232,6 +232,7 @@
     "urlInvalid": "Saisissez une URL valide (http/https)",
     "requiredLegend": "Les champs marqués d'un * sont obligatoires",
     "skuTaken": "Ce SKU est déjà utilisé",
-    "variantPriceCurrency": "en {{currency}}"
+    "variantPriceCurrency": "en {{currency}}",
+    "fixErrors": "Renseignez les champs obligatoires pour continuer."
   }
 }

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -31,8 +31,10 @@
       "price": "Prix",
       "status": "Statut",
       "variants": "Variantes",
-      "actions": "Actions"
-    }
+      "actions": "Actions",
+      "stock": "Stock"
+    },
+    "outOfStock": "Épuisé"
   },
   "modal": {
     "createTitle": "Créer un produit",

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -59,7 +59,10 @@
     "descriptionPlaceholder": "Courte description du produit (également visible par l'agent IA)",
     "labels": "Catégories / étiquettes",
     "labelsPlaceholder": "Séparées par des virgules, ex.: vetements, collection-ete",
-    "labelsHint": "Les catégories aident à filtrer les produits et peuvent être utilisées par les règles d'automatisation."
+    "labelsHint": "Les catégories aident à filtrer les produits et peuvent être utilisées par les règles d'automatisation.",
+    "skuPlaceholder": "SKU-001",
+    "purchaseUrlPlaceholder": "https://...",
+    "digitalNoStockHint": "Les produits numériques n'ont pas de stock."
   },
   "media": {
     "uploadHint": "Faites glisser des images ici ou utilisez le bouton ci-dessous.",
@@ -74,7 +77,8 @@
     "sku": "SKU",
     "priceOverride": "Prix (remplace celui par défaut)",
     "stock": "Stock",
-    "digitalHint": "Les variantes ne sont généralement pas utilisées pour les produits numériques."
+    "digitalHint": "Les variantes ne sont généralement pas utilisées pour les produits numériques.",
+    "namePlaceholder": "ex. : S / M / L"
   },
   "actions": {
     "cancel": "Annuler",
@@ -215,5 +219,19 @@
     "noVariant": "Sans variante",
     "quantity": "Quantité",
     "notes": "Notes (facultatif)"
+  },
+  "currency": {
+    "BRL": "Réal (BRL)",
+    "USD": "Dollar (USD)",
+    "EUR": "Euro (EUR)"
+  },
+  "validation": {
+    "nameRequired": "Le nom est obligatoire",
+    "priceRequired": "Le prix est obligatoire",
+    "priceMin": "Le prix doit être 0 ou plus",
+    "urlInvalid": "Saisissez une URL valide (http/https)",
+    "requiredLegend": "Les champs marqués d'un * sont obligatoires",
+    "skuTaken": "Ce SKU est déjà utilisé",
+    "variantPriceCurrency": "en {{currency}}"
   }
 }

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -42,7 +42,8 @@
       "general": "Général",
       "media": "Médias",
       "variants": "Variantes",
-      "labels": "Catégories"
+      "labels": "Catégories",
+      "mediaSoon": "Médias (bientôt)"
     }
   },
   "fields": {

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -42,8 +42,7 @@
       "general": "Général",
       "media": "Médias",
       "variants": "Variantes",
-      "labels": "Catégories",
-      "mediaSoon": "Médias (bientôt)"
+      "labels": "Catégories"
     }
   },
   "fields": {

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -42,7 +42,8 @@
       "general": "Generale",
       "media": "Media",
       "variants": "Varianti",
-      "labels": "Categorie"
+      "labels": "Categorie",
+      "mediaSoon": "Media (a breve)"
     }
   },
   "fields": {

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -42,8 +42,7 @@
       "general": "Generale",
       "media": "Media",
       "variants": "Varianti",
-      "labels": "Categorie",
-      "mediaSoon": "Media (a breve)"
+      "labels": "Categorie"
     }
   },
   "fields": {

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -59,7 +59,10 @@
     "descriptionPlaceholder": "Breve descrizione del prodotto (anche visibile all'agente IA)",
     "labels": "Categorie / etichette",
     "labelsPlaceholder": "Separate da virgola, es.: abbigliamento, collezione-estate",
-    "labelsHint": "Le categorie aiutano a filtrare i prodotti e possono essere usate da regole di automazione."
+    "labelsHint": "Le categorie aiutano a filtrare i prodotti e possono essere usate da regole di automazione.",
+    "skuPlaceholder": "SKU-001",
+    "purchaseUrlPlaceholder": "https://...",
+    "digitalNoStockHint": "I prodotti digitali non hanno scorte."
   },
   "media": {
     "uploadHint": "Trascina le immagini qui o usa il pulsante in basso.",
@@ -74,7 +77,8 @@
     "sku": "SKU",
     "priceOverride": "Prezzo (sovrascrive il predefinito)",
     "stock": "Stock",
-    "digitalHint": "Le varianti non sono solitamente utilizzate per prodotti digitali."
+    "digitalHint": "Le varianti non sono solitamente utilizzate per prodotti digitali.",
+    "namePlaceholder": "es.: S / M / L"
   },
   "actions": {
     "cancel": "Annulla",
@@ -215,5 +219,19 @@
     "noVariant": "Senza variante",
     "quantity": "Quantità",
     "notes": "Note (facoltativo)"
+  },
+  "currency": {
+    "BRL": "Real (BRL)",
+    "USD": "Dollaro (USD)",
+    "EUR": "Euro (EUR)"
+  },
+  "validation": {
+    "nameRequired": "Il nome è obbligatorio",
+    "priceRequired": "Il prezzo è obbligatorio",
+    "priceMin": "Il prezzo deve essere 0 o maggiore",
+    "urlInvalid": "Inserisci un URL valido (http/https)",
+    "requiredLegend": "I campi contrassegnati con * sono obbligatori",
+    "skuTaken": "Questo SKU è già in uso",
+    "variantPriceCurrency": "in {{currency}}"
   }
 }

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -31,8 +31,10 @@
       "price": "Prezzo",
       "status": "Stato",
       "variants": "Varianti",
-      "actions": "Azioni"
-    }
+      "actions": "Azioni",
+      "stock": "Scorte"
+    },
+    "outOfStock": "Esaurito"
   },
   "modal": {
     "createTitle": "Crea prodotto",

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -232,6 +232,7 @@
     "urlInvalid": "Inserisci un URL valido (http/https)",
     "requiredLegend": "I campi contrassegnati con * sono obbligatori",
     "skuTaken": "Questo SKU è già in uso",
-    "variantPriceCurrency": "in {{currency}}"
+    "variantPriceCurrency": "in {{currency}}",
+    "fixErrors": "Compila i campi obbligatori per continuare."
   }
 }

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -31,8 +31,10 @@
       "price": "Preço",
       "status": "Status",
       "variants": "Variantes",
-      "actions": "Ações"
-    }
+      "actions": "Ações",
+      "stock": "Estoque"
+    },
+    "outOfStock": "Esgotado"
   },
   "modal": {
     "createTitle": "Criar produto",

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -42,8 +42,7 @@
       "general": "Geral",
       "media": "Mídias",
       "variants": "Variantes",
-      "labels": "Categorias",
-      "mediaSoon": "Mídia (em breve)"
+      "labels": "Categorias"
     }
   },
   "fields": {

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -232,6 +232,7 @@
     "urlInvalid": "Informe uma URL válida (http/https)",
     "requiredLegend": "Campos marcados com * são obrigatórios",
     "skuTaken": "Este SKU já está em uso",
-    "variantPriceCurrency": "em {{currency}}"
+    "variantPriceCurrency": "em {{currency}}",
+    "fixErrors": "Preencha os campos obrigatórios para continuar."
   }
 }

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -42,7 +42,8 @@
       "general": "Geral",
       "media": "Mídias",
       "variants": "Variantes",
-      "labels": "Categorias"
+      "labels": "Categorias",
+      "mediaSoon": "Mídia (em breve)"
     }
   },
   "fields": {

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -59,7 +59,10 @@
     "descriptionPlaceholder": "Descrição curta do produto (também usada pelo agente de IA)",
     "labels": "Categorias / etiquetas",
     "labelsPlaceholder": "Separadas por vírgula, ex.: vestuario, colecao-verao",
-    "labelsHint": "Categorias ajudam a filtrar produtos e podem ser usadas por regras de automação."
+    "labelsHint": "Categorias ajudam a filtrar produtos e podem ser usadas por regras de automação.",
+    "skuPlaceholder": "SKU-001",
+    "purchaseUrlPlaceholder": "https://...",
+    "digitalNoStockHint": "Produtos digitais não têm estoque."
   },
   "media": {
     "uploadHint": "Arraste imagens ou clique no botão abaixo.",
@@ -74,7 +77,8 @@
     "sku": "SKU",
     "priceOverride": "Preço (override)",
     "stock": "Estoque",
-    "digitalHint": "Geralmente não são usadas variantes em produtos digitais."
+    "digitalHint": "Geralmente não são usadas variantes em produtos digitais.",
+    "namePlaceholder": "ex.: P / M / G"
   },
   "actions": {
     "cancel": "Cancelar",
@@ -215,5 +219,19 @@
     "noVariant": "Sem variante",
     "quantity": "Quantidade",
     "notes": "Observações (opcional)"
+  },
+  "currency": {
+    "BRL": "Real (BRL)",
+    "USD": "Dólar (USD)",
+    "EUR": "Euro (EUR)"
+  },
+  "validation": {
+    "nameRequired": "Nome é obrigatório",
+    "priceRequired": "Preço é obrigatório",
+    "priceMin": "Preço deve ser 0 ou maior",
+    "urlInvalid": "Informe uma URL válida (http/https)",
+    "requiredLegend": "Campos marcados com * são obrigatórios",
+    "skuTaken": "Este SKU já está em uso",
+    "variantPriceCurrency": "em {{currency}}"
   }
 }

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -42,8 +42,7 @@
       "general": "Geral",
       "media": "Multimédia",
       "variants": "Variantes",
-      "labels": "Categorias",
-      "mediaSoon": "Multimédia (em breve)"
+      "labels": "Categorias"
     }
   },
   "fields": {

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -59,7 +59,10 @@
     "descriptionPlaceholder": "Descrição curta do produto (também usada pelo agente de IA)",
     "labels": "Categorias / etiquetas",
     "labelsPlaceholder": "Separadas por vírgula, ex.: vestuario, colecao-verao",
-    "labelsHint": "As categorias ajudam a filtrar produtos e podem ser usadas por regras de automação."
+    "labelsHint": "As categorias ajudam a filtrar produtos e podem ser usadas por regras de automação.",
+    "skuPlaceholder": "SKU-001",
+    "purchaseUrlPlaceholder": "https://...",
+    "digitalNoStockHint": "Produtos digitais não têm stock."
   },
   "media": {
     "uploadHint": "Arraste imagens para aqui ou utilize o botão em baixo.",
@@ -74,7 +77,8 @@
     "sku": "SKU",
     "priceOverride": "Preço (substitui o padrão)",
     "stock": "Stock",
-    "digitalHint": "Normalmente não se utilizam variantes em produtos digitais."
+    "digitalHint": "Normalmente não se utilizam variantes em produtos digitais.",
+    "namePlaceholder": "ex.: P / M / G"
   },
   "actions": {
     "cancel": "Cancelar",
@@ -215,5 +219,19 @@
     "noVariant": "Sem variante",
     "quantity": "Quantidade",
     "notes": "Notas (opcional)"
+  },
+  "currency": {
+    "BRL": "Real (BRL)",
+    "USD": "Dólar (USD)",
+    "EUR": "Euro (EUR)"
+  },
+  "validation": {
+    "nameRequired": "O nome é obrigatório",
+    "priceRequired": "O preço é obrigatório",
+    "priceMin": "O preço deve ser 0 ou superior",
+    "urlInvalid": "Introduza um URL válido (http/https)",
+    "requiredLegend": "Os campos marcados com * são obrigatórios",
+    "skuTaken": "Este SKU já está em uso",
+    "variantPriceCurrency": "em {{currency}}"
   }
 }

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -31,8 +31,10 @@
       "price": "Preço",
       "status": "Estado",
       "variants": "Variantes",
-      "actions": "Ações"
-    }
+      "actions": "Ações",
+      "stock": "Stock"
+    },
+    "outOfStock": "Esgotado"
   },
   "modal": {
     "createTitle": "Criar produto",

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -232,6 +232,7 @@
     "urlInvalid": "Introduza um URL válido (http/https)",
     "requiredLegend": "Os campos marcados com * são obrigatórios",
     "skuTaken": "Este SKU já está em uso",
-    "variantPriceCurrency": "em {{currency}}"
+    "variantPriceCurrency": "em {{currency}}",
+    "fixErrors": "Preencha os campos obrigatórios para continuar."
   }
 }

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -42,7 +42,8 @@
       "general": "Geral",
       "media": "Multimédia",
       "variants": "Variantes",
-      "labels": "Categorias"
+      "labels": "Categorias",
+      "mediaSoon": "Multimédia (em breve)"
     }
   },
   "fields": {

--- a/src/pages/Customer/Settings/Products/Products.tsx
+++ b/src/pages/Customer/Settings/Products/Products.tsx
@@ -3,7 +3,7 @@ import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { productsService } from '@/services/products/productsService';
-import { extractError } from '@/utils/apiHelpers';
+import { toFieldErrors } from './productErrors';
 import type {
   Product,
   ProductFormData,
@@ -25,26 +25,6 @@ import {
 } from '@evoapi/design-system';
 
 const DEFAULT_PAGE_SIZE = 25;
-
-// Maps a 422 validation error into a { field: message } map so the modal can
-// show server errors (e.g. SKU uniqueness) inline. Returns {} for non-field errors.
-function toFieldErrors(error: unknown): Record<string, string> {
-  const { details } = extractError(error);
-  const out: Record<string, string> = {};
-  if (Array.isArray(details)) {
-    details.forEach((d) => {
-      if (d && typeof d === 'object' && 'field' in d) {
-        const detail = d as { field: string; message?: string };
-        out[detail.field] = detail.message ?? '';
-      }
-    });
-  } else if (details && typeof details === 'object') {
-    Object.entries(details as Record<string, unknown>).forEach(([field, msgs]) => {
-      out[field] = Array.isArray(msgs) ? String(msgs[0]) : String(msgs);
-    });
-  }
-  return out;
-}
 
 export default function Products() {
   const { t } = useLanguage('products');

--- a/src/pages/Customer/Settings/Products/Products.tsx
+++ b/src/pages/Customer/Settings/Products/Products.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { productsService } from '@/services/products/productsService';
+import { extractError } from '@/utils/apiHelpers';
 import type {
   Product,
   ProductFormData,
@@ -25,6 +26,26 @@ import {
 
 const DEFAULT_PAGE_SIZE = 25;
 
+// Maps a 422 validation error into a { field: message } map so the modal can
+// show server errors (e.g. SKU uniqueness) inline. Returns {} for non-field errors.
+function toFieldErrors(error: unknown): Record<string, string> {
+  const { details } = extractError(error);
+  const out: Record<string, string> = {};
+  if (Array.isArray(details)) {
+    details.forEach((d) => {
+      if (d && typeof d === 'object' && 'field' in d) {
+        const detail = d as { field: string; message?: string };
+        out[detail.field] = detail.message ?? '';
+      }
+    });
+  } else if (details && typeof details === 'object') {
+    Object.entries(details as Record<string, unknown>).forEach(([field, msgs]) => {
+      out[field] = Array.isArray(msgs) ? String(msgs[0]) : String(msgs);
+    });
+  }
+  return out;
+}
+
 export default function Products() {
   const { t } = useLanguage('products');
   const { can } = useUserPermissions();
@@ -44,6 +65,7 @@ export default function Products() {
 
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<Product | null>(null);
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
 
   const [confirmDelete, setConfirmDelete] = useState<Product | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -78,16 +100,19 @@ export default function Products() {
 
   const openCreate = () => {
     setEditing(null);
+    setFormErrors({});
     setModalOpen(true);
   };
 
   const openEdit = (product: Product) => {
     setEditing(product);
+    setFormErrors({});
     setModalOpen(true);
   };
 
   const handleSubmit = async (payload: ProductFormData, files?: File[]) => {
     setSaving(true);
+    setFormErrors({});
     try {
       if (editing?.id) {
         await productsService.updateProduct(editing.id, payload, files);
@@ -101,7 +126,12 @@ export default function Products() {
       fetchProducts();
     } catch (error) {
       console.error(error);
-      toast.error(editing ? t('messages.updateError') : t('messages.createError'));
+      const fieldErrors = toFieldErrors(error);
+      if (Object.keys(fieldErrors).length > 0) {
+        setFormErrors(fieldErrors);
+      } else {
+        toast.error(editing ? t('messages.updateError') : t('messages.createError'));
+      }
     } finally {
       setSaving(false);
     }
@@ -173,6 +203,7 @@ export default function Products() {
         open={modalOpen}
         product={editing}
         loading={saving}
+        errors={formErrors}
         onOpenChange={(open) => {
           setModalOpen(open);
           if (!open) setEditing(null);

--- a/src/pages/Customer/Settings/Products/productErrors.spec.ts
+++ b/src/pages/Customer/Settings/Products/productErrors.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { toFieldErrors } from './productErrors';
+
+// Builds an Axios-like error matching the CRM `error_response` envelope so the
+// parser is exercised against the real 422 payload, not a pre-formatted stub.
+const error422 = (details: unknown) => ({
+  response: {
+    status: 422,
+    data: {
+      success: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Validation failed', details },
+    },
+  },
+});
+
+describe('toFieldErrors', () => {
+  it('maps the real backend payload (format_validation_errors) to field messages', () => {
+    const err = error422([
+      { field: 'sku', messages: ['has already been taken'], full_messages: ['Sku has already been taken'] },
+    ]);
+    expect(toFieldErrors(err)).toEqual({ sku: 'has already been taken' });
+  });
+
+  it('maps multiple fields from the structured payload', () => {
+    const err = error422([
+      { field: 'name', messages: ["can't be blank"], full_messages: ["Name can't be blank"] },
+      { field: 'default_price', messages: ['is not a number'], full_messages: ['Default price is not a number'] },
+    ]);
+    expect(toFieldErrors(err)).toEqual({
+      name: "can't be blank",
+      default_price: 'is not a number',
+    });
+  });
+
+  it('falls back to full_messages when messages is absent', () => {
+    const err = error422([{ field: 'sku', full_messages: ['Sku has already been taken'] }]);
+    expect(toFieldErrors(err)).toEqual({ sku: 'Sku has already been taken' });
+  });
+
+  it('still supports the legacy { field, message } shape', () => {
+    const err = error422([{ field: 'sku', message: 'has already been taken' }]);
+    expect(toFieldErrors(err)).toEqual({ sku: 'has already been taken' });
+  });
+
+  it('still supports the legacy { field: [messages] } object shape', () => {
+    const err = error422({ sku: ['has already been taken'] });
+    expect(toFieldErrors(err)).toEqual({ sku: 'has already been taken' });
+  });
+
+  it('returns {} for a flat string-array payload (no field anchor)', () => {
+    const err = error422(['Sku has already been taken']);
+    expect(toFieldErrors(err)).toEqual({});
+  });
+
+  it('returns {} when there are no details (non-field error)', () => {
+    const err = error422(undefined);
+    expect(toFieldErrors(err)).toEqual({});
+  });
+});

--- a/src/pages/Customer/Settings/Products/productErrors.ts
+++ b/src/pages/Customer/Settings/Products/productErrors.ts
@@ -1,0 +1,30 @@
+import { extractError } from '@/utils/apiHelpers';
+
+// Maps a 422 validation error into a { field: message } map so the modal can
+// show server errors (e.g. SKU uniqueness) inline. Returns {} for non-field errors.
+// The backend emits structured details as [{ field, messages, full_messages }] via
+// format_validation_errors; the legacy { field, message } and { field: [msgs] } shapes
+// stay supported for resilience.
+export function toFieldErrors(error: unknown): Record<string, string> {
+  const { details } = extractError(error);
+  const out: Record<string, string> = {};
+  if (Array.isArray(details)) {
+    details.forEach((d) => {
+      if (d && typeof d === 'object' && 'field' in d) {
+        const detail = d as {
+          field: string;
+          message?: string;
+          messages?: string[];
+          full_messages?: string[];
+        };
+        out[detail.field] =
+          detail.message ?? detail.messages?.[0] ?? detail.full_messages?.[0] ?? '';
+      }
+    });
+  } else if (details && typeof details === 'object') {
+    Object.entries(details as Record<string, unknown>).forEach(([field, msgs]) => {
+      out[field] = Array.isArray(msgs) ? String(msgs[0]) : String(msgs);
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
Phase 1 UX polish of the product create/edit form (`ProductModal`) + the catalog table. **Frontend-only** — the community `Product` model/API/validations already cover everything (no backend change).

- **Stock only for physical** products (general field + per-variant); stock is nulled for digital on submit.
- **Visible validation** — submit is never a silent disabled button: clicking an invalid form reveals field errors and jumps to the General tab; required-field legend; empty price stays `null` (not `0`).
- **Server 422 field errors** (e.g. SKU uniqueness) surfaced **inline** in the form instead of a generic toast.
- **Price + currency on one row**; field order per the UX spec.
- **i18n** — hardcoded placeholders + currency labels across all 6 locales.
- **a11y** — `htmlFor`/`id` on every select + variant input; `aria-required`/`aria-invalid`.
- **Media tab removed** — image upload is not wired end-to-end (backend `attach_images` drops raw multipart files, expects ActiveStorage signed_ids). A code comment documents how to restore it; a real upload flow is a separate follow-up.
- **Catalog table: Stock column** — digital → "—"; untracked → "—"; physical → number; with variants → summed; `0` → "Out of stock" (red).

## Security
No new endpoints, no authZ change. Client validation mirrors server rules for fast feedback; the backend stays the source of truth (its 422 is surfaced inline).

## Test plan
- `frontend: pnpm exec vitest run src/components/products/` — 11 tests pass
- `frontend: pnpm exec eslint <changed files>` — 0 warnings
- `frontend: pnpm exec tsc -b --noEmit` — no errors in changed files
- Manual smoke: create physical/digital product (stock conditional), trigger required validation + a duplicate-SKU 422 (inline), verify the catalog Stock column.

## Changed Files
- `src/components/products/ProductModal.tsx`
- `src/components/products/ProductModal.spec.tsx`
- `src/components/products/ProductsTable.tsx`
- `src/components/products/ProductsTable.spec.tsx`
- `src/components/products/productStock.ts`
- `src/pages/Customer/Settings/Products/Products.tsx`
- `src/i18n/locales/{en,pt-BR,es,fr,it,pt}/products.json`

## Out of scope / follow-ups
- Phase 2 (labels → chips, variant grid header, loading state, post-create visibility) + Phase 3 (single-screen redesign, deep-link `/products/:id`).
- Real product image upload (needs backend signed_ids / direct-upload flow).

## Linked Issue
- EVO-1783
