### PR TITLE
feat(frontend): label usage count in table + delete dialog warnings (EVO-1863)

### DIFF
--- a/src/components/labels/LabelsTable.tsx
+++ b/src/components/labels/LabelsTable.tsx
@@ -78,6 +78,13 @@ export default function LabelsTable({
       ),
     },
     {
+      key: 'usage_count',
+      label: t('table.columns.usage'),
+      render: (label: Label) => (
+        <span className="text-sm text-muted-foreground">{label.usage_count ?? 0}</span>
+      ),
+    },
+    {
       key: 'created_at',
       label: t('table.columns.createdAt'),
       sortable: true,

--- a/src/i18n/locales/en/labels.json
+++ b/src/i18n/locales/en/labels.json
@@ -108,7 +108,8 @@
       "description": "Are you sure you want to delete {{count}} selected label(s)? This action cannot be undone.",
       "cancel": "Cancel",
       "confirm": "Delete All",
-      "deleting": "Deleting..."
+      "deleting": "Deleting...",
+      "usageWarning": "{{labels}} of the selected labels are in use by {{records}} record(s) and will be removed from them."
     }
   }
 }

--- a/src/i18n/locales/en/labels.json
+++ b/src/i18n/locales/en/labels.json
@@ -57,7 +57,8 @@
       "description": "Description",
       "color": "Color",
       "sidebar": "Sidebar",
-      "createdAt": "Created at"
+      "createdAt": "Created at",
+      "usage": "In use"
     },
     "noDescription": "-",
     "sidebar": {
@@ -99,7 +100,8 @@
       "description": "Are you sure you want to delete the label \"{{title}}\"? This action cannot be undone.",
       "cancel": "Cancel",
       "confirm": "Delete",
-      "deleting": "Deleting..."
+      "deleting": "Deleting...",
+      "usageWarning": "This label is used by {{count}} record(s). Deleting it will remove the label from them."
     },
     "bulkDelete": {
       "title": "Delete Labels",

--- a/src/i18n/locales/es/labels.json
+++ b/src/i18n/locales/es/labels.json
@@ -57,7 +57,8 @@
       "description": "Descripción",
       "color": "Color",
       "sidebar": "Barra Lateral",
-      "createdAt": "Creado el"
+      "createdAt": "Creado el",
+      "usage": "En uso"
     },
     "noDescription": "-",
     "sidebar": {
@@ -99,7 +100,8 @@
       "description": "¿Está seguro de que desea eliminar la etiqueta \"{{title}}\"? Esta acción no se puede deshacer.",
       "cancel": "Cancelar",
       "confirm": "Eliminar",
-      "deleting": "Eliminando..."
+      "deleting": "Eliminando...",
+      "usageWarning": "Esta etiqueta es usada por {{count}} registro(s). Al eliminarla, se quitará de ellos."
     },
     "bulkDelete": {
       "title": "Eliminar Etiquetas",

--- a/src/i18n/locales/es/labels.json
+++ b/src/i18n/locales/es/labels.json
@@ -108,7 +108,8 @@
       "description": "¿Está seguro de que desea eliminar {{count}} etiqueta(s) seleccionada(s)? Esta acción no se puede deshacer.",
       "cancel": "Cancelar",
       "confirm": "Eliminar Todas",
-      "deleting": "Eliminando..."
+      "deleting": "Eliminando...",
+      "usageWarning": "{{labels}} de las etiquetas seleccionadas están en uso por {{records}} registro(s) y se quitarán de ellos."
     }
   }
 }

--- a/src/i18n/locales/fr/labels.json
+++ b/src/i18n/locales/fr/labels.json
@@ -57,7 +57,8 @@
       "description": "Description",
       "color": "Couleur",
       "sidebar": "Barre Latérale",
-      "createdAt": "Créé le"
+      "createdAt": "Créé le",
+      "usage": "Utilisée"
     },
     "noDescription": "-",
     "sidebar": {
@@ -99,7 +100,8 @@
       "description": "Êtes-vous sûr de vouloir supprimer l'étiquette \"{{title}}\" ? Cette action ne peut pas être annulée.",
       "cancel": "Annuler",
       "confirm": "Supprimer",
-      "deleting": "Suppression..."
+      "deleting": "Suppression...",
+      "usageWarning": "Cette étiquette est utilisée par {{count}} enregistrement(s). La supprimer la retirera de ceux-ci."
     },
     "bulkDelete": {
       "title": "Supprimer les Étiquettes",

--- a/src/i18n/locales/fr/labels.json
+++ b/src/i18n/locales/fr/labels.json
@@ -108,7 +108,8 @@
       "description": "Êtes-vous sûr de vouloir supprimer {{count}} étiquette(s) sélectionnée(s) ? Cette action ne peut pas être annulée.",
       "cancel": "Annuler",
       "confirm": "Tout Supprimer",
-      "deleting": "Suppression..."
+      "deleting": "Suppression...",
+      "usageWarning": "{{labels}} des étiquettes sélectionnées sont utilisées par {{records}} enregistrement(s) et en seront retirées."
     }
   }
 }

--- a/src/i18n/locales/it/labels.json
+++ b/src/i18n/locales/it/labels.json
@@ -108,7 +108,8 @@
       "description": "Sei sicuro di voler eliminare {{count}} etichetta/e selezionata/e? Questa azione non può essere annullata.",
       "cancel": "Annulla",
       "confirm": "Elimina Tutte",
-      "deleting": "Eliminazione..."
+      "deleting": "Eliminazione...",
+      "usageWarning": "{{labels}} delle etichette selezionate sono in uso da {{records}} record e verranno rimosse da essi."
     }
   }
 }

--- a/src/i18n/locales/it/labels.json
+++ b/src/i18n/locales/it/labels.json
@@ -57,7 +57,8 @@
       "description": "Descrizione",
       "color": "Colore",
       "sidebar": "Barra Laterale",
-      "createdAt": "Creato il"
+      "createdAt": "Creato il",
+      "usage": "In uso"
     },
     "noDescription": "-",
     "sidebar": {
@@ -99,7 +100,8 @@
       "description": "Sei sicuro di voler eliminare l'etichetta \"{{title}}\"? Questa azione non può essere annullata.",
       "cancel": "Annulla",
       "confirm": "Elimina",
-      "deleting": "Eliminazione..."
+      "deleting": "Eliminazione...",
+      "usageWarning": "Questa etichetta è usata da {{count}} record. Eliminandola, verrà rimossa da essi."
     },
     "bulkDelete": {
       "title": "Elimina Etichette",

--- a/src/i18n/locales/pt-BR/labels.json
+++ b/src/i18n/locales/pt-BR/labels.json
@@ -57,7 +57,8 @@
       "description": "Descrição",
       "color": "Cor",
       "sidebar": "Barra Lateral",
-      "createdAt": "Criado em"
+      "createdAt": "Criado em",
+      "usage": "Em uso"
     },
     "noDescription": "-",
     "sidebar": {
@@ -99,7 +100,8 @@
       "description": "Tem certeza de que deseja deletar a etiqueta \"{{title}}\"? Esta ação não pode ser desfeita.",
       "cancel": "Cancelar",
       "confirm": "Deletar",
-      "deleting": "Deletando..."
+      "deleting": "Deletando...",
+      "usageWarning": "Esta etiqueta é usada por {{count}} registro(s). Ao excluí-la, ela será removida deles."
     },
     "bulkDelete": {
       "title": "Deletar Etiquetas",

--- a/src/i18n/locales/pt-BR/labels.json
+++ b/src/i18n/locales/pt-BR/labels.json
@@ -108,7 +108,8 @@
       "description": "Tem certeza de que deseja deletar {{count}} etiqueta(s) selecionada(s)? Esta ação não pode ser desfeita.",
       "cancel": "Cancelar",
       "confirm": "Deletar Todas",
-      "deleting": "Deletando..."
+      "deleting": "Deletando...",
+      "usageWarning": "{{labels}} das etiquetas selecionadas estão em uso por {{records}} registro(s) e serão removidas deles."
     }
   }
 }

--- a/src/i18n/locales/pt/labels.json
+++ b/src/i18n/locales/pt/labels.json
@@ -57,7 +57,8 @@
       "description": "Descrição",
       "color": "Cor",
       "sidebar": "Barra Lateral",
-      "createdAt": "Criado em"
+      "createdAt": "Criado em",
+      "usage": "Em uso"
     },
     "noDescription": "-",
     "sidebar": {
@@ -99,7 +100,8 @@
       "description": "Tem certeza de que deseja deletar a etiqueta \"{{title}}\"? Esta ação não pode ser desfeita.",
       "cancel": "Cancelar",
       "confirm": "Deletar",
-      "deleting": "Deletando..."
+      "deleting": "Deletando...",
+      "usageWarning": "Esta etiqueta é usada por {{count}} registro(s). Ao excluí-la, ela será removida deles."
     },
     "bulkDelete": {
       "title": "Deletar Etiquetas",

--- a/src/i18n/locales/pt/labels.json
+++ b/src/i18n/locales/pt/labels.json
@@ -108,7 +108,8 @@
       "description": "Tem certeza de que deseja deletar {{count}} etiqueta(s) selecionada(s)? Esta ação não pode ser desfeita.",
       "cancel": "Cancelar",
       "confirm": "Deletar Todas",
-      "deleting": "Deletando..."
+      "deleting": "Deletando...",
+      "usageWarning": "{{labels}} das etiquetas selecionadas estão em uso por {{records}} registro(s) e serão removidas deles."
     }
   }
 }

--- a/src/pages/Customer/Settings/Labels/Labels.tsx
+++ b/src/pages/Customer/Settings/Labels/Labels.tsx
@@ -408,6 +408,11 @@ export default function Labels() {
               {t('dialog.delete.description', { title: labelToDelete?.title })}
             </DialogDescription>
           </DialogHeader>
+          {!!labelToDelete?.usage_count && labelToDelete.usage_count > 0 && (
+            <p className="text-sm text-amber-600 dark:text-amber-500">
+              {t('dialog.delete.usageWarning', { count: labelToDelete.usage_count })}
+            </p>
+          )}
           <DialogFooter>
             <Button
               variant="outline"

--- a/src/pages/Customer/Settings/Labels/Labels.tsx
+++ b/src/pages/Customer/Settings/Labels/Labels.tsx
@@ -306,6 +306,14 @@ export default function Labels() {
     currentPage * pageSize,
   );
 
+  const selectedInUse = state.labels.filter(
+    label => state.selectedLabelIds.includes(label.id) && (label.usage_count ?? 0) > 0,
+  );
+  const selectedInUseRecords = selectedInUse.reduce(
+    (sum, label) => sum + (label.usage_count ?? 0),
+    0,
+  );
+
   return (
     <div className="h-full flex flex-col p-4" data-tour="settings-labels-page">
       <SettingsLabelsTour />
@@ -441,6 +449,14 @@ export default function Labels() {
               {t('dialog.bulkDelete.description', { count: state.selectedLabelIds.length })}
             </DialogDescription>
           </DialogHeader>
+          {selectedInUse.length > 0 && (
+            <p className="text-sm text-amber-600 dark:text-amber-500">
+              {t('dialog.bulkDelete.usageWarning', {
+                labels: selectedInUse.length,
+                records: selectedInUseRecords,
+              })}
+            </p>
+          )}
           <DialogFooter>
             <Button
               variant="outline"

--- a/src/types/settings/labels.ts
+++ b/src/types/settings/labels.ts
@@ -6,6 +6,7 @@ export interface Label {
   description?: string;
   color: string;
   show_on_sidebar: boolean;
+  usage_count?: number;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- `Label` type gains `usage_count`.
- Labels table shows an "In use" column.
- Delete confirmation (single) warns how many records use the label before deleting.
- Bulk delete confirmation aggregates the warning across selected labels in use.
- i18n keys `table.columns.usage`, `dialog.delete.usageWarning`, `dialog.bulkDelete.usageWarning` added across all 6 locales.

## Security
- No new inputs; counts are integers rendered as text (no XSS surface).

## Test plan
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` (clean)
- `evo-ai-frontend-community: npx eslint <changed files>` (clean; pre-existing empty-interface lints in labels.ts left untouched)
- Manual smoke: usage column reflects tagging count; single + bulk delete dialogs warn when labels are in use; deletion removes the label from records with no orphan.

## Changed Files
- `src/types/settings/labels.ts`
- `src/components/labels/LabelsTable.tsx`
- `src/pages/Customer/Settings/Labels/Labels.tsx`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/labels.json`

## Related PRs
- crm: https://github.com/evolution-foundation/evo-ai-crm-community/pull/163

## Linked Issue
- EVO-1863

## Summary by Sourcery

Add label usage visibility and warnings to the labels management UI.

New Features:
- Display a label usage count column in the labels table.
- Show a warning in the single delete dialog when the label is currently in use.
- Show an aggregated warning in the bulk delete dialog summarizing usage across selected labels.

Enhancements:
- Extend the Label type with an optional usage_count field for usage-aware UI behavior.
- Add new i18n strings for usage columns and delete warnings across all supported locales.