### PR TITLE
fix(journey): list contact custom attributes in Conditional field picker (EVO-1837)

### DIFF
--- a/src/components/journey/environment-manager/VariableSelect.tsx
+++ b/src/components/journey/environment-manager/VariableSelect.tsx
@@ -33,6 +33,7 @@ export interface VariableSelectProps {
   showContactAttributes?: boolean;
   disabled?: boolean;
   journeyId?: string; // Para buscar variáveis da jornada
+  triggerTestId?: string; // Stable hook for the trigger (locale-independent tests)
 }
 
 const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
@@ -48,6 +49,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
       showContactAttributes = false,
       disabled = false,
       journeyId,
+      triggerTestId,
       ...props
     },
     ref,
@@ -153,6 +155,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
         >
           <SelectTrigger
             ref={ref}
+            data-testid={triggerTestId}
             className={cn(
               'w-full bg-sidebar border-sidebar-border text-sidebar-foreground',
               className,
@@ -229,7 +232,14 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                 <div className="px-2 py-1 text-xs font-medium text-gray-500">
                   {t('environmentManager.categories.contactAttributes')}
                 </div>
-                {contactAttributes.map(attribute => (
+                {contactAttributes
+                  .slice()
+                  .sort((a, b) =>
+                    (a.attribute_display_name || a.attribute_key || '').localeCompare(
+                      b.attribute_display_name || b.attribute_key || '',
+                    ),
+                  )
+                  .map(attribute => (
                   <SelectItem
                     key={attribute.id}
                     value={`{{contact.customAttributes.${attribute.attribute_key}}}`}

--- a/src/components/journey/environment-manager/VariableSelect.tsx
+++ b/src/components/journey/environment-manager/VariableSelect.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import {
   Select,
   SelectContent,
@@ -18,6 +18,8 @@ import { Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useJourneyVariables } from '@/hooks/useJourneyVariables';
 import { useLanguage } from '@/hooks/useLanguage';
+import { customAttributesService } from '@/services/customAttributes/customAttributesService';
+import type { CustomAttributeDefinition } from '@/types/settings';
 import { getSystemVariables } from './EnvironmentManager';
 
 export interface VariableSelectProps {
@@ -28,6 +30,7 @@ export interface VariableSelectProps {
   className?: string;
   showCreateOption?: boolean;
   showSystemVariables?: boolean;
+  showContactAttributes?: boolean;
   disabled?: boolean;
   journeyId?: string; // Para buscar variáveis da jornada
 }
@@ -42,6 +45,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
       className,
       showCreateOption = true,
       showSystemVariables = false,
+      showContactAttributes = false,
       disabled = false,
       journeyId,
       ...props
@@ -50,6 +54,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
   ) => {
     const { t } = useLanguage('journey');
     const [showCreateModal, setShowCreateModal] = useState(false);
+    const [contactAttributes, setContactAttributes] = useState<CustomAttributeDefinition[]>([]);
     const [newVariableName, setNewVariableName] = useState('');
     const [newVariableType, setNewVariableType] = useState<'text' | 'number' | 'boolean' | 'date'>(
       'text',
@@ -59,6 +64,27 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
     const { variables, addVariable } = useJourneyVariables(journeyId);
 
     const SYSTEM_VARIABLES = getSystemVariables(t);
+
+    // Fetch contact custom attribute definitions so they can be branched on as
+    // condition fields. On error, leave the list empty — the section simply
+    // does not render and the rest of the picker keeps working.
+    useEffect(() => {
+      if (!showContactAttributes) return;
+
+      let active = true;
+      customAttributesService
+        .getCustomAttributes('contact_attribute')
+        .then(res => {
+          if (active) setContactAttributes(res.data);
+        })
+        .catch(error => {
+          console.error('Error fetching contact custom attributes:', error);
+        });
+
+      return () => {
+        active = false;
+      };
+    }, [showContactAttributes]);
 
     const handleValueChange = (selectedValue: string) => {
       if (selectedValue === '__new__') {
@@ -186,6 +212,34 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                     </div>
                   );
                 })}
+
+                {variables.length > 0 && <Separator className="my-2" />}
+              </>
+            )}
+
+            {/* Atributos do Contato */}
+            {showContactAttributes && contactAttributes.length > 0 && (
+              <>
+                {/* Only add a leading separator when the system block above did
+                    not already render its trailing one (which it does iff there
+                    are custom journey variables) — avoids a double separator. */}
+                {showSystemVariables && variables.length === 0 && (
+                  <Separator className="my-2" />
+                )}
+                <div className="px-2 py-1 text-xs font-medium text-gray-500">
+                  {t('environmentManager.categories.contactAttributes')}
+                </div>
+                {contactAttributes.map(attribute => (
+                  <SelectItem
+                    key={attribute.id}
+                    value={`{{contact.customAttributes.${attribute.attribute_key}}}`}
+                    className="text-sidebar-foreground"
+                  >
+                    <div className="flex flex-col gap-0.5">
+                      <span className="font-medium">{attribute.attribute_display_name}</span>
+                    </div>
+                  </SelectItem>
+                ))}
 
                 {variables.length > 0 && <Separator className="my-2" />}
               </>

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
@@ -12,11 +12,28 @@ vi.mock('@/services/pipelines/pipelinesService', () => ({
   },
 }));
 
+vi.mock('@/services/customAttributes/customAttributesService', () => ({
+  customAttributesService: {
+    getCustomAttributes: vi.fn(),
+  },
+}));
+
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import { customAttributesService } from '@/services/customAttributes/customAttributesService';
 
 const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
 const mockGetPipelineStages =
   pipelinesService.getPipelineStages as unknown as ReturnType<typeof vi.fn>;
+const mockGetCustomAttributes =
+  customAttributesService.getCustomAttributes as unknown as ReturnType<typeof vi.fn>;
+
+const PLAN_INTEREST_ATTR = {
+  id: 'attr-1',
+  attribute_key: 'plan_interest',
+  attribute_display_name: 'Plan Interest',
+  attribute_display_type: 'list',
+  attribute_model: 'contact_attribute',
+};
 
 const PIPELINE_STAGE_FIELD = '{{conversation.pipeline_stage_id}}';
 
@@ -48,7 +65,7 @@ function dataWithStageCondition(value = ''): ConditionalNodeData {
   } as ConditionalNodeData;
 }
 
-function dataWithContactCondition(): ConditionalNodeData {
+function dataWithContactCondition(field = '{{contact.email}}'): ConditionalNodeData {
   return {
     paths: [
       {
@@ -60,7 +77,7 @@ function dataWithContactCondition(): ConditionalNodeData {
           {
             id: 'cond-1',
             type: 'contact',
-            field: '{{contact.email}}',
+            field,
             operator: 'equals',
             value: '',
           },
@@ -68,6 +85,18 @@ function dataWithContactCondition(): ConditionalNodeData {
       },
     ],
   } as ConditionalNodeData;
+}
+
+// The field picker (VariableSelect) is the combobox showing the
+// "Select a variable..." placeholder while no field is selected.
+function getFieldTrigger(): HTMLElement {
+  // The field picker shows a "Select variable…" style placeholder while empty;
+  // match the `variable` stem across locales (variable/variável/variabile).
+  const trigger = screen
+    .getAllByRole('combobox')
+    .find(el => /variabl|variáv|variabil/i.test(el.textContent || ''));
+  if (!trigger) throw new Error('field picker trigger not found');
+  return trigger;
 }
 
 // The value picker is one of several comboboxes in the panel; identify it by
@@ -79,6 +108,12 @@ function getStageTrigger(): HTMLElement {
   if (!trigger) throw new Error('stage picker trigger not found');
   return trigger;
 }
+
+beforeEach(() => {
+  // Default: empty attribute list so the always-on fetch in the field picker
+  // resolves to a promise in every test (per-test cases override this).
+  mockGetCustomAttributes.mockResolvedValue({ data: [] });
+});
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -163,5 +198,69 @@ describe('ConditionalPanel — pipeline stage picker', () => {
     // Let any effects settle, then assert the lazy loader stayed gated.
     await waitFor(() => expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0));
     expect(mockGetPipelines).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConditionalPanel — contact custom attributes in the field picker', () => {
+  it('lists fetched contact custom attributes and emits {{contact.customAttributes.<key>}} on select', async () => {
+    mockGetCustomAttributes.mockResolvedValue({ data: [PLAN_INTEREST_ATTR] });
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithContactCondition('')}
+        onUpdate={onUpdate}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mockGetCustomAttributes).toHaveBeenCalledWith('contact_attribute'),
+    );
+
+    await user.click(getFieldTrigger());
+    const listbox = await screen.findByRole('listbox');
+    const option = within(listbox).getByText('Plan Interest');
+    await user.click(option);
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /save|salvar|guardar|enregistrer|salva/i,
+    });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    expect(onUpdate).toHaveBeenCalled();
+    const [, updatedData] = onUpdate.mock.calls[0];
+    expect(updatedData.paths[0].conditions[0].field).toBe(
+      '{{contact.customAttributes.plan_interest}}',
+    );
+  });
+
+  it('degrades gracefully when the custom-attributes fetch fails (no crash, picker still opens)', async () => {
+    mockGetCustomAttributes.mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup();
+
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithContactCondition('')}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCustomAttributes).toHaveBeenCalled());
+
+    // Picker still opens and remains usable (system + journey variables): the
+    // listbox renders options, and the failed-fetch Contact Attributes section
+    // is simply absent (no "Plan Interest", no crash).
+    await user.click(getFieldTrigger());
+    const listbox = await screen.findByRole('listbox');
+    expect(within(listbox).getAllByRole('option').length).toBeGreaterThan(0);
+    expect(within(listbox).queryByText('Plan Interest')).toBeNull();
   });
 });

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
@@ -87,16 +87,11 @@ function dataWithContactCondition(field = '{{contact.email}}'): ConditionalNodeD
   } as ConditionalNodeData;
 }
 
-// The field picker (VariableSelect) is the combobox showing the
-// "Select a variable..." placeholder while no field is selected.
+// The field picker (VariableSelect) carries a stable, locale-independent test
+// id (see ConditionalPanel's `triggerTestId`) so the lookup does not depend on
+// localized placeholder copy. Use the first one (single-condition fixtures).
 function getFieldTrigger(): HTMLElement {
-  // The field picker shows a "Select variable…" style placeholder while empty;
-  // match the `variable` stem across locales (variable/variável/variabile).
-  const trigger = screen
-    .getAllByRole('combobox')
-    .find(el => /variabl|variáv|variabil/i.test(el.textContent || ''));
-  if (!trigger) throw new Error('field picker trigger not found');
-  return trigger;
+  return screen.getAllByTestId('conditional-field-select')[0];
 }
 
 // The value picker is one of several comboboxes in the panel; identify it by

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -295,6 +295,7 @@ export function ConditionalPanel({
               className="w-full"
               showSystemVariables={true}
               showContactAttributes={true}
+              triggerTestId="conditional-field-select"
             />
           </div>
 

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -294,6 +294,7 @@ export function ConditionalPanel({
               journeyId={journeyId}
               className="w-full"
               showSystemVariables={true}
+              showContactAttributes={true}
             />
           </div>
 

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -493,6 +493,7 @@
       "webhook": "Webhook",
       "journey": "Journey",
       "conversation": "Conversation",
+      "contactAttributes": "Contact Attributes",
       "others": "Others"
     },
     "form": {

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -476,6 +476,7 @@
       "event": "Evento",
       "webhook": "Webhook",
       "journey": "Jornada",
+      "contactAttributes": "Atributos del Contacto",
       "others": "Otros"
     },
     "form": {

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -476,6 +476,7 @@
       "event": "Événement",
       "webhook": "Webhook",
       "journey": "Parcours",
+      "contactAttributes": "Attributs du Contact",
       "others": "Autres"
     },
     "form": {

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -488,6 +488,7 @@
       "event": "Evento",
       "webhook": "Webhook",
       "journey": "Percorso",
+      "contactAttributes": "Attributi del Contatto",
       "others": "Altri"
     },
     "form": {

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -493,6 +493,7 @@
       "webhook": "Webhook",
       "journey": "Jornada",
       "conversation": "Conversa",
+      "contactAttributes": "Atributos do Contato",
       "others": "Outros"
     },
     "form": {

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -476,6 +476,7 @@
       "event": "Evento",
       "webhook": "Webhook",
       "journey": "Jornada",
+      "contactAttributes": "Atributos do Contato",
       "others": "Outros"
     },
     "form": {


### PR DESCRIPTION
## Summary

The Journey **Conditional** node field picker can now offer contact custom attributes (EVO-1837).

- Adds a `showContactAttributes` flag to `VariableSelect` that fetches contact custom attribute definitions (`customAttributesService.getCustomAttributes('contact_attribute')`) and lists them as selectable condition fields, emitting `{{contact.customAttributes.<attribute_key>}}`.
- Enables the flag in `ConditionalPanel`.
- Adds the **Contact Attributes** section label to all 6 journey locales (en/pt/pt-BR/es/fr/it).
- The section degrades to absent on fetch error (picker keeps working).

Pairs with the evo-flow runtime PR that resolves these fields at execution time. **Merge the runtime PR first or together** — this FE change alone would offer a field the runtime couldn't resolve.

## Test plan

- `vitest run ConditionalPanel.spec.tsx` → 5/5 green, incl. 2 new: attribute appears under "Contact Attributes" + selecting it emits `{{contact.customAttributes.plan_interest}}` (AC1), and fetch-failure degrades gracefully without crashing the picker (AC5).
- Lint and typecheck clean.

## Notas

- New flag defaults `false`, so the other `VariableSelect` callers (`SetVariablePanel`, `VariableMapping`) are unaffected.

## Summary by Sourcery

Add support for selecting contact custom attributes as condition fields in journey conditional nodes and ensure the picker degrades gracefully on fetch errors.

New Features:
- Expose contact custom attributes in the journey variable picker and emit them as contact.customAttributes fields when selected.

Enhancements:
- Extend VariableSelect with an optional flag to load and display contact attribute definitions alongside existing system and journey variables.
- Localize the new Contact Attributes section label across all supported journey locales.

Tests:
- Add ConditionalPanel tests covering listing and selecting contact custom attributes and graceful behavior when the attribute fetch fails.