### PR TITLE
feat(journey): structured webhook body builder (EVO-1742)

### DIFF
--- a/src/components/journey/nodes/actions/send-webhook/SendWebhookNode.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/SendWebhookNode.tsx
@@ -14,6 +14,15 @@ export interface WebhookResponseMapping {
   description?: string;
 }
 
+export type WebhookBodyValueType = 'string' | 'number' | 'boolean';
+
+export interface WebhookBodyField {
+  id: string;
+  key: string;
+  value: string; // raw text; preserves {{variables}} verbatim
+  type: WebhookBodyValueType;
+}
+
 export interface SendWebhookNodeData {
   label: string;
   description?: string;
@@ -22,6 +31,8 @@ export interface SendWebhookNodeData {
   headers?: WebhookHeader[];
   body?: string;
   bodyType?: 'json' | 'form' | 'text' | 'xml';
+  bodyStructured?: WebhookBodyField[];
+  bodyMode?: 'structured' | 'raw';
   timeout?: number;
   retryAttempts?: number;
   authenticationType?: 'none' | 'bearer' | 'basic' | 'api_key';

--- a/src/components/journey/nodes/actions/send-webhook/SendWebhookPanel.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/SendWebhookPanel.tsx
@@ -7,6 +7,11 @@ import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableSelect } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
+  getEffectiveBodyMode,
+  isValidJsonBody,
+  validateFields,
+} from './components/webhookBody';
+import {
   WebhookBasicConfig,
   WebhookHeadersConfig,
   WebhookBodyConfig,
@@ -275,6 +280,20 @@ export function SendWebhookPanel({
       (!formData.authApiKey || !formData.authApiKeyHeader)
     ) {
       issues.push(t('panels.sendWebhook.requiredApiKey'));
+    }
+
+    // Body validation — caught in the editor, not at runtime (EVO-1742).
+    const bodyApplies = ['POST', 'PUT', 'PATCH'].includes(formData.method || 'POST');
+    if (bodyApplies) {
+      const bodyMode = getEffectiveBodyMode(formData);
+      if (bodyMode === 'structured') {
+        const result = validateFields(formData.bodyStructured || []);
+        if (!result.ok) {
+          issues.push(t(`panels.sendWebhook.body.validation.${result.error}`));
+        }
+      } else if (formData.bodyType === 'json' && !isValidJsonBody(formData.body || '')) {
+        issues.push(t('panels.sendWebhook.invalidJson'));
+      }
     }
 
     return issues;

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
@@ -1,0 +1,120 @@
+import {
+  Button,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { Plus, X } from 'lucide-react';
+import { WebhookBodyField, WebhookBodyValueType } from '../SendWebhookNode';
+import { VariableInput } from '@/components/journey/environment-manager';
+import { useLanguage } from '@/hooks/useLanguage';
+import { newBodyField, StructuredBodyType } from './webhookBody';
+
+interface WebhookBodyBuilderProps {
+  fields: WebhookBodyField[];
+  bodyType: StructuredBodyType;
+  onChange: (fields: WebhookBodyField[]) => void;
+  journeyId: string;
+}
+
+const VALUE_TYPES: WebhookBodyValueType[] = ['string', 'number', 'boolean'];
+
+export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: WebhookBodyBuilderProps) {
+  const { t } = useLanguage('journey');
+  const showTypeColumn = bodyType === 'json';
+
+  const addField = () => onChange([...fields, newBodyField()]);
+
+  const updateField = (id: string, updates: Partial<WebhookBodyField>) =>
+    onChange(fields.map(field => (field.id === id ? { ...field, ...updates } : field)));
+
+  const removeField = (id: string) => onChange(fields.filter(field => field.id !== id));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <Label className="text-sm font-medium">{t('panels.sendWebhook.body.bodyContent')}</Label>
+        <Button variant="outline" size="sm" onClick={addField}>
+          <Plus className="w-4 h-4 mr-1" />
+          {t('panels.sendWebhook.body.builder.addField')}
+        </Button>
+      </div>
+
+      <div className="space-y-3">
+        {fields.length === 0 ? (
+          <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
+            <p className="text-sm text-gray-500">{t('panels.sendWebhook.body.builder.noFields')}</p>
+          </div>
+        ) : (
+          fields.map(field => (
+            <div key={field.id} className="p-3 border rounded-lg bg-sidebar-accent/10">
+              <div className="grid grid-cols-12 gap-3 items-end">
+                {/* Key */}
+                <div className={showTypeColumn ? 'col-span-4' : 'col-span-5'}>
+                  <Label className="text-xs">{t('panels.sendWebhook.body.builder.keyLabel')}</Label>
+                  <VariableInput
+                    value={field.key}
+                    onChange={e => updateField(field.id, { key: e.target.value })}
+                    placeholder={t('panels.sendWebhook.body.builder.keyPlaceholder')}
+                    className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                    journeyId={journeyId}
+                  />
+                </div>
+
+                {/* Value */}
+                <div className={showTypeColumn ? 'col-span-4' : 'col-span-6'}>
+                  <Label className="text-xs">{t('panels.sendWebhook.body.builder.valueLabel')}</Label>
+                  <VariableInput
+                    value={field.value}
+                    onChange={e => updateField(field.id, { value: e.target.value })}
+                    placeholder={t('panels.sendWebhook.body.builder.valuePlaceholder')}
+                    className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                    journeyId={journeyId}
+                  />
+                </div>
+
+                {/* Type (JSON only) */}
+                {showTypeColumn && (
+                  <div className="col-span-3">
+                    <Label className="text-xs">{t('panels.sendWebhook.body.builder.typeLabel')}</Label>
+                    <Select
+                      value={field.type}
+                      onValueChange={(value: WebhookBodyValueType) => updateField(field.id, { type: value })}
+                    >
+                      <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent className="bg-sidebar border-sidebar-border">
+                        {VALUE_TYPES.map(type => (
+                          <SelectItem key={type} value={type} className="text-sidebar-foreground">
+                            {t(`panels.sendWebhook.body.builder.types.${type}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                {/* Remove */}
+                <div className="col-span-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeField(field.id)}
+                    aria-label={t('panels.sendWebhook.body.builder.removeField')}
+                    className="h-10 w-full p-0 text-red-500 hover:text-red-700"
+                  >
+                    <X className="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.spec.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.spec.tsx
@@ -1,0 +1,143 @@
+import { useRef, useState } from 'react';
+import type { ChangeEventHandler } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { WebhookBodyConfig } from './WebhookBodyConfig';
+import { SendWebhookNodeData } from '../SendWebhookNode';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+// Stub the variable-aware inputs with plain controls so we avoid the journey
+// variables fetch / radix popover and can drive them directly.
+vi.mock('@/components/journey/environment-manager', () => ({
+  VariableInput: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: ChangeEventHandler<HTMLInputElement>;
+    placeholder?: string;
+  }) => <input value={value} onChange={onChange} placeholder={placeholder} />,
+  VariableTextarea: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value?: string;
+    onChange?: ChangeEventHandler<HTMLTextAreaElement>;
+    placeholder?: string;
+  }) => <textarea value={value} onChange={onChange} placeholder={placeholder} />,
+}));
+
+const KEY_PH = 'panels.sendWebhook.body.builder.keyPlaceholder';
+const VALUE_PH = 'panels.sendWebhook.body.builder.valuePlaceholder';
+const ADD_FIELD = 'panels.sendWebhook.body.builder.addField';
+const MODE_RAW = 'panels.sendWebhook.body.modeRaw';
+const MODE_STRUCTURED = 'panels.sendWebhook.body.modeStructured';
+const NESTED_HINT = 'panels.sendWebhook.body.nestedRawOnlyHint';
+const TYPE_LABEL = 'panels.sendWebhook.body.builder.typeLabel';
+
+interface HarnessHandle {
+  data: () => SendWebhookNodeData;
+  changeCount: () => number;
+}
+
+function Harness({ initial, handle }: { initial: SendWebhookNodeData; handle: HarnessHandle }) {
+  const [data, setData] = useState<SendWebhookNodeData>(initial);
+  const changes = useRef(0);
+  handle.data = () => data;
+  handle.changeCount = () => changes.current;
+  return (
+    <WebhookBodyConfig
+      data={data}
+      journeyId="test-journey-id"
+      onChange={updates => {
+        changes.current += 1;
+        setData(prev => ({ ...prev, ...updates }));
+      }}
+    />
+  );
+}
+
+function setup(initial: Partial<SendWebhookNodeData>) {
+  const handle = { data: () => ({}) as SendWebhookNodeData, changeCount: () => 0 } as HarnessHandle;
+  const base: SendWebhookNodeData = { label: 'Webhook', method: 'POST', bodyType: 'json', ...initial };
+  render(<Harness initial={base} handle={handle} />);
+  return { handle, user: userEvent.setup() };
+}
+
+describe('WebhookBodyConfig — structured builder (EVO-1742)', () => {
+  it('AC1: builds typed JSON field-by-field and serializes into body', async () => {
+    const { handle, user } = setup({ bodyType: 'json' });
+    // New json node defaults to structured mode.
+    await user.click(screen.getByText(ADD_FIELD));
+    await user.type(screen.getByPlaceholderText(KEY_PH), 'name');
+    // paste (not type) — userEvent.type treats `{{` as an escape sequence.
+    await user.click(screen.getByPlaceholderText(VALUE_PH));
+    await user.paste('{{contact.name}}');
+
+    const data = handle.data();
+    expect(data.bodyStructured).toHaveLength(1);
+    expect(data.bodyStructured![0]).toMatchObject({ key: 'name', value: '{{contact.name}}', type: 'string' });
+    expect(JSON.parse(data.body!)).toEqual({ name: '{{contact.name}}' });
+  });
+
+  it('AC4: existing raw body opens in raw mode, verbatim, with no mount-time onChange', () => {
+    const raw = '{\n  "hi": 1\n}';
+    const { handle } = setup({ bodyType: 'json', body: raw });
+    // Raw textarea shows the original body; structured builder is absent.
+    expect((screen.getByPlaceholderText('panels.sendWebhook.body.jsonPlaceholder') as HTMLTextAreaElement).value).toBe(raw);
+    expect(screen.queryByText(ADD_FIELD)).toBeNull();
+    // F3: deriving the mode must not fire onChange on mount (no spurious dirty).
+    expect(handle.changeCount()).toBe(0);
+  });
+
+  it('AC5: round-trips structured ⇄ raw', async () => {
+    const { handle, user } = setup({
+      bodyType: 'json',
+      bodyMode: 'structured',
+      bodyStructured: [{ id: 'a', key: 'a', value: '1', type: 'number' }],
+      body: '{\n  "a": 1\n}',
+    });
+    await user.click(screen.getByText(MODE_RAW));
+    expect(handle.data().bodyMode).toBe('raw');
+    expect((screen.getByPlaceholderText('panels.sendWebhook.body.jsonPlaceholder') as HTMLTextAreaElement).value).toContain('"a": 1');
+
+    await user.click(screen.getByText(MODE_STRUCTURED));
+    expect(handle.data().bodyMode).toBe('structured');
+    expect(handle.data().bodyStructured!.map(f => [f.key, f.value, f.type])).toEqual([['a', '1', 'number']]);
+  });
+
+  it('AC6: refuses raw→structured for nested bodies and shows the hint', async () => {
+    const { handle, user } = setup({
+      bodyType: 'json',
+      bodyMode: 'raw',
+      body: '{ "contact": { "id": "1" } }',
+    });
+    await user.click(screen.getByText(MODE_STRUCTURED));
+    expect(screen.getByText(NESTED_HINT, { exact: false })).toBeTruthy();
+    expect(handle.data().bodyMode).toBe('raw'); // unchanged — no lossy flatten
+  });
+
+  it('AC7: form bodyType serializes urlencoded with no type column', async () => {
+    const { handle, user } = setup({ bodyType: 'form' });
+    await user.click(screen.getByText(ADD_FIELD));
+    await user.type(screen.getByPlaceholderText(KEY_PH), 'a');
+    await user.type(screen.getByPlaceholderText(VALUE_PH), '1');
+
+    expect(screen.queryByText(TYPE_LABEL)).toBeNull();
+    expect(handle.data().body).toBe('a=1');
+  });
+});

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
@@ -8,10 +8,18 @@ import {
   SelectValue,
   Button,
 } from '@evoapi/design-system';
-import { Code, Copy, Check } from 'lucide-react';
+import { Code, Copy, Check, Table, FileText } from 'lucide-react';
 import { SendWebhookNodeData } from '../SendWebhookNode';
 import { VariableTextarea } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
+import { WebhookBodyBuilder } from './WebhookBodyBuilder';
+import {
+  getEffectiveBodyMode,
+  isStructuredBodyType,
+  serializeBody,
+  tryParseToFields,
+  StructuredBodyType,
+} from './webhookBody';
 
 interface WebhookBodyConfigProps {
   data: SendWebhookNodeData;
@@ -60,6 +68,7 @@ const JSON_TEMPLATES = {
 export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConfigProps) {
   const { t } = useLanguage('journey');
   const [copiedTemplate, setCopiedTemplate] = useState<string | null>(null);
+  const [showNestedHint, setShowNestedHint] = useState(false);
 
   const BODY_TYPES = [
     { value: 'json', label: t('panels.sendWebhook.body.types.json.label'), description: t('panels.sendWebhook.body.types.json.description') },
@@ -72,8 +81,20 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
     { value: 'xml', label: t('panels.sendWebhook.body.types.xml.label'), description: t('panels.sendWebhook.body.types.xml.description') },
   ];
 
+  const bodyType = data.bodyType || 'json';
+  const structuredCapable = isStructuredBodyType(bodyType);
+  const mode = getEffectiveBodyMode(data);
+
   const handleBodyTypeChange = (value: 'json' | 'form' | 'text' | 'xml') => {
-    onChange({ bodyType: value });
+    setShowNestedHint(false);
+
+    // When staying in structured mode across json⇄form, re-serialize the existing
+    // rows into the new wire format so `body` keeps matching the builder.
+    if (mode === 'structured' && isStructuredBodyType(value)) {
+      onChange({ bodyType: value, body: serializeBody(data.bodyStructured || [], value) });
+    } else {
+      onChange({ bodyType: value });
+    }
 
     // Auto-definir Content-Type header se não existir
     const currentHeaders = data.headers || [];
@@ -101,6 +122,32 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
 
   const handleBodyChange = (value: string) => {
     onChange({ body: value });
+  };
+
+  const handleStructuredChange = (fields: SendWebhookNodeData['bodyStructured']) => {
+    const next = fields || [];
+    onChange({ bodyStructured: next, body: serializeBody(next, bodyType as StructuredBodyType) });
+  };
+
+  const switchToStructured = () => {
+    const parsed = tryParseToFields(data.body || '', bodyType as StructuredBodyType);
+    if (parsed === null) {
+      // Nested/invalid body cannot be flattened — keep raw, surface the hint.
+      setShowNestedHint(true);
+      return;
+    }
+    setShowNestedHint(false);
+    onChange({
+      bodyMode: 'structured',
+      bodyStructured: parsed,
+      body: serializeBody(parsed, bodyType as StructuredBodyType),
+    });
+  };
+
+  const switchToRaw = () => {
+    setShowNestedHint(false);
+    // `body` already holds the serialized structured output — pass it through untouched.
+    onChange({ bodyMode: 'raw' });
   };
 
   const copyTemplate = async (template: string, templateName: string) => {
@@ -147,60 +194,106 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
         </Select>
       </div>
 
-      {/* Templates para JSON */}
-      {data.bodyType === 'json' && (
-        <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('panels.sendWebhook.body.jsonTemplates')}</Label>
-          <div className="flex gap-2 flex-wrap">
-            {Object.entries(JSON_TEMPLATES).map(([name, template]) => (
-              <Button
-                key={name}
-                variant="outline"
-                size="sm"
-                onClick={() => copyTemplate(template, name)}
-                className="text-xs"
-              >
-                {copiedTemplate === name ? (
-                  <Check className="w-3 h-3 mr-1" />
-                ) : (
-                  <Copy className="w-3 h-3 mr-1" />
-                )}
-                {name === 'contact'
-                  ? t('panels.sendWebhook.body.templateContact')
-                  : name === 'event'
-                  ? t('panels.sendWebhook.body.templateEvent')
-                  : t('panels.sendWebhook.body.templateCustom')}
-              </Button>
-            ))}
-          </div>
+      {/* Toggle Estruturado / Bruto (apenas json/form) */}
+      {structuredCapable && (
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant={mode === 'structured' ? 'default' : 'outline'}
+            size="sm"
+            onClick={switchToStructured}
+            className="flex items-center gap-1"
+          >
+            <Table className="w-3.5 h-3.5" />
+            {t('panels.sendWebhook.body.modeStructured')}
+          </Button>
+          <Button
+            type="button"
+            variant={mode === 'raw' ? 'default' : 'outline'}
+            size="sm"
+            onClick={switchToRaw}
+            className="flex items-center gap-1"
+          >
+            <FileText className="w-3.5 h-3.5" />
+            {t('panels.sendWebhook.body.modeRaw')}
+          </Button>
         </div>
       )}
 
-      {/* Editor do Body */}
-      <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.body.bodyContent')}</Label>
-        <div className="relative">
-          <VariableTextarea
-            value={data.body || ''}
-            onChange={e => handleBodyChange(e.target.value)}
-            placeholder={
-              data.bodyType === 'json'
-                ? t('panels.sendWebhook.body.jsonPlaceholder')
-                : data.bodyType === 'form'
-                ? t('panels.sendWebhook.body.formPlaceholder')
-                : data.bodyType === 'xml'
-                ? t('panels.sendWebhook.body.xmlPlaceholder')
-                : t('panels.sendWebhook.body.textPlaceholder')
-            }
-            className="w-full h-32 p-3 text-sm bg-sidebar border-sidebar-border text-sidebar-foreground rounded-md font-mono resize-y"
-            style={{ minHeight: '120px' }}
-            journeyId={journeyId}
-          />
+      {showNestedHint && (
+        <div className="p-3 rounded-lg bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30">
+          <p className="text-xs text-yellow-700 dark:text-yellow-300">
+            ⚠️ {t('panels.sendWebhook.body.nestedRawOnlyHint')}
+          </p>
         </div>
-        <div className="text-xs text-gray-500 dark:text-gray-400">
-          {t('panels.sendWebhook.body.useVariables')}
-        </div>
-      </div>
+      )}
+
+      {/* Modo Estruturado */}
+      {structuredCapable && mode === 'structured' ? (
+        <WebhookBodyBuilder
+          fields={data.bodyStructured || []}
+          bodyType={bodyType as StructuredBodyType}
+          onChange={handleStructuredChange}
+          journeyId={journeyId}
+        />
+      ) : (
+        <>
+          {/* Templates para JSON (apenas modo bruto) */}
+          {bodyType === 'json' && (
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">{t('panels.sendWebhook.body.jsonTemplates')}</Label>
+              <div className="flex gap-2 flex-wrap">
+                {Object.entries(JSON_TEMPLATES).map(([name, template]) => (
+                  <Button
+                    key={name}
+                    variant="outline"
+                    size="sm"
+                    onClick={() => copyTemplate(template, name)}
+                    className="text-xs"
+                  >
+                    {copiedTemplate === name ? (
+                      <Check className="w-3 h-3 mr-1" />
+                    ) : (
+                      <Copy className="w-3 h-3 mr-1" />
+                    )}
+                    {name === 'contact'
+                      ? t('panels.sendWebhook.body.templateContact')
+                      : name === 'event'
+                      ? t('panels.sendWebhook.body.templateEvent')
+                      : t('panels.sendWebhook.body.templateCustom')}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Editor do Body (bruto) */}
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">{t('panels.sendWebhook.body.bodyContent')}</Label>
+            <div className="relative">
+              <VariableTextarea
+                value={data.body || ''}
+                onChange={e => handleBodyChange(e.target.value)}
+                placeholder={
+                  bodyType === 'json'
+                    ? t('panels.sendWebhook.body.jsonPlaceholder')
+                    : bodyType === 'form'
+                    ? t('panels.sendWebhook.body.formPlaceholder')
+                    : bodyType === 'xml'
+                    ? t('panels.sendWebhook.body.xmlPlaceholder')
+                    : t('panels.sendWebhook.body.textPlaceholder')
+                }
+                className="w-full h-32 p-3 text-sm bg-sidebar border-sidebar-border text-sidebar-foreground rounded-md font-mono resize-y"
+                style={{ minHeight: '120px' }}
+                journeyId={journeyId}
+              />
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">
+              {t('panels.sendWebhook.body.useVariables')}
+            </div>
+          </div>
+        </>
+      )}
 
       {/* Variáveis disponíveis */}
       <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">

--- a/src/components/journey/nodes/actions/send-webhook/components/index.ts
+++ b/src/components/journey/nodes/actions/send-webhook/components/index.ts
@@ -1,4 +1,5 @@
 export * from './WebhookBasicConfig';
 export * from './WebhookHeadersConfig';
 export * from './WebhookBodyConfig';
+export * from './WebhookBodyBuilder';
 export * from './WebhookAuthConfig';

--- a/src/components/journey/nodes/actions/send-webhook/components/webhookBody.spec.ts
+++ b/src/components/journey/nodes/actions/send-webhook/components/webhookBody.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  coerceJsonValue,
+  getEffectiveBodyMode,
+  isValidJsonBody,
+  serializeBody,
+  tryParseToFields,
+  validateFields,
+} from './webhookBody';
+import { WebhookBodyField } from '../SendWebhookNode';
+
+const field = (key: string, value: string, type: WebhookBodyField['type'] = 'string'): WebhookBodyField => ({
+  id: `${key}-${value}`,
+  key,
+  value,
+  type,
+});
+
+describe('coerceJsonValue', () => {
+  it('emits real number for numeric literal', () => {
+    expect(coerceJsonValue('30', 'number')).toBe(30);
+  });
+  it('keeps a {{variable}} as string even when typed number', () => {
+    expect(coerceJsonValue('{{contact.age}}', 'number')).toBe('{{contact.age}}');
+  });
+  it('keeps a non-numeric literal as string rather than NaN', () => {
+    expect(coerceJsonValue('abc', 'number')).toBe('abc');
+    expect(coerceJsonValue('', 'number')).toBe('');
+  });
+  it('emits real booleans for true/false', () => {
+    expect(coerceJsonValue('true', 'boolean')).toBe(true);
+    expect(coerceJsonValue('false', 'boolean')).toBe(false);
+  });
+  it('keeps non-boolean text as string for boolean type', () => {
+    expect(coerceJsonValue('maybe', 'boolean')).toBe('maybe');
+  });
+});
+
+describe('serializeBody (json)', () => {
+  it('builds typed JSON, preserving variable tokens and dropping blank keys', () => {
+    const fields = [
+      field('name', '{{contact.name}}', 'string'),
+      field('age', '30', 'number'),
+      field('active', 'true', 'boolean'),
+      field('', 'orphan', 'string'),
+    ];
+    const out = serializeBody(fields, 'json');
+    expect(JSON.parse(out)).toEqual({ name: '{{contact.name}}', age: 30, active: true });
+  });
+  it('serializes empty fields to an empty object', () => {
+    expect(serializeBody([], 'json')).toBe('{}');
+  });
+});
+
+describe('serializeBody (form)', () => {
+  it('joins key=value without percent-encoding so variables survive', () => {
+    const fields = [field('a', '1'), field('b', '{{contact.name}}')];
+    expect(serializeBody(fields, 'form')).toBe('a=1&b={{contact.name}}');
+  });
+});
+
+describe('tryParseToFields (json)', () => {
+  it('parses a flat object into typed rows', () => {
+    const fields = tryParseToFields('{"name":"x","age":30,"active":true}', 'json');
+    expect(fields).not.toBeNull();
+    expect(fields!.map(f => [f.key, f.value, f.type])).toEqual([
+      ['name', 'x', 'string'],
+      ['age', '30', 'number'],
+      ['active', 'true', 'boolean'],
+    ]);
+  });
+  it('returns null for invalid JSON', () => {
+    expect(tryParseToFields('{ "a": }', 'json')).toBeNull();
+  });
+  it('returns null when a top-level value is nested (guard against lossy flatten)', () => {
+    expect(tryParseToFields('{"contact":{"id":"1"}}', 'json')).toBeNull();
+    expect(tryParseToFields('{"tags":["a","b"]}', 'json')).toBeNull();
+  });
+  it('returns [] for empty body', () => {
+    expect(tryParseToFields('', 'json')).toEqual([]);
+  });
+});
+
+describe('tryParseToFields (form)', () => {
+  it('parses urlencoded pairs into string rows', () => {
+    const fields = tryParseToFields('a=1&b=2', 'form');
+    expect(fields!.map(f => [f.key, f.value, f.type])).toEqual([
+      ['a', '1', 'string'],
+      ['b', '2', 'string'],
+    ]);
+  });
+});
+
+describe('validateFields', () => {
+  it('passes for distinct keys', () => {
+    expect(validateFields([field('a', '1'), field('b', '2')])).toEqual({ ok: true });
+  });
+  it('ignores a fully-empty row', () => {
+    expect(validateFields([field('', ''), field('a', '1')])).toEqual({ ok: true });
+  });
+  it('flags a valued row with a blank key', () => {
+    expect(validateFields([field('', 'x')])).toEqual({ ok: false, error: 'blankKey' });
+  });
+  it('flags duplicate keys', () => {
+    expect(validateFields([field('a', '1'), field('a', '2')])).toEqual({ ok: false, error: 'duplicateKey' });
+  });
+});
+
+describe('isValidJsonBody', () => {
+  it('accepts empty', () => expect(isValidJsonBody('')).toBe(true));
+  it('accepts valid JSON', () => expect(isValidJsonBody('{"a":1}')).toBe(true));
+  it('tolerates {{variables}} (quoted or unquoted)', () => {
+    expect(isValidJsonBody('{"name":"{{contact.name}}"}')).toBe(true);
+    expect(isValidJsonBody('{"id": {{contact.id}} }')).toBe(true);
+  });
+  it('rejects genuinely malformed JSON', () => {
+    expect(isValidJsonBody('{ "a": }')).toBe(false);
+  });
+});
+
+describe('getEffectiveBodyMode', () => {
+  it('forces raw for non-structured body types', () => {
+    expect(getEffectiveBodyMode({ bodyType: 'xml', body: '<x/>' })).toBe('raw');
+  });
+  it('honors a persisted bodyMode above all', () => {
+    expect(getEffectiveBodyMode({ bodyType: 'json', body: '{}', bodyMode: 'raw' })).toBe('raw');
+    expect(getEffectiveBodyMode({ bodyType: 'json', bodyMode: 'structured' })).toBe('structured');
+  });
+  it('opens legacy raw body (no structured, no mode) in raw', () => {
+    expect(getEffectiveBodyMode({ bodyType: 'json', body: '{"a":1}' })).toBe('raw');
+  });
+  it('opens existing structured rows in structured', () => {
+    expect(getEffectiveBodyMode({ bodyType: 'json', bodyStructured: [field('a', '1')] })).toBe('structured');
+  });
+  it('defaults a brand-new structured-capable node to structured', () => {
+    expect(getEffectiveBodyMode({ bodyType: 'json' })).toBe('structured');
+  });
+});

--- a/src/components/journey/nodes/actions/send-webhook/components/webhookBody.ts
+++ b/src/components/journey/nodes/actions/send-webhook/components/webhookBody.ts
@@ -1,0 +1,188 @@
+import { SendWebhookNodeData, WebhookBodyField, WebhookBodyValueType } from '../SendWebhookNode';
+
+/**
+ * Pure helpers for the Send Webhook structured body builder (EVO-1742).
+ *
+ * The structured key/value rows (`bodyStructured`) are the editor model, but the
+ * raw `body` string stays the wire source-of-truth the executor reads — so every
+ * structured edit is serialized back into `body`. These functions own that
+ * serialization, the raw→structured parse (with a nested-JSON guard so we never
+ * lossily flatten), and field validation. No React here — fully unit-testable.
+ */
+
+/** Body types that support the structured key/value builder. */
+export type StructuredBodyType = 'json' | 'form';
+
+export function isStructuredBodyType(bodyType: string | undefined): bodyType is StructuredBodyType {
+  return bodyType === 'json' || bodyType === 'form';
+}
+
+// Monotonic id generator. Date.now() alone collides when rows are added in the
+// same tick, so we salt with a process-local counter (mirrors the intent of the
+// response-mapping ids, which this builder's rows are modelled on).
+let __fieldSeq = 0;
+export function genFieldId(): string {
+  __fieldSeq += 1;
+  return `bf_${Date.now().toString(36)}_${__fieldSeq}`;
+}
+
+export function newBodyField(): WebhookBodyField {
+  return { id: genFieldId(), key: '', value: '', type: 'string' };
+}
+
+const hasVariableToken = (value: string): boolean => value.includes('{{');
+
+/**
+ * Coerce a row value to the JS primitive its `type` declares, for JSON output.
+ *
+ * Single source of truth for the number/boolean/variable rules (decision #5):
+ * a value carrying a `{{variable}}` token can never be a real JS number/boolean,
+ * so it is preserved verbatim as a string (the executor substitutes it later).
+ * A `number` row whose value is not a finite numeric literal also stays a string
+ * rather than emitting `NaN`.
+ */
+export function coerceJsonValue(value: string, type: WebhookBodyValueType): string | number | boolean {
+  if (hasVariableToken(value)) return value;
+  if (type === 'number') {
+    const trimmed = value.trim();
+    if (trimmed !== '' && Number.isFinite(Number(trimmed))) return Number(trimmed);
+    return value;
+  }
+  if (type === 'boolean') {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  }
+  return value;
+}
+
+const fieldsWithKey = (fields: WebhookBodyField[]): WebhookBodyField[] =>
+  fields.filter(f => f.key.trim() !== '');
+
+/**
+ * Serialize structured fields into the raw `body` string the executor reads.
+ * - json: a pretty-printed JSON object, values coerced by their declared type.
+ * - form: `key=value&key=value` WITHOUT percent-encoding, so `{{variables}}`
+ *   survive untouched (matches the pre-existing raw form-body behavior).
+ */
+export function serializeBody(fields: WebhookBodyField[], bodyType: StructuredBodyType): string {
+  const kept = fieldsWithKey(fields);
+  if (bodyType === 'form') {
+    return kept.map(f => `${f.key}=${f.value}`).join('&');
+  }
+  const obj: Record<string, string | number | boolean> = {};
+  for (const f of kept) {
+    obj[f.key] = coerceJsonValue(f.value, f.type);
+  }
+  return JSON.stringify(obj, null, 2);
+}
+
+function inferType(value: unknown): WebhookBodyValueType {
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'boolean') return 'boolean';
+  return 'string';
+}
+
+/**
+ * Parse a raw `body` string into flat structured fields, or return `null` when
+ * it cannot be represented as flat key/value rows (so the caller keeps raw mode).
+ *
+ * The nested guard is the back-compat safety net (decision #8): any top-level
+ * value that is an object or array means the body cannot round-trip flatly, so
+ * we refuse rather than silently dropping the nested data.
+ */
+export function tryParseToFields(
+  body: string,
+  bodyType: StructuredBodyType,
+): WebhookBodyField[] | null {
+  const trimmed = (body ?? '').trim();
+  if (trimmed === '') return [];
+
+  if (bodyType === 'form') {
+    return trimmed.split('&').reduce<WebhookBodyField[]>((acc, pair) => {
+      if (pair === '') return acc;
+      const eq = pair.indexOf('=');
+      const key = eq >= 0 ? pair.slice(0, eq) : pair;
+      const value = eq >= 0 ? pair.slice(eq + 1) : '';
+      acc.push({ id: genFieldId(), key, value, type: 'string' });
+      return acc;
+    }, []);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+  const fields: WebhookBodyField[] = [];
+  for (const [key, raw] of Object.entries(parsed as Record<string, unknown>)) {
+    // Nested object/array at the top level → cannot flatten without loss.
+    if (raw !== null && typeof raw === 'object') return null;
+    const type = inferType(raw);
+    const value = raw === null ? '' : String(raw);
+    fields.push({ id: genFieldId(), key, value, type });
+  }
+  return fields;
+}
+
+export type BodyFieldsError = 'blankKey' | 'duplicateKey';
+
+/**
+ * Validate structured rows for save. A fully-empty row (no key, no value) is
+ * ignored; a row with a value but no key is a blankKey error; repeated keys are
+ * a duplicateKey error.
+ */
+export function validateFields(fields: WebhookBodyField[]): { ok: true } | { ok: false; error: BodyFieldsError } {
+  const seen = new Set<string>();
+  for (const f of fields) {
+    const key = f.key.trim();
+    if (key === '') {
+      if (f.value.trim() !== '') return { ok: false, error: 'blankKey' };
+      continue;
+    }
+    if (seen.has(key)) return { ok: false, error: 'duplicateKey' };
+    seen.add(key);
+  }
+  return { ok: true };
+}
+
+/**
+ * Variable-tolerant JSON validity check for raw-mode bodies. Bodies routinely
+ * embed `{{variables}}` (the executor substitutes them before sending), so a
+ * naive `JSON.parse` would false-positive on legitimate bodies. We replace
+ * variable tokens with a string literal before parsing.
+ */
+export function isValidJsonBody(body: string): boolean {
+  const trimmed = (body ?? '').trim();
+  if (trimmed === '') return true;
+  // Replace each {{variable}} with the literal `1`, which is valid JSON in both
+  // string position ("...1...") and value position (: 1), so variable-laden but
+  // otherwise well-formed bodies aren't false-flagged.
+  const stubbed = trimmed.replace(/\{\{[^}]*\}\}/g, '1');
+  try {
+    JSON.parse(stubbed);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Effective editor mode for a node, render-only — NEVER persisted on mount
+ * (that would spuriously dirty the panel and rewrite untouched legacy bodies).
+ * Precedence: an explicitly persisted `bodyMode` always wins; otherwise existing
+ * structured rows → structured; a non-empty legacy raw body → raw; a brand-new
+ * structured-capable node → structured; everything else → raw.
+ */
+export function getEffectiveBodyMode(
+  data: Pick<SendWebhookNodeData, 'bodyType' | 'body' | 'bodyStructured' | 'bodyMode'>,
+): 'structured' | 'raw' {
+  if (!isStructuredBodyType(data.bodyType)) return 'raw';
+  if (data.bodyMode) return data.bodyMode;
+  if (data.bodyStructured && data.bodyStructured.length > 0) return 'structured';
+  if (data.body && data.body.trim() !== '') return 'raw';
+  return 'structured';
+}

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -898,7 +898,29 @@
         "availableVariables": "Available Variables:",
         "contact": "Contact:",
         "system": "System:",
-        "bodyPreview": "Preview of Body:"
+        "bodyPreview": "Preview of Body:",
+        "modeStructured": "Structured",
+        "modeRaw": "Raw",
+        "nestedRawOnlyHint": "This body has nested structures — edit it in raw mode.",
+        "builder": {
+          "addField": "Add field",
+          "keyLabel": "Key",
+          "valueLabel": "Value",
+          "keyPlaceholder": "key",
+          "valuePlaceholder": "value",
+          "typeLabel": "Type",
+          "noFields": "No fields yet. Add one to build the body.",
+          "removeField": "Remove field",
+          "types": {
+            "string": "Text",
+            "number": "Number",
+            "boolean": "Boolean"
+          }
+        },
+        "validation": {
+          "blankKey": "The body has a field with an empty key",
+          "duplicateKey": "The body has duplicate keys"
+        }
       },
       "headers": {
         "httpHeaders": "Headers HTTP",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -881,7 +881,29 @@
         "availableVariables": "Available Variables:",
         "contact": "Contact:",
         "system": "System:",
-        "bodyPreview": "Preview of Body:"
+        "bodyPreview": "Preview of Body:",
+        "modeStructured": "Estructurado",
+        "modeRaw": "Crudo",
+        "nestedRawOnlyHint": "Este cuerpo tiene estructuras anidadas — edítalo en modo crudo.",
+        "builder": {
+          "addField": "Añadir campo",
+          "keyLabel": "Clave",
+          "valueLabel": "Valor",
+          "keyPlaceholder": "clave",
+          "valuePlaceholder": "valor",
+          "typeLabel": "Tipo",
+          "noFields": "Aún no hay campos. Añade uno para construir el cuerpo.",
+          "removeField": "Eliminar campo",
+          "types": {
+            "string": "Texto",
+            "number": "Número",
+            "boolean": "Booleano"
+          }
+        },
+        "validation": {
+          "blankKey": "El cuerpo tiene un campo con clave vacía",
+          "duplicateKey": "El cuerpo tiene claves duplicadas"
+        }
       },
       "headers": {
         "httpHeaders": "Headers HTTP",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -881,7 +881,29 @@
         "availableVariables": "Available Variables:",
         "contact": "Contact:",
         "system": "System:",
-        "bodyPreview": "Preview of Body:"
+        "bodyPreview": "Preview of Body:",
+        "modeStructured": "Structuré",
+        "modeRaw": "Brut",
+        "nestedRawOnlyHint": "Ce corps contient des structures imbriquées — modifiez-le en mode brut.",
+        "builder": {
+          "addField": "Ajouter un champ",
+          "keyLabel": "Clé",
+          "valueLabel": "Valeur",
+          "keyPlaceholder": "clé",
+          "valuePlaceholder": "valeur",
+          "typeLabel": "Type",
+          "noFields": "Aucun champ pour le moment. Ajoutez-en un pour construire le corps.",
+          "removeField": "Supprimer le champ",
+          "types": {
+            "string": "Texte",
+            "number": "Nombre",
+            "boolean": "Booléen"
+          }
+        },
+        "validation": {
+          "blankKey": "Le corps a un champ avec une clé vide",
+          "duplicateKey": "Le corps a des clés en double"
+        }
       },
       "headers": {
         "httpHeaders": "Headers HTTP",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -893,7 +893,29 @@
         "availableVariables": "Available Variables:",
         "contact": "Contact:",
         "system": "System:",
-        "bodyPreview": "Preview of Body:"
+        "bodyPreview": "Preview of Body:",
+        "modeStructured": "Strutturato",
+        "modeRaw": "Grezzo",
+        "nestedRawOnlyHint": "Questo corpo ha strutture annidate — modificalo in modalità grezza.",
+        "builder": {
+          "addField": "Aggiungi campo",
+          "keyLabel": "Chiave",
+          "valueLabel": "Valore",
+          "keyPlaceholder": "chiave",
+          "valuePlaceholder": "valore",
+          "typeLabel": "Tipo",
+          "noFields": "Ancora nessun campo. Aggiungine uno per costruire il corpo.",
+          "removeField": "Rimuovi campo",
+          "types": {
+            "string": "Testo",
+            "number": "Numero",
+            "boolean": "Booleano"
+          }
+        },
+        "validation": {
+          "blankKey": "Il corpo ha un campo con chiave vuota",
+          "duplicateKey": "Il corpo ha chiavi duplicate"
+        }
       },
       "headers": {
         "httpHeaders": "Headers HTTP",

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -94,6 +94,44 @@ describe('journey i18n parity (EVO-1260)', () => {
     expect(offenders).toEqual([]);
   });
 
+  // EVO-1742: the structured webhook-body builder keys were added to ALL
+  // six locales. The strict en↔pt-BR mirror covers those two; assert
+  // presence + non-empty across every shipped locale so pt/es/fr/it can't
+  // silently drift (same pattern as EVO-1260 / EVO-1275 above).
+  const evo1742Keys = [
+    'panels.sendWebhook.body.modeStructured',
+    'panels.sendWebhook.body.modeRaw',
+    'panels.sendWebhook.body.nestedRawOnlyHint',
+    'panels.sendWebhook.body.builder.addField',
+    'panels.sendWebhook.body.builder.keyLabel',
+    'panels.sendWebhook.body.builder.valueLabel',
+    'panels.sendWebhook.body.builder.keyPlaceholder',
+    'panels.sendWebhook.body.builder.valuePlaceholder',
+    'panels.sendWebhook.body.builder.typeLabel',
+    'panels.sendWebhook.body.builder.noFields',
+    'panels.sendWebhook.body.builder.removeField',
+    'panels.sendWebhook.body.builder.types.string',
+    'panels.sendWebhook.body.builder.types.number',
+    'panels.sendWebhook.body.builder.types.boolean',
+    'panels.sendWebhook.body.validation.blankKey',
+    'panels.sendWebhook.body.validation.duplicateKey',
+  ];
+
+  it.each([
+    ['en', en],
+    ['pt-BR', ptBR],
+    ['pt', pt],
+    ['es', es],
+    ['fr', fr],
+    ['it', itLocale],
+  ])('%s contains every EVO-1742 webhook-body key, non-empty', (_name, locale) => {
+    const offenders = evo1742Keys.filter((k) => {
+      const v = getAtPath(locale, k);
+      return typeof v !== 'string' || v.trim() === '';
+    });
+    expect(offenders).toEqual([]);
+  });
+
   // Anti-leakage: catches the EVO-1260 review finding class — pt-BR
   // values byte-identical to EN that are NOT legitimate tech terms,
   // sample literals, or pure-interpolation strings. Uses the shared

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -898,7 +898,29 @@
         "availableVariables": "Variáveis Disponíveis:",
         "contact": "Contato:",
         "system": "Sistema:",
-        "bodyPreview": "Pré-visualização do Corpo:"
+        "bodyPreview": "Pré-visualização do Corpo:",
+        "modeStructured": "Estruturado",
+        "modeRaw": "Bruto",
+        "nestedRawOnlyHint": "Este corpo tem estruturas aninhadas — edite no modo bruto.",
+        "builder": {
+          "addField": "Adicionar campo",
+          "keyLabel": "Chave",
+          "valueLabel": "Valor",
+          "keyPlaceholder": "chave",
+          "valuePlaceholder": "valor",
+          "typeLabel": "Tipo",
+          "noFields": "Nenhum campo ainda. Adicione um para montar o corpo.",
+          "removeField": "Remover campo",
+          "types": {
+            "string": "Texto",
+            "number": "Número",
+            "boolean": "Booleano"
+          }
+        },
+        "validation": {
+          "blankKey": "O corpo tem um campo com chave vazia",
+          "duplicateKey": "O corpo tem chaves duplicadas"
+        }
       },
       "headers": {
         "httpHeaders": "Headers HTTP",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -881,7 +881,29 @@
         "availableVariables": "Available Variables:",
         "contact": "Contact:",
         "system": "System:",
-        "bodyPreview": "Preview of Body:"
+        "bodyPreview": "Preview of Body:",
+        "modeStructured": "Estruturado",
+        "modeRaw": "Bruto",
+        "nestedRawOnlyHint": "Este corpo tem estruturas aninhadas — edite no modo bruto.",
+        "builder": {
+          "addField": "Adicionar campo",
+          "keyLabel": "Chave",
+          "valueLabel": "Valor",
+          "keyPlaceholder": "chave",
+          "valuePlaceholder": "valor",
+          "typeLabel": "Tipo",
+          "noFields": "Ainda não há campos. Adicione um para montar o corpo.",
+          "removeField": "Remover campo",
+          "types": {
+            "string": "Texto",
+            "number": "Número",
+            "boolean": "Booleano"
+          }
+        },
+        "validation": {
+          "blankKey": "O corpo tem um campo com chave vazia",
+          "duplicateKey": "O corpo tem chaves duplicadas"
+        }
       },
       "headers": {
         "httpHeaders": "Headers HTTP",


### PR DESCRIPTION
## Summary

Replaces the raw hand-typed JSON body in the Journey **Send Webhook** node with an n8n-style **structured key/value builder** (typed `string` / `number` / `boolean`), mirroring the existing `WebhookHeadersConfig` pattern already in the node. A raw **"advanced" mode** toggle is kept for nested/complex bodies, and the body is now **validated in the editor** instead of failing silently at journey runtime (`SendWebhookPanel.tsx` previously only `JSON.parse`d in the Test flow).

**Frontend-only.** The new `bodyStructured` rows are serialized into the existing `body` string, which stays the wire source-of-truth — so the live executor and the Test tab keep working with **zero backend change**.

### What changed
- **Node data:** new `bodyStructured: WebhookBodyField[]` (`{id,key,value,type}`) + `bodyMode: 'structured' | 'raw'` (`SendWebhookNode.tsx`).
- **Pure helpers** (`webhookBody.ts`): `serializeBody`, `tryParseToFields` (with a nested-JSON guard), `validateFields`, `coerceJsonValue`, `isValidJsonBody`, `getEffectiveBodyMode`.
- **Builder** (`WebhookBodyBuilder.tsx`): typed key/value rows; type column for `json`, hidden for `form`.
- **Body tab** (`WebhookBodyConfig.tsx`): hosts the Structured⇄Raw toggle + round-trip; JSON templates only in raw mode.
- **Validation** wired into the existing `dirty && isValid` save gate (`SendWebhookPanel.tsx`): invalid JSON / blank key / duplicate key block save.
- **i18n:** new keys across all 7 locales + `evo1742Keys` registered in `journey-parity.spec.ts`.

### Design notes / back-compat
- **Existing raw-body journeys** open in **raw mode untouched** — the effective mode is derived **render-only** (no mount-time `onChange`, so no spurious dirty / no-op re-serialization of legacy bodies).
- A persisted `bodyMode` always wins on reopen; new structured-capable nodes default to structured.
- **Nested-JSON guard:** `raw → structured` is refused (with an inline hint) when the body has nested objects/arrays, so we never lossily flatten.
- A `number`-typed field holding a `{{variable}}` is preserved as a string token (the executor substitutes it later) rather than emitting `NaN`. JSON validity is checked variable-tolerantly.
- Builder covers `json` + `form`; `text`/`xml` keep the raw textarea.

## Test plan
- `frontend: npx tsc --noEmit` — exit 0
- `frontend: npx eslint <changed files>` — clean
- `frontend: npx vitest run` — **55 green**: `webhookBody.spec.ts` (26 pure-fn), `WebhookBodyConfig.spec.tsx` (5 component: build field-by-field, raw back-compat + no mount onChange, mode round-trip, nested guard, form urlencoded), `journey-parity.spec.ts` (24).
- Full `src/components/journey` suite: 230 passing. The single failing file (`tokens.contrast.spec.ts`) is a **pre-existing** `colorjs.io` transform error — confirmed it fails identically on clean `develop`, unrelated to this change.

> **Follow-up owed (separate card):** teach the journey webhook **executor to read `bodyStructured`** (typed values) directly. Until then `body` remains the wire format, which this PR keeps serialized.