### PR TITLE
feat(frontend): canned response attachments UX — show, remove, single-cap (EVO-1861)

### DIFF
--- a/src/components/cannedResponses/CannedResponseModal.tsx
+++ b/src/components/cannedResponses/CannedResponseModal.tsx
@@ -136,13 +136,21 @@ export default function CannedResponseModal({
     }
   };
 
-  // 🎯 FILE UPLOAD: Gerenciar arquivos
+  // 🎯 FILE UPLOAD: 1 anexo por resposta rápida (canais enviam só 1 mídia hoje)
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
+    e.target.value = '';
 
     if (files.length === 0) return;
 
-    // Validar tamanho e tipo
+    const currentCount =
+      existingAttachments.filter(a => !removedAttachmentIds.includes(a.id)).length +
+      (formData.attachments?.length ?? 0);
+    if (currentCount >= 1) {
+      toast.error('Apenas 1 anexo por resposta rápida');
+      return;
+    }
+
     const maxSize = 10 * 1024 * 1024; // 10MB
     const allowedTypes = [
       'image/jpeg', 'image/png', 'image/gif', 'image/webp',
@@ -152,31 +160,17 @@ export default function CannedResponseModal({
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     ];
 
-    const validFiles: File[] = [];
-
-    files.forEach(file => {
-      if (file.size > maxSize) {
-        toast.error(`Arquivo ${file.name} é muito grande (máximo 10MB)`);
-        return;
-      }
-
-      if (!allowedTypes.includes(file.type)) {
-        toast.error(`Tipo de arquivo ${file.name} não permitido`);
-        return;
-      }
-
-      validFiles.push(file);
-    });
-
-    if (validFiles.length > 0) {
-      setFormData(prev => ({
-        ...prev,
-        attachments: [...(prev.attachments || []), ...validFiles]
-      }));
+    const file = files[0];
+    if (file.size > maxSize) {
+      toast.error(`Arquivo ${file.name} é muito grande (máximo 10MB)`);
+      return;
+    }
+    if (!allowedTypes.includes(file.type)) {
+      toast.error(`Tipo de arquivo ${file.name} não permitido`);
+      return;
     }
 
-    // Limpar input
-    e.target.value = '';
+    setFormData(prev => ({ ...prev, attachments: [file] }));
   };
 
   const handleRemoveFile = (index: number) => {
@@ -232,6 +226,11 @@ export default function CannedResponseModal({
       textarea.setSelectionRange(newCursorPosition, newCursorPosition);
     });
   };
+
+  const attachmentCount =
+    existingAttachments.filter(a => !removedAttachmentIds.includes(a.id)).length +
+    (formData.attachments?.length ?? 0);
+  const attachmentLimitReached = attachmentCount >= 1;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -304,17 +303,16 @@ export default function CannedResponseModal({
                 type="file"
                 id="file-upload"
                 className="hidden"
-                multiple
                 accept="image/*,audio/*,video/*,.pdf,.doc,.docx"
                 onChange={handleFileSelect}
-                disabled={loading}
+                disabled={loading || attachmentLimitReached}
               />
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 onClick={() => document.getElementById('file-upload')?.click()}
-                disabled={loading}
+                disabled={loading || attachmentLimitReached}
               >
                 <Paperclip className="h-4 w-4 mr-2" />
                 {t('modal.fields.attachments.addButton')}

--- a/src/components/cannedResponses/CannedResponseModal.tsx
+++ b/src/components/cannedResponses/CannedResponseModal.tsx
@@ -147,7 +147,7 @@ export default function CannedResponseModal({
       existingAttachments.filter(a => !removedAttachmentIds.includes(a.id)).length +
       (formData.attachments?.length ?? 0);
     if (currentCount >= 1) {
-      toast.error('Apenas 1 anexo por resposta rápida');
+      toast.error(t('modal.fields.attachments.errors.limitReached'));
       return;
     }
 
@@ -162,11 +162,11 @@ export default function CannedResponseModal({
 
     const file = files[0];
     if (file.size > maxSize) {
-      toast.error(`Arquivo ${file.name} é muito grande (máximo 10MB)`);
+      toast.error(t('modal.fields.attachments.errors.tooLarge', { name: file.name }));
       return;
     }
     if (!allowedTypes.includes(file.type)) {
-      toast.error(`Tipo de arquivo ${file.name} não permitido`);
+      toast.error(t('modal.fields.attachments.errors.invalidType', { name: file.name }));
       return;
     }
 
@@ -361,13 +361,14 @@ export default function CannedResponseModal({
                         rel="noopener noreferrer"
                         className="text-xs underline text-primary"
                       >
-                        Abrir
+                        {t('modal.fields.attachments.openAction')}
                       </a>
                       <Button
                         type="button"
                         variant="ghost"
                         size="icon"
                         className="h-8 w-8"
+                        aria-label={t('modal.fields.attachments.removeAriaLabel')}
                         onClick={() => setRemovedAttachmentIds(prev => [...prev, attachment.id])}
                         disabled={loading}
                       >
@@ -405,6 +406,7 @@ export default function CannedResponseModal({
                       variant="ghost"
                       size="icon"
                       className="h-8 w-8 flex-shrink-0"
+                      aria-label={t('modal.fields.attachments.removeAriaLabel')}
                       onClick={() => handleRemoveFile(index)}
                       disabled={loading}
                     >

--- a/src/components/cannedResponses/CannedResponseModal.tsx
+++ b/src/components/cannedResponses/CannedResponseModal.tsx
@@ -59,6 +59,7 @@ export default function CannedResponseModal({
 
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [existingAttachments, setExistingAttachments] = useState<CannedResponseAttachment[]>([]);
+  const [removedAttachmentIds, setRemovedAttachmentIds] = useState<string[]>([]);
   const contentRef = useRef<HTMLTextAreaElement | null>(null);
   const contentSelectionRef = useRef({ start: 0, end: 0 });
 
@@ -80,6 +81,7 @@ export default function CannedResponseModal({
         setExistingAttachments([]);
       }
       setErrors({});
+      setRemovedAttachmentIds([]);
     }
   }, [open, cannedResponse, isNew]);
 
@@ -111,7 +113,7 @@ export default function CannedResponseModal({
       return;
     }
 
-    onSubmit(formData);
+    onSubmit({ ...formData, removeAttachmentIds: removedAttachmentIds });
   };
 
   const handleInputChange = (field: keyof CannedResponseFormData, value: string) => {
@@ -323,12 +325,14 @@ export default function CannedResponseModal({
             </div>
 
             {/* Preview de anexos existentes (ao editar) */}
-            {existingAttachments.length > 0 && (
+            {existingAttachments.some(a => !removedAttachmentIds.includes(a.id)) && (
               <div className="space-y-2">
                 <p className="text-xs font-medium text-muted-foreground">
                   {t('modal.fields.attachments.existing')}
                 </p>
-                {existingAttachments.map((attachment) => (
+                {existingAttachments
+                  .filter(a => !removedAttachmentIds.includes(a.id))
+                  .map((attachment) => (
                   <div
                     key={attachment.id}
                     className="flex items-center justify-between p-2 bg-muted/30 rounded-md"
@@ -352,17 +356,28 @@ export default function CannedResponseModal({
                       </div>
                     </div>
 
-                    {/* opcional: botão pra abrir o arquivo */}
-                    <a
-                      href={attachment.data_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-xs underline text-primary"
-                    >
-                      Abrir
-                    </a>
+                    <div className="flex items-center gap-2 flex-shrink-0">
+                      <a
+                        href={attachment.data_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs underline text-primary"
+                      >
+                        Abrir
+                      </a>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => setRemovedAttachmentIds(prev => [...prev, attachment.id])}
+                        disabled={loading}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </div>
-                ))}
+                  ))}
               </div>
             )}
 

--- a/src/components/cannedResponses/CannedResponsesTable.tsx
+++ b/src/components/cannedResponses/CannedResponsesTable.tsx
@@ -1,5 +1,5 @@
 import { useLanguage } from '@/hooks/useLanguage';
-import { Edit, Trash2 } from 'lucide-react';
+import { Edit, Paperclip, Trash2 } from 'lucide-react';
 import BaseTable from '@/components/base/BaseTable';
 import { CannedResponse } from '@/types/knowledge';
 
@@ -34,8 +34,16 @@ export default function CannedResponsesTable({
       label: t('table.columns.shortCode'),
       sortable: true,
       render: (cannedResponse: CannedResponse) => (
-        <div className="font-mono font-medium text-sm bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded border inline-block">
-          {cannedResponse.short_code}
+        <div className="flex items-center gap-2">
+          <span className="font-mono font-medium text-sm bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded border inline-block">
+            {cannedResponse.short_code}
+          </span>
+          {!!cannedResponse.attachments?.length && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Paperclip className="h-3 w-3" />
+              {cannedResponse.attachments.length}
+            </span>
+          )}
         </div>
       ),
     },

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -181,7 +181,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
       // attachment); drop any manually-added files so both are never sent together.
       if ((cannedResponse.attachments?.length ?? 0) > 0) {
         if (selectedFiles.length > 0) {
-          toast.info('Os anexos manuais foram removidos: a resposta rápida já inclui mídia.');
+          toast.info(t('messageInput.cannedResponse.manualAttachmentsRemoved'));
           setSelectedFiles([]);
         }
       }
@@ -197,7 +197,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         richEditorRef.current?.focus();
       }, 0);
     },
-    [selectedFiles],
+    [selectedFiles, t],
   );
 
   // 🎯 CANNED RESPONSES: Filtrar respostas com base na query
@@ -471,6 +471,10 @@ const MessageInput: React.FC<MessageInputProps> = ({
   );
 
   const handleFilesSelected = useCallback((files: File[]) => {
+    if (hasCannedMedia) {
+      toast.info(t('messageInput.cannedResponse.mediaBlocksManualUpload'));
+      return;
+    }
     setSelectedFiles(prev => [...prev, ...files]);
     const count = files.length;
     toast.success(
@@ -481,7 +485,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         duration: 2000,
       },
     );
-  }, [t]);
+  }, [t, hasCannedMedia]);
 
   // Handle media paste from clipboard (Ctrl+V / Cmd+V)
   useEffect(() => {
@@ -622,8 +626,9 @@ const MessageInput: React.FC<MessageInputProps> = ({
           <div className="border-b border-border bg-muted/20 px-4 py-2 flex items-center justify-between gap-2">
             <div className="flex items-center gap-2">
               <span className="text-xs text-muted-foreground">
-                Esta resposta rápida inclui {selectedCannedResponse!.attachments!.length} arquivo(s)
-                de mídia. Eles serão enviados junto com a mensagem.
+                {t('messageInput.cannedResponse.mediaBanner', {
+                  count: selectedCannedResponse!.attachments!.length,
+                })}
               </span>
             </div>
             <Button
@@ -631,6 +636,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
               variant="ghost"
               size="icon"
               className="h-6 w-6 flex-shrink-0"
+              aria-label={t('messageInput.cannedResponse.removeMediaAriaLabel')}
               onClick={() => {
                 setSelectedCannedResponse(null);
                 setSelectedCannedResponseId(null);

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -180,12 +180,10 @@ const MessageInput: React.FC<MessageInputProps> = ({
       // A canned response with media owns the attachment slot (channels send a single
       // attachment); drop any manually-added files so both are never sent together.
       if ((cannedResponse.attachments?.length ?? 0) > 0) {
-        setSelectedFiles(prev => {
-          if (prev.length > 0) {
-            toast.info('Os anexos manuais foram removidos: a resposta rápida já inclui mídia.');
-          }
-          return [];
-        });
+        if (selectedFiles.length > 0) {
+          toast.info('Os anexos manuais foram removidos: a resposta rápida já inclui mídia.');
+          setSelectedFiles([]);
+        }
       }
 
       setSelectedCannedResponse(cannedResponse);
@@ -199,7 +197,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
         richEditorRef.current?.focus();
       }, 0);
     },
-    [],
+    [selectedFiles],
   );
 
   // 🎯 CANNED RESPONSES: Filtrar respostas com base na query

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -177,6 +177,17 @@ const MessageInput: React.FC<MessageInputProps> = ({
       richEditorRef.current?.setContent(newMessage);
       setCurrentEditorMessage(newMessage);
 
+      // A canned response with media owns the attachment slot (channels send a single
+      // attachment); drop any manually-added files so both are never sent together.
+      if ((cannedResponse.attachments?.length ?? 0) > 0) {
+        setSelectedFiles(prev => {
+          if (prev.length > 0) {
+            toast.info('Os anexos manuais foram removidos: a resposta rápida já inclui mídia.');
+          }
+          return [];
+        });
+      }
+
       setSelectedCannedResponse(cannedResponse);
       setSelectedCannedResponseId(cannedResponse.id);
 

--- a/src/i18n/locales/en/cannedResponses.json
+++ b/src/i18n/locales/en/cannedResponses.json
@@ -57,7 +57,14 @@
         "addButton": "Add File",
         "hint": "Maximum 10MB per file. Formats: images, audios, videos, PDF, DOC",
         "existing": "Existing attachments:",
-        "new": "New attachments:"
+        "new": "New attachments:",
+        "openAction": "Open",
+        "removeAriaLabel": "Remove attachment",
+        "errors": {
+          "limitReached": "Only 1 attachment per canned response",
+          "tooLarge": "File {{name}} is too large (max 10MB)",
+          "invalidType": "File type {{name}} not allowed"
+        }
       }
     },
     "variables": {

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -651,6 +651,12 @@
     }
   },
   "messageInput": {
+    "cannedResponse": {
+      "manualAttachmentsRemoved": "Manual attachments removed: the canned response already includes media.",
+      "mediaBanner": "This canned response includes {{count}} media file(s). They will be sent with the message.",
+      "mediaBlocksManualUpload": "This canned response already includes media; remove it to attach another file.",
+      "removeMediaAriaLabel": "Remove canned response media"
+    },
     "pendingPlaceholder": "This conversation is pending. Only private notes can be sent.",
     "restrictedPlaceholder": "Cannot send messages due to 24-hour messaging window",
     "defaultPlaceholder": "Type your message...",

--- a/src/i18n/locales/es/cannedResponses.json
+++ b/src/i18n/locales/es/cannedResponses.json
@@ -42,6 +42,20 @@
       "description": "Edite la información de la respuesta rápida."
     },
     "fields": {
+      "attachments": {
+        "label": "Adjuntos (Imágenes, Audios, Vídeos, Documentos)",
+        "addButton": "Añadir archivo",
+        "hint": "Máximo 10MB por archivo. Formatos: imágenes, audios, vídeos, PDF, DOC",
+        "existing": "Adjuntos existentes:",
+        "new": "Nuevos adjuntos:",
+        "openAction": "Abrir",
+        "removeAriaLabel": "Eliminar adjunto",
+        "errors": {
+          "limitReached": "Solo 1 adjunto por respuesta rápida",
+          "tooLarge": "El archivo {{name}} es demasiado grande (máximo 10MB)",
+          "invalidType": "Tipo de archivo {{name}} no permitido"
+        }
+      },
       "shortCode": {
         "label": "Código",
         "placeholder": "Ej: saludo, agradecimiento, despedida",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -619,6 +619,12 @@
     }
   },
   "messageInput": {
+    "cannedResponse": {
+      "manualAttachmentsRemoved": "Los adjuntos manuales se eliminaron: la respuesta rápida ya incluye contenido multimedia.",
+      "mediaBanner": "Esta respuesta rápida incluye {{count}} archivo(s) multimedia. Se enviarán junto con el mensaje.",
+      "mediaBlocksManualUpload": "Esta respuesta rápida ya incluye contenido multimedia; elimínalo para adjuntar otro archivo.",
+      "removeMediaAriaLabel": "Eliminar el contenido multimedia de la respuesta rápida"
+    },
     "pendingPlaceholder": "Esta conversación está pendiente. Solo se pueden enviar notas privadas.",
     "restrictedPlaceholder": "No se pueden enviar mensajes debido a la ventana de mensajería de 24 horas",
     "defaultPlaceholder": "Escribe tu mensaje...",

--- a/src/i18n/locales/fr/cannedResponses.json
+++ b/src/i18n/locales/fr/cannedResponses.json
@@ -42,6 +42,20 @@
       "description": "Modifiez les informations de la réponse rapide."
     },
     "fields": {
+      "attachments": {
+        "label": "Pièces jointes (Images, Audios, Vidéos, Documents)",
+        "addButton": "Ajouter un fichier",
+        "hint": "Maximum 10 Mo par fichier. Formats : images, audios, vidéos, PDF, DOC",
+        "existing": "Pièces jointes existantes :",
+        "new": "Nouvelles pièces jointes :",
+        "openAction": "Ouvrir",
+        "removeAriaLabel": "Supprimer la pièce jointe",
+        "errors": {
+          "limitReached": "Une seule pièce jointe par réponse rapide",
+          "tooLarge": "Le fichier {{name}} est trop volumineux (max 10 Mo)",
+          "invalidType": "Type de fichier {{name}} non autorisé"
+        }
+      },
       "shortCode": {
         "label": "Code",
         "placeholder": "Ex : salutation, remerciement, au_revoir",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -619,6 +619,12 @@
     }
   },
   "messageInput": {
+    "cannedResponse": {
+      "manualAttachmentsRemoved": "Les pièces jointes manuelles ont été supprimées : la réponse rapide inclut déjà un média.",
+      "mediaBanner": "Cette réponse rapide inclut {{count}} fichier(s) multimédia. Ils seront envoyés avec le message.",
+      "mediaBlocksManualUpload": "Cette réponse rapide inclut déjà un média ; supprimez-le pour joindre un autre fichier.",
+      "removeMediaAriaLabel": "Supprimer le média de la réponse rapide"
+    },
     "pendingPlaceholder": "Cette conversation est en attente. Seules les notes privées peuvent être envoyées.",
     "restrictedPlaceholder": "Impossible d'envoyer des messages en raison de la fenêtre de messagerie de 24 heures",
     "defaultPlaceholder": "Tapez votre message...",

--- a/src/i18n/locales/it/cannedResponses.json
+++ b/src/i18n/locales/it/cannedResponses.json
@@ -42,6 +42,20 @@
       "description": "Modifica le informazioni della risposta rapida."
     },
     "fields": {
+      "attachments": {
+        "label": "Allegati (Immagini, Audio, Video, Documenti)",
+        "addButton": "Aggiungi file",
+        "hint": "Massimo 10MB per file. Formati: immagini, audio, video, PDF, DOC",
+        "existing": "Allegati esistenti:",
+        "new": "Nuovi allegati:",
+        "openAction": "Apri",
+        "removeAriaLabel": "Rimuovi allegato",
+        "errors": {
+          "limitReached": "Solo 1 allegato per risposta rapida",
+          "tooLarge": "Il file {{name}} è troppo grande (massimo 10MB)",
+          "invalidType": "Tipo di file {{name}} non consentito"
+        }
+      },
       "shortCode": {
         "label": "Codice",
         "placeholder": "Es: saluto, ringraziamento, commiato",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -619,6 +619,12 @@
     }
   },
   "messageInput": {
+    "cannedResponse": {
+      "manualAttachmentsRemoved": "Gli allegati manuali sono stati rimossi: la risposta rapida include già un contenuto multimediale.",
+      "mediaBanner": "Questa risposta rapida include {{count}} file multimediali. Verranno inviati insieme al messaggio.",
+      "mediaBlocksManualUpload": "Questa risposta rapida include già un contenuto multimediale; rimuovilo per allegare un altro file.",
+      "removeMediaAriaLabel": "Rimuovi il contenuto multimediale della risposta rapida"
+    },
     "pendingPlaceholder": "Questa conversazione è in sospeso. È possibile inviare solo note private.",
     "restrictedPlaceholder": "Impossibile inviare messaggi a causa della finestra di messaggistica di 24 ore",
     "defaultPlaceholder": "Digita il tuo messaggio...",

--- a/src/i18n/locales/pt-BR/cannedResponses.json
+++ b/src/i18n/locales/pt-BR/cannedResponses.json
@@ -57,7 +57,14 @@
         "addButton": "Adicionar Arquivo",
         "hint": "Máximo 10MB por arquivo. Formatos: imagens, áudios, vídeos, PDF, DOC",
         "existing": "Anexos existentes:",
-        "new": "Novos anexos:"
+        "new": "Novos anexos:",
+        "openAction": "Abrir",
+        "removeAriaLabel": "Remover anexo",
+        "errors": {
+          "limitReached": "Apenas 1 anexo por resposta rápida",
+          "tooLarge": "Arquivo {{name}} é muito grande (máximo 10MB)",
+          "invalidType": "Tipo de arquivo {{name}} não permitido"
+        }
       }
     },
     "variables": {

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -651,6 +651,12 @@
     }
   },
   "messageInput": {
+    "cannedResponse": {
+      "manualAttachmentsRemoved": "Os anexos manuais foram removidos: a resposta rápida já inclui mídia.",
+      "mediaBanner": "Esta resposta rápida inclui {{count}} arquivo(s) de mídia. Eles serão enviados junto com a mensagem.",
+      "mediaBlocksManualUpload": "Esta resposta rápida já inclui mídia; remova-a para anexar outro arquivo.",
+      "removeMediaAriaLabel": "Remover mídia da resposta rápida"
+    },
     "pendingPlaceholder": "Esta conversa está pendente. Só é possível enviar notas privadas.",
     "restrictedPlaceholder": "Não é possível enviar mensagens devido à janela de mensagem de 24 horas",
     "defaultPlaceholder": "Digite sua mensagem...",

--- a/src/i18n/locales/pt/cannedResponses.json
+++ b/src/i18n/locales/pt/cannedResponses.json
@@ -42,6 +42,20 @@
       "description": "Edite as informações da resposta rápida."
     },
     "fields": {
+      "attachments": {
+        "label": "Anexos (Imagens, Áudios, Vídeos, Documentos)",
+        "addButton": "Adicionar ficheiro",
+        "hint": "Máximo 10MB por ficheiro. Formatos: imagens, áudios, vídeos, PDF, DOC",
+        "existing": "Anexos existentes:",
+        "new": "Novos anexos:",
+        "openAction": "Abrir",
+        "removeAriaLabel": "Remover anexo",
+        "errors": {
+          "limitReached": "Apenas 1 anexo por resposta rápida",
+          "tooLarge": "O ficheiro {{name}} é demasiado grande (máximo 10MB)",
+          "invalidType": "Tipo de ficheiro {{name}} não permitido"
+        }
+      },
       "shortCode": {
         "label": "Código",
         "placeholder": "Ex: saudacao, agradecimento, despedida",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -619,6 +619,12 @@
     }
   },
   "messageInput": {
+    "cannedResponse": {
+      "manualAttachmentsRemoved": "Os anexos manuais foram removidos: a resposta rápida já inclui multimédia.",
+      "mediaBanner": "Esta resposta rápida inclui {{count}} ficheiro(s) multimédia. Serão enviados juntamente com a mensagem.",
+      "mediaBlocksManualUpload": "Esta resposta rápida já inclui multimédia; remova-a para anexar outro ficheiro.",
+      "removeMediaAriaLabel": "Remover multimédia da resposta rápida"
+    },
     "pendingPlaceholder": "Esta conversa está pendente. Só é possível enviar notas privadas.",
     "restrictedPlaceholder": "Não é possível enviar mensagens devido à janela de mensagem de 24 horas",
     "defaultPlaceholder": "Digite sua mensagem...",

--- a/src/services/cannedResponses/cannedResponsesService.ts
+++ b/src/services/cannedResponses/cannedResponsesService.ts
@@ -60,15 +60,21 @@ class CannedResponsesService {
     cannedResponseId: string,
     data: Partial<CannedResponseFormData>,
   ): Promise<CannedResponseResponse> {
-    // Se tem attachments, enviar como FormData
-    if (data.attachments && data.attachments.length > 0) {
+    const hasNewFiles = !!(data.attachments && data.attachments.length > 0);
+    const hasRemovals = !!(data.removeAttachmentIds && data.removeAttachmentIds.length > 0);
+
+    // Adições ou remoções de anexo exigem multipart
+    if (hasNewFiles || hasRemovals) {
       const formData = new FormData();
       if (data.short_code) formData.append('canned_response[short_code]', data.short_code);
       if (data.content) formData.append('canned_response[content]', data.content);
 
-      // Adicionar cada arquivo
-      data.attachments.forEach(file => {
+      data.attachments?.forEach(file => {
         formData.append('attachments[]', file);
+      });
+
+      data.removeAttachmentIds?.forEach(id => {
+        formData.append('remove_attachment_ids[]', id);
       });
 
       const response = await api.patch(`${this.baseUrl}/${cannedResponseId}`, formData, {
@@ -79,7 +85,7 @@ class CannedResponsesService {
       return extractData<any>(response);
     }
 
-    // Sem attachments, enviar como JSON normal
+    // Sem alteração de anexos, enviar como JSON normal
     const response = await api.patch(`${this.baseUrl}/${cannedResponseId}`, {
       canned_response: data,
     });

--- a/src/types/knowledge/index.ts
+++ b/src/types/knowledge/index.ts
@@ -23,6 +23,7 @@ export interface CannedResponseFormData {
   short_code: string;
   content: string;
   attachments?: File[];
+  removeAttachmentIds?: string[];
 }
 
 export type CannedResponseResponse = CannedResponse;


### PR DESCRIPTION
## Summary
With the serializer now returning attachments (paired CRM PR), wire the read + remove UX for canned response attachments, cap at a single attachment, and keep the chat composer's attachment sources mutually exclusive.

- Modal: existing attachments render with a remove (X) button; removed ids are tracked, hidden, and sent on save (remove + re-upload = replace). One attachment per canned response — the file input is single, the add button/input disable once one exists, and extra selections are rejected with a toast.
- Service: `CannedResponseFormData.removeAttachmentIds`; `updateCannedResponse` sends `remove_attachment_ids[]` (switches to multipart on adds OR removals).
- Settings table: paperclip + count indicator when a canned response has an attachment.
- Composer: selecting a canned response that has media clears any manually-added files (with a toast), mirroring the existing guard that disables manual upload while canned media is active — so the two sources are never combined.
- Chat dropdown indicator already reads `attachments` and now lights up because the read payload includes them.

## Security
- Frontend-only change; no new data exposure. Server-side size validation lives in the paired CRM PR.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec eslint <changed files>` — 0 errors (pre-existing `any` in the service and a pre-existing `useCallback` warning untouched)
- `pnpm exec vitest related --run` — 0 new failures (`SendCannedResponsePanel` passes; the 4 `Chat.spec` failures are pre-existing on `develop`)
- Manual smoke: upload → reopen shows the attachment + X; remove persists; second attachment blocked; >10 MB blocked; manual-attachment-then-`/`-canned-with-media clears the manual file.

## Changed Files
- `src/components/cannedResponses/CannedResponseModal.tsx`
- `src/components/cannedResponses/CannedResponsesTable.tsx`
- `src/services/cannedResponses/cannedResponsesService.ts`
- `src/components/chat/message-input/MessageInput.tsx`
- `src/types/knowledge/index.ts`

## Related PRs
- crm: https://github.com/evolution-foundation/evo-ai-crm-community/pull/162

## Linked Issue
- EVO-1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk9VSPAVSDo3cG8caUbNND

## Summary by Sourcery

Add support for managing single attachments on canned responses, including editing, display, and composer behavior, while ensuring attachment changes are correctly sent to the backend.

New Features:
- Allow canned responses to carry a single attachment, enforcing a one-attachment limit in the modal with validation and user feedback.
- Enable removal of existing canned response attachments during edit, tracking removed IDs and sending them to the backend for processing.
- Surface an attachment indicator in the canned responses table to show when a canned response has associated media.
- Ensure selecting a canned response with media clears any manually added chat attachments so canned and manual media are never combined in a message.

Enhancements:
- Update the canned responses service to switch to multipart requests whenever attachments are added or removed, including sending remove_attachment_ids to the API.