### PR TITLE
fix(frontend): make data tables usable on mobile — horizontal scroll + dvh shell height (EVO-1869)

### DIFF
--- a/src/components/base/BaseTable.tsx
+++ b/src/components/base/BaseTable.tsx
@@ -217,7 +217,7 @@ export default function BaseTable<T extends Record<string, any>>({
 
   return (
     <div
-      className={`rounded-lg border border-sidebar-border bg-sidebar overflow-hidden ${className}`}
+      className={`rounded-lg border border-sidebar-border bg-sidebar overflow-x-auto ${className}`}
     >
       <Table>
         <TableHeader>

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -107,7 +107,7 @@ export default function MainLayout({ children }: MainLayoutProps) {
   }
 
   return (
-    <div className="flex flex-col h-screen bg-background transition-colors duration-150 ease-in-out">
+    <div className="flex flex-col h-dvh bg-background transition-colors duration-150 ease-in-out">
 
       {/* Header */}
       <Header


### PR DESCRIPTION
## Summary
Two 1-line mobile fixes for the data-table screens (surfaced during EVO-1860/EVO-1869 smoke):

- **`BaseTable` horizontal scroll** — the wrapper was `overflow-hidden`, so on narrow viewports a wide table was clipped with no horizontal scroll and the rightmost columns (incl. the row actions menu) were unreachable. Switched to `overflow-x-auto`. Shared by ~15+ table screens (strict improvement). The row actions `DropdownMenu` is portaled, so it isn't clipped.
- **App-shell viewport height** — `MainLayout` used `h-screen` (100vh), which on mobile includes the browser address bar, making the shell taller than the visible viewport; with `body { overflow: hidden }` the bottom of each page (e.g. the table pagination footer, pinned with `mt-auto`) fell below the fold with no scroll. Switched to `h-dvh` (dynamic viewport height). Desktop unchanged (`dvh == vh`); the inner `<main>` keeps its own `overflow-auto`.

## Security
- CSS-only changes; no logic, data exposure, or auth surface.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec eslint <changed files>` — 0 new errors (a pre-existing `any` on BaseTable's generic constraint is untouched)
- `pnpm exec vitest related --run src/components/base/BaseTable.tsx` — 18/18 passed
- Manual smoke (mobile viewport): tables scroll horizontally and the actions menu is reachable; the pagination footer is now visible; desktop and other screens (Chat, Pipelines) unchanged.

## Changed Files
- `src/components/base/BaseTable.tsx`
- `src/components/layout/MainLayout.tsx`

## Linked Issue
- EVO-1869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk9VSPAVSDo3cG8caUbNND

## Summary by Sourcery

Improve mobile usability of table views and the main app layout by adjusting container overflow and viewport height handling.

Bug Fixes:
- Allow horizontal scrolling of wide data tables so all columns and row actions are accessible on narrow viewports.
- Ensure the main app shell height matches the visible mobile viewport so bottom content like pagination remains visible and scrollable.