### PR TITLE
fix(frontend): persist audio transcription toggle (EVO-1681)

### DIFF
--- a/src/pages/Customer/Settings/Account/AccountSettings.tsx
+++ b/src/pages/Customer/Settings/Account/AccountSettings.tsx
@@ -265,10 +265,19 @@ export default function AccountSettings() {
 
   const handleAudioTranscriptionToggle = async (enabled: boolean) => {
     try {
-      await accountService.updateAccount({
-        audio_transcriptions: enabled,
+      const updated = await accountService.updateAccount({
+        settings: {
+          ...(account?.settings ?? {}),
+          audio_transcriptions: enabled,
+        },
       });
+      setAccount(updated);
       setFormData(prev => ({ ...prev, audioTranscriptions: enabled }));
+      try {
+        await useAppDataStore.getState().fetchAccount(true);
+      } catch (cacheError) {
+        console.warn('Failed to refresh appDataStore.account cache:', cacheError);
+      }
       toast.success(
         enabled
           ? t('messages.success.audioTranscriptionEnabled')


### PR DESCRIPTION
## Summary
Fix the Account Settings **"Audio Transcription"** toggle not persisting after reload. The handler sent `audio_transcriptions` at the **root** of the `PATCH /account` payload, but the backend `account_controller` permits it only under `settings: {}` — so it was silently dropped and reverted on F5. Now nested under `settings` (preserving existing keys) + account/appDataStore cache refresh, mirroring `handleMaskContactPiiToggle` (EVO-1551).

Frontend-only, 1 file, zero backend change.

## Test plan
- **Manual smoke (confirmed):** enable "Audio Transcription" → F5 → stays ON (previously reverted to OFF). The sibling `Mask Contact Data` toggle (same `settings` merge) keeps working.
- `frontend: pnpm exec tsc -b --noEmit` (clean for the changed file)
- `frontend: pnpm exec eslint` (no new errors; the file has 1 pre-existing `any` + 1 pre-existing exhaustive-deps warning, both unrelated to this change)

> Note for reviewers: the toggle is only visible when an Evolution integration is configured (`hasEvolutionConfig || hasEvolutionGoConfig` from `/global_config`). To surface it, set `EVOLUTION_GO_API_URL` + `EVOLUTION_GO_ADMIN_SECRET` (any non-empty values) in Admin → Channel Config.

## Changed Files
- `src/pages/Customer/Settings/Account/AccountSettings.tsx`

## Linked Issue
- EVO-1681

## Summary by Sourcery

Bug Fixes:
- Fix Audio Transcription toggle not persisting after page reload by sending it under account settings and refreshing account state caches.