### PR TITLE
fix(journey): persist Update Custom Attribute node value by attribute_key (EVO-1850)

### DIFF
--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributeNode.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributeNode.tsx
@@ -6,7 +6,10 @@ export interface UpdateCustomAttributeNodeData {
   label: string;
   description?: string;
   attributeId?: string;
+  // attributeName carries the attribute_key (slug) used as the CRM api key.
   attributeName?: string;
+  // attributeDisplayName is the human-readable label, for UI only (EVO-1850).
+  attributeDisplayName?: string;
   attributeDisplayType?: string;
   newValue?: string;
 }
@@ -44,7 +47,7 @@ export function UpdateCustomAttributeNode({ selected, data, id }: UpdateCustomAt
     }
 
     return t('panels.updateCustomAttribute.updates', {
-      attribute: data.attributeName,
+      attribute: data.attributeDisplayName || data.attributeName,
       value: data.newValue,
     });
   };
@@ -91,7 +94,7 @@ export function UpdateCustomAttributeNode({ selected, data, id }: UpdateCustomAt
             <div className="flex items-center gap-2 mt-1">
               <span className="text-xs">{getTypeIcon()}</span>
               <span className="text-xs text-pink-700 dark:text-pink-300 font-medium">
-                {data.attributeName}
+                {data.attributeDisplayName || data.attributeName}
               </span>
               <span className="text-xs text-pink-600 dark:text-pink-400">→ {data.newValue}</span>
             </div>

--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.spec.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateCustomAttributePanel } from './UpdateCustomAttributePanel';
+import { UpdateCustomAttributeNodeData } from './UpdateCustomAttributeNode';
+import '@/i18n/config';
+
+vi.mock('@/services/customAttributes/customAttributesService', () => ({
+  customAttributesService: {
+    getCustomAttributes: vi.fn(),
+  },
+}));
+
+import { customAttributesService } from '@/services/customAttributes/customAttributesService';
+
+const mockGetCustomAttributes =
+  customAttributesService.getCustomAttributes as unknown as ReturnType<typeof vi.fn>;
+
+// Display name and slug deliberately differ so the test proves the node-data
+// persists the slug (attribute_key) while the UI shows the display name.
+const PLAN_INTEREST_ATTR = {
+  id: 'attr-1',
+  attribute_key: 'plan_interest',
+  attribute_display_name: 'Plan Interest',
+  attribute_display_type: 'text',
+  attribute_model: 'contact_attribute',
+};
+
+function emptyData(): UpdateCustomAttributeNodeData {
+  return { label: 'Update Custom Attribute' } as UpdateCustomAttributeNodeData;
+}
+
+function getAttributeTrigger(): HTMLElement {
+  // The attribute selector is the only combobox before a value field renders.
+  return screen.getAllByRole('combobox')[0];
+}
+
+beforeEach(() => {
+  mockGetCustomAttributes.mockResolvedValue({ data: [] });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('UpdateCustomAttributePanel — persists attribute_key (EVO-1850)', () => {
+  it('saves attributeName=attribute_key (slug) and attributeDisplayName=display name', async () => {
+    mockGetCustomAttributes.mockResolvedValue({ data: [PLAN_INTEREST_ATTR] });
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <UpdateCustomAttributePanel
+        nodeId="n1"
+        data={emptyData()}
+        onUpdate={onUpdate}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(mockGetCustomAttributes).toHaveBeenCalledWith('contact_attribute'),
+    );
+
+    // Pick the attribute by its human-readable display name.
+    await user.click(getAttributeTrigger());
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Plan Interest'));
+
+    // Set a value so the form is valid + dirty (Save is gated on both).
+    const valueInput = await screen.findByRole('textbox');
+    await user.type(valueInput, 'gold');
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /save|salvar|guardar|enregistrer|salva/i,
+    });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    expect(onUpdate).toHaveBeenCalled();
+    const [, updatedData] = onUpdate.mock.calls[0];
+    expect(updatedData).toMatchObject({
+      attributeId: 'attr-1',
+      attributeName: 'plan_interest', // slug — the CRM api key
+      attributeDisplayName: 'Plan Interest', // human label, UI only
+      newValue: 'gold',
+    });
+  });
+
+  it('shows the display name (not the slug) in the preview', async () => {
+    mockGetCustomAttributes.mockResolvedValue({ data: [PLAN_INTEREST_ATTR] });
+    const user = userEvent.setup();
+
+    render(
+      <UpdateCustomAttributePanel
+        nodeId="n1"
+        data={emptyData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCustomAttributes).toHaveBeenCalled());
+
+    await user.click(getAttributeTrigger());
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Plan Interest'));
+
+    const valueInput = await screen.findByRole('textbox');
+    await user.type(valueInput, 'gold');
+
+    // The display name is shown; the raw slug must never surface in the UI.
+    await waitFor(() => expect(screen.getAllByText('Plan Interest').length).toBeGreaterThan(0));
+    expect(screen.queryByText('plan_interest')).toBeNull();
+  });
+});

--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.tsx
@@ -89,7 +89,12 @@ export function UpdateCustomAttributePanel({
     setFormData(prev => ({
       ...prev,
       attributeId,
-      attributeName: selectedAttribute?.attribute_display_name || '',
+      // attributeName MUST be the attribute_key (slug) — it is what the
+      // evo-flow Update node persists as the CRM custom_attributes key, and
+      // what a downstream Conditional reads via
+      // {{contact.customAttributes.<attribute_key>}} (EVO-1850 / EVO-1837).
+      attributeName: selectedAttribute?.attribute_key || '',
+      attributeDisplayName: selectedAttribute?.attribute_display_name || '',
       attributeDisplayType: selectedAttribute?.attribute_display_type || '',
       newValue: '',
     }));
@@ -332,7 +337,10 @@ export function UpdateCustomAttributePanel({
               <span className="text-sm">
                 {ATTRIBUTE_TYPE_ICONS[selectedAttribute?.attribute_display_type || ''] || '⚙️'}
               </span>
-              <span className="font-medium">{formData.attributeName}</span>
+              <span className="font-medium">
+                {formData.attributeDisplayName ||
+                  selectedAttribute?.attribute_display_name}
+              </span>
               <span>→</span>
               <span className="font-medium">
                 {selectedAttribute?.attribute_display_type === 'checkbox'


### PR DESCRIPTION
## Summary
The journey **Update Custom Attribute** node persisted the contact attribute keyed by `attribute_display_name`, while everything else (CRM contact UI/API/import, and the Conditional node from EVO-1837) keys `custom_attributes` by `attribute_key` (the slug). So "set an attribute, then branch on it" silently failed — the Conditional read `{{contact.customAttributes.<attribute_key>}}` → `undefined`.

This PR makes the node persist `attributeName` as the **`attribute_key` slug** (the value the evo-flow runtime already uses as the CRM api key), and adds a dedicated `attributeDisplayName` field carrying the human-readable name for the UI (panel preview + canvas card), with a fallback to `attributeName` for legacy nodes.

## Test plan
- New `UpdateCustomAttributePanel.spec.tsx` (vitest) — asserts the saved node-data has `attributeName = slug` and `attributeDisplayName = display name`, and that the UI shows the display name (not the slug). **2/2 green.**
- `tsc -b` clean.

## Notas
- Part of EVO-1850 (3 repos): this FE PR + evo-flow (runtime merge/slug) + evo-ai-crm-community (backfill migration).
- Write-side counterpart to EVO-1837 (read side).

## Summary by Sourcery

Ensure the journey Update Custom Attribute node persists custom attributes by slug while displaying human-readable labels in the UI.

Bug Fixes:
- Fix incorrect persistence of custom attribute updates that previously used the display name instead of the attribute_key slug, enabling downstream conditionals to read the updated value correctly.

Enhancements:
- Introduce a separate attributeDisplayName field so node previews and panels show the human-readable attribute label while keeping attributeName as the slug for API integration.

Tests:
- Add unit tests for UpdateCustomAttributePanel to verify node data stores attributeName as attribute_key, uses attributeDisplayName for UI, and hides the raw slug in the preview.