### PR TITLE
fix(frontend): expand Contacts advanced filter + space the view toggle (EVO-1835)

### DIFF
--- a/src/components/contacts/ContactsFilter.tsx
+++ b/src/components/contacts/ContactsFilter.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import BaseFilter from '@/components/base/BaseFilter';
 import {
@@ -5,6 +6,7 @@ import {
   CONTACT_FILTER_TYPES,
   DEFAULT_CONTACT_FILTER,
 } from '@/types/core';
+import { useContactFilterOptions } from '@/hooks/contacts/useContactFilterOptions';
 
 interface ContactsFilterProps {
   open: boolean;
@@ -24,6 +26,15 @@ export default function ContactsFilter({
   onClearFilters,
 }: ContactsFilterProps) {
   const { t } = useLanguage('contacts');
+  const { labels } = useContactFilterOptions({ enabled: open });
+
+  const enrichedFilterTypes = useMemo(
+    () =>
+      CONTACT_FILTER_TYPES.map(filterType =>
+        filterType.attributeKey === 'labels' ? { ...filterType, options: labels } : filterType,
+      ),
+    [labels],
+  );
 
   return (
     <BaseFilter
@@ -33,7 +44,7 @@ export default function ContactsFilter({
       onFiltersChange={onFiltersChange}
       onApplyFilters={onApplyFilters}
       onClearFilters={onClearFilters}
-      filterTypes={CONTACT_FILTER_TYPES}
+      filterTypes={enrichedFilterTypes}
       defaultFilter={DEFAULT_CONTACT_FILTER}
       title={t('filter.title')}
       description={t('filter.description')}

--- a/src/hooks/contacts/useContactFilterOptions.ts
+++ b/src/hooks/contacts/useContactFilterOptions.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { labelsService } from '@/services/contacts/labelsService';
+import type { Label } from '@/types/settings';
+
+interface FilterOption {
+  label: string;
+  value: string;
+}
+
+interface ContactFilterOptions {
+  labels: FilterOption[];
+  loading: boolean;
+}
+
+interface UseContactFilterOptionsParams {
+  enabled?: boolean;
+}
+
+/**
+ * Loads the dynamic options for the Contacts advanced filter. Only labels are
+ * dynamic today; mirrors the labels block of useFilterOptions (conversations)
+ * but without the conversation-only lists (inboxes/teams/pipelines/contacts).
+ */
+export const useContactFilterOptions = (
+  params: UseContactFilterOptionsParams = {},
+): ContactFilterOptions => {
+  const { enabled = true } = params;
+  const [options, setOptions] = useState<ContactFilterOptions>({ labels: [], loading: false });
+
+  useEffect(() => {
+    if (!enabled) return;
+    let active = true;
+
+    const load = async () => {
+      setOptions(prev => ({ ...prev, loading: true }));
+      try {
+        const response = await labelsService.getLabels({ per_page: 200 });
+        const data = response?.data ?? [];
+        // value = label.title to match filter_service tag query (compares tags.name).
+        const labels = Array.isArray(data)
+          ? data.map((label: Label) => ({ label: label.title, value: label.title }))
+          : [];
+        if (active) setOptions({ labels, loading: false });
+      } catch (error) {
+        console.warn('Erro ao carregar labels para o filtro de contatos:', error);
+        if (active) setOptions({ labels: [], loading: false });
+      }
+    };
+
+    load();
+    return () => {
+      active = false;
+    };
+  }, [enabled]);
+
+  return options;
+};

--- a/src/i18n/locales/en/contacts.json
+++ b/src/i18n/locales/en/contacts.json
@@ -386,7 +386,18 @@
       "identifier": "Identifier",
       "created_at": "Creation Date",
       "last_activity_at": "Last Activity",
-      "type": "Contact Type"
+      "type": "Contact Type",
+      "labels": "Labels",
+      "country_code": "Country",
+      "city": "City",
+      "company": "Company",
+      "blocked": "Blocked"
+    },
+    "options": {
+      "blocked": {
+        "true": "Blocked",
+        "false": "Not blocked"
+      }
     }
   },
   "import": {

--- a/src/i18n/locales/es/contacts.json
+++ b/src/i18n/locales/es/contacts.json
@@ -378,7 +378,18 @@
       "identifier": "Identificador",
       "created_at": "Fecha de Creación",
       "last_activity_at": "Última Actividad",
-      "type": "Tipo de Contacto"
+      "type": "Tipo de Contacto",
+      "labels": "Etiquetas",
+      "country_code": "País",
+      "city": "Ciudad",
+      "company": "Empresa",
+      "blocked": "Bloqueado"
+    },
+    "options": {
+      "blocked": {
+        "true": "Bloqueado",
+        "false": "No bloqueado"
+      }
     }
   },
   "import": {

--- a/src/i18n/locales/fr/contacts.json
+++ b/src/i18n/locales/fr/contacts.json
@@ -378,7 +378,18 @@
       "identifier": "Identifiant",
       "created_at": "Date de Création",
       "last_activity_at": "Dernière Activité",
-      "type": "Type de Contact"
+      "type": "Type de Contact",
+      "labels": "Étiquettes",
+      "country_code": "Pays",
+      "city": "Ville",
+      "company": "Entreprise",
+      "blocked": "Bloqué"
+    },
+    "options": {
+      "blocked": {
+        "true": "Bloqué",
+        "false": "Non bloqué"
+      }
     }
   },
   "import": {

--- a/src/i18n/locales/it/contacts.json
+++ b/src/i18n/locales/it/contacts.json
@@ -378,7 +378,18 @@
       "identifier": "Identificatore",
       "created_at": "Data di Creazione",
       "last_activity_at": "Ultima Attività",
-      "type": "Tipo di Contatto"
+      "type": "Tipo di Contatto",
+      "labels": "Etichette",
+      "country_code": "Paese",
+      "city": "Città",
+      "company": "Azienda",
+      "blocked": "Bloccato"
+    },
+    "options": {
+      "blocked": {
+        "true": "Bloccato",
+        "false": "Non bloccato"
+      }
     }
   },
   "import": {

--- a/src/i18n/locales/pt-BR/contacts.json
+++ b/src/i18n/locales/pt-BR/contacts.json
@@ -386,7 +386,18 @@
       "identifier": "Identificador",
       "created_at": "Data de Criação",
       "last_activity_at": "Última Atividade",
-      "type": "Tipo de Contato"
+      "type": "Tipo de Contato",
+      "labels": "Etiquetas",
+      "country_code": "País",
+      "city": "Cidade",
+      "company": "Empresa",
+      "blocked": "Bloqueado"
+    },
+    "options": {
+      "blocked": {
+        "true": "Bloqueado",
+        "false": "Não bloqueado"
+      }
     }
   },
   "import": {

--- a/src/i18n/locales/pt/contacts.json
+++ b/src/i18n/locales/pt/contacts.json
@@ -386,7 +386,18 @@
       "identifier": "Identificador",
       "created_at": "Data de Criação",
       "last_activity_at": "Última Atividade",
-      "type": "Tipo de Contato"
+      "type": "Tipo de Contato",
+      "labels": "Etiquetas",
+      "country_code": "País",
+      "city": "Cidade",
+      "company": "Empresa",
+      "blocked": "Bloqueado"
+    },
+    "options": {
+      "blocked": {
+        "true": "Bloqueado",
+        "false": "Não bloqueado"
+      }
     }
   },
   "import": {

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -782,7 +782,7 @@ export default function Contacts() {
       </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mb-3" data-tour="contacts-view-toggle">
+      <div className="flex items-center justify-end mt-6 mb-3" data-tour="contacts-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}

--- a/src/types/core/filters.contacts.spec.ts
+++ b/src/types/core/filters.contacts.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { CONTACT_FILTER_TYPES } from './filters';
+
+describe('CONTACT_FILTER_TYPES (EVO-1835)', () => {
+  const byKey = (k: string) => CONTACT_FILTER_TYPES.find(f => f.attributeKey === k);
+  const keys = CONTACT_FILTER_TYPES.map(f => f.attributeKey);
+
+  it('exposes the new contact filters (labels, country_code, city, company, blocked)', () => {
+    for (const k of ['labels', 'country_code', 'city', 'company', 'blocked']) {
+      expect(keys).toContain(k);
+    }
+  });
+
+  it('keeps the original filters', () => {
+    for (const k of ['name', 'email', 'phone_number', 'identifier', 'created_at', 'last_activity_at']) {
+      expect(keys).toContain(k);
+    }
+  });
+
+  it('labels is a search_select with a dynamic-options placeholder', () => {
+    expect(byKey('labels')?.inputType).toBe('search_select');
+    expect(byKey('labels')?.options).toEqual([]);
+  });
+
+  it('blocked offers boolean options', () => {
+    expect(byKey('blocked')?.options?.map(o => o.value)).toEqual(['true', 'false']);
+  });
+
+  it('city/company allow contains operators, country_code does not', () => {
+    expect(byKey('city')?.filterOperators.map(o => o.key)).toContain('contains');
+    expect(byKey('company')?.filterOperators.map(o => o.key)).toContain('contains');
+    expect(byKey('country_code')?.filterOperators.map(o => o.key)).not.toContain('contains');
+  });
+});

--- a/src/types/core/filters.ts
+++ b/src/types/core/filters.ts
@@ -103,6 +103,51 @@ export const CONTACT_FILTER_TYPES: FilterType[] = [
     filterOperators: OPERATOR_TYPES_5,
     attribute_type: 'standard',
   },
+  {
+    attributeKey: 'labels',
+    attributeI18nKey: 'filter.attributes.labels',
+    inputType: 'search_select',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_1,
+    attribute_type: 'standard',
+    options: [], // populated dynamically (labels) in ContactsFilter
+  },
+  {
+    attributeKey: 'country_code',
+    attributeI18nKey: 'filter.attributes.country_code',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_1,
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'city',
+    attributeI18nKey: 'filter.attributes.city',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_3,
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'company',
+    attributeI18nKey: 'filter.attributes.company',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_3,
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'blocked',
+    attributeI18nKey: 'filter.attributes.blocked',
+    inputType: 'search_select',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_1,
+    attribute_type: 'standard',
+    options: [
+      { label: 'filter.options.blocked.true', value: 'true' },
+      { label: 'filter.options.blocked.false', value: 'false' },
+    ],
+  },
 ];
 
 // Filtro padrão genérico


### PR DESCRIPTION
## Summary
Expand the Contacts advanced filter (6 → 11 attributes) by exposing the contact-relevant filters already supported by the backend, plus a small header spacing fix.

- **New filters:** `labels` (dynamic options), `country_code`, `city`, `company`, `blocked` — operators mirror `filter_keys.yml` (`city`/`company` allow *contains*; the rest equal/not-equal).
- **Frontend-only:** the `/contacts/filter` payload sends `attribute_key/values/filter_operator/query_operator`; the backend resolves `additional_attributes` (country_code/city/company) by key. **No backend change.**
- New lean `useContactFilterOptions` hook (labels only, `value=label.title` to match the tag query) wired into `ContactsFilter` (same pattern as `ConversationsFilter`).
- i18n in all 6 locales + a unit test for the new filter config.
- **UI:** added spacing (`mt-4`) between the header actions and the grid/list view toggle, matching the header-to-content gap used on `/products`.

## Scope / decisions
- **Out of scope:** the 7 conversation-scoped attributes (status, assignee, inbox, channel, team, priority, contact_id) — they don't map to a contact (none exist in the backend `contacts:` block).
- **pipeline_id** deferred to Phase 2 (needs backend contact modeling).
- **Pre-existing, not touched:** contact date-operator labels don't fully match the backend date operators; and a `react-hooks/exhaustive-deps` warning on `Contacts.tsx:187`.

## Audit (AC1) — filter surfaces
`BaseFilter` is reused by Conversations, Contacts, Users, Tools, MCPServers, CustomTools, CustomMCPServers (each `*_FILTER_TYPES` in `filters.ts`). This change only touches `CONTACT_FILTER_TYPES` + `ContactsFilter`; the other surfaces are different domains and intentionally untouched. Segments is a separate, richer feature (`SegmentConditionEditor`) — not the source of confusion.

## Security
No new endpoints; the client filter mirrors backend-allowed keys/operators; the backend stays the source of truth.

## Test plan
- `frontend: pnpm exec vitest run src/types/core/filters.contacts.spec.ts` (5 pass)
- `frontend: pnpm exec eslint <changed files>` (no new errors)
- `frontend: pnpm exec tsc -b --noEmit` (clean for changed files)
- Manual smoke: `/contacts` → Filter → new attributes present; labels load; city/company "contains"; blocked Yes/No; results filter via backend.

## Changed Files
- `src/types/core/filters.ts` (+ `filters.contacts.spec.ts`)
- `src/hooks/contacts/useContactFilterOptions.ts` (new)
- `src/components/contacts/ContactsFilter.tsx`
- `src/pages/Customer/Contacts/Contacts.tsx` (spacing)
- `src/i18n/locales/{en,pt-BR,es,fr,it,pt}/contacts.json`

## Linked Issue
- EVO-1835
