### PR TITLE
feat(journey): polir pickers de variável/expressão (EVO-1855)

### DIFF
--- a/src/components/journey/environment-manager/VariableInput.tsx
+++ b/src/components/journey/environment-manager/VariableInput.tsx
@@ -211,8 +211,13 @@ const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
                   variant="ghost"
                   size="sm"
                   className="h-7 w-7 p-0 hover:bg-muted"
+                  aria-label={
+                    variableButtonTooltip ||
+                    t('environmentManager.customVariables.actions.insertVariable')
+                  }
                   title={
-                    variableButtonTooltip || t('environmentManager.customVariables.actions.copy')
+                    variableButtonTooltip ||
+                    t('environmentManager.customVariables.actions.insertVariable')
                   }
                 >
                   <Variable className="h-3 w-3" />

--- a/src/components/journey/environment-manager/VariableTextarea.spec.tsx
+++ b/src/components/journey/environment-manager/VariableTextarea.spec.tsx
@@ -1,12 +1,25 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { VariableTextarea } from './VariableTextarea';
 import '@/i18n/config';
 
-// The picker only needs an (empty) variable list; avoid the real fetch.
-vi.mock('@/hooks/useJourneyVariables', () => ({
-  useJourneyVariables: () => ({ variables: [], loading: false, error: null }),
+// The picker reads custom variables from this hook; drive it per-test so the
+// insertion path can exercise a real journey variable.
+const hooked = vi.hoisted(() => ({
+  variables: [] as Array<{ name: string; type: string; description?: string }>,
 }));
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: hooked.variables,
+    loading: false,
+    error: null,
+  }),
+}));
+
+afterEach(() => {
+  hooked.variables = [];
+});
 
 const INSERT_VARIABLE_NAME =
   /insert variable|inserir variável|insertar variable|insérer une variable|inserisci variabile/i;
@@ -20,5 +33,63 @@ describe('VariableTextarea — accessibility', () => {
   it('honors an explicit variableButtonTooltip as the accessible name', () => {
     render(<VariableTextarea journeyId="j1" variableButtonTooltip="Pick a token" />);
     expect(screen.getByRole('button', { name: 'Pick a token' })).toBeInTheDocument();
+  });
+
+  // EVO-1855 item 5: the panels pass aria-invalid/aria-describedby to wire the
+  // expression error to the field for screen readers; the picker must forward
+  // them to the underlying textarea (it spreads {...props}).
+  it('forwards aria-invalid and aria-describedby to the textarea (EVO-1855)', () => {
+    render(
+      <VariableTextarea
+        journeyId="j1"
+        aria-invalid
+        aria-describedby="expr-error-1"
+      />,
+    );
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    expect(textarea).toHaveAttribute('aria-describedby', 'expr-error-1');
+  });
+});
+
+describe('VariableTextarea — variable insertion (EVO-1855 item 4)', () => {
+  // Capture synchronously inside the handler: the panels are controlled, so a
+  // spy that doesn't write state back lets React reset the DOM value after the
+  // event — but the value delivered to onChange at call time is what matters.
+  it('inserts the picked variable token into the value and fires onChange', async () => {
+    hooked.variables = [{ name: 'order_id', type: 'string' }];
+    const user = userEvent.setup();
+    let emitted = '';
+    const onChange = vi.fn((e: { target: HTMLTextAreaElement }) => {
+      emitted = e.target.value;
+    });
+    render(<VariableTextarea journeyId="j1" value="" onChange={onChange} />);
+
+    // Open the picker and choose the journey's custom variable.
+    await user.click(screen.getByRole('button', { name: INSERT_VARIABLE_NAME }));
+    await user.click(screen.getByRole('button', { name: /order_id/i }));
+
+    // The real insertion path (handleVariableSelect → props.onChange) ran, not a
+    // mocked textarea: onChange receives the token written into the field value.
+    expect(onChange).toHaveBeenCalled();
+    expect(emitted).toContain('{{order_id}}');
+  });
+
+  it('inserts at the caret, preserving surrounding text', async () => {
+    hooked.variables = [{ name: 'order_id', type: 'string' }];
+    const user = userEvent.setup();
+    let emitted = '';
+    const onChange = vi.fn((e: { target: HTMLTextAreaElement }) => {
+      emitted = e.target.value;
+    });
+    render(<VariableTextarea journeyId="j1" defaultValue="Hi  there" onChange={onChange} />);
+
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
+    // Caret between the two spaces ("Hi |there" → index 3).
+    textarea.setSelectionRange(3, 3);
+    await user.click(screen.getByRole('button', { name: INSERT_VARIABLE_NAME }));
+    await user.click(screen.getByRole('button', { name: /order_id/i }));
+
+    expect(emitted).toBe('Hi {{order_id}} there');
   });
 });

--- a/src/components/journey/environment-manager/VariableTextarea.spec.tsx
+++ b/src/components/journey/environment-manager/VariableTextarea.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { VariableTextarea } from './VariableTextarea';
+import '@/i18n/config';
+
+// The picker only needs an (empty) variable list; avoid the real fetch.
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({ variables: [], loading: false, error: null }),
+}));
+
+const INSERT_VARIABLE_NAME =
+  /insert variable|inserir variável|insertar variable|insérer une variable|inserisci variabile/i;
+
+describe('VariableTextarea — accessibility', () => {
+  it('gives the variable picker button an accessible name (EVO-1855)', () => {
+    render(<VariableTextarea journeyId="j1" />);
+    expect(screen.getByRole('button', { name: INSERT_VARIABLE_NAME })).toBeInTheDocument();
+  });
+
+  it('honors an explicit variableButtonTooltip as the accessible name', () => {
+    render(<VariableTextarea journeyId="j1" variableButtonTooltip="Pick a token" />);
+    expect(screen.getByRole('button', { name: 'Pick a token' })).toBeInTheDocument();
+  });
+});

--- a/src/components/journey/environment-manager/VariableTextarea.tsx
+++ b/src/components/journey/environment-manager/VariableTextarea.tsx
@@ -136,8 +136,13 @@ const VariableTextarea = forwardRef<HTMLTextAreaElement, VariableTextareaProps>(
                   variant="ghost"
                   size="sm"
                   className="h-7 w-7 p-0 hover:bg-muted"
+                  aria-label={
+                    variableButtonTooltip ||
+                    t('environmentManager.customVariables.actions.insertVariable')
+                  }
                   title={
-                    variableButtonTooltip || t('environmentManager.customVariables.actions.copy')
+                    variableButtonTooltip ||
+                    t('environmentManager.customVariables.actions.insertVariable')
                   }
                 >
                   <Variable className="h-3 w-3" />

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConditionalPanel } from './ConditionalPanel';
@@ -257,5 +257,80 @@ describe('ConditionalPanel — contact custom attributes in the field picker', (
     const listbox = await screen.findByRole('listbox');
     expect(within(listbox).getAllByRole('option').length).toBeGreaterThan(0);
     expect(within(listbox).queryByText('Plan Interest')).toBeNull();
+  });
+});
+
+// EVO-1855: the value picker accepts free-text expressions; unbalanced
+// {{ }}/parentheses must be surfaced and block Save (reusing the shared
+// isBalancedExpression from @/utils/templateVariables).
+const SAVE_NAME = /save|salvar|guardar|enregistrer|salva/i;
+const INSERT_VARIABLE_NAME =
+  /insert variable|inserir variável|insertar variable|insérer une variable|inserisci variabile/i;
+
+describe('ConditionalPanel — expression validation', () => {
+  it('flags an unbalanced condition value: aria-invalid, inline error, Save blocked (AC1)', async () => {
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithContactCondition('{{contact.email}}')}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    const valueInput = await screen.findByPlaceholderText(/^value$/i);
+    fireEvent.change(valueInput, { target: { value: '{{contact.name' } });
+
+    expect(valueInput).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = valueInput.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: SAVE_NAME })).toBeDisabled();
+  });
+
+  it('enables Save and persists when the condition value is balanced (AC2)', async () => {
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithContactCondition('{{contact.email}}')}
+        onUpdate={onUpdate}
+        onClose={onClose}
+        journeyId="j1"
+      />,
+    );
+
+    const valueInput = await screen.findByPlaceholderText(/^value$/i);
+    fireEvent.change(valueInput, { target: { value: '{{contact.name}}' } });
+
+    expect(valueInput).toHaveAttribute('aria-invalid', 'false');
+
+    const saveBtn = screen.getByRole('button', { name: SAVE_NAME });
+    expect(saveBtn).not.toBeDisabled();
+
+    fireEvent.click(saveBtn);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const [, updated] = onUpdate.mock.calls[0];
+    expect(updated.paths[0].conditions[0].value).toBe('{{contact.name}}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes an accessible label on the value picker button (AC4)', async () => {
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithContactCondition('{{contact.email}}')}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    expect(
+      await screen.findByRole('button', { name: INSERT_VARIABLE_NAME }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -27,6 +27,7 @@ import { VariableInput, VariableSelect } from '@/components/journey/environment-
 import { v4 as uuidv4 } from 'uuid';
 import { useLanguage } from '@/hooks/useLanguage';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import { isBalancedExpression } from '@/utils/templateVariables';
 
 const PIPELINE_STAGE_OPERATORS = ['equals', 'not_equals'];
 
@@ -132,6 +133,8 @@ export function ConditionalPanel({
   }, [hasPipelineStageCondition, stageOptions.length]);
 
   const handleSave = () => {
+    // Save is gated by saveDisabled below; this guard is defense-in-depth.
+    if (hasInvalidExpression) return;
     onUpdate(nodeId, formData);
     onClose();
   };
@@ -237,6 +240,25 @@ export function ConditionalPanel({
     return !['is_empty', 'is_not_empty'].includes(operator);
   };
 
+  // A condition's value is only validated when it actually drives a free-text
+  // expression: skip pipeline-stage (id-only) and operators that take no value.
+  // Non-string / blank values are treated as balanced so a numeric value never
+  // throws at render (the shared util expects a string).
+  const isConditionValueBalanced = (condition: Condition) => {
+    if (condition.field === PIPELINE_STAGE_FIELD) return true;
+    if (!needsValue(condition.operator)) return true;
+    const value = condition.value;
+    if (typeof value !== 'string' || value.trim() === '') return true;
+    return isBalancedExpression(value);
+  };
+
+  // Cheap derived traversal (a handful of conditions) — recompute on each
+  // render rather than memoizing, which would force isConditionValueBalanced
+  // into the dep array and re-run every render anyway.
+  const hasInvalidExpression = formData.paths.some(path =>
+    path.conditions.some(condition => !isConditionValueBalanced(condition)),
+  );
+
   const dirty = useMemo(
     () => JSON.stringify(formData) !== JSON.stringify(originalData),
     [formData, originalData],
@@ -268,6 +290,9 @@ export function ConditionalPanel({
     const operatorOptions = isPipelineStageField
       ? OPERATORS.filter(option => PIPELINE_STAGE_OPERATORS.includes(option.value))
       : OPERATORS;
+
+    const valueBalanced = isConditionValueBalanced(condition);
+    const exprErrorId = `conditional-expr-error-${condition.id}`;
 
     return (
       <div
@@ -352,21 +377,27 @@ export function ConditionalPanel({
                 </SelectContent>
               </Select>
             ) : needsValue(condition.operator) ? (
-              <VariableInput
-                value={condition.value || ''}
-                onChange={e =>
-                  updateCondition(pathId, condition.id, {
-                    value: e.target.value,
-                    valueLabel: undefined,
-                  })
-                }
-                placeholder={t('panels.conditional.value')}
-                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-                journeyId={journeyId}
-                onVariableInsert={variable => {
-                  console.log('Variable inserted in condition:', variable);
-                }}
-              />
+              <>
+                <VariableInput
+                  value={condition.value || ''}
+                  onChange={e =>
+                    updateCondition(pathId, condition.id, {
+                      value: e.target.value,
+                      valueLabel: undefined,
+                    })
+                  }
+                  placeholder={t('panels.conditional.value')}
+                  className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                  journeyId={journeyId}
+                  aria-invalid={!valueBalanced}
+                  aria-describedby={valueBalanced ? undefined : exprErrorId}
+                />
+                {!valueBalanced && (
+                  <p id={exprErrorId} className="mt-1 text-xs text-flow-feedback-error-fg">
+                    {t('environmentManager.invalidExpression')}
+                  </p>
+                )}
+              </>
             ) : (
               <div className="h-10 flex items-center text-xs text-muted-foreground italic px-3">
                 {t('panels.conditional.notNecessary')}
@@ -518,6 +549,7 @@ export function ConditionalPanel({
       onCancel={onClose}
       onSave={handleSave}
       dirty={dirty}
+      saveDisabled={hasInvalidExpression}
       saveLabel={t('actions.save')}
       cancelLabel={t('actions.cancel')}
       contentClassName="max-w-4xl"

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.spec.tsx
@@ -24,10 +24,16 @@ vi.mock('@/services/channels/messageTemplatesService', () => ({
   default: { getTemplates: vi.fn() },
 }));
 
+// Capture every VariableTextarea render so we can assert journeyId is wired
+// through (EVO-1855: the picker fetches journey custom variables via
+// useJourneyVariables(journeyId) — a dropped prop silently degrades it to
+// system-only variables).
+const variableTextareaProps: any[] = [];
 vi.mock('@/components/journey/environment-manager', () => ({
-  VariableTextarea: ({ value, onChange, placeholder }: any) => (
-    <textarea value={value} onChange={onChange} placeholder={placeholder} />
-  ),
+  VariableTextarea: ({ value, onChange, placeholder, ...rest }: any) => {
+    variableTextareaProps.push({ value, placeholder, ...rest });
+    return <textarea value={value} onChange={onChange} placeholder={placeholder} />;
+  },
 }));
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
@@ -52,12 +58,19 @@ const template = {
 
 const noop = () => {};
 
-const renderPanel = (data: Record<string, unknown>) =>
+const renderPanel = (data: Record<string, unknown>, journeyId?: string) =>
   render(
-    <SendMessagePanel nodeId="n1" data={data as any} onUpdate={noop} onClose={noop} />,
+    <SendMessagePanel
+      nodeId="n1"
+      data={data as any}
+      onUpdate={noop}
+      onClose={noop}
+      journeyId={journeyId}
+    />,
   );
 
 beforeEach(() => {
+  variableTextareaProps.length = 0;
   mockedFormData.mockReset().mockResolvedValue({ inboxes } as any);
   mockedGetTemplates.mockReset().mockResolvedValue({ success: true, data: [template] } as any);
 });
@@ -124,6 +137,35 @@ describe('SendMessagePanel template mode (EVO-1255)', () => {
     await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalled());
     expect(screen.queryByText('panels.sendMessage.useEventChannel')).toBeNull();
     expect(screen.queryByText('panels.sendMessage.attachments')).toBeNull();
+  });
+});
+
+describe('SendMessagePanel journey variable wiring (EVO-1855)', () => {
+  it('passes journeyId to the free-text message picker so it can fetch journey variables', async () => {
+    renderPanel({ inboxId: 'i2', messageMode: 'text', message: 'hi' }, 'journey-99');
+
+    await waitFor(() => expect(mockedFormData).toHaveBeenCalled());
+    await waitFor(() => expect(variableTextareaProps.length).toBeGreaterThan(0));
+    expect(variableTextareaProps.every(p => p.journeyId === 'journey-99')).toBe(true);
+  });
+
+  it('passes journeyId to the expression picker in template mode', async () => {
+    renderPanel(
+      {
+        inboxId: 'i2',
+        messageMode: 'template',
+        templateId: 'tpl-1',
+        message: '',
+        templateVariables: [
+          { variable: 'first_name', source: 'expression', expression: '{{contact.name}}' },
+        ],
+      },
+      'journey-99',
+    );
+
+    await waitFor(() => expect(mockedGetTemplates).toHaveBeenCalled());
+    await waitFor(() => expect(variableTextareaProps.length).toBeGreaterThan(0));
+    expect(variableTextareaProps.every(p => p.journeyId === 'journey-99')).toBe(true);
   });
 });
 

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
@@ -786,6 +786,7 @@ export function SendMessagePanel({
                       mapping.source === 'expression' &&
                       !!(mapping.expression ?? '').trim() &&
                       !isBalancedExpression(mapping.expression!);
+                    const exprErrorId = `send-message-expr-error-${variable.name}`;
 
                     return (
                       <div key={variable.name} className="space-y-1">
@@ -867,9 +868,14 @@ export function SendMessagePanel({
                                 placeholder={t('panels.sendMessage.expressionPlaceholder')}
                                 className="min-h-[40px] resize-none"
                                 journeyId={journeyId}
+                                aria-invalid={expressionInvalid}
+                                aria-describedby={expressionInvalid ? exprErrorId : undefined}
                               />
                               {expressionInvalid && (
-                                <p className="text-xs text-flow-feedback-error-fg">
+                                <p
+                                  id={exprErrorId}
+                                  className="text-xs text-flow-feedback-error-fg"
+                                >
                                   {t('panels.sendMessage.invalidExpression')}
                                 </p>
                               )}

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
@@ -150,7 +150,13 @@ const getChannelTypeName = (channelType: string) => {
   }
 };
 
-export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessagePanelProps) {
+export function SendMessagePanel({
+  nodeId,
+  data,
+  onUpdate,
+  onClose,
+  journeyId,
+}: SendMessagePanelProps) {
   const { t } = useLanguage('journey');
 
   const initialFormData: SendMessageNodeData = {
@@ -860,6 +866,7 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
                                 }
                                 placeholder={t('panels.sendMessage.expressionPlaceholder')}
                                 className="min-h-[40px] resize-none"
+                                journeyId={journeyId}
                               />
                               {expressionInvalid && (
                                 <p className="text-xs text-flow-feedback-error-fg">
@@ -900,9 +907,7 @@ export function SendMessagePanel({ nodeId, data, onUpdate, onClose }: SendMessag
               placeholder={t('panels.sendMessage.messagePlaceholder')}
               className="min-h-[120px] resize-none"
               disabled={loading}
-              onVariableInsert={variable => {
-                console.log('Variable inserted:', variable);
-              }}
+              journeyId={journeyId}
             />
 
             <div className="flex justify-between items-center text-xs">

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -451,6 +451,7 @@
   },
   "environmentManager": {
     "title": "Environment Variables",
+    "invalidExpression": "Custom expression has unbalanced braces or parentheses",
     "description": "Configure variables to use throughout the journey with {variable} syntax",
     "searchPlaceholder": "Search variables...",
     "loading": "Loading variables...",
@@ -560,6 +561,7 @@
       },
       "actions": {
         "new": "New Variable",
+        "insertVariable": "Insert variable",
         "copy": "Copy",
         "edit": "Edit variable",
         "delete": "Remove variable",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -439,6 +439,7 @@
   },
   "environmentManager": {
     "title": "Variables de Entorno",
+    "invalidExpression": "La expresión personalizada tiene llaves o paréntesis desbalanceados",
     "description": "Configure variables para usar en toda la jornada con la sintaxis {variavel}",
     "searchPlaceholder": "Buscar variables...",
     "loading": "Cargando variables...",
@@ -543,6 +544,7 @@
       },
       "actions": {
         "new": "Nueva Variable",
+        "insertVariable": "Insertar variable",
         "copy": "Copiar",
         "edit": "Editar variable",
         "delete": "Remover variable",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -439,6 +439,7 @@
   },
   "environmentManager": {
     "title": "Variables d'environnement",
+    "invalidExpression": "L'expression personnalisée comporte des accolades ou des parenthèses non équilibrées",
     "description": "Configurez des variables à utiliser dans tout le parcours avec la syntaxe {variable}",
     "searchPlaceholder": "Rechercher des variables...",
     "loading": "Chargement des variables...",
@@ -543,6 +544,7 @@
       },
       "actions": {
         "new": "Nouvelle variable",
+        "insertVariable": "Insérer une variable",
         "copy": "Copier",
         "edit": "Modifier la variable",
         "delete": "Supprimer la variable",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -451,6 +451,7 @@
   },
   "environmentManager": {
     "title": "Variabili d'Ambiente",
+    "invalidExpression": "L'espressione personalizzata ha parentesi graffe o tonde non bilanciate",
     "description": "Configura variabili da usare in tutto il percorso con la sintassi {variabile}",
     "searchPlaceholder": "Cerca variabili...",
     "loading": "Caricamento variabili...",
@@ -555,6 +556,7 @@
       },
       "actions": {
         "new": "Nuova Variabile",
+        "insertVariable": "Inserisci variabile",
         "copy": "Copia",
         "edit": "Modifica variabile",
         "delete": "Rimuovi variabile",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -451,6 +451,7 @@
   },
   "environmentManager": {
     "title": "Variáveis de Ambiente",
+    "invalidExpression": "A expressão personalizada tem chaves ou parênteses desbalanceados",
     "description": "Configure variáveis para usar em toda a jornada com a sintaxe {variavel}",
     "searchPlaceholder": "Buscar variáveis...",
     "loading": "Carregando variáveis...",
@@ -560,6 +561,7 @@
       },
       "actions": {
         "new": "Nova Variável",
+        "insertVariable": "Inserir variável",
         "copy": "Copiar",
         "edit": "Editar variável",
         "delete": "Remover variável",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -439,6 +439,7 @@
   },
   "environmentManager": {
     "title": "Variáveis de Ambiente",
+    "invalidExpression": "A expressão personalizada tem chaves ou parênteses desbalanceados",
     "description": "Configure variáveis para usar em toda a jornada com a sintaxe {variavel}",
     "searchPlaceholder": "Buscar variáveis...",
     "loading": "Carregando variáveis...",
@@ -543,6 +544,7 @@
       },
       "actions": {
         "new": "Nova Variável",
+        "insertVariable": "Inserir variável",
         "copy": "Copiar",
         "edit": "Editar variável",
         "delete": "Remover variável",


### PR DESCRIPTION
## Resumo
Follow-up da EVO-1743, portado para o fork **Community** (a primeira implementação foi feita por engano no repo enterprise `evo-ai-frontend` — PR #159 lá foi fechado e a branch removida).

O fork community já havia divergido: `isBalancedExpression` já existe em `src/utils/templateVariables.ts` e o `SendMessagePanel` já estava completo (journeyId + validação template-mode). Então o escopo real aqui ficou **Conditional + a11y dos pickers**.

## Mudanças
- **ConditionalPanel**: validação de expressão (`{{ }}`/parênteses balanceados) nos valores de condição, **reusando** `isBalancedExpression` de `@/utils/templateVariables` (sem helper concorrente). Erro inline, `aria-invalid`/`aria-describedby` no `VariableInput`, `saveDisabled` no `NodeConfigModal` e guard defense-in-depth em `handleSave`. Valores não-string são tratados como válidos (nunca quebra o render).
- Remove o `console.log` solto no handler no-op `onVariableInsert`.
- **a11y**: `aria-label` no botão do picker em `VariableInput`/`VariableTextarea`; `title` coerente ("inserir variável", antes "copy").
- **i18n**: `environmentManager.invalidExpression` e `environmentManager.customVariables.actions.insertVariable` nos 6 locales (sem `{{ }}` literal).

## Test plan
- `npx tsc -b` limpo.
- vitest: `ConditionalPanel.spec.tsx` (validação aria/erro/save + a11y do picker) e `VariableTextarea.spec.tsx` (a11y) — 14 testes verdes (incl. `templateVariables.spec.ts`).
- ESLint limpo no ConditionalPanel (os `no-explicit-any` remanescentes em VariableInput/VariableTextarea são pré-existentes, em linhas não tocadas).

## Notas
Condições `is_empty`/`is_not_empty` e o campo pipeline-stage (id-only) não são validados — só valores free-text. Follow-up natural: mover a validação para dentro dos próprios pickers (cobre os ~demais painéis).