### PR TITLE
feat(frontend): full-width composer input + mobile back deselects conversation (EVO-1884)

### DIFF
--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -702,62 +702,10 @@ const MessageInput: React.FC<MessageInputProps> = ({
             </div>
           </div>
 
-          {/* Segunda linha: Botões de formatação + Input + Botões de envio */}
-          <div className="flex items-end gap-2 w-full overflow-visible">
-            {/* Botões de formatação à esquerda */}
-            <div className="flex-shrink-0 flex items-center gap-1.5 pb-1">
-              {/* File Upload Button */}
-              <FileUpload
-                onFilesSelected={handleFilesSelected}
-                maxFileSize={100}
-                multiple={true}
-                disabled={isDisabled || isSending || isPendingConversation || hasCannedMedia}
-              />
-
-              {/* Emoji Button */}
-              <div className="relative">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  disabled={isDisabled || isSending || isPendingConversation}
-                  className="h-9 w-9 flex-shrink-0 hover:bg-accent disabled:opacity-50"
-                  onClick={handleEmojiClick}
-                >
-                  <Smile className="h-4 w-4" />
-                </Button>
-                <EmojiPicker
-                  isOpen={showEmojiPicker}
-                  onEmojiSelect={handleEmojiSelect}
-                  onClose={() => setShowEmojiPicker(false)}
-                />
-              </div>
-              {/* Canned Responses Button */}
-              <Button
-                variant={showCannedResponses ? 'default' : 'ghost'}
-                size="icon"
-                disabled={isDisabled || isSending || isPendingConversation}
-                className="h-9 w-9 flex-shrink-0 hover:bg-accent disabled:opacity-50"
-                onClick={handleCannedResponsesClick}
-                title={t('messageInput.cannedResponses.tooltip')}
-              >
-                <MessageSquareText className="h-4 w-4" />
-              </Button>
-
-              {/* Template Button */}
-              <Button
-                variant="ghost"
-                size="icon"
-                disabled={isSending || isPendingConversation}
-                className="h-9 w-9 flex-shrink-0 hover:bg-accent disabled:opacity-50"
-                onClick={handleTemplateClick}
-                title={t('messageTemplates.button.title')}
-              >
-                <FileText className="h-4 w-4" />
-              </Button>
-            </div>
-
+          {/* Input full-width, action buttons in a row below */}
+          <div className="w-full overflow-visible">
             {/* Text Input Container */}
-            <div className="flex-1 min-w-0 overflow-hidden">
+            <div className="w-full min-w-0 overflow-hidden">
               <RichTextEditor
                 ref={richEditorRef}
                 placeholder={
@@ -818,45 +766,99 @@ const MessageInput: React.FC<MessageInputProps> = ({
               />
             </div>
 
-            {/* Action Buttons */}
-            <div className="flex-shrink-0 flex items-center gap-1.5 pb-1">
-              {replyMode === ReplyMode.REPLY && !isPendingConversation && (
-                <Button
-                  variant={isRecordingAudio ? 'default' : 'ghost'}
-                  size="icon"
-                  disabled={isDisabled || isSending}
-                  className={
-                    isRecordingAudio
-                      ? 'bg-primary hover:bg-primary/85 text-primary-foreground h-9 w-9 flex-shrink-0 shadow-md transition-all duration-200'
-                      : 'h-9 w-9 flex-shrink-0 hover:bg-accent transition-all duration-200'
-                  }
-                  onClick={startAudioRecording}
-                >
-                  <Mic className="h-4 w-4" />
-                </Button>
-              )}
+            {/* Action row: file / emoji / canned / template (left) + mic / send (right) */}
+            <div className="flex items-center justify-between gap-2 mt-2">
+              <div className="flex items-center gap-1.5">
+                {/* File Upload Button */}
+                <FileUpload
+                  onFilesSelected={handleFilesSelected}
+                  maxFileSize={100}
+                  multiple={true}
+                  disabled={isDisabled || isSending || isPendingConversation || hasCannedMedia}
+                />
 
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="icon"
-                      onClick={handleSend}
-                      disabled={!canSend}
-                      className="bg-primary hover:bg-primary/85 text-primary-foreground h-9 w-9 flex-shrink-0 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-50"
-                    >
-                      {isSending ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Send className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{sendButtonTooltip}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+                {/* Emoji Button */}
+                <div className="relative">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    disabled={isDisabled || isSending || isPendingConversation}
+                    className="h-9 w-9 flex-shrink-0 hover:bg-accent disabled:opacity-50"
+                    onClick={handleEmojiClick}
+                  >
+                    <Smile className="h-4 w-4" />
+                  </Button>
+                  <EmojiPicker
+                    isOpen={showEmojiPicker}
+                    onEmojiSelect={handleEmojiSelect}
+                    onClose={() => setShowEmojiPicker(false)}
+                  />
+                </div>
+
+                {/* Canned Responses Button */}
+                <Button
+                  variant={showCannedResponses ? 'default' : 'ghost'}
+                  size="icon"
+                  disabled={isDisabled || isSending || isPendingConversation}
+                  className="h-9 w-9 flex-shrink-0 hover:bg-accent disabled:opacity-50"
+                  onClick={handleCannedResponsesClick}
+                  title={t('messageInput.cannedResponses.tooltip')}
+                >
+                  <MessageSquareText className="h-4 w-4" />
+                </Button>
+
+                {/* Template Button */}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  disabled={isSending || isPendingConversation}
+                  className="h-9 w-9 flex-shrink-0 hover:bg-accent disabled:opacity-50"
+                  onClick={handleTemplateClick}
+                  title={t('messageTemplates.button.title')}
+                >
+                  <FileText className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="flex items-center gap-1.5">
+                {replyMode === ReplyMode.REPLY && !isPendingConversation && (
+                  <Button
+                    variant={isRecordingAudio ? 'default' : 'ghost'}
+                    size="icon"
+                    disabled={isDisabled || isSending}
+                    className={
+                      isRecordingAudio
+                        ? 'bg-primary hover:bg-primary/85 text-primary-foreground h-9 w-9 flex-shrink-0 shadow-md transition-all duration-200'
+                        : 'h-9 w-9 flex-shrink-0 hover:bg-accent transition-all duration-200'
+                    }
+                    onClick={startAudioRecording}
+                  >
+                    <Mic className="h-4 w-4" />
+                  </Button>
+                )}
+
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="icon"
+                        onClick={handleSend}
+                        disabled={!canSend}
+                        className="bg-primary hover:bg-primary/85 text-primary-foreground h-9 w-9 flex-shrink-0 disabled:bg-muted disabled:text-muted-foreground disabled:opacity-50"
+                      >
+                        {isSending ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Send className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>{sendButtonTooltip}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
             </div>
           </div>
         </CardContent>

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -807,7 +807,7 @@ const Chat = () => {
               {/* Chat Header */}
               <ChatHeader
                 conversation={selectedConversation}
-                onBackClick={() => setMobileView('list')}
+                onBackClick={handleCloseConversation}
                 onCloseConversation={handleCloseConversation}
                 onContactSidebarOpen={() => setIsContactSidebarOpen(true)}
                 isContactSidebarOpen={isContactSidebarOpen}


### PR DESCRIPTION
## Summary
Two chat-conversation UX fixes (found during EVO-1869 mobile smoke):

- **Composer layout** — the message input grew into a large rich-text editor but the composer kept it in a single horizontal row sandwiched between the action buttons, so on narrow widths (mobile, and desktop at smaller sizes) the editor's formatting toolbar was clipped and the text wrapped into an unreadable column. The input now takes the **full composer width** on its own row, and the action buttons move to a **row below** it (attach / emoji / canned / template on the left, mic / send on the right). The Reply/Note toggle + signature/AI row on top is unchanged.
- **Mobile back-button** — the conversation-view back button (`md:hidden`, mobile-only) now clears the selection (reuses `handleCloseConversation` → `clearSelectionAndGoToList`) instead of only toggling the mobile view. Previously `selectedConversationId` stayed set, so re-tapping the same conversation was a no-op (the select handler early-returns on a stale selection). Desktop is unaffected (the back button is hidden on `md+`).

## Security
- Frontend-only; no logic/data/auth surface beyond the chat composer + navigation.

## Test plan
- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec eslint src/components/chat/message-input/MessageInput.tsx src/pages/Customer/Chat/Chat.tsx` — 0 errors (a pre-existing `useCallback` deps warning is untouched)
- `pnpm exec vitest related --run` — 0 new failures (the 4 `Chat.spec` failures are pre-existing on `develop`)
- Manual smoke (desktop + mobile ~375px): input full-width with the formatting toolbar fully visible; action buttons in the row below; all buttons functional (attach / emoji / `/`-canned / template / mic / send); mobile back returns to the list and the same conversation can be re-opened.

## Changed Files
- `src/components/chat/message-input/MessageInput.tsx`
- `src/pages/Customer/Chat/Chat.tsx`

## Note
- `MessageInput.tsx` is also touched by EVO-1861 (PR #183, In Review) in a different region (`handleSelectCannedResponse` logic). If #183 merges first, a trivial rebase here may be needed.

## Linked Issue
- EVO-1884

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dk9VSPAVSDo3cG8caUbNND