### PR TITLE
fix(frontend): relabel country_code as ISO; remove dead company filter (EVO-1849)

### DIFF
--- a/src/i18n/locales/en/contacts.json
+++ b/src/i18n/locales/en/contacts.json
@@ -388,7 +388,7 @@
       "last_activity_at": "Last Activity",
       "type": "Contact Type",
       "labels": "Labels",
-      "country_code": "Country",
+      "country_code": "Country (ISO code)",
       "city": "City",
       "company": "Company",
       "blocked": "Blocked"

--- a/src/i18n/locales/es/contacts.json
+++ b/src/i18n/locales/es/contacts.json
@@ -380,7 +380,7 @@
       "last_activity_at": "Última Actividad",
       "type": "Tipo de Contacto",
       "labels": "Etiquetas",
-      "country_code": "País",
+      "country_code": "País (código ISO)",
       "city": "Ciudad",
       "company": "Empresa",
       "blocked": "Bloqueado"

--- a/src/i18n/locales/fr/contacts.json
+++ b/src/i18n/locales/fr/contacts.json
@@ -380,7 +380,7 @@
       "last_activity_at": "Dernière Activité",
       "type": "Type de Contact",
       "labels": "Étiquettes",
-      "country_code": "Pays",
+      "country_code": "Pays (code ISO)",
       "city": "Ville",
       "company": "Entreprise",
       "blocked": "Bloqué"

--- a/src/i18n/locales/it/contacts.json
+++ b/src/i18n/locales/it/contacts.json
@@ -380,7 +380,7 @@
       "last_activity_at": "Ultima Attività",
       "type": "Tipo di Contatto",
       "labels": "Etichette",
-      "country_code": "Paese",
+      "country_code": "Paese (codice ISO)",
       "city": "Città",
       "company": "Azienda",
       "blocked": "Bloccato"

--- a/src/i18n/locales/pt-BR/contacts.json
+++ b/src/i18n/locales/pt-BR/contacts.json
@@ -388,7 +388,7 @@
       "last_activity_at": "Última Atividade",
       "type": "Tipo de Contato",
       "labels": "Etiquetas",
-      "country_code": "País",
+      "country_code": "País (código ISO)",
       "city": "Cidade",
       "company": "Empresa",
       "blocked": "Bloqueado"

--- a/src/i18n/locales/pt/contacts.json
+++ b/src/i18n/locales/pt/contacts.json
@@ -388,7 +388,7 @@
       "last_activity_at": "Última Atividade",
       "type": "Tipo de Contato",
       "labels": "Etiquetas",
-      "country_code": "País",
+      "country_code": "País (código ISO)",
       "city": "Cidade",
       "company": "Empresa",
       "blocked": "Bloqueado"

--- a/src/types/core/filters.ts
+++ b/src/types/core/filters.ts
@@ -129,14 +129,6 @@ export const CONTACT_FILTER_TYPES: FilterType[] = [
     attribute_type: 'standard',
   },
   {
-    attributeKey: 'company',
-    attributeI18nKey: 'filter.attributes.company',
-    inputType: 'plain_text',
-    dataType: 'text',
-    filterOperators: OPERATOR_TYPES_3,
-    attribute_type: 'standard',
-  },
-  {
     attributeKey: 'blocked',
     attributeI18nKey: 'filter.attributes.blocked',
     inputType: 'search_select',


### PR DESCRIPTION
## Summary
- Relabel the `country_code` contact filter to **"Country (ISO code)"** (6 locales) so users enter the ISO alpha-2 code (e.g. `br`) instead of a country name.
- Remove the `company` entry from `CONTACT_FILTER_TYPES`: the backend key was a no-op (pointed at a never-written `additional_attributes` key). The real company link is the `ContactCompany` association ("Linked Companies" picker); an association-based filter is tracked as a follow-up.

## Security
- No new inputs; label/option-list only.

## Test plan
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` (clean)
- Manual smoke: Contacts advanced filter — "Country (ISO code)" relabel shows; "Company" option no longer listed.

## Changed Files
- `src/types/core/filters.ts`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/contacts.json`

## Related PRs
- crm: https://github.com/evolution-foundation/evo-ai-crm-community/pull/164

## Linked Issue
- EVO-1849

## Summary by Sourcery

Clarify the contacts advanced filter labels and remove an unused company filter option.

Bug Fixes:
- Remove the non-functional "Company" contact filter entry that referenced an unused backend attribute.

Enhancements:
- Relabel the contact country_code filter as an ISO-based "Country (ISO code)" field across supported locales to guide correct input.