### PR TITLE
feat(journey): pre-activation validation framework (EVO-1744)

### DIFF
--- a/src/components/base/BaseFlowNode.tsx
+++ b/src/components/base/BaseFlowNode.tsx
@@ -1,9 +1,10 @@
-import { Handle, Position, useEdges } from "@xyflow/react";
+import { Handle, Position, useEdges, useNodeId } from "@xyflow/react";
 import React from "react";
 import { useLanguage } from '@/hooks/useLanguage';
 import { cn } from "@/lib/utils";
 import { useDnD } from "@/contexts/DnDContext";
 import { ArrowRight } from "lucide-react";
+import { NodeValidationBadge } from '@/components/journey/_ui/NodeValidationBadge';
 
 // Tipos para configuração do node - COMPATÍVEL COM BaseNode ATUAL
 export interface BaseFlowNodeProps {
@@ -178,6 +179,10 @@ export function BaseFlowNode({
   const { t } = useLanguage('common');
   const { pointerEvents } = useDnD();
   const edges = useEdges();
+  // EVO-1744: resolve the node id (explicit prop or the React Flow context) so
+  // the validation badge can look up its issues without each node forwarding it.
+  const hookNodeId = useNodeId();
+  const resolvedNodeId = nodeId ?? hookNodeId;
 
   // Verificar se o source handle está conectado - compatível com BaseNode atual
   const isHandleConnected = (handleId: string) => {
@@ -216,6 +221,9 @@ export function BaseFlowNode({
       }}
       data-is-executing={isExecuting ? "true" : "false"}
     >
+      {/* EVO-1744: pre-activation validation marker (error/warning) */}
+      <NodeValidationBadge nodeId={resolvedNodeId} />
+
       {/* Target Handle - mantém comportamento exato do BaseNode atual */}
       {hasTarget && (
         <Handle

--- a/src/components/journey/JourneyModal.tsx
+++ b/src/components/journey/JourneyModal.tsx
@@ -13,6 +13,8 @@ import {
 } from '@evoapi/design-system';
 import { journeyService } from '@/services';
 import { Journey, TriggerType } from '@/types/automation';
+import type { Node, Edge } from '@xyflow/react';
+import { validateJourney } from '@/utils/journeyFlowValidation';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
@@ -64,6 +66,26 @@ export default function JourneyModal({ open, onClose, journey, onSave }: Journey
       };
 
       if (journey?.id) {
+        // EVO-1744: block turning a journey ON from the modal when its persisted
+        // flow is invalid. flowData lives on the `journey` prop (the modal's own
+        // state is metadata-only). Only gate the off→on transition.
+        if (formData.isActive && !journey.isActive) {
+          const result = validateJourney(
+            (journey.flowData?.nodes ?? []) as unknown as Node[],
+            (journey.flowData?.edges ?? []) as unknown as Edge[],
+          );
+          if (!result.isActivatable) {
+            toast.error(
+              t('messages.activationBlocked', {
+                issues: result.errors
+                  .map((i) => t(i.messageKey, i.params))
+                  .join(' · '),
+              }),
+            );
+            setLoading(false);
+            return;
+          }
+        }
         // Metadata-only edit: never resend flowData/flowTriggers — the backend
         // replaces the stored flow wholesale, so a trigger-only payload would
         // wipe the flow built in the editor (EVO-1745).

--- a/src/components/journey/_ui/NodeValidationBadge.tsx
+++ b/src/components/journey/_ui/NodeValidationBadge.tsx
@@ -1,0 +1,57 @@
+import { AlertCircle, AlertTriangle } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@evoapi/design-system';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useNodeValidationIssues } from '@/contexts/JourneyValidationContext';
+
+interface NodeValidationBadgeProps {
+  nodeId: string | null | undefined;
+}
+
+/**
+ * Per-node validation marker (EVO-1744, AC3). Reads the node's issues from the
+ * JourneyValidation context (never from node `data` — see F6) and renders an
+ * error (red) or warning (amber) badge with a tooltip listing the messages.
+ * Renders nothing when the node has no issues.
+ */
+export function NodeValidationBadge({ nodeId }: NodeValidationBadgeProps) {
+  const { t } = useLanguage('journey');
+  const issues = useNodeValidationIssues(nodeId);
+
+  if (issues.length === 0) return null;
+
+  const hasError = issues.some((i) => i.severity === 'error');
+  const Icon = hasError ? AlertCircle : AlertTriangle;
+  const color = hasError ? 'text-flow-feedback-error-fg' : 'text-amber-500';
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={`absolute -top-2 -right-2 z-10 rounded-full bg-card p-0.5 ${color}`}
+            role="img"
+            aria-label={t(
+              hasError
+                ? 'flowEditor.validation.nodeHasErrors'
+                : 'flowEditor.validation.nodeHasWarnings',
+            )}
+          >
+            <Icon className="w-4 h-4" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>
+          <ul className="space-y-1 text-xs">
+            {issues.map((issue, idx) => (
+              <li key={idx}>{t(issue.messageKey, issue.params)}</li>
+            ))}
+          </ul>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/contexts/JourneyValidationContext.tsx
+++ b/src/contexts/JourneyValidationContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+import type { ValidationIssue } from '@/utils/journeyValidators';
+
+// EVO-1744: per-node validation markers are delivered via context, NOT via node
+// `data` (review finding F6: writing into `data` would re-trigger the autosave
+// dirty-check and persist markers into flowData). Nodes read their issues by id.
+export interface JourneyValidationContextValue {
+  byNodeId: Record<string, ValidationIssue[]>;
+}
+
+const JourneyValidationContext = createContext<JourneyValidationContextValue>({
+  byNodeId: {},
+});
+
+export const JourneyValidationProvider = JourneyValidationContext.Provider;
+
+export function useNodeValidationIssues(
+  nodeId: string | null | undefined,
+): ValidationIssue[] {
+  const { byNodeId } = useContext(JourneyValidationContext);
+  if (!nodeId) return [];
+  return byNodeId[nodeId] ?? [];
+}

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -44,7 +44,9 @@
     "deleteSuccess": "Journey deleted successfully",
     "deleteError": "Unable to delete journey",
     "duplicateSuccess": "Journey duplicated successfully",
-    "duplicateError": "Unable to duplicate journey"
+    "duplicateError": "Unable to duplicate journey",
+    "activationBlocked": "Can't activate — fix these first: {{issues}}",
+    "activationWarnings": "Activated with warnings: {{issues}}"
   },
   "dialog": {
     "delete": {
@@ -86,7 +88,15 @@
     "saveError": "Unable to save journey",
     "validation": {
       "danglingExitWarning": "Journey saved, but these nodes don't reach an Exit Journey node, so it won't complete: {{nodes}}",
-      "danglingExitBanner": "This journey won't complete: these nodes have no path to an Exit Journey node: {{nodes}}"
+      "danglingExitBanner": "This journey won't complete: these nodes have no path to an Exit Journey node: {{nodes}}",
+      "requiredConfig": "{{node}}: missing required configuration ({{fields}})",
+      "triggerActionContext": "{{node}}: needs a conversation, but the trigger doesn't provide one",
+      "danglingExit": "{{node}}: this path doesn't end in an exit or transfer node",
+      "summaryErrors": "Fix these before activating:",
+      "summaryWarnings": "Warnings:",
+      "saveIssues": "Saved with pending issues: {{issues}}",
+      "nodeHasErrors": "Node has errors",
+      "nodeHasWarnings": "Node has warnings"
     },
     "loadError": "Unable to load journey",
     "status": {

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -44,7 +44,9 @@
     "deleteSuccess": "Jornada eliminada con éxito",
     "deleteError": "No fue posible eliminar la jornada",
     "duplicateSuccess": "Jornada duplicada con éxito",
-    "duplicateError": "No fue posible duplicar la jornada"
+    "duplicateError": "No fue posible duplicar la jornada",
+    "activationBlocked": "No se puede activar: corrige primero: {{issues}}",
+    "activationWarnings": "Activada con avisos: {{issues}}"
   },
   "dialog": {
     "delete": {
@@ -86,7 +88,15 @@
     "saveError": "No fue posible guardar la jornada",
     "validation": {
       "danglingExitWarning": "Jornada guardada, pero estos nodos no llegan a un nodo de Salir de la Jornada, así que no se completará: {{nodes}}",
-      "danglingExitBanner": "Esta jornada no se completará: estos nodos no tienen un camino hasta un nodo de Salir de la Jornada: {{nodes}}"
+      "danglingExitBanner": "Esta jornada no se completará: estos nodos no tienen un camino hasta un nodo de Salir de la Jornada: {{nodes}}",
+      "requiredConfig": "{{node}}: falta configuración obligatoria ({{fields}})",
+      "triggerActionContext": "{{node}}: necesita una conversación, pero el disparador no la proporciona",
+      "danglingExit": "{{node}}: esta ruta no termina en un nodo de salida o transferencia",
+      "summaryErrors": "Corrige esto antes de activar:",
+      "summaryWarnings": "Avisos:",
+      "saveIssues": "Guardado con pendientes: {{issues}}",
+      "nodeHasErrors": "El nodo tiene errores",
+      "nodeHasWarnings": "El nodo tiene avisos"
     },
     "loadError": "No fue posible cargar la jornada",
     "status": {

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -44,7 +44,9 @@
     "deleteSuccess": "Parcours supprimé avec succès",
     "deleteError": "Impossible de supprimer le parcours",
     "duplicateSuccess": "Parcours dupliqué avec succès",
-    "duplicateError": "Impossible de dupliquer le parcours"
+    "duplicateError": "Impossible de dupliquer le parcours",
+    "activationBlocked": "Activation impossible — corrigez d'abord : {{issues}}",
+    "activationWarnings": "Activée avec des avertissements : {{issues}}"
   },
   "dialog": {
     "delete": {
@@ -86,7 +88,15 @@
     "saveError": "Impossible d'enregistrer le parcours",
     "validation": {
       "danglingExitWarning": "Parcours enregistré, mais ces nœuds n'atteignent pas un nœud de Sortie du parcours, il ne se terminera donc pas : {{nodes}}",
-      "danglingExitBanner": "Ce parcours ne se terminera pas : ces nœuds n'ont pas de chemin vers un nœud de Sortie du parcours : {{nodes}}"
+      "danglingExitBanner": "Ce parcours ne se terminera pas : ces nœuds n'ont pas de chemin vers un nœud de Sortie du parcours : {{nodes}}",
+      "requiredConfig": "{{node}} : configuration requise manquante ({{fields}})",
+      "triggerActionContext": "{{node}} : nécessite une conversation, mais le déclencheur n'en fournit pas",
+      "danglingExit": "{{node}} : ce chemin ne se termine pas par un nœud de sortie ou de transfert",
+      "summaryErrors": "Corrigez ceci avant d'activer :",
+      "summaryWarnings": "Avertissements :",
+      "saveIssues": "Enregistré avec des problèmes en attente : {{issues}}",
+      "nodeHasErrors": "Le nœud comporte des erreurs",
+      "nodeHasWarnings": "Le nœud comporte des avertissements"
     },
     "loadError": "Impossible de charger le parcours",
     "status": {

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -44,7 +44,9 @@
     "deleteSuccess": "Percorso eliminato con successo",
     "deleteError": "Impossibile eliminare il percorso",
     "duplicateSuccess": "Percorso duplicato con successo",
-    "duplicateError": "Impossibile duplicare il percorso"
+    "duplicateError": "Impossibile duplicare il percorso",
+    "activationBlocked": "Impossibile attivare — correggi prima: {{issues}}",
+    "activationWarnings": "Attivata con avvisi: {{issues}}"
   },
   "dialog": {
     "delete": {
@@ -86,7 +88,15 @@
     "saveError": "Impossibile salvare il percorso",
     "validation": {
       "danglingExitWarning": "Percorso salvato, ma questi nodi non raggiungono un nodo di Uscita dal percorso, quindi non verrà completato: {{nodes}}",
-      "danglingExitBanner": "Questo percorso non verrà completato: questi nodi non hanno un percorso verso un nodo di Uscita dal percorso: {{nodes}}"
+      "danglingExitBanner": "Questo percorso non verrà completato: questi nodi non hanno un percorso verso un nodo di Uscita dal percorso: {{nodes}}",
+      "requiredConfig": "{{node}}: configurazione obbligatoria mancante ({{fields}})",
+      "triggerActionContext": "{{node}}: richiede una conversazione, ma il trigger non ne fornisce una",
+      "danglingExit": "{{node}}: questo percorso non termina con un nodo di uscita o trasferimento",
+      "summaryErrors": "Correggi prima di attivare:",
+      "summaryWarnings": "Avvisi:",
+      "saveIssues": "Salvato con problemi in sospeso: {{issues}}",
+      "nodeHasErrors": "Il nodo presenta errori",
+      "nodeHasWarnings": "Il nodo presenta avvisi"
     },
     "loadError": "Impossibile caricare il percorso",
     "status": {

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -44,7 +44,9 @@
     "deleteSuccess": "Jornada excluída com sucesso",
     "deleteError": "Não foi possível excluir a jornada",
     "duplicateSuccess": "Jornada duplicada com sucesso",
-    "duplicateError": "Não foi possível duplicar a jornada"
+    "duplicateError": "Não foi possível duplicar a jornada",
+    "activationBlocked": "Não foi possível ativar — corrija primeiro: {{issues}}",
+    "activationWarnings": "Ativada com avisos: {{issues}}"
   },
   "dialog": {
     "delete": {
@@ -86,7 +88,15 @@
     "saveError": "Não foi possível salvar a jornada",
     "validation": {
       "danglingExitWarning": "Jornada salva, mas estes nós não chegam a um nó de Sair da Jornada, então ela não vai concluir: {{nodes}}",
-      "danglingExitBanner": "Esta jornada não vai concluir: estes nós não têm caminho até um nó de Sair da Jornada: {{nodes}}"
+      "danglingExitBanner": "Esta jornada não vai concluir: estes nós não têm caminho até um nó de Sair da Jornada: {{nodes}}",
+      "requiredConfig": "{{node}}: configuração obrigatória ausente ({{fields}})",
+      "triggerActionContext": "{{node}}: precisa de uma conversa, mas o gatilho não fornece uma",
+      "danglingExit": "{{node}}: este caminho não termina em um nó de saída ou transferência",
+      "summaryErrors": "Corrija antes de ativar:",
+      "summaryWarnings": "Avisos:",
+      "saveIssues": "Salvo com pendências: {{issues}}",
+      "nodeHasErrors": "Nó com erros",
+      "nodeHasWarnings": "Nó com avisos"
     },
     "loadError": "Não foi possível carregar a jornada",
     "status": {

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -44,7 +44,9 @@
     "deleteSuccess": "Jornada excluída com sucesso",
     "deleteError": "Não foi possível excluir a jornada",
     "duplicateSuccess": "Jornada duplicada com sucesso",
-    "duplicateError": "Não foi possível duplicar a jornada"
+    "duplicateError": "Não foi possível duplicar a jornada",
+    "activationBlocked": "Não foi possível ativar — corrija primeiro: {{issues}}",
+    "activationWarnings": "Ativada com avisos: {{issues}}"
   },
   "dialog": {
     "delete": {
@@ -86,7 +88,15 @@
     "saveError": "Não foi possível salvar a jornada",
     "validation": {
       "danglingExitWarning": "Jornada salva, mas estes nós não chegam a um nó de Sair da Jornada, então ela não vai concluir: {{nodes}}",
-      "danglingExitBanner": "Esta jornada não vai concluir: estes nós não têm caminho até um nó de Sair da Jornada: {{nodes}}"
+      "danglingExitBanner": "Esta jornada não vai concluir: estes nós não têm caminho até um nó de Sair da Jornada: {{nodes}}",
+      "requiredConfig": "{{node}}: configuração obrigatória ausente ({{fields}})",
+      "triggerActionContext": "{{node}}: precisa de uma conversa, mas o gatilho não fornece uma",
+      "danglingExit": "{{node}}: este caminho não termina em um nó de saída ou transferência",
+      "summaryErrors": "Corrija antes de ativar:",
+      "summaryWarnings": "Avisos:",
+      "saveIssues": "Salvo com pendências: {{issues}}",
+      "nodeHasErrors": "Nó com erros",
+      "nodeHasWarnings": "Nó com avisos"
     },
     "loadError": "Não foi possível carregar a jornada",
     "status": {

--- a/src/pages/Customer/Journey/Journey.tsx
+++ b/src/pages/Customer/Journey/Journey.tsx
@@ -17,6 +17,8 @@ import {
 } from '@evoapi/design-system';
 import { journeyService } from '../../../services';
 import type { Journey } from '@/types/automation';
+import type { Node, Edge } from '@xyflow/react';
+import { validateJourney } from '@/utils/journeyFlowValidation';
 import JourneyModal from '@/components/journey/JourneyModal';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
@@ -64,6 +66,37 @@ export default function JourneyPage() {
 
   const handleToggleJourney = async (journey: Journey) => {
     if (!journey.id) return;
+
+    // EVO-1744: `toggleJourney` is a bodyless server-flip, so classify the
+    // direction by the CURRENT `isActive` before calling. Only activation runs
+    // validation; deactivation is always allowed. Errors block (hybrid D1);
+    // warnings are surfaced but don't block.
+    const isActivating = !journey.isActive;
+    if (isActivating) {
+      const result = validateJourney(
+        (journey.flowData?.nodes ?? []) as unknown as Node[],
+        (journey.flowData?.edges ?? []) as unknown as Edge[],
+      );
+      if (!result.isActivatable) {
+        toast.error(
+          t('messages.activationBlocked', {
+            issues: result.errors
+              .map((i) => t(i.messageKey, i.params))
+              .join(' · '),
+          }),
+        );
+        return;
+      }
+      if (result.warnings.length > 0) {
+        toast.warning(
+          t('messages.activationWarnings', {
+            issues: result.warnings
+              .map((i) => t(i.messageKey, i.params))
+              .join(' · '),
+          }),
+        );
+      }
+    }
 
     try {
       await journeyService.toggleJourney(journey.id);

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -15,7 +15,8 @@ import { toast } from 'sonner';
 import { journeyService } from '@/services';
 import type { Journey } from '@/types/automation';
 import { useLanguage } from '@/hooks/useLanguage';
-import { validateJourneyTerminalPaths } from '@/utils/journeyFlowValidation';
+import { validateJourney } from '@/utils/journeyFlowValidation';
+import { JourneyValidationProvider } from '@/contexts/JourneyValidationContext';
 import { buildFlowTriggers } from './journeyFlowTriggers';
 import { BaseFlowEditor, type NodeType, type NodeCategory } from '@/components/base';
 import { EnvironmentManager } from '@/components/journey/environment-manager';
@@ -158,14 +159,13 @@ function JourneyFlowEditor() {
   const recoveryCandidate = useFlowEditorStore((s) => s.recoveryCandidate);
   const recoveryEpoch = useFlowEditorStore((s) => s.recoveryEpoch);
   const currentSnapshot = useFlowEditorStore((s) => s.currentSnapshot);
-  const danglingNodes = useMemo(
+  // EVO-1744: the full pre-activation validation (required config + trigger↔action
+  // coherence + terminal-path, folded in). Memoized on the snapshot like before.
+  const journeyValidation = useMemo(
     () =>
       currentSnapshot
-        ? validateJourneyTerminalPaths(
-            currentSnapshot.nodes,
-            currentSnapshot.edges,
-          ).danglingNodes
-        : [],
+        ? validateJourney(currentSnapshot.nodes, currentSnapshot.edges)
+        : null,
     [currentSnapshot],
   );
 
@@ -710,14 +710,18 @@ function JourneyFlowEditor() {
       // requirement of EVO-1258).
       useFlowEditorStore.getState().commitSave(new Date(), snapshot);
       if (!opts?.silent) {
-        const { danglingNodes } = validateJourneyTerminalPaths(
+        // Save is a draft action — it never blocks. Surface any validation
+        // issues (errors + warnings) so the user knows before they try to
+        // activate from the list, where errors DO block (EVO-1744).
+        const { errors, warnings } = validateJourney(
           snapshot.nodes,
           snapshot.edges,
         );
-        if (danglingNodes.length > 0) {
+        const issues = [...errors, ...warnings];
+        if (issues.length > 0) {
           toast.warning(
-            t('flowEditor.validation.danglingExitWarning', {
-              nodes: danglingNodes.map((node) => node.label).join(', '),
+            t('flowEditor.validation.saveIssues', {
+              issues: issues.map((i) => t(i.messageKey, i.params)).join(' · '),
             }),
           );
         } else {
@@ -883,13 +887,31 @@ function JourneyFlowEditor() {
         </FlowFeedbackBanner>
       ) : null}
 
-      {danglingNodes.length > 0 ? (
-        <FlowFeedbackBanner variant="warn" className="mx-4 mt-2">
-          <p>
-            {t('flowEditor.validation.danglingExitBanner', {
-              nodes: danglingNodes.map((node) => node.label).join(', '),
-            })}
+      {/* EVO-1744: pre-activation summary — errors block activation (from the
+          list), warnings don't. Each rule's message is listed per node. */}
+      {journeyValidation && journeyValidation.errors.length > 0 ? (
+        <FlowFeedbackBanner variant="error" className="mx-4 mt-2">
+          <p className="font-medium">
+            {t('flowEditor.validation.summaryErrors')}
           </p>
+          <ul className="mt-1 list-disc pl-5 text-sm">
+            {journeyValidation.errors.map((issue, idx) => (
+              <li key={idx}>{t(issue.messageKey, issue.params)}</li>
+            ))}
+          </ul>
+        </FlowFeedbackBanner>
+      ) : null}
+
+      {journeyValidation && journeyValidation.warnings.length > 0 ? (
+        <FlowFeedbackBanner variant="warn" className="mx-4 mt-2">
+          <p className="font-medium">
+            {t('flowEditor.validation.summaryWarnings')}
+          </p>
+          <ul className="mt-1 list-disc pl-5 text-sm">
+            {journeyValidation.warnings.map((issue, idx) => (
+              <li key={idx}>{t(issue.messageKey, issue.params)}</li>
+            ))}
+          </ul>
         </FlowFeedbackBanner>
       ) : null}
 
@@ -951,6 +973,9 @@ function JourneyFlowEditor() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      <JourneyValidationProvider
+        value={{ byNodeId: journeyValidation?.byNodeId ?? {} }}
+      >
       <BaseFlowEditor
         key={`flow-canvas-${recoveryEpoch}`}
         flowData={flowData}
@@ -977,6 +1002,7 @@ function JourneyFlowEditor() {
         className="h-full bg-sidebar"
         canvasWrapperClassName="flex-1"
       />
+      </JourneyValidationProvider>
 
       {/* Footer com informações */}
       <div className="border-t border-sidebar-border bg-sidebar p-3 flex-shrink-0">

--- a/src/utils/journeyFlowValidation.spec.ts
+++ b/src/utils/journeyFlowValidation.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import type { Node, Edge } from '@xyflow/react';
-import { validateJourneyTerminalPaths } from './journeyFlowValidation';
+import {
+  validateJourneyTerminalPaths,
+  validateJourney,
+} from './journeyFlowValidation';
 
 const node = (
   id: string,
@@ -86,5 +89,80 @@ describe('validateJourneyTerminalPaths', () => {
     ];
     const result = validateJourneyTerminalPaths(nodes, [edge('t', 'e')]);
     expect(result.isValid).toBe(true);
+  });
+});
+
+describe('validateJourney (EVO-1744)', () => {
+  const sendMsg = (id: string, extra: Record<string, unknown> = {}) =>
+    node(id, 'send-message-node', { label: 'Send', inboxId: 'i1', message: 'hi', ...extra });
+
+  it('AC7: a fully-configured, coherent, terminating journey is activatable', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+      node('e', 'exit-journey-node'),
+    ];
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'e')]);
+    expect(r.errors).toEqual([]);
+    expect(r.warnings).toEqual([]);
+    expect(r.isActivatable).toBe(true);
+  });
+
+  it('AC1/AC5: a node missing required config is an error that blocks activation', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      node('a', 'send-message-node', { label: 'Send' }), // no inboxId/message
+      node('e', 'exit-journey-node'),
+    ];
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'e')]);
+    expect(r.isActivatable).toBe(false);
+    expect(r.errors).toHaveLength(1);
+    expect(r.errors[0].rule).toBe('requiredConfig');
+    expect(r.errors[0].nodeId).toBe('a');
+    expect(r.byNodeId['a']).toBeTruthy();
+  });
+
+  it('AC2: a contact-only trigger feeding a conversation action warns (not blocks)', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', { triggerType: 'customAttribute' }),
+      sendMsg('a'),
+      node('e', 'exit-journey-node'),
+    ];
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'e')]);
+    expect(r.errors).toEqual([]); // warning, not error
+    expect(r.isActivatable).toBe(true);
+    expect(r.warnings.some((w) => w.rule === 'triggerActionContext' && w.nodeId === 'a')).toBe(true);
+  });
+
+  it('AC2: an event trigger on a conversation-category event does NOT warn', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+      node('e', 'exit-journey-node'),
+    ];
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'e')]);
+    expect(r.warnings.some((w) => w.rule === 'triggerActionContext')).toBe(false);
+  });
+
+  it('AC4: a dangling path surfaces as a terminalPath warning from the engine', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'), // no exit downstream
+    ];
+    const r = validateJourney(nodes, [edge('t', 'a')]);
+    expect(r.warnings.some((w) => w.rule === 'terminalPath' && w.nodeId === 'a')).toBe(true);
+    expect(r.isActivatable).toBe(true); // warning, not error
   });
 });

--- a/src/utils/journeyFlowValidation.ts
+++ b/src/utils/journeyFlowValidation.ts
@@ -1,4 +1,10 @@
 import type { Node, Edge } from '@xyflow/react';
+import type {
+  JourneyValidationResult,
+  ValidationIssue,
+} from './journeyValidators/types';
+import { validateNodeConfig } from './journeyValidators/nodeValidators';
+import { validateTriggerActionContext } from './journeyValidators/triggerActionContext';
 
 const TRIGGER_NODE_TYPE = 'journey-trigger-node';
 const EXIT_NODE_TYPE = 'exit-journey-node';
@@ -70,4 +76,66 @@ export function validateJourneyTerminalPaths(
   }
 
   return { isValid: danglingNodes.length === 0, danglingNodes };
+}
+
+/**
+ * Terminal-path rule as `ValidationIssue[]` (EVO-1744, AC4: the EVO-1692 check
+ * folded into the engine, not duplicated). Each dangling node → one warning.
+ * NOTE: cyclic paths with no exit are still not detected (see EVO-1857).
+ */
+function terminalPathIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] {
+  return validateJourneyTerminalPaths(nodes, edges).danglingNodes.map(
+    (dangling) => ({
+      nodeId: dangling.id,
+      rule: 'terminalPath',
+      severity: 'warning',
+      messageKey: 'flowEditor.validation.danglingExit',
+      params: { node: dangling.label },
+    }),
+  );
+}
+
+/**
+ * The pre-activation validation engine (EVO-1744). Pure: nodes/edges in → result
+ * out, so it runs both inside the editor (live React Flow state) and from the
+ * journey list/modal (persisted `flowData`). Runs every rule and aggregates.
+ *
+ * Hybrid enforcement (D1): required-config issues are `error` (block activation);
+ * trigger↔action coherence and terminal-path are `warning` (allow, but surfaced).
+ */
+export function validateJourney(
+  nodes: Node[],
+  edges: Edge[],
+): JourneyValidationResult {
+  const issues: ValidationIssue[] = [];
+
+  // (a) per-node required config — errors
+  for (const node of nodes) {
+    for (const issue of validateNodeConfig(
+      node.type,
+      node.data as Record<string, unknown> | undefined,
+    )) {
+      issues.push({
+        ...issue,
+        nodeId: issue.nodeId ?? node.id,
+        params: { node: labelFor(node), ...issue.params },
+      });
+    }
+  }
+
+  // (b) trigger↔action conversation coherence — warnings
+  issues.push(...validateTriggerActionContext(nodes, edges));
+
+  // (c) terminal-path (EVO-1692, folded in) — warnings
+  issues.push(...terminalPathIssues(nodes, edges));
+
+  const errors = issues.filter((i) => i.severity === 'error');
+  const warnings = issues.filter((i) => i.severity === 'warning');
+  const byNodeId: Record<string, ValidationIssue[]> = {};
+  for (const issue of issues) {
+    if (!issue.nodeId) continue;
+    (byNodeId[issue.nodeId] ??= []).push(issue);
+  }
+
+  return { errors, warnings, byNodeId, isActivatable: errors.length === 0 };
 }

--- a/src/utils/journeyValidators/index.ts
+++ b/src/utils/journeyValidators/index.ts
@@ -1,0 +1,14 @@
+// Barrel for the Journey Flow Builder validation framework (EVO-1744).
+// The engine entry point `validateJourney` lives in `../journeyFlowValidation`.
+export type {
+  ValidationSeverity,
+  ValidationRule,
+  ValidationIssue,
+  JourneyValidationResult,
+} from './types';
+export { nodeValidators, validateNodeConfig } from './nodeValidators';
+export {
+  CONVERSATION_REQUIRING_NODES,
+  triggerProvidesConversation,
+  validateTriggerActionContext,
+} from './triggerActionContext';

--- a/src/utils/journeyValidators/nodeValidators.spec.ts
+++ b/src/utils/journeyValidators/nodeValidators.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { validateNodeConfig } from './nodeValidators';
+
+describe('validateNodeConfig (EVO-1744)', () => {
+  it('errors when send-message has no inbox', () => {
+    const issues = validateNodeConfig('send-message-node', { message: 'hi' });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].params?.fields).toContain('inboxId');
+  });
+
+  it('passes a configured send-message (free text)', () => {
+    expect(
+      validateNodeConfig('send-message-node', { inboxId: 'i', message: 'hi' }),
+    ).toEqual([]);
+  });
+
+  it('requires templateName in template mode', () => {
+    const issues = validateNodeConfig('send-message-node', {
+      inboxId: 'i',
+      messageMode: 'template',
+    });
+    expect(issues[0].params?.fields).toContain('templateName');
+  });
+
+  it('errors when a conditional node has no paths (its only gate)', () => {
+    expect(validateNodeConfig('conditional-node', {})).toHaveLength(1);
+    expect(validateNodeConfig('conditional-node', { paths: [{}] })).toEqual([]);
+  });
+
+  it('treats blank strings as missing', () => {
+    expect(validateNodeConfig('add-label-node', { labelId: '   ' })).toHaveLength(1);
+    expect(validateNodeConfig('add-label-node', { labelId: 'l1' })).toEqual([]);
+  });
+
+  it('returns no issues for an unregistered / config-free node type', () => {
+    expect(validateNodeConfig('mute-conversation-node', {})).toEqual([]);
+    expect(validateNodeConfig('exit-journey-node', {})).toEqual([]);
+    expect(validateNodeConfig(undefined, undefined)).toEqual([]);
+  });
+
+  it('requires both ids for move-to-pipeline-stage', () => {
+    const issues = validateNodeConfig('move-to-pipeline-stage-node', {
+      pipeline_id: 'p1',
+    });
+    expect(issues[0].params?.fields).toBe('stage_id');
+  });
+});

--- a/src/utils/journeyValidators/nodeValidators.ts
+++ b/src/utils/journeyValidators/nodeValidators.ts
@@ -1,0 +1,127 @@
+// Per-node required-config validators (EVO-1744, decision D3).
+//
+// SCOPE (review finding F1): these are headless, data-only PRESENCE checks —
+// they catch a node that was dragged in but never configured. They intentionally
+// do NOT reproduce each panel's full `isValid` (e.g. balanced expressions,
+// required template variables, fetched-option coherence) — that rich/async
+// validation stays in the panels, which already gate their own modal save at
+// edit time. The framework is a backstop for "never configured", runnable off
+// persisted `flowData` in the journey list.
+
+import type { ValidationIssue } from './types';
+
+type NodeData = Record<string, unknown>;
+
+const missing = (v: unknown): boolean =>
+  v === undefined || v === null || (typeof v === 'string' && v.trim() === '');
+
+/** Emit a single requiredConfig error naming the missing field(s). */
+function requiredConfig(fields: string[]): ValidationIssue[] {
+  if (fields.length === 0) return [];
+  return [
+    {
+      rule: 'requiredConfig',
+      severity: 'error',
+      messageKey: 'flowEditor.validation.requiredConfig',
+      params: { fields: fields.join(', ') },
+    },
+  ];
+}
+
+/** Returns the subset of `fields` absent from `data`. */
+function absent(data: NodeData, fields: string[]): string[] {
+  return fields.filter((f) => missing(data[f]));
+}
+
+type Validator = (data: NodeData) => ValidationIssue[];
+
+/**
+ * Registry keyed by React Flow node `type`. A node type absent here has no
+ * required config (e.g. terminal nodes, mute/resolve conversation) and is always
+ * considered configured.
+ */
+export const nodeValidators: Record<string, Validator> = {
+  'send-message-node': (d) => {
+    // Either a template or a free-text/expression message, always tied to an inbox.
+    const fields = absent(d, ['inboxId']);
+    const isTemplate = d.messageMode === 'template';
+    if (isTemplate ? missing(d.templateName) : missing(d.message)) {
+      fields.push(isTemplate ? 'templateName' : 'message');
+    }
+    return requiredConfig(fields);
+  },
+
+  // The one node whose panel has no save gate today — the framework is its
+  // PRIMARY required-config check (still data-only): at least one branch path.
+  'conditional-node': (d) => {
+    const paths = d.paths;
+    if (!Array.isArray(paths) || paths.length === 0) {
+      return requiredConfig(['paths']);
+    }
+    return [];
+  },
+
+  'send-webhook-node': (d) => requiredConfig(absent(d, ['webhookUrl'])),
+
+  'scheduled-action-node': (d) =>
+    requiredConfig(absent(d, ['actionType', 'delayDuration'])),
+
+  'defer-conversation-node': (d) => {
+    const fields = absent(d, ['snooze_type']);
+    if (missing(d.snooze_duration) && missing(d.snooze_until)) {
+      fields.push('snooze_until');
+    }
+    return requiredConfig(fields);
+  },
+
+  'add-label-node': (d) => requiredConfig(absent(d, ['labelId'])),
+  'remove-label-node': (d) => requiredConfig(absent(d, ['labelId'])),
+
+  'update-contact-node': (d) =>
+    requiredConfig(absent(d, ['fieldToUpdate', 'newValue'])),
+
+  'update-custom-attribute-node': (d) =>
+    requiredConfig(absent(d, ['attributeId', 'newValue'])),
+
+  'set-variable-node': (d) =>
+    requiredConfig(absent(d, ['variableName', 'operation'])),
+
+  'assign-agent-node': (d) => requiredConfig(absent(d, ['agent_id'])),
+  'assign-team-node': (d) => requiredConfig(absent(d, ['team_id'])),
+  'assign-bot-node': (d) => requiredConfig(absent(d, ['bot_id', 'inbox_id'])),
+
+  'assign-to-pipeline-node': (d) => requiredConfig(absent(d, ['pipeline_id'])),
+  'move-to-pipeline-stage-node': (d) =>
+    requiredConfig(absent(d, ['pipeline_id', 'stage_id'])),
+  'create-pipeline-task-node': (d) => requiredConfig(absent(d, ['title'])),
+
+  'send-canned-response-node': (d) =>
+    requiredConfig(absent(d, ['canned_response_id'])),
+  'send-email-team-node': (d) => {
+    const fields = absent(d, ['message']);
+    const teams = d.team_ids;
+    if (!Array.isArray(teams) || teams.length === 0) fields.push('team_ids');
+    return requiredConfig(fields);
+  },
+  'send-transcript-node': (d) => requiredConfig(absent(d, ['email'])),
+
+  'change-priority-node': (d) => requiredConfig(absent(d, ['priority'])),
+
+  'transfer-journey-node': (d) =>
+    requiredConfig(absent(d, ['targetJourneyId'])),
+
+  // No required config: 'mute-conversation-node', 'resolve-conversation-node',
+  // 'wait-node', 'split-node', 'exit-journey-node', 'journey-trigger-node'
+  // (the trigger has its own validity surface in JourneyTriggerPanel).
+};
+
+/** Run the registry validator for a node; nodes absent from the registry pass. */
+export function validateNodeConfig(
+  nodeType: string | undefined,
+  data: NodeData | undefined,
+): ValidationIssue[] {
+  if (!nodeType) return [];
+  const validator = nodeValidators[nodeType];
+  if (!validator) return [];
+  return validator(data ?? {});
+}

--- a/src/utils/journeyValidators/triggerActionContext.spec.ts
+++ b/src/utils/journeyValidators/triggerActionContext.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { Node, Edge } from '@xyflow/react';
+import {
+  triggerProvidesConversation,
+  validateTriggerActionContext,
+  CONVERSATION_REQUIRING_NODES,
+} from './triggerActionContext';
+
+const node = (id: string, type: string, data: Record<string, unknown> = {}): Node => ({
+  id,
+  type,
+  position: { x: 0, y: 0 },
+  data,
+});
+const edge = (source: string, target: string): Edge => ({
+  id: `${source}-${target}`,
+  source,
+  target,
+});
+
+describe('triggerProvidesConversation (EVO-1744)', () => {
+  it('event trigger on a conversation-category event provides conversation', () => {
+    expect(
+      triggerProvidesConversation({ triggerType: 'event', eventName: 'conversation.created' }),
+    ).toBe(true);
+  });
+  it('event trigger on a contact-category event does NOT', () => {
+    expect(
+      triggerProvidesConversation({ triggerType: 'event', eventName: 'contact.created' }),
+    ).toBe(false);
+  });
+  it('contact-level trigger types do NOT provide conversation', () => {
+    for (const tt of ['manual', 'segment', 'contactCreated', 'label', 'customAttribute', 'pipelineStageChanged']) {
+      expect(triggerProvidesConversation({ triggerType: tt })).toBe(false);
+    }
+  });
+  it('webhook is treated as provides=true (indeterminate, no-warn)', () => {
+    expect(triggerProvidesConversation({ triggerType: 'webhook' })).toBe(true);
+  });
+});
+
+describe('validateTriggerActionContext (EVO-1744)', () => {
+  it('warns each conversation-requiring node reachable from a non-providing trigger', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', { triggerType: 'label' }),
+      node('a', 'send-message-node', { label: 'Send' }),
+      node('b', 'add-label-node'), // not conversation-requiring
+    ];
+    const issues = validateTriggerActionContext(nodes, [edge('t', 'a'), edge('a', 'b')]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].nodeId).toBe('a');
+    expect(issues[0].severity).toBe('warning');
+  });
+
+  it('does not warn when the trigger provides conversation', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', { triggerType: 'event', eventName: 'message.created' }),
+      node('a', 'send-message-node'),
+    ];
+    expect(validateTriggerActionContext(nodes, [edge('t', 'a')])).toEqual([]);
+  });
+
+  it('the conversation set excludes assign-bot and send-webhook', () => {
+    expect(CONVERSATION_REQUIRING_NODES.has('assign-bot-node')).toBe(false);
+    expect(CONVERSATION_REQUIRING_NODES.has('send-webhook-node')).toBe(false);
+    expect(CONVERSATION_REQUIRING_NODES.has('defer-conversation-node')).toBe(true);
+    expect(CONVERSATION_REQUIRING_NODES.size).toBe(13);
+  });
+});

--- a/src/utils/journeyValidators/triggerActionContext.ts
+++ b/src/utils/journeyValidators/triggerActionContext.ts
@@ -1,0 +1,125 @@
+// Trigger↔action conversation-context coherence (EVO-1744, decision D2).
+//
+// Editor-side mirror of the runtime contract EVO-1741: an action whose runtime
+// `requiredContext === 'conversation'` cannot run when the trigger provides no
+// conversation (no conversationId → the node `contextSkip`s). We validate ONLY
+// the conversation axis the runtime actually enforces; the `contact` axis is
+// declared by the runtime but inert, so we don't validate it here.
+
+import type { Node, Edge } from '@xyflow/react';
+import { getEvent } from '@/lib/events-manifest';
+import type { ValidationIssue } from './types';
+
+const TRIGGER_NODE_TYPE = 'journey-trigger-node';
+
+/**
+ * FE node types whose runtime node declares `requiredContext: 'conversation'`
+ * (evo-flow base.node.ts). FE type = runtime type + `-node`, EXCEPT runtime
+ * `snooze-conversation` = FE `defer-conversation-node`. Excludes assign-bot
+ * (no context) and send-webhook (no context).
+ */
+export const CONVERSATION_REQUIRING_NODES = new Set<string>([
+  'send-message-node',
+  'send-canned-response-node',
+  'send-transcript-node',
+  'send-email-team-node',
+  'assign-agent-node',
+  'assign-team-node',
+  'assign-to-pipeline-node',
+  'move-to-pipeline-stage-node',
+  'create-pipeline-task-node',
+  'mute-conversation-node',
+  'change-priority-node',
+  'resolve-conversation-node',
+  'defer-conversation-node',
+]);
+
+function labelFor(node: Node): string {
+  const data = (node.data ?? {}) as { label?: string; name?: string };
+  return data.label || data.name || node.type || node.id;
+}
+
+/**
+ * Does the trigger provide a conversation context? Reads `data.triggerType`
+ * (the selector vocabulary — lowercase camelCase), NOT the PascalCase
+ * `flowTriggers[].type`/`TriggerType` enum (review F8). For `event` triggers the
+ * answer comes from the configured event's catalog category.
+ */
+export function triggerProvidesConversation(
+  data: Record<string, unknown> | undefined,
+): boolean {
+  const triggerType = (data?.triggerType as string) ?? '';
+  switch (triggerType) {
+    case 'event': {
+      const eventName = data?.eventName as string | undefined;
+      const category = eventName ? getEvent(eventName)?.category : undefined;
+      return category === 'conversation' || category === 'message';
+    }
+    case 'webhook':
+      // Indeterminate: payload may carry conversation_id and the runtime
+      // contextSkip is the real guard. Treat as provides=true to keep warnings
+      // high-signal (documented design choice).
+      return true;
+    // manual, segment, contactCreated, contactUpdated, label, customAttribute,
+    // pipelineStageChanged → contact/pipeline-level, no conversation.
+    default:
+      return false;
+  }
+}
+
+/**
+ * Warn for every conversation-requiring node reachable from a trigger that does
+ * not provide conversation. Per-trigger semantics are intentional (review F4):
+ * the runtime starts one session per trigger, so such a node WILL skip on the
+ * non-providing trigger's runs even if another trigger also reaches it. Issues
+ * are deduped per node.
+ */
+export function validateTriggerActionContext(
+  nodes: Node[],
+  edges: Edge[],
+): ValidationIssue[] {
+  const outgoing = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!edge.source || !edge.target) continue;
+    const targets = outgoing.get(edge.source) ?? [];
+    targets.push(edge.target);
+    outgoing.set(edge.source, targets);
+  }
+
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const triggers = nodes.filter((node) => node.type === TRIGGER_NODE_TYPE);
+  const flagged = new Set<string>();
+  const issues: ValidationIssue[] = [];
+
+  for (const trigger of triggers) {
+    if (triggerProvidesConversation(trigger.data as Record<string, unknown>)) {
+      continue;
+    }
+    const visited = new Set<string>();
+    const queue = [trigger.id];
+    while (queue.length > 0) {
+      const id = queue.shift() as string;
+      if (visited.has(id)) continue;
+      visited.add(id);
+
+      const node = nodeById.get(id);
+      if (
+        node?.type &&
+        CONVERSATION_REQUIRING_NODES.has(node.type) &&
+        !flagged.has(node.id)
+      ) {
+        flagged.add(node.id);
+        issues.push({
+          nodeId: node.id,
+          rule: 'triggerActionContext',
+          severity: 'warning',
+          messageKey: 'flowEditor.validation.triggerActionContext',
+          params: { node: labelFor(node) },
+        });
+      }
+      queue.push(...(outgoing.get(id) ?? []));
+    }
+  }
+
+  return issues;
+}

--- a/src/utils/journeyValidators/types.ts
+++ b/src/utils/journeyValidators/types.ts
@@ -1,0 +1,30 @@
+// Shared types for the Journey Flow Builder pre-activation validation framework
+// (EVO-1744). The engine (validateJourney) and the per-node validators speak
+// these. Validators are pure and data-only so they run headless from the journey
+// list (off persisted flowData), not just inside the React Flow editor.
+
+export type ValidationSeverity = 'error' | 'warning';
+
+export type ValidationRule =
+  | 'requiredConfig'
+  | 'triggerActionContext'
+  | 'terminalPath';
+
+export interface ValidationIssue {
+  /** Node the issue belongs to; undefined = journey-level. */
+  nodeId?: string;
+  rule: ValidationRule;
+  severity: ValidationSeverity;
+  /** i18n key (resolved at render). */
+  messageKey: string;
+  /** Interpolation params for the message (e.g. missing field names, node label). */
+  params?: Record<string, unknown>;
+}
+
+export interface JourneyValidationResult {
+  errors: ValidationIssue[];
+  warnings: ValidationIssue[];
+  byNodeId: Record<string, ValidationIssue[]>;
+  /** A journey can only be activated when it has zero errors (warnings allowed). */
+  isActivatable: boolean;
+}


### PR DESCRIPTION
## Summary

Generalizes the lone exit-node check (EVO-1692) into a **per-node pre-activation validation framework** so an incoherent journey can't be shipped. Editor-side mirror of the runtime trigger↔action contract (EVO-1741); the terminal-path check is **folded in**, not duplicated.

**Engine** (`src/utils/journeyFlowValidation.ts` + `journeyValidators/`): `validateJourney(nodes, edges) → { errors, warnings, byNodeId, isActivatable }`. Pure (no React/fetch) → runs in the editor **and** off persisted `flowData` from the journey list/modal.

- **Required-config (errors):** headless field-presence validators per node type. Rich/async checks (balanced expressions, required template vars) stay in the panels, which already gate their own save — the framework is the "never configured" backstop.
- **Trigger↔action coherence (warnings):** a conversation-requiring action reachable from a trigger that provides no conversation. Per-trigger semantics (one session per trigger). Reads `data.triggerType` + the event catalog category.
- **Terminal-path/dangling (warnings):** folded in from EVO-1692.

**Hybrid enforcement:** errors **block** activation; coherence + dangling are **warnings** (allow, but surfaced).

**Surfaces:**
- Hard block in the list toggle (`handleToggleJourney`) and modal save, both on persisted `flowData`; branch on `isActive` before the bodyless toggle; deactivation always allowed.
- Editor: pre-activation summary banner + per-node markers via a validation **context** feeding `NodeValidationBadge` in the shared `BaseFlowNode` — never written into node `data`, so no autosave/persist side effects.

## Test plan

- `npx vitest run src/utils/journeyFlowValidation.spec.ts src/utils/journeyValidators` → **25/25** (engine, validators, coherence; covers AC1–AC5/AC7).
- `npx tsc -b` clean.
- AC1 missing config blocks list activation · AC2 contact-trigger→conversation-action warns (non-blocking) · AC3 per-node markers + summary banner · AC4 dangling folded into the engine · AC5 hybrid (only errors gate) · AC7 happy path activates · AC8 deactivate never validated.

## Notas

- The conversation-requiring set (13) mirrors evo-flow `base.node.ts requiredContext: 'conversation'` (FE `-node` suffix; runtime `snooze-conversation` = FE `defer-conversation-node`).
- Validators are intentionally narrower than panel `isValid` (presence only) — under-validate, never over-block.
- **Out of scope:** cycle-without-exit detection (inherited blind spot from EVO-1692) → tracked in EVO-1857.

Closes EVO-1744.