### PR TITLE
fix(frontend): functional pagination, search & sort on config screens (EVO-1860)

### DIFF
--- a/src/components/cannedResponses/CannedResponsesPagination.tsx
+++ b/src/components/cannedResponses/CannedResponsesPagination.tsx
@@ -16,6 +16,8 @@ export default function CannedResponsesPagination({
   totalCount,
   perPage,
   onPageChange,
+  onPerPageChange,
+  loading,
 }: CannedResponsesPaginationProps) {
   return (
     <BasePagination
@@ -24,6 +26,8 @@ export default function CannedResponsesPagination({
       totalItems={totalCount}
       itemsPerPage={perPage}
       onPageChange={onPageChange}
+      onItemsPerPageChange={onPerPageChange}
+      disabled={loading}
     />
   );
 }

--- a/src/components/customAttributes/CustomAttributesPagination.tsx
+++ b/src/components/customAttributes/CustomAttributesPagination.tsx
@@ -14,8 +14,10 @@ export default function CustomAttributesPagination({
   currentPage,
   totalPages,
   onPageChange,
+  onPerPageChange,
   totalCount,
   perPage,
+  loading,
 }: CustomAttributesPaginationProps) {
   return (
     <BasePagination
@@ -24,6 +26,8 @@ export default function CustomAttributesPagination({
       totalItems={totalCount}
       itemsPerPage={perPage}
       onPageChange={onPageChange}
+      onItemsPerPageChange={onPerPageChange}
+      disabled={loading}
     />
   );
 }

--- a/src/components/labels/LabelsPagination.tsx
+++ b/src/components/labels/LabelsPagination.tsx
@@ -7,14 +7,17 @@ interface LabelsPaginationProps {
   perPage: number;
   onPageChange: (page: number) => void;
   onPerPageChange: (perPage: number) => void;
+  loading?: boolean;
 }
 
 export default function LabelsPagination({
   currentPage,
   totalPages,
   onPageChange,
+  onPerPageChange,
   totalCount,
   perPage,
+  loading,
 }: LabelsPaginationProps) {
   return (
     <BasePagination
@@ -23,6 +26,8 @@ export default function LabelsPagination({
       totalItems={totalCount}
       itemsPerPage={perPage}
       onPageChange={onPageChange}
+      onItemsPerPageChange={onPerPageChange}
+      disabled={loading}
     />
   );
 }

--- a/src/constants/pagination.ts
+++ b/src/constants/pagination.ts
@@ -4,3 +4,8 @@
  */
 export const DEFAULT_PAGE_SIZE = 20;
 export const DEFAULT_PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+
+// Bounded config catalogs (labels, canned responses, custom attribute definitions) are loaded
+// fully in a single request and paginated client-side. Soft cap — if a catalog ever exceeds it,
+// migrate that screen to the server-side list pattern (see EVO-1860).
+export const SETTINGS_LIST_FETCH_SIZE = 500;

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -16,6 +16,11 @@
   },
   "noResultsFound": "No results found",
   "base": {
+    "noResults": {
+      "title": "No results found",
+      "description": "No items match your search.",
+      "clearSearch": "Clear search"
+    },
     "pagination": {
       "itemsPerPage": "Items per page:",
       "showing": "Showing {{start}} to {{end}} of {{total}} items",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1,5 +1,10 @@
 {
   "base": {
+    "noResults": {
+      "title": "Sin resultados",
+      "description": "Ningún elemento coincide con tu búsqueda.",
+      "clearSearch": "Limpiar búsqueda"
+    },
     "pagination": {
       "itemsPerPage": "Ítems por página:",
       "showing": "Mostrando {{start}} a {{end}} de {{total}} ítems",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1,5 +1,10 @@
 {
   "base": {
+    "noResults": {
+      "title": "Aucun résultat",
+      "description": "Aucun élément ne correspond à votre recherche.",
+      "clearSearch": "Effacer la recherche"
+    },
     "pagination": {
       "itemsPerPage": "Éléments par page :",
       "showing": "Affichage de {{start}} à {{end}} sur {{total}} éléments",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -1,5 +1,10 @@
 {
   "base": {
+    "noResults": {
+      "title": "Nessun risultato",
+      "description": "Nessun elemento corrisponde alla tua ricerca.",
+      "clearSearch": "Cancella ricerca"
+    },
     "pagination": {
       "itemsPerPage": "Elementi per pagina:",
       "showing": "Mostrando {{start}} a {{end}} di {{total}} elementi",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -16,6 +16,11 @@
   },
   "noResultsFound": "Nenhum resultado encontrado",
   "base": {
+    "noResults": {
+      "title": "Nenhum resultado encontrado",
+      "description": "Nenhum item corresponde à sua busca.",
+      "clearSearch": "Limpar busca"
+    },
     "pagination": {
       "itemsPerPage": "Itens por página:",
       "showing": "Mostrando {{start}} a {{end}} de {{total}} itens",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1,5 +1,10 @@
 {
   "base": {
+    "noResults": {
+      "title": "Nenhum resultado encontrado",
+      "description": "Nenhum item corresponde à sua pesquisa.",
+      "clearSearch": "Limpar pesquisa"
+    },
     "pagination": {
       "itemsPerPage": "Itens por página:",
       "showing": "Mostrando {{start}} a {{end}} de {{total}} itens",

--- a/src/pages/Customer/Settings/CannedResponses/CannedResponses.tsx
+++ b/src/pages/Customer/Settings/CannedResponses/CannedResponses.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
   Button,
 } from '@evoapi/design-system';
-import { MessageSquare } from 'lucide-react';
+import { MessageSquare, Search } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
 import { useUserPermissions } from '@/hooks/useUserPermissions';
@@ -26,7 +26,7 @@ import CannedResponsesHeader from '@/components/cannedResponses/CannedResponsesH
 import CannedResponsesTable from '@/components/cannedResponses/CannedResponsesTable';
 import CannedResponsesPagination from '@/components/cannedResponses/CannedResponsesPagination';
 import CannedResponseModal from '@/components/cannedResponses/CannedResponseModal';
-import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { DEFAULT_PAGE_SIZE, SETTINGS_LIST_FETCH_SIZE } from '@/constants/pagination';
 
 const INITIAL_STATE: CannedResponsesState = {
   cannedResponses: [],
@@ -71,22 +71,18 @@ export default function CannedResponses() {
     setState(prev => ({ ...prev, loading: { ...prev.loading, list: true } }));
 
     try {
-      const response = await cannedResponsesService.getCannedResponses();
-      const total = response.meta?.pagination?.total || 0;
-      const pageSize = response.meta?.pagination?.page_size || DEFAULT_PAGE_SIZE;
+      const response = await cannedResponsesService.getCannedResponses(
+        undefined,
+        SETTINGS_LIST_FETCH_SIZE,
+      );
 
       setState(prev => ({
         ...prev,
         cannedResponses: response.data,
+        selectedCannedResponseIds: [],
         meta: {
-          pagination: {
-            page: response.meta?.pagination?.page || 1,
-            page_size: pageSize,
-            total: total,
-            total_pages: response.meta?.pagination?.total_pages || Math.ceil(total / pageSize),
-            has_next_page: response.meta?.pagination?.has_next_page,
-            has_previous_page: response.meta?.pagination?.has_previous_page,
-          },
+          ...prev.meta,
+          pagination: { ...prev.meta.pagination, page: 1 },
         },
         loading: { ...prev.loading, list: false },
       }));
@@ -121,11 +117,20 @@ export default function CannedResponses() {
     state.searchQuery,
   );
 
+  const pageSize = state.meta.pagination.page_size ?? DEFAULT_PAGE_SIZE;
+  const totalPages = Math.max(1, Math.ceil(searchFilteredCannedResponses.length / pageSize));
+  const currentPage = Math.min(state.meta.pagination.page, totalPages);
+  const paginatedCannedResponses = searchFilteredCannedResponses.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  );
+
   // Handlers
   const handleSearchChange = (query: string) => {
     setState(prev => ({
       ...prev,
       searchQuery: query,
+      selectedCannedResponseIds: [],
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
     }));
   };
@@ -133,6 +138,7 @@ export default function CannedResponses() {
   const handlePageChange = (page: number) => {
     setState(prev => ({
       ...prev,
+      selectedCannedResponseIds: [],
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page } },
     }));
   };
@@ -140,6 +146,7 @@ export default function CannedResponses() {
   const handlePerPageChange = (perPage: number) => {
     setState(prev => ({
       ...prev,
+      selectedCannedResponseIds: [],
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page_size: perPage, page: 1 } },
     }));
   };
@@ -299,20 +306,34 @@ export default function CannedResponses() {
             <div className="text-muted-foreground">{t('loading')}</div>
           </div>
         ) : searchFilteredCannedResponses.length === 0 ? (
-          <EmptyState
-            icon={MessageSquare}
-            title={t('empty.title')}
-            description={t('empty.description')}
-            action={{
-              label: t('empty.action'),
-              onClick: handleCreateCannedResponse,
-            }}
-            className="h-full"
-          />
+          state.searchQuery.trim() ? (
+            <EmptyState
+              icon={Search}
+              title={t('common:base.noResults.title')}
+              description={t('common:base.noResults.description')}
+              action={{
+                label: t('common:base.noResults.clearSearch'),
+                onClick: () => handleSearchChange(''),
+                variant: 'outline',
+              }}
+              className="h-full"
+            />
+          ) : (
+            <EmptyState
+              icon={MessageSquare}
+              title={t('empty.title')}
+              description={t('empty.description')}
+              action={{
+                label: t('empty.action'),
+                onClick: handleCreateCannedResponse,
+              }}
+              className="h-full"
+            />
+          )
         ) : (
           <CannedResponsesTable
-            cannedResponses={searchFilteredCannedResponses}
-            selectedCannedResponses={searchFilteredCannedResponses.filter(cr =>
+            cannedResponses={paginatedCannedResponses}
+            selectedCannedResponses={paginatedCannedResponses.filter(cr =>
               state.selectedCannedResponseIds.includes(cr.id),
             )}
             loading={state.loading.list}
@@ -330,7 +351,13 @@ export default function CannedResponses() {
             onSort={column => {
               const newOrder =
                 state.sortBy === column && state.sortOrder === 'asc' ? 'desc' : 'asc';
-              setState(prev => ({ ...prev, sortBy: column, sortOrder: newOrder }));
+              setState(prev => ({
+                ...prev,
+                sortBy: column,
+                sortOrder: newOrder,
+                selectedCannedResponseIds: [],
+                meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
+              }));
             }}
           />
         )}
@@ -340,12 +367,10 @@ export default function CannedResponses() {
       {searchFilteredCannedResponses.length > 0 && (
         <div className="mt-auto pt-4 border-t">
           <CannedResponsesPagination
-            currentPage={state.meta.pagination.page}
-            totalPages={Math.ceil(
-              searchFilteredCannedResponses.length / (state.meta.pagination.page_size ?? DEFAULT_PAGE_SIZE),
-            )}
+            currentPage={currentPage}
+            totalPages={totalPages}
             totalCount={searchFilteredCannedResponses.length}
-            perPage={state.meta.pagination.page_size ?? DEFAULT_PAGE_SIZE}
+            perPage={pageSize}
             onPageChange={handlePageChange}
             onPerPageChange={handlePerPageChange}
             loading={state.loading.list}

--- a/src/pages/Customer/Settings/CustomAttributes/CustomAttributes.tsx
+++ b/src/pages/Customer/Settings/CustomAttributes/CustomAttributes.tsx
@@ -15,7 +15,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@evoapi/design-system';
-import { Settings } from 'lucide-react';
+import { Search, Settings } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
 import { useUserPermissions } from '@/hooks/useUserPermissions';
@@ -136,11 +136,27 @@ export default function CustomAttributes() {
       : true,
   );
 
+  const pageSize = state.meta.pagination.page_size;
+  const sortedAttributes = [...searchFilteredAttributes].sort((a, b) => {
+    const direction = state.sortOrder === 'asc' ? 1 : -1;
+    if (state.sortBy === 'created_at') {
+      return (new Date(a.created_at).getTime() - new Date(b.created_at).getTime()) * direction;
+    }
+    return a.attribute_display_name.localeCompare(b.attribute_display_name) * direction;
+  });
+  const totalPages = Math.max(1, Math.ceil(sortedAttributes.length / pageSize));
+  const currentPage = Math.min(state.meta.pagination.page, totalPages);
+  const paginatedAttributes = sortedAttributes.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  );
+
   // Handlers
   const handleSearchChange = (query: string) => {
     setState(prev => ({
       ...prev,
       searchQuery: query,
+      selectedAttributeIds: [],
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
     }));
   };
@@ -152,12 +168,14 @@ export default function CustomAttributes() {
       activeTab: newTab,
       selectedAttributeIds: [],
       searchQuery: '',
+      meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
     }));
   };
 
   const handlePageChange = (page: number) => {
     setState(prev => ({
       ...prev,
+      selectedAttributeIds: [],
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page } },
     }));
   };
@@ -165,6 +183,7 @@ export default function CustomAttributes() {
   const handlePerPageChange = (perPage: number) => {
     setState(prev => ({
       ...prev,
+      selectedAttributeIds: [],
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page_size: perPage, page: 1 } },
     }));
   };
@@ -304,7 +323,7 @@ export default function CustomAttributes() {
       <SettingsCustomAttributesTour />
       <div data-tour="settings-custom-attributes-header">
         <CustomAttributesHeader
-          totalCount={searchFilteredAttributes.length}
+          totalCount={sortedAttributes.length}
           selectedCount={state.selectedAttributeIds.length}
           searchValue={state.searchQuery}
           onSearchChange={handleSearchChange}
@@ -335,28 +354,42 @@ export default function CustomAttributes() {
                 <div className="flex items-center justify-center py-16">
                   <div className="text-muted-foreground">{t('loading')}</div>
                 </div>
-              ) : searchFilteredAttributes.length === 0 ? (
-                <EmptyState
-                  icon={Settings}
-                  title={t('empty.title')}
-                  description={
-                    tab.key === 'conversation_attribute'
-                      ? t('empty.descriptionConversation')
-                      : tab.key === 'contact_attribute'
-                      ? t('empty.descriptionContact')
-                      : t('empty.descriptionPipeline')
-                  }
-                  action={{
-                    label: t('empty.action'),
-                    onClick: handleCreateAttribute,
-                  }}
-                  className="h-full"
-                />
+              ) : sortedAttributes.length === 0 ? (
+                state.searchQuery.trim() ? (
+                  <EmptyState
+                    icon={Search}
+                    title={t('common:base.noResults.title')}
+                    description={t('common:base.noResults.description')}
+                    action={{
+                      label: t('common:base.noResults.clearSearch'),
+                      onClick: () => handleSearchChange(''),
+                      variant: 'outline',
+                    }}
+                    className="h-full"
+                  />
+                ) : (
+                  <EmptyState
+                    icon={Settings}
+                    title={t('empty.title')}
+                    description={
+                      tab.key === 'conversation_attribute'
+                        ? t('empty.descriptionConversation')
+                        : tab.key === 'contact_attribute'
+                        ? t('empty.descriptionContact')
+                        : t('empty.descriptionPipeline')
+                    }
+                    action={{
+                      label: t('empty.action'),
+                      onClick: handleCreateAttribute,
+                    }}
+                    className="h-full"
+                  />
+                )
               ) : (
                 <CustomAttributesTable
                   activeTab={state.activeTab}
-                  attributes={searchFilteredAttributes}
-                  selectedAttributes={searchFilteredAttributes.filter(attr =>
+                  attributes={paginatedAttributes}
+                  selectedAttributes={paginatedAttributes.filter(attr =>
                     state.selectedAttributeIds.includes(attr.id),
                   )}
                   loading={state.loading.list}
@@ -378,6 +411,8 @@ export default function CustomAttributes() {
                       ...prev,
                       sortBy: column as 'attribute_display_name' | 'created_at',
                       sortOrder: newOrder,
+                      selectedAttributeIds: [],
+                      meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
                     }));
                   }}
                 />
@@ -389,15 +424,13 @@ export default function CustomAttributes() {
       </div>
 
       {/* Pagination fixa em baixo */}
-      {searchFilteredAttributes.length > 0 && (
+      {sortedAttributes.length > 0 && (
         <div className="mt-auto pt-4 border-t">
           <CustomAttributesPagination
-            currentPage={state.meta.pagination.page}
-            totalPages={Math.ceil(
-              searchFilteredAttributes.length / state.meta.pagination.page_size,
-            )}
-            totalCount={searchFilteredAttributes.length}
-            perPage={state.meta.pagination.page_size}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalCount={sortedAttributes.length}
+            perPage={pageSize}
             onPageChange={handlePageChange}
             onPerPageChange={handlePerPageChange}
             loading={state.loading.list}

--- a/src/pages/Customer/Settings/Labels/Labels.tsx
+++ b/src/pages/Customer/Settings/Labels/Labels.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
   Button,
 } from '@evoapi/design-system';
-import { Tags } from 'lucide-react';
+import { Search, Tags } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
 import { labelsService } from '@/services/contacts/labelsService';
@@ -22,7 +22,7 @@ import LabelsHeader from '@/components/labels/LabelsHeader';
 import LabelsTable from '@/components/labels/LabelsTable';
 import LabelsPagination from '@/components/labels/LabelsPagination';
 import LabelModal from '@/components/labels/LabelModal';
-import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { DEFAULT_PAGE_SIZE, SETTINGS_LIST_FETCH_SIZE } from '@/constants/pagination';
 
 const INITIAL_STATE: LabelsState = {
   labels: [],
@@ -68,22 +68,15 @@ export default function Labels() {
     setState(prev => ({ ...prev, loading: { ...prev.loading, list: true } }));
 
     try {
-      const response = await labelsService.getLabels();
-      const total = response.meta.pagination.total;
-      const pageSize = response.meta.pagination.page_size;
+      const response = await labelsService.getLabels({ per_page: SETTINGS_LIST_FETCH_SIZE });
 
       setState(prev => ({
         ...prev,
         labels: response.data,
+        selectedLabelIds: [],
         meta: {
-          pagination: {
-            page: response.meta.pagination.page,
-            page_size: pageSize,
-            total: total,
-            total_pages: response.meta.pagination.total_pages,
-            has_next_page: response.meta.pagination.has_next_page,
-            has_previous_page: response.meta.pagination.has_previous_page,
-          }
+          ...prev.meta,
+          pagination: { ...prev.meta.pagination, page: 1 },
         },
         loading: { ...prev.loading, list: false },
       }));
@@ -112,39 +105,24 @@ export default function Labels() {
     setState(prev => ({
       ...prev,
       searchQuery: query,
-      meta: { pagination: { ...prev.meta.pagination, page: 1 } },
+      selectedLabelIds: [],
+      meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
     }));
-
-    // For now, just filter client-side. In production, this should be server-side
-    if (query.trim()) {
-      const filteredLabels = state.labels.filter(
-        label =>
-          label.title.toLowerCase().includes(query.toLowerCase()) ||
-          label.description?.toLowerCase().includes(query.toLowerCase()),
-      );
-      setState(prev => ({
-        ...prev,
-        labels: filteredLabels,
-      }));
-    } else {
-      loadLabels();
-    }
   };
 
   const handlePageChange = (page: number) => {
     setState(prev => ({
       ...prev,
-      meta: { pagination: { ...prev.meta.pagination, page } },
+      selectedLabelIds: [],
+      meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page } },
     }));
-
-    // For client-side pagination, this is just for UI state
-    // In production, this would trigger a new API call
   };
 
   const handlePerPageChange = (perPage: number) => {
     setState(prev => ({
       ...prev,
-      meta: { pagination: { ...prev.meta.pagination, page_size: perPage, page: 1 } },
+      selectedLabelIds: [],
+      meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page_size: perPage, page: 1 } },
     }));
   };
 
@@ -304,12 +282,36 @@ export default function Labels() {
     }
   };
 
+  const pageSize = state.meta.pagination.page_size;
+  const filteredLabels = state.searchQuery.trim()
+    ? state.labels.filter(label => {
+        const query = state.searchQuery.toLowerCase();
+        return (
+          label.title.toLowerCase().includes(query) ||
+          label.description?.toLowerCase().includes(query)
+        );
+      })
+    : state.labels;
+  const sortedLabels = [...filteredLabels].sort((a, b) => {
+    const direction = state.sortOrder === 'asc' ? 1 : -1;
+    if (state.sortBy === 'created_at') {
+      return (new Date(a.created_at).getTime() - new Date(b.created_at).getTime()) * direction;
+    }
+    return a.title.localeCompare(b.title) * direction;
+  });
+  const totalPages = Math.max(1, Math.ceil(sortedLabels.length / pageSize));
+  const currentPage = Math.min(state.meta.pagination.page, totalPages);
+  const paginatedLabels = sortedLabels.slice(
+    (currentPage - 1) * pageSize,
+    currentPage * pageSize,
+  );
+
   return (
     <div className="h-full flex flex-col p-4" data-tour="settings-labels-page">
       <SettingsLabelsTour />
       <div data-tour="settings-labels-header">
         <LabelsHeader
-          totalCount={state.meta.pagination.total}
+          totalCount={sortedLabels.length}
           selectedCount={state.selectedLabelIds.length}
           searchValue={state.searchQuery}
           onSearchChange={handleSearchChange}
@@ -326,21 +328,35 @@ export default function Labels() {
           <div className="flex items-center justify-center py-16">
             <div className="text-muted-foreground">{t('loading')}</div>
           </div>
-        ) : state.labels.length === 0 ? (
-          <EmptyState
-            icon={Tags}
-            title={t('empty.title')}
-            description={t('empty.description')}
-            action={can('labels', 'create') ? {
-              label: t('empty.action'),
-              onClick: handleCreateLabel,
-            } : undefined}
-            className="h-full"
-          />
+        ) : sortedLabels.length === 0 ? (
+          state.searchQuery.trim() ? (
+            <EmptyState
+              icon={Search}
+              title={t('common:base.noResults.title')}
+              description={t('common:base.noResults.description')}
+              action={{
+                label: t('common:base.noResults.clearSearch'),
+                onClick: () => handleSearchChange(''),
+                variant: 'outline',
+              }}
+              className="h-full"
+            />
+          ) : (
+            <EmptyState
+              icon={Tags}
+              title={t('empty.title')}
+              description={t('empty.description')}
+              action={can('labels', 'create') ? {
+                label: t('empty.action'),
+                onClick: handleCreateLabel,
+              } : undefined}
+              className="h-full"
+            />
+          )
         ) : (
           <LabelsTable
-            labels={state.labels}
-            selectedLabels={state.labels.filter(label => state.selectedLabelIds.includes(label.id))}
+            labels={paginatedLabels}
+            selectedLabels={paginatedLabels.filter(label => state.selectedLabelIds.includes(label.id))}
             loading={state.loading.list}
             onSelectionChange={labels =>
               setState(prev => ({
@@ -359,24 +375,28 @@ export default function Labels() {
               setState(prev => ({
                 ...prev,
                 sortBy: column as 'title' | 'created_at',
-                sortOrder: newOrder
+                sortOrder: newOrder,
+                selectedLabelIds: [],
+                meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
               }));
-              // In production, this would trigger a new API call with sort parameters
             }}
           />
         )}
       </div>
 
       {/* Pagination */}
-      {state.meta.pagination.total > 0 && (
-        <LabelsPagination
-          currentPage={state.meta.pagination.page}
-          totalPages={state.meta.pagination.total_pages}
-          totalCount={state.meta.pagination.total}
-          perPage={state.meta.pagination.page_size}
-          onPageChange={handlePageChange}
-          onPerPageChange={handlePerPageChange}
-        />
+      {sortedLabels.length > 0 && (
+        <div className="mt-auto pt-4 border-t">
+          <LabelsPagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalCount={sortedLabels.length}
+            perPage={pageSize}
+            onPageChange={handlePageChange}
+            onPerPageChange={handlePerPageChange}
+            loading={state.loading.list}
+          />
+        </div>
       )}
 
       {/* Delete Label Dialog */}

--- a/src/services/cannedResponses/cannedResponsesService.ts
+++ b/src/services/cannedResponses/cannedResponsesService.ts
@@ -13,9 +13,12 @@ class CannedResponsesService {
     return '/canned_responses';
   }
 
-  async getCannedResponses(searchKey?: string): Promise<CannedResponsesResponse> {
+  async getCannedResponses(searchKey?: string, perPage?: number): Promise<CannedResponsesResponse> {
     try {
-      const params = searchKey ? { search: searchKey } : {};
+      const params = {
+        ...(searchKey ? { search: searchKey } : {}),
+        ...(perPage ? { per_page: perPage } : {}),
+      };
       const response = await api.get(this.baseUrl, { params });
       return extractResponse<CannedResponse>(response) as CannedResponsesResponse;
     } catch (error) {


### PR DESCRIPTION
## Summary
Make the list controls on the three Settings config screens (Labels, Canned Responses, Custom Attributes) actually work. They were cosmetic: Labels and Canned Responses silently fetched only the first 20 rows (no `per_page` sent) and the pagination / sort / per-page controls never acted on the data.

- Load the full catalog in one request (`SETTINGS_LIST_FETCH_SIZE = 500` for the `apply_pagination`-capped Labels/Canned endpoints) and do search / sort / pagination client-side.
- Page slice is applied before the table; column sort actually reorders rows; the items-per-page selector is wired (the pagination wrappers were dropping `onPerPageChange`).
- Remove the destructive Labels search that overwrote `state.labels` (lost items when narrowing then widening the query).
- Distinct "no results" empty state on a non-matching search (shared `common:base.noResults`, all 6 locales) instead of the misleading "create first" CTA.
- Standardize table-to-pagination spacing across the three screens.

## Approach note
Rescoped to **client-side** (frontend-only, no backend changes) — these are bounded config catalogs (labels / canned / attribute definitions, realistically dozens), unlike Contacts/Conversations which justify the server-side pattern. Soft cap = 500; if a catalog ever exceeds it, migrate that screen to the Contacts server-side pattern. Full decision record in the EVO-1860 description.

## Known limitation (deliberate)
Row selection is scoped to the visible page (cleared on page / per-page / search / sort change) to avoid cross-page selection corruption in the shared `BaseTable` (which rebuilds selection from the array it is handed). Bulk actions operate per page. Cross-page selection would be a future enhancement.

## Security
No new endpoints or data exposure; frontend-only; permission gating unchanged.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec eslint <changed files>` — clean (0 new; pre-existing `any` debt in cannedResponsesService left untouched)
- `pnpm exec vitest related --run` — 0 new failures (`SendCannedResponsePanel` passes → the `getCannedResponses(searchKey?, perPage?)` signature change is backward-compatible; the 4 `Chat.spec` failures are pre-existing on `develop`, proven via stash)
- Manual: Settings → Labels / Canned Responses / Custom Attributes — per-page selector works, page change re-slices, column sort reorders, search filters live (Labels no longer loses items on backspace), no-results state shows "Clear search".

## Changed Files
- `src/pages/Customer/Settings/{Labels,CannedResponses,CustomAttributes}/*.tsx`
- `src/components/{labels,cannedResponses,customAttributes}/*Pagination.tsx`
- `src/services/cannedResponses/cannedResponsesService.ts`
- `src/constants/pagination.ts`
- `src/i18n/locales/{en,pt-BR,es,fr,it,pt}/common.json`

## Linked Issue
- EVO-1860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk9VSPAVSDo3cG8caUbNND