### PR TITLE
feat(journey): warn on no-exit cycles in pre-activation validation (EVO-1857)

### DIFF
--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -92,6 +92,7 @@
       "requiredConfig": "{{node}}: missing required configuration ({{fields}})",
       "triggerActionContext": "{{node}}: needs a conversation, but the trigger doesn't provide one",
       "danglingExit": "{{node}}: this path doesn't end in an exit or transfer node",
+      "unreachableExit": "{{node}}: this node is stuck in a loop that can never reach an exit or transfer node",
       "summaryErrors": "Fix these before activating:",
       "summaryWarnings": "Warnings:",
       "saveIssues": "Saved with pending issues: {{issues}}",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -92,6 +92,7 @@
       "requiredConfig": "{{node}}: falta configuración obligatoria ({{fields}})",
       "triggerActionContext": "{{node}}: necesita una conversación, pero el disparador no la proporciona",
       "danglingExit": "{{node}}: esta ruta no termina en un nodo de salida o transferencia",
+      "unreachableExit": "{{node}}: este nodo está atrapado en un bucle que nunca puede llegar a un nodo de salida o transferencia",
       "summaryErrors": "Corrige esto antes de activar:",
       "summaryWarnings": "Avisos:",
       "saveIssues": "Guardado con pendientes: {{issues}}",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -92,6 +92,7 @@
       "requiredConfig": "{{node}} : configuration requise manquante ({{fields}})",
       "triggerActionContext": "{{node}} : nécessite une conversation, mais le déclencheur n'en fournit pas",
       "danglingExit": "{{node}} : ce chemin ne se termine pas par un nœud de sortie ou de transfert",
+      "unreachableExit": "{{node}} : ce nœud est bloqué dans une boucle qui ne peut jamais atteindre un nœud de sortie ou de transfert",
       "summaryErrors": "Corrigez ceci avant d'activer :",
       "summaryWarnings": "Avertissements :",
       "saveIssues": "Enregistré avec des problèmes en attente : {{issues}}",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -92,6 +92,7 @@
       "requiredConfig": "{{node}}: configurazione obbligatoria mancante ({{fields}})",
       "triggerActionContext": "{{node}}: richiede una conversazione, ma il trigger non ne fornisce una",
       "danglingExit": "{{node}}: questo percorso non termina con un nodo di uscita o trasferimento",
+      "unreachableExit": "{{node}}: questo nodo è bloccato in un ciclo che non può mai raggiungere un nodo di uscita o trasferimento",
       "summaryErrors": "Correggi prima di attivare:",
       "summaryWarnings": "Avvisi:",
       "saveIssues": "Salvato con problemi in sospeso: {{issues}}",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -92,6 +92,7 @@
       "requiredConfig": "{{node}}: configuração obrigatória ausente ({{fields}})",
       "triggerActionContext": "{{node}}: precisa de uma conversa, mas o gatilho não fornece uma",
       "danglingExit": "{{node}}: este caminho não termina em um nó de saída ou transferência",
+      "unreachableExit": "{{node}}: este nó está preso em um ciclo que nunca alcança um nó de saída ou transferência",
       "summaryErrors": "Corrija antes de ativar:",
       "summaryWarnings": "Avisos:",
       "saveIssues": "Salvo com pendências: {{issues}}",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -92,6 +92,7 @@
       "requiredConfig": "{{node}}: configuração obrigatória ausente ({{fields}})",
       "triggerActionContext": "{{node}}: precisa de uma conversa, mas o gatilho não fornece uma",
       "danglingExit": "{{node}}: este caminho não termina em um nó de saída ou transferência",
+      "unreachableExit": "{{node}}: este nó está preso em um ciclo que nunca alcança um nó de saída ou transferência",
       "summaryErrors": "Corrija antes de ativar:",
       "summaryWarnings": "Avisos:",
       "saveIssues": "Salvo com pendências: {{issues}}",

--- a/src/utils/journeyFlowValidation.spec.ts
+++ b/src/utils/journeyFlowValidation.spec.ts
@@ -165,4 +165,79 @@ describe('validateJourney (EVO-1744)', () => {
     expect(r.warnings.some((w) => w.rule === 'terminalPath' && w.nodeId === 'a')).toBe(true);
     expect(r.isActivatable).toBe(true); // warning, not error
   });
+
+  // EVO-1857: terminalPath's blind spot — a closed loop with no exit. Every
+  // cyclic node has an outgoing edge, so terminalPath never flags it.
+  it('EVO-1857 AC1: a cycle with no reachable exit warns (unreachableExit)', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+      sendMsg('b'),
+    ];
+    // trigger → a → b → a (closed loop, no exit/transfer anywhere)
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'b'), edge('b', 'a')]);
+    expect(r.errors).toEqual([]);
+    expect(r.isActivatable).toBe(true); // warning, not error
+    expect(r.warnings.some((w) => w.rule === 'unreachableExit' && w.nodeId === 'a')).toBe(true);
+    expect(r.warnings.some((w) => w.rule === 'unreachableExit' && w.nodeId === 'b')).toBe(true);
+    // The cyclic nodes have outgoing edges, so terminalPath must NOT also flag them.
+    expect(r.warnings.some((w) => w.rule === 'terminalPath')).toBe(false);
+  });
+
+  it('EVO-1857 AC1: a self-looping node with no exit warns', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+    ];
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'a')]);
+    expect(r.warnings.some((w) => w.rule === 'unreachableExit' && w.nodeId === 'a')).toBe(true);
+  });
+
+  it('EVO-1857 AC2: a cycle that CAN reach an exit is not a false positive', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+      sendMsg('b'),
+      node('e', 'exit-journey-node'),
+    ];
+    // trigger → a → b → a (loop) but b → e gives every cyclic node a way out.
+    const r = validateJourney(nodes, [
+      edge('t', 'a'),
+      edge('a', 'b'),
+      edge('b', 'a'),
+      edge('b', 'e'),
+    ]);
+    expect(r.warnings.some((w) => w.rule === 'unreachableExit')).toBe(false);
+    expect(r.isActivatable).toBe(true);
+  });
+
+  it('EVO-1857: a no-exit cycle NOT reachable from any trigger is ignored', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+      node('e', 'exit-journey-node'),
+      // Detached loop c → d → c, no trigger reaches it: never executes, no warning.
+      sendMsg('c'),
+      sendMsg('d'),
+    ];
+    const r = validateJourney(nodes, [
+      edge('t', 'a'),
+      edge('a', 'e'),
+      edge('c', 'd'),
+      edge('d', 'c'),
+    ]);
+    expect(r.warnings.some((w) => w.rule === 'unreachableExit')).toBe(false);
+  });
 });

--- a/src/utils/journeyFlowValidation.ts
+++ b/src/utils/journeyFlowValidation.ts
@@ -36,7 +36,9 @@ function labelFor(node: Node): string {
  * or `transfer-journey-node`). Such nodes leave the journey "running" for up to
  * 30 days instead of completing (EVO-1691), so the editor warns about them on
  * save (EVO-1692). A lone trigger (no downstream) counts as dangling too.
- * Cyclic paths with no exit are not detected.
+ * Cyclic paths with no exit are out of this check's reach (every cyclic node has
+ * an outgoing edge) — they are caught separately by `unreachableExitIssues`
+ * (EVO-1857).
  */
 export function validateJourneyTerminalPaths(
   nodes: Node[],
@@ -81,7 +83,7 @@ export function validateJourneyTerminalPaths(
 /**
  * Terminal-path rule as `ValidationIssue[]` (EVO-1744, AC4: the EVO-1692 check
  * folded into the engine, not duplicated). Each dangling node → one warning.
- * NOTE: cyclic paths with no exit are still not detected (see EVO-1857).
+ * Cyclic paths with no exit are handled by `unreachableExitIssues` (EVO-1857).
  */
 function terminalPathIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] {
   return validateJourneyTerminalPaths(nodes, edges).danglingNodes.map(
@@ -93,6 +95,81 @@ function terminalPathIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] {
       params: { node: dangling.label },
     }),
   );
+}
+
+/**
+ * Detects the blind spot `terminalPath` misses (EVO-1857, follow-up to EVO-1744
+ * F5): nodes reachable from a trigger that can **never** reach a terminating node
+ * (`exit-journey-node`/`transfer-journey-node`) — e.g. a closed loop with no exit
+ * (`trigger → A → B → A`). `terminalPath` only flags nodes with *no outgoing
+ * edge*, so a node inside a cycle (which always has one) escapes it, yet at
+ * runtime its session stays "running" for ~30 days (EVO-1691).
+ *
+ * Algorithm (as specced on the card): one reverse-reachability pass from the
+ * terminal nodes yields the set that *can* reach a terminal; any trigger-reachable
+ * node outside it is trapped. Linear, no memoization needed. Two exclusions keep
+ * it from doubling up with `terminalPath`: trigger nodes (the entry, not the
+ * offending step) and no-outgoing nodes (already its `danglingExit` domain).
+ */
+function unreachableExitIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const outgoing = new Map<string, string[]>();
+  const incoming = new Map<string, string[]>();
+  for (const edge of edges) {
+    if (!edge.source || !edge.target) continue;
+    const outs = outgoing.get(edge.source) ?? [];
+    outs.push(edge.target);
+    outgoing.set(edge.source, outs);
+    const ins = incoming.get(edge.target) ?? [];
+    ins.push(edge.source);
+    incoming.set(edge.target, ins);
+  }
+
+  // Reverse-BFS from every terminal node → the set that can reach a terminal.
+  const canReachTerminal = new Set<string>();
+  const revQueue = nodes
+    .filter((node) => node.type && TERMINAL_NODE_TYPES.has(node.type))
+    .map((node) => node.id);
+  while (revQueue.length > 0) {
+    const id = revQueue.shift() as string;
+    if (canReachTerminal.has(id)) continue;
+    canReachTerminal.add(id);
+    for (const src of incoming.get(id) ?? []) {
+      if (!canReachTerminal.has(src)) revQueue.push(src);
+    }
+  }
+
+  // Forward-BFS from every trigger → nodes that actually execute. Insertion order
+  // is deterministic (BFS from triggers), so emitted warnings are stable.
+  const reachable = new Set<string>();
+  const fwdQueue = nodes
+    .filter((node) => node.type === TRIGGER_NODE_TYPE)
+    .map((node) => node.id);
+  while (fwdQueue.length > 0) {
+    const id = fwdQueue.shift() as string;
+    if (reachable.has(id)) continue;
+    reachable.add(id);
+    for (const tgt of outgoing.get(id) ?? []) {
+      if (!reachable.has(tgt)) fwdQueue.push(tgt);
+    }
+  }
+
+  const issues: ValidationIssue[] = [];
+  for (const id of reachable) {
+    if (canReachTerminal.has(id)) continue; // has a way out → fine
+    const node = nodeById.get(id);
+    if (!node) continue;
+    if (node.type === TRIGGER_NODE_TYPE) continue; // entry, not the offending step
+    if ((outgoing.get(id) ?? []).length === 0) continue; // danglingExit's domain
+    issues.push({
+      nodeId: id,
+      rule: 'unreachableExit',
+      severity: 'warning',
+      messageKey: 'flowEditor.validation.unreachableExit',
+      params: { node: labelFor(node) },
+    });
+  }
+  return issues;
 }
 
 /**
@@ -128,6 +205,9 @@ export function validateJourney(
 
   // (c) terminal-path (EVO-1692, folded in) — warnings
   issues.push(...terminalPathIssues(nodes, edges));
+
+  // (d) cycles with no reachable exit (EVO-1857, terminalPath's blind spot) — warnings
+  issues.push(...unreachableExitIssues(nodes, edges));
 
   const errors = issues.filter((i) => i.severity === 'error');
   const warnings = issues.filter((i) => i.severity === 'warning');

--- a/src/utils/journeyValidators/types.ts
+++ b/src/utils/journeyValidators/types.ts
@@ -8,7 +8,8 @@ export type ValidationSeverity = 'error' | 'warning';
 export type ValidationRule =
   | 'requiredConfig'
   | 'triggerActionContext'
-  | 'terminalPath';
+  | 'terminalPath'
+  | 'unreachableExit';
 
 export interface ValidationIssue {
   /** Node the issue belongs to; undefined = journey-level. */


### PR DESCRIPTION
## Summary
Follow-up to EVO-1744 (adversarial finding F5). `validateJourneyTerminalPaths` (the EVO-1692 seed, folded into the `validateJourney` engine) flags only nodes with **no outgoing edge**, so a closed loop with no reachable exit/transfer node (`trigger → A → B → A`) **passed** validation — yet at runtime the contact's session stays "running" for ~30 days (EVO-1691). Every cyclic node has an outgoing edge, so the existing BFS never sees it (`journeyFlowValidation.ts:39` literally noted "Cyclic paths with no exit are not detected").

This adds an `unreachableExit` rule (warning, same severity as the dangling check) to the engine:
- One **reverse-reachability** pass from the terminal nodes (`exit-journey-node`/`transfer-journey-node`) yields the set that *can* reach a terminal; any trigger-reachable node outside it is trapped → warn.
- Excludes trigger nodes (the entry, not the offending step) and no-outgoing nodes (already `terminalPath`'s `danglingExit` domain) so it never double-flags.
- Linear (O(V+E)). Consumers render `t(issue.messageKey)` generically, so the new rule surfaces in the editor banner, node badge, and list/modal with no further wiring.

## Test plan
- `vitest run src/utils/journeyFlowValidation.spec.ts` — 15 tests (+4): cycle-without-exit warns (AC1), cycle-with-reachable-exit is **not** a false positive (AC2), self-loop warns, and a detached (non-trigger-reachable) cycle is ignored.
- Validation-related suites green (`journeyFlowValidation` + `journeyValidators`, 29 tests). `journeyFlowValidation.spec.ts` is the only spec that imports the engine.
- `tsc -b` clean (repo convention). All 6 locale JSONs valid.

## Notas
- Adds `flowEditor.validation.unreachableExit` in en/es/fr/it/pt/pt-BR.
- Pure FE engine change; no runtime (evo-flow) changes. Builds on `develop` which has EVO-1744 (#180).
