### PR TITLE
fix(stage-automation): coagir trigger_value para string nos Selects/Input (TS2322)

### DIFF
--- a/src/components/pipelines/StageAutomationRules.tsx
+++ b/src/components/pipelines/StageAutomationRules.tsx
@@ -87,6 +87,12 @@ function asInactivityValue(value: StageAutomationRule['trigger_value']): Inactiv
   return { minutes: INACTIVITY_MINUTES[1], base: 'no_customer_reply' };
 }
 
+// Narrow the union to the string form for the non-inactivity triggers (label /
+// status / generic input), where trigger_value is always a string at runtime.
+function asStringValue(value: StageAutomationRule['trigger_value']): string {
+  return typeof value === 'string' ? value : '';
+}
+
 function generateKey() {
   return `rule-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
@@ -181,7 +187,7 @@ export default function StageAutomationRules({
     if (rule.trigger === 'label_added') {
       return (
         <Select
-          value={rule.trigger_value || ANY_VALUE_SENTINEL}
+          value={asStringValue(rule.trigger_value) || ANY_VALUE_SENTINEL}
           onValueChange={v =>
             updateRule(index, { trigger_value: v === ANY_VALUE_SENTINEL ? '' : v })
           }
@@ -217,7 +223,7 @@ export default function StageAutomationRules({
     if (rule.trigger === 'conversation_status_changed') {
       return (
         <Select
-          value={rule.trigger_value || ANY_VALUE_SENTINEL}
+          value={asStringValue(rule.trigger_value) || ANY_VALUE_SENTINEL}
           onValueChange={v =>
             updateRule(index, { trigger_value: v === ANY_VALUE_SENTINEL ? '' : v })
           }
@@ -242,7 +248,7 @@ export default function StageAutomationRules({
       <Input
         className="flex-1"
         placeholder={t('stageAutomation.labelNamePlaceholder')}
-        value={rule.trigger_value}
+        value={asStringValue(rule.trigger_value)}
         onChange={e => updateRule(index, { trigger_value: e.target.value })}
         disabled={disabled}
       />


### PR DESCRIPTION
## O quê
Conserta o build do front (`tsc -b`), que quebrava em `StageAutomationRules.tsx` (linhas 184/220/245):

```
TS2322: Type 'string | InactivityTriggerValue' is not assignable to type 'string | undefined'.
```

`trigger_value` é `string | InactivityTriggerValue` (objeto só no trigger de inatividade), mas os `<Select value>`/`<Input value>` dos ramos `label_added` / `conversation_status_changed` / input genérico esperam `string`. O TS não estreita o union nesses ramos.

## Como
Adiciona o helper `asStringValue` (irmão do `asInactivityValue` já existente) e coage nos 3 sites. **Runtime idêntico** — nesses ramos o valor já é sempre string; a coerção só satisfaz o compilador.

## Por que
O build do front estava quebrado no `develop` — qualquer `npm run build` / imagem Docker do `vendor/crm` falha. Bloqueava o empacotamento self-hosted (a imagem do front não buildava).

## Validação
`docker build` do front passou (`✓ built in 21.74s`); SPA serve 200.
