### PR TITLE
feat(custom-tools): redesign as 6-step wizard with edit support (EVO-1790)

### DIFF
--- a/src/components/ai_agents/shared/AdvancedJsonCollapse.spec.tsx
+++ b/src/components/ai_agents/shared/AdvancedJsonCollapse.spec.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import AdvancedJsonCollapse from './AdvancedJsonCollapse';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+describe('AdvancedJsonCollapse', () => {
+  it('is closed by default and children are not visible', () => {
+    render(
+      <AdvancedJsonCollapse>
+        <div data-testid="child">child-content</div>
+      </AdvancedJsonCollapse>,
+    );
+    expect(screen.queryByTestId('child')).toBeNull();
+  });
+
+  it('opens by default when defaultOpen is true', () => {
+    render(
+      <AdvancedJsonCollapse defaultOpen>
+        <div data-testid="child">child-content</div>
+      </AdvancedJsonCollapse>,
+    );
+    expect(screen.getByTestId('child')).toBeTruthy();
+  });
+
+  it('toggles open/closed when the header is clicked', () => {
+    render(
+      <AdvancedJsonCollapse>
+        <div data-testid="child">child-content</div>
+      </AdvancedJsonCollapse>,
+    );
+    const trigger = screen.getByText('advancedConfig.title');
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('child')).toBeTruthy();
+    fireEvent.click(trigger);
+    expect(screen.queryByTestId('child')).toBeNull();
+  });
+
+  it('uses custom title when provided', () => {
+    render(
+      <AdvancedJsonCollapse title="Custom Title">
+        <div>x</div>
+      </AdvancedJsonCollapse>,
+    );
+    expect(screen.getByText('Custom Title')).toBeTruthy();
+  });
+});

--- a/src/components/ai_agents/shared/AdvancedJsonCollapse.tsx
+++ b/src/components/ai_agents/shared/AdvancedJsonCollapse.tsx
@@ -1,0 +1,41 @@
+import { ReactNode, useState } from 'react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@evoapi/design-system';
+import { ChevronDown, Settings } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+
+/** Shared between Custom Tools (EVO-1790) and Custom MCP (EVO-1791) UIs. */
+export interface AdvancedJsonCollapseProps {
+  title?: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export default function AdvancedJsonCollapse({
+  title,
+  defaultOpen = false,
+  children,
+}: AdvancedJsonCollapseProps) {
+  const { t } = useLanguage('customTools');
+  const [open, setOpen] = useState(defaultOpen);
+  const resolvedTitle = title || t('advancedConfig.title');
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="border rounded-md">
+      <CollapsibleTrigger
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium hover:bg-muted/40"
+        aria-expanded={open}
+      >
+        <span className="flex items-center gap-2">
+          <Settings className="h-4 w-4" />
+          {resolvedTitle}
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="px-4 py-4 space-y-4 border-t">
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/src/components/ai_agents/shared/KeyValueEditor.spec.tsx
+++ b/src/components/ai_agents/shared/KeyValueEditor.spec.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import KeyValueEditor from './KeyValueEditor';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+describe('KeyValueEditor', () => {
+  it('renders rows from initial object value', () => {
+    render(
+      <KeyValueEditor
+        value={{ Authorization: 'Bearer abc', 'Content-Type': 'application/json' }}
+        onChange={() => {}}
+        label="Headers"
+      />,
+    );
+    expect(screen.getByDisplayValue('Authorization')).toBeTruthy();
+    expect(screen.getByDisplayValue('Bearer abc')).toBeTruthy();
+    expect(screen.getByDisplayValue('Content-Type')).toBeTruthy();
+  });
+
+  it('adds a new empty row when "+ add" is clicked', () => {
+    const onChange = vi.fn();
+    render(<KeyValueEditor value={{}} onChange={onChange} label="Params" />);
+    fireEvent.click(screen.getByText('keyValueEditor.addRow'));
+    const keyInputs = screen.getAllByLabelText('Params key');
+    expect(keyInputs.length).toBe(1);
+  });
+
+  it('removes a row when X is clicked and emits updated object', () => {
+    const onChange = vi.fn();
+    render(
+      <KeyValueEditor value={{ a: '1', b: '2' }} onChange={onChange} label="Q" />,
+    );
+    const removeButtons = screen.getAllByLabelText('keyValueEditor.removeRow');
+    fireEvent.click(removeButtons[0]);
+    expect(onChange).toHaveBeenLastCalledWith({ b: '2' });
+  });
+
+  it('emits onChange with reconstructed object when value edited', () => {
+    const onChange = vi.fn();
+    render(
+      <KeyValueEditor value={{ name: 'old' }} onChange={onChange} label="X" />,
+    );
+    const valueInput = screen.getByDisplayValue('old');
+    fireEvent.change(valueInput, { target: { value: 'new' } });
+    expect(onChange).toHaveBeenLastCalledWith({ name: 'new' });
+  });
+
+  it('shows inline error for duplicate keys', () => {
+    render(
+      <KeyValueEditor value={{}} onChange={() => {}} label="H" />,
+    );
+    fireEvent.click(screen.getByText('keyValueEditor.addRow'));
+    fireEvent.click(screen.getByText('keyValueEditor.addRow'));
+    const keyInputs = screen.getAllByLabelText('H key');
+    fireEvent.change(keyInputs[0], { target: { value: 'foo' } });
+    fireEvent.change(keyInputs[1], { target: { value: 'foo' } });
+    expect(screen.getByText('keyValueEditor.errors.duplicateKey')).toBeTruthy();
+  });
+
+  it('shows inline error for empty value when key filled', () => {
+    render(<KeyValueEditor value={{}} onChange={() => {}} label="H" />);
+    fireEvent.click(screen.getByText('keyValueEditor.addRow'));
+    const keyInput = screen.getByLabelText('H key');
+    fireEvent.change(keyInput, { target: { value: 'k' } });
+    expect(screen.getByText('keyValueEditor.errors.emptyValue')).toBeTruthy();
+  });
+
+  it('renders nested object value as readonly JSON with complex badge', () => {
+    render(
+      <KeyValueEditor
+        value={{ auth: { bearer: 'abc' } }}
+        onChange={() => {}}
+        label="Headers"
+      />,
+    );
+    expect(screen.getByDisplayValue('auth')).toBeTruthy();
+    expect(screen.getByText('{"bearer":"abc"}')).toBeTruthy();
+    expect(screen.getAllByText('keyValueEditor.complexValueBadge').length).toBeGreaterThan(0);
+  });
+
+  it('preserves nested object value when row not edited', () => {
+    const onChange = vi.fn();
+    render(
+      <KeyValueEditor
+        value={{ auth: { bearer: 'abc' }, simple: 'x' }}
+        onChange={onChange}
+        label="H"
+      />,
+    );
+    const simpleInput = screen.getByDisplayValue('x');
+    fireEvent.change(simpleInput, { target: { value: 'y' } });
+    expect(onChange).toHaveBeenLastCalledWith({
+      auth: { bearer: 'abc' },
+      simple: 'y',
+    });
+  });
+});

--- a/src/components/ai_agents/shared/KeyValueEditor.tsx
+++ b/src/components/ai_agents/shared/KeyValueEditor.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Button, Input, Label } from '@evoapi/design-system';
+import { Plus, X } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+
+/** Shared between Custom Tools (EVO-1790) and Custom MCP (EVO-1791) UIs. */
+export interface KeyValueEditorProps {
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  label: string;
+  hint?: string;
+  addRowLabel?: string;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  disabled?: boolean;
+  id?: string;
+}
+
+interface Row {
+  id: number;
+  key: string;
+  value: unknown;
+  isComplex: boolean;
+}
+
+let rowCounter = 0;
+const nextRowId = () => ++rowCounter;
+
+const isComplexValue = (v: unknown): boolean =>
+  typeof v === 'object' && v !== null;
+
+const stringifyComplex = (v: unknown): string => {
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+};
+
+const valueToString = (v: unknown): string => {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'string') return v;
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return stringifyComplex(v);
+};
+
+const objectToRows = (obj: Record<string, unknown>): Row[] => {
+  const entries = Object.entries(obj || {});
+  if (entries.length === 0) return [];
+  return entries.map(([k, v]) => ({
+    id: nextRowId(),
+    key: k,
+    value: v,
+    isComplex: isComplexValue(v),
+  }));
+};
+
+const rowsToObject = (rows: Row[]): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  for (const row of rows) {
+    if (!row.key.trim()) continue;
+    out[row.key] = row.value;
+  }
+  return out;
+};
+
+export default function KeyValueEditor({
+  value,
+  onChange,
+  label,
+  hint,
+  addRowLabel,
+  keyPlaceholder,
+  valuePlaceholder,
+  disabled = false,
+  id,
+}: KeyValueEditorProps) {
+  const { t } = useLanguage('customTools');
+  const [rows, setRows] = useState<Row[]>(() => objectToRows(value || {}));
+  const lastEmittedRef = useRef<string>('');
+
+  useEffect(() => {
+    const currentSerialized = JSON.stringify(rowsToObject(rows));
+    const incomingSerialized = JSON.stringify(value || {});
+    if (currentSerialized !== incomingSerialized && incomingSerialized !== lastEmittedRef.current) {
+      setRows(objectToRows(value || {}));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const emit = (next: Row[]) => {
+    const obj = rowsToObject(next);
+    lastEmittedRef.current = JSON.stringify(obj);
+    onChange(obj);
+  };
+
+  const errors = useMemo(() => {
+    const errs: Record<number, string> = {};
+    const keys = new Map<string, number>();
+    rows.forEach(row => {
+      const trimmed = row.key.trim();
+      const valStr = typeof row.value === 'string' ? row.value : valueToString(row.value);
+      if (!trimmed && valStr.length > 0) {
+        errs[row.id] = t('keyValueEditor.errors.emptyKey');
+        return;
+      }
+      if (trimmed) {
+        if (keys.has(trimmed)) {
+          errs[row.id] = t('keyValueEditor.errors.duplicateKey');
+        } else {
+          keys.set(trimmed, row.id);
+        }
+        if (!row.isComplex && valStr.length === 0) {
+          if (!errs[row.id]) errs[row.id] = t('keyValueEditor.errors.emptyValue');
+        }
+      }
+    });
+    return errs;
+  }, [rows, t]);
+
+  const updateRow = (rowId: number, patch: Partial<Row>) => {
+    const next = rows.map(r => (r.id === rowId ? { ...r, ...patch } : r));
+    setRows(next);
+    emit(next);
+  };
+
+  const handleAddRow = () => {
+    const next = [...rows, { id: nextRowId(), key: '', value: '', isComplex: false }];
+    setRows(next);
+    emit(next);
+  };
+
+  const handleRemoveRow = (rowId: number) => {
+    const next = rows.filter(r => r.id !== rowId);
+    setRows(next);
+    emit(next);
+  };
+
+  return (
+    <div className="space-y-2" data-testid={id ? `${id}-kv-editor` : 'kv-editor'}>
+      <Label>{label}</Label>
+      {rows.length > 0 && (
+        <div className="space-y-2">
+          {rows.map(row => {
+            const err = errors[row.id];
+            const complexStr = row.isComplex ? stringifyComplex(row.value) : '';
+            return (
+              <div key={row.id} className="space-y-1">
+                <div className="flex gap-2 items-start">
+                  <Input
+                    value={row.key}
+                    onChange={e => updateRow(row.id, { key: e.target.value })}
+                    placeholder={keyPlaceholder || t('keyValueEditor.keyPlaceholder')}
+                    disabled={disabled}
+                    aria-label={`${label} key`}
+                    aria-invalid={!!err}
+                    aria-describedby={err ? `${row.id}-err` : undefined}
+                    className={err ? 'border-destructive' : ''}
+                  />
+                  {row.isComplex ? (
+                    <div className="flex-1 flex items-center gap-2 px-3 py-2 text-sm font-mono bg-muted/30 rounded border border-input min-h-[40px]">
+                      <span className="truncate flex-1">{complexStr}</span>
+                      <span
+                        className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground whitespace-nowrap"
+                        title={t('keyValueEditor.complexValueBadge')}
+                      >
+                        {t('keyValueEditor.complexValueBadge')}
+                      </span>
+                    </div>
+                  ) : (
+                    <Input
+                      value={valueToString(row.value)}
+                      onChange={e => updateRow(row.id, { value: e.target.value })}
+                      placeholder={valuePlaceholder || t('keyValueEditor.valuePlaceholder')}
+                      disabled={disabled}
+                      aria-label={`${label} value`}
+                      aria-invalid={!!err}
+                      aria-describedby={err ? `${row.id}-err` : undefined}
+                      className={err ? 'border-destructive' : ''}
+                    />
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemoveRow(row.id)}
+                    disabled={disabled}
+                    aria-label={t('keyValueEditor.removeRow')}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                {err && (
+                  <p id={`${row.id}-err`} className="text-sm text-destructive">
+                    {err}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleAddRow}
+        disabled={disabled}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        {addRowLabel || t('keyValueEditor.addRow')}
+      </Button>
+      {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}

--- a/src/components/ai_agents/shared/TagInput.spec.tsx
+++ b/src/components/ai_agents/shared/TagInput.spec.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import TagInput from './TagInput';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+describe('TagInput', () => {
+  it('renders existing tags as chips with remove buttons', () => {
+    render(<TagInput value={['api', 'http']} onChange={() => {}} label="Tags" />);
+    expect(screen.getByText('api')).toBeTruthy();
+    expect(screen.getByText('http')).toBeTruthy();
+  });
+
+  it('commits a tag on Enter', () => {
+    const onChange = vi.fn();
+    render(<TagInput value={[]} onChange={onChange} label="Tags" />);
+    const input = screen.getByLabelText('Tags');
+    fireEvent.change(input, { target: { value: 'webhook' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith(['webhook']);
+  });
+
+  it('commits a tag on comma', () => {
+    const onChange = vi.fn();
+    render(<TagInput value={['api']} onChange={onChange} label="Tags" />);
+    const input = screen.getByLabelText('Tags');
+    fireEvent.change(input, { target: { value: 'http' } });
+    fireEvent.keyDown(input, { key: ',' });
+    expect(onChange).toHaveBeenLastCalledWith(['api', 'http']);
+  });
+
+  it('ignores duplicate tags', () => {
+    const onChange = vi.fn();
+    render(<TagInput value={['api']} onChange={onChange} label="Tags" />);
+    const input = screen.getByLabelText('Tags');
+    fireEvent.change(input, { target: { value: 'api' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('removes a tag when X is clicked', () => {
+    const onChange = vi.fn();
+    render(<TagInput value={['api', 'http']} onChange={onChange} label="Tags" />);
+    const removeButtons = screen.getAllByRole('button');
+    fireEvent.click(removeButtons[0]);
+    expect(onChange).toHaveBeenLastCalledWith(['http']);
+  });
+
+  it('removes last tag on Backspace with empty input', () => {
+    const onChange = vi.fn();
+    render(<TagInput value={['api', 'http']} onChange={onChange} label="Tags" />);
+    const input = screen.getByLabelText('Tags');
+    fireEvent.keyDown(input, { key: 'Backspace' });
+    expect(onChange).toHaveBeenLastCalledWith(['api']);
+  });
+
+  it('shows suggestions matching the draft', () => {
+    render(
+      <TagInput
+        value={[]}
+        onChange={() => {}}
+        label="Modes"
+        suggestions={['text', 'image', 'audio']}
+      />,
+    );
+    const input = screen.getByLabelText('Modes');
+    fireEvent.change(input, { target: { value: 'i' } });
+    expect(screen.getByText('+ image')).toBeTruthy();
+    expect(screen.queryByText('+ text')).toBeNull();
+  });
+
+  it('clicking a suggestion commits it as a tag', () => {
+    const onChange = vi.fn();
+    render(
+      <TagInput
+        value={[]}
+        onChange={onChange}
+        label="Modes"
+        suggestions={['text', 'image']}
+      />,
+    );
+    const input = screen.getByLabelText('Modes');
+    fireEvent.change(input, { target: { value: 't' } });
+    fireEvent.click(screen.getByText('+ text'));
+    expect(onChange).toHaveBeenLastCalledWith(['text']);
+  });
+});

--- a/src/components/ai_agents/shared/TagInput.tsx
+++ b/src/components/ai_agents/shared/TagInput.tsx
@@ -1,0 +1,127 @@
+import { useState, useRef, KeyboardEvent } from 'react';
+import { Input, Label, Badge } from '@evoapi/design-system';
+import { X } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+
+/** Shared between Custom Tools (EVO-1790) and Custom MCP (EVO-1791) UIs. */
+export interface TagInputProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  label?: string;
+  placeholder?: string;
+  hint?: string;
+  suggestions?: string[];
+  disabled?: boolean;
+  id?: string;
+}
+
+export default function TagInput({
+  value,
+  onChange,
+  label,
+  placeholder,
+  hint,
+  suggestions,
+  disabled = false,
+  id,
+}: TagInputProps) {
+  const { t } = useLanguage('customTools');
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const commitTag = (raw: string) => {
+    const trimmed = raw.trim().replace(/,$/, '').trim();
+    if (!trimmed) return;
+    if (value.includes(trimmed)) {
+      setDraft('');
+      return;
+    }
+    onChange([...value, trimmed]);
+    setDraft('');
+  };
+
+  const removeTag = (idx: number) => {
+    onChange(value.filter((_, i) => i !== idx));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      commitTag(draft);
+    } else if (e.key === 'Backspace' && draft === '' && value.length > 0) {
+      e.preventDefault();
+      removeTag(value.length - 1);
+    }
+  };
+
+  const handleBlur = () => {
+    if (draft.trim()) commitTag(draft);
+  };
+
+  const visibleSuggestions = suggestions?.filter(
+    s => !value.includes(s) && s.toLowerCase().includes(draft.toLowerCase().trim()),
+  );
+
+  return (
+    <div className="space-y-1.5" data-testid={id ? `${id}-tag-input` : 'tag-input'}>
+      {label && <Label className="text-sm font-semibold">{label}</Label>}
+      <div
+        className={`flex flex-wrap gap-1.5 p-2 min-h-[40px] rounded-md border bg-background ${
+          disabled ? 'opacity-60' : 'cursor-text'
+        }`}
+        onClick={() => !disabled && inputRef.current?.focus()}
+      >
+        {value.map((tag, idx) => (
+          <Badge
+            key={`${tag}-${idx}`}
+            variant="secondary"
+            className="gap-1 pl-2 pr-1 py-0.5 text-sm font-normal"
+          >
+            <span>{tag}</span>
+            <button
+              type="button"
+              onClick={e => {
+                e.stopPropagation();
+                removeTag(idx);
+              }}
+              disabled={disabled}
+              aria-label={t('tagInput.removeTag', { tag })}
+              className="hover:bg-muted/50 rounded-sm p-0.5"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        ))}
+        <Input
+          ref={inputRef}
+          value={draft}
+          onChange={e => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          placeholder={value.length === 0 ? placeholder || t('tagInput.placeholder') : ''}
+          disabled={disabled}
+          className="flex-1 min-w-[120px] border-0 shadow-none p-0 h-7 text-sm focus-visible:ring-0"
+          aria-label={label || t('tagInput.placeholder')}
+        />
+      </div>
+      {visibleSuggestions && visibleSuggestions.length > 0 && draft.length > 0 && (
+        <div className="flex flex-wrap gap-1 pt-1">
+          <span className="text-xs text-muted-foreground self-center pr-1">
+            {t('tagInput.suggestions')}:
+          </span>
+          {visibleSuggestions.slice(0, 6).map(sug => (
+            <button
+              key={sug}
+              type="button"
+              onClick={() => commitTag(sug)}
+              className="text-xs px-2 py-0.5 rounded bg-muted hover:bg-muted/70 transition-colors"
+            >
+              + {sug}
+            </button>
+          ))}
+        </div>
+      )}
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}

--- a/src/components/ai_agents/shared/TestRequestButton.spec.tsx
+++ b/src/components/ai_agents/shared/TestRequestButton.spec.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TestRequestButton from './TestRequestButton';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+const mockTestCustomTool = vi.fn();
+vi.mock('@/services/agents/customToolsService', () => ({
+  testCustomTool: (...args: unknown[]) => mockTestCustomTool(...args),
+}));
+
+describe('TestRequestButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('in create mode the button is disabled', () => {
+    render(<TestRequestButton mode="create" />);
+    const btn = screen.getByRole('button', { name: 'testRequest.button' });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('in edit mode without toolId the button is disabled', () => {
+    render(<TestRequestButton mode="edit" />);
+    const btn = screen.getByRole('button', { name: 'testRequest.button' });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('in edit mode with toolId calls testCustomTool and renders result', async () => {
+    mockTestCustomTool.mockResolvedValue({
+      test_result: {
+        error: '',
+        headers: { 'content-type': 'application/json' },
+        response_time: 0.123,
+        status_code: 200,
+        success: true,
+      },
+      tools: {},
+    });
+    render(<TestRequestButton mode="edit" toolId="abc-1" />);
+    const btn = screen.getByRole('button', { name: 'testRequest.button' });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(btn);
+    await waitFor(() => {
+      expect(screen.getByTestId('test-request-result')).toBeTruthy();
+    });
+    expect(mockTestCustomTool).toHaveBeenCalledWith('abc-1');
+    expect(screen.getByText('200')).toBeTruthy();
+    expect(screen.getByText('123ms')).toBeTruthy();
+  });
+
+  it('surfaces error message on failure', async () => {
+    mockTestCustomTool.mockRejectedValue(new Error('network down'));
+    render(<TestRequestButton mode="edit" toolId="abc-2" />);
+    fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+    await waitFor(() => {
+      expect(screen.getByText('network down')).toBeTruthy();
+    });
+  });
+});

--- a/src/components/ai_agents/shared/TestRequestButton.tsx
+++ b/src/components/ai_agents/shared/TestRequestButton.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react';
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@evoapi/design-system';
+import { Play, ChevronDown, Loader2 } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { testCustomTool } from '@/services/agents/customToolsService';
+import type { CustomToolTestResponse } from '@/types/ai';
+
+/** Shared between Custom Tools (EVO-1790) and Custom MCP (EVO-1791) UIs. */
+export interface TestRequestButtonProps {
+  mode: 'create' | 'edit';
+  toolId?: string;
+  onResult?: (result: CustomToolTestResponse['test_result']) => void;
+  disabled?: boolean;
+}
+
+type TestResult = CustomToolTestResponse['test_result'];
+
+const statusColor = (code: number): string => {
+  if (code >= 200 && code < 300) return 'text-emerald-600';
+  if (code >= 300 && code < 400) return 'text-sky-600';
+  if (code >= 400 && code < 500) return 'text-amber-600';
+  if (code >= 500) return 'text-destructive';
+  return 'text-muted-foreground';
+};
+
+const formatBody = (raw: unknown): string => {
+  if (raw === null || raw === undefined) return '';
+  if (typeof raw === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      return raw;
+    }
+  }
+  try {
+    return JSON.stringify(raw, null, 2);
+  } catch {
+    return String(raw);
+  }
+};
+
+export default function TestRequestButton({
+  mode,
+  toolId,
+  onResult,
+  disabled = false,
+}: TestRequestButtonProps) {
+  const { t } = useLanguage('customTools');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [responseBody, setResponseBody] = useState<unknown>(null);
+  const [headersOpen, setHeadersOpen] = useState(false);
+
+  const isCreateMode = mode === 'create';
+  const buttonDisabled = disabled || loading || isCreateMode || !toolId;
+
+  const handleClick = async () => {
+    if (!toolId) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    setResponseBody(null);
+    try {
+      const resp = await testCustomTool(toolId);
+      setResult(resp.test_result);
+      const body = (resp as unknown as Record<string, unknown>).body
+        ?? (resp.test_result as unknown as Record<string, unknown>).body;
+      setResponseBody(body ?? null);
+      onResult?.(resp.test_result);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg || t('testRequest.error'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const button = (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={handleClick}
+      disabled={buttonDisabled}
+      aria-label={t('testRequest.button')}
+    >
+      {loading ? (
+        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+      ) : (
+        <Play className="h-4 w-4 mr-2" />
+      )}
+      {loading ? t('testRequest.testing') : t('testRequest.button')}
+    </Button>
+  );
+
+  return (
+    <div className="space-y-3" data-testid="test-request-button-root">
+      {isCreateMode ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={0}>{button}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {t('testRequest.disabledTooltipCreateMode')}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        button
+      )}
+
+      {error && (
+        <div className="rounded border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {result && (
+        <div
+          className="rounded border bg-muted/20 p-3 space-y-2 text-sm"
+          data-testid="test-request-result"
+        >
+          <div className="flex items-center gap-4">
+            <div>
+              <span className="text-muted-foreground">
+                {t('testRequest.statusCode')}:{' '}
+              </span>
+              <span className={`font-semibold ${statusColor(result.status_code)}`}>
+                {result.status_code}
+              </span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">
+                {t('testRequest.responseTime')}:{' '}
+              </span>
+              <span className="font-medium">{Math.round(result.response_time * 1000)}ms</span>
+            </div>
+          </div>
+
+          {result.error && (
+            <div className="text-destructive text-xs">{result.error}</div>
+          )}
+
+          {result.headers && Object.keys(result.headers).length > 0 && (
+            <Collapsible open={headersOpen} onOpenChange={setHeadersOpen}>
+              <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+                <ChevronDown
+                  className={`h-3 w-3 transition-transform ${
+                    headersOpen ? 'rotate-180' : ''
+                  }`}
+                />
+                {t('testRequest.responseHeaders')} ({Object.keys(result.headers).length})
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-1 rounded bg-background/60 p-2 font-mono text-xs space-y-1">
+                {Object.entries(result.headers).map(([k, v]) => (
+                  <div key={k}>
+                    <span className="text-muted-foreground">{k}:</span>{' '}
+                    <span>{v}</span>
+                  </div>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+
+          {responseBody !== null && (
+            <div>
+              <div className="text-xs text-muted-foreground mb-1">
+                {t('testRequest.responseBody')}
+              </div>
+              <pre className="rounded bg-background/60 p-2 font-mono text-xs overflow-x-auto max-h-64">
+                {formatBody(responseBody)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ai_agents/shared/index.ts
+++ b/src/components/ai_agents/shared/index.ts
@@ -1,0 +1,8 @@
+export { default as KeyValueEditor } from './KeyValueEditor';
+export type { KeyValueEditorProps } from './KeyValueEditor';
+export { default as AdvancedJsonCollapse } from './AdvancedJsonCollapse';
+export type { AdvancedJsonCollapseProps } from './AdvancedJsonCollapse';
+export { default as TestRequestButton } from './TestRequestButton';
+export type { TestRequestButtonProps } from './TestRequestButton';
+export { default as TagInput } from './TagInput';
+export type { TagInputProps } from './TagInput';

--- a/src/components/customTools/CustomToolForm.spec.tsx
+++ b/src/components/customTools/CustomToolForm.spec.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CustomToolForm from './CustomToolForm';
+import type { CustomTool } from '@/types/ai';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/agents/customToolsService', () => ({
+  testCustomTool: vi.fn(),
+}));
+
+const baseTool: CustomTool = {
+  id: 'tool-1',
+  name: 'My Tool',
+  description: 'desc',
+  method: 'GET',
+  endpoint: 'https://api.example.com/users',
+  headers: { Authorization: 'Bearer x' },
+  path_params: { user_id: '{user_id}' },
+  query_params: { page: '1' },
+  body_params: {},
+  error_handling: { timeout: 30 },
+  values: { default_key: 'v' },
+  tags: ['api'],
+  examples: ['ex1'],
+  input_modes: ['text'],
+  output_modes: ['text'],
+  created_at: '2026-06-23T00:00:00Z',
+  updated_at: '2026-06-23T00:00:00Z',
+};
+
+describe('CustomToolForm (refactored)', () => {
+  it('renders no JSON textarea visible by default for headers/params (AC1)', () => {
+    const { container } = render(
+      <CustomToolForm mode="create" onSubmit={() => {}} />,
+    );
+    const monoTextareas = container.querySelectorAll('textarea.font-mono');
+    expect(monoTextareas.length).toBe(0);
+    expect(screen.getAllByText('keyValueEditor.addRow').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('keeps advanced collapse closed by default (AC2)', () => {
+    render(<CustomToolForm mode="create" onSubmit={() => {}} />);
+    expect(screen.queryByLabelText('form.fields.values.label' as never)).toBeNull();
+  });
+
+  it('preserves nested header value byte-identical on save (AC6)', () => {
+    const toolWithNested: CustomTool = {
+      ...baseTool,
+      headers: { auth: { bearer: 'abc' }, plain: 'v' },
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolForm tool={toolWithNested} mode="edit" onSubmit={onSubmit} />);
+    fireEvent.submit(screen.getByText('form.actions.save').closest('form')!);
+    expect(onSubmit).toHaveBeenCalled();
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.headers).toEqual({ auth: { bearer: 'abc' }, plain: 'v' });
+    expect(payload.path_params).toEqual({ user_id: '{user_id}' });
+    expect(payload.query_params).toEqual({ page: '1' });
+    expect(payload.values).toEqual({ default_key: 'v' });
+    expect(payload.error_handling).toEqual({ timeout: 30 });
+    expect(payload.input_modes).toEqual(['text']);
+    expect(payload.output_modes).toEqual(['text']);
+  });
+
+  it('shows body_params editor only for POST/PUT/PATCH', () => {
+    const { rerender } = render(
+      <CustomToolForm mode="create" onSubmit={() => {}} />,
+    );
+    // GET default: 3 key-value editors (headers, query, path)
+    expect(screen.getAllByText('keyValueEditor.addRow').length).toBe(3);
+
+    const toolPost: CustomTool = { ...baseTool, method: 'POST' };
+    rerender(<CustomToolForm tool={toolPost} mode="edit" onSubmit={() => {}} />);
+    // 4 with body_params
+    expect(screen.getAllByText('keyValueEditor.addRow').length).toBe(4);
+  });
+
+  it('opens advanced collapse and shows values/error_handling fields when expanded', () => {
+    render(<CustomToolForm mode="create" onSubmit={() => {}} />);
+    fireEvent.click(screen.getByText('advancedConfig.title'));
+    expect(screen.getByLabelText('form.fields.values.label')).toBeTruthy();
+    expect(screen.getByLabelText('form.fields.errorHandling.label')).toBeTruthy();
+  });
+});

--- a/src/components/customTools/CustomToolForm.tsx
+++ b/src/components/customTools/CustomToolForm.tsx
@@ -21,6 +21,11 @@ import {
   X,
 } from 'lucide-react';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
+import {
+  KeyValueEditor,
+  AdvancedJsonCollapse,
+  TestRequestButton,
+} from '@/components/ai_agents/shared';
 
 
 interface CustomToolFormProps {
@@ -36,7 +41,7 @@ interface FormData {
   description: string;
   method: string;
   endpoint: string;
-  headers: Record<string, string>;
+  headers: Record<string, unknown>;
   path_params: Record<string, unknown>;
   query_params: Record<string, unknown>;
   body_params: Record<string, unknown>;
@@ -76,17 +81,14 @@ export default function CustomToolForm({
 }: CustomToolFormProps) {
   const { t } = useLanguage('customTools');
   const [formData, setFormData] = useState<FormData>(initialFormData);
-  const [headersJson, setHeadersJson] = useState('{}');
-  const [bodyParamsJson, setBodyParamsJson] = useState('{}');
-  const [queryParamsJson, setQueryParamsJson] = useState('{}');
-  const [pathParamsJson, setPathParamsJson] = useState('{}');
   const [valuesJson, setValuesJson] = useState('{}');
   const [errorHandlingJson, setErrorHandlingJson] = useState('{}');
+  const [inputModesJson, setInputModesJson] = useState('[]');
+  const [outputModesJson, setOutputModesJson] = useState('[]');
   const [tagsInput, setTagsInput] = useState('');
   const [newExample, setNewExample] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  // Initialize form data when tool changes
   useEffect(() => {
     if (tool && mode !== 'create') {
       const newFormData: FormData = {
@@ -94,34 +96,30 @@ export default function CustomToolForm({
         description: tool.description || '',
         method: tool.method || 'GET',
         endpoint: tool.endpoint || '',
-        headers: tool.headers as Record<string, string> || {},
-        path_params: tool.path_params as Record<string, unknown> || {},
-        query_params: tool.query_params as Record<string, unknown> || {},
-        body_params: tool.body_params as Record<string, unknown> || {},
-        error_handling: tool.error_handling as Record<string, unknown> || {},
-        values: tool.values as Record<string, unknown> || {},
+        headers: (tool.headers as Record<string, unknown>) || {},
+        path_params: (tool.path_params as Record<string, unknown>) || {},
+        query_params: (tool.query_params as Record<string, unknown>) || {},
+        body_params: (tool.body_params as Record<string, unknown>) || {},
+        error_handling: (tool.error_handling as Record<string, unknown>) || {},
+        values: (tool.values as Record<string, unknown>) || {},
         tags: tool.tags || [],
         examples: tool.examples || [],
-        input_modes: tool.input_modes as string[] || [],
-        output_modes: tool.output_modes as string[] || [],
+        input_modes: (tool.input_modes as string[]) || [],
+        output_modes: (tool.output_modes as string[]) || [],
       };
 
       setFormData(newFormData);
-      setHeadersJson(JSON.stringify(newFormData.headers, null, 2));
-      setBodyParamsJson(JSON.stringify(newFormData.body_params, null, 2));
-      setQueryParamsJson(JSON.stringify(newFormData.query_params, null, 2));
-      setPathParamsJson(JSON.stringify(newFormData.path_params, null, 2));
       setValuesJson(JSON.stringify(newFormData.values, null, 2));
       setErrorHandlingJson(JSON.stringify(newFormData.error_handling, null, 2));
+      setInputModesJson(JSON.stringify(newFormData.input_modes, null, 2));
+      setOutputModesJson(JSON.stringify(newFormData.output_modes, null, 2));
       setTagsInput(newFormData.tags.join(', '));
     } else {
       setFormData(initialFormData);
-      setHeadersJson('{}');
-      setBodyParamsJson('{}');
-      setQueryParamsJson('{}');
-      setPathParamsJson('{}');
       setValuesJson('{}');
       setErrorHandlingJson('{}');
+      setInputModesJson('[]');
+      setOutputModesJson('[]');
       setTagsInput('');
     }
   }, [tool, mode]);
@@ -132,29 +130,24 @@ export default function CustomToolForm({
       [field]: value,
     }));
 
-    // Clear error when user types
     if (errors[field]) {
       setErrors(prev => ({ ...prev, [field]: '' }));
     }
   };
 
-  const handleHeadersChange = (value: string) => {
-    setHeadersJson(value);
-    try {
-      const parsed = JSON.parse(value);
-      setFormData(prev => ({ ...prev, headers: parsed }));
-      if (errors.headers) {
-        setErrors(prev => ({ ...prev, headers: '' }));
-      }
-    } catch {
-      // Invalid JSON, don't update formData but show error on submit
+  const handleKvChange = (
+    field: 'headers' | 'body_params' | 'query_params' | 'path_params',
+  ) => (next: Record<string, unknown>) => {
+    setFormData(prev => ({ ...prev, [field]: next }));
+    if (errors[field]) {
+      setErrors(prev => ({ ...prev, [field]: '' }));
     }
   };
 
-  const handleJsonFieldChange = (
-    field: 'body_params' | 'query_params' | 'path_params' | 'values' | 'error_handling',
+  const handleAdvancedJsonChange = (
+    field: 'values' | 'error_handling',
     value: string,
-    setter: (value: string) => void
+    setter: (value: string) => void,
   ) => {
     setter(value);
     try {
@@ -164,7 +157,26 @@ export default function CustomToolForm({
         setErrors(prev => ({ ...prev, [field]: '' }));
       }
     } catch {
-      // Invalid JSON, don't update formData but show error on submit
+      // Surface on submit
+    }
+  };
+
+  const handleModesJsonChange = (
+    field: 'input_modes' | 'output_modes',
+    value: string,
+    setter: (value: string) => void,
+  ) => {
+    setter(value);
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        setFormData(prev => ({ ...prev, [field]: parsed as string[] }));
+        if (errors[field]) {
+          setErrors(prev => ({ ...prev, [field]: '' }));
+        }
+      }
+    } catch {
+      // Surface on submit
     }
   };
 
@@ -213,30 +225,6 @@ export default function CustomToolForm({
     }
 
     try {
-      JSON.parse(headersJson);
-    } catch {
-      newErrors.headers = t('form.validation.headersInvalid');
-    }
-
-    try {
-      JSON.parse(bodyParamsJson);
-    } catch {
-      newErrors.body_params = t('form.validation.bodyParamsInvalid');
-    }
-
-    try {
-      JSON.parse(queryParamsJson);
-    } catch {
-      newErrors.query_params = t('form.validation.queryParamsInvalid');
-    }
-
-    try {
-      JSON.parse(pathParamsJson);
-    } catch {
-      newErrors.path_params = t('form.validation.pathParamsInvalid');
-    }
-
-    try {
       JSON.parse(valuesJson);
     } catch {
       newErrors.values = t('form.validation.valuesInvalid');
@@ -246,6 +234,24 @@ export default function CustomToolForm({
       JSON.parse(errorHandlingJson);
     } catch {
       newErrors.error_handling = t('form.validation.errorHandlingInvalid');
+    }
+
+    try {
+      const parsedInputModes = JSON.parse(inputModesJson);
+      if (!Array.isArray(parsedInputModes)) {
+        newErrors.input_modes = t('form.validation.inputModesInvalid');
+      }
+    } catch {
+      newErrors.input_modes = t('form.validation.inputModesInvalid');
+    }
+
+    try {
+      const parsedOutputModes = JSON.parse(outputModesJson);
+      if (!Array.isArray(parsedOutputModes)) {
+        newErrors.output_modes = t('form.validation.outputModesInvalid');
+      }
+    } catch {
+      newErrors.output_modes = t('form.validation.outputModesInvalid');
     }
 
     setErrors(newErrors);
@@ -278,6 +284,11 @@ export default function CustomToolForm({
 
     onSubmit(submitData);
   };
+
+  const showBodyParams =
+    formData.method === 'POST' ||
+    formData.method === 'PUT' ||
+    formData.method === 'PATCH';
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -366,109 +377,119 @@ export default function CustomToolForm({
             {errors.endpoint && <p className="text-sm text-destructive">{errors.endpoint}</p>}
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="headers">{t('form.fields.headers.label')}</Label>
-            <Textarea
-              id="headers"
-              value={headersJson}
-              onChange={e => handleHeadersChange(e.target.value)}
-              placeholder={t('form.fields.headers.placeholder')}
-              disabled={loading}
-              rows={6}
-              className={`font-mono ${errors.headers ? 'border-destructive' : ''}`}
-            />
-            {errors.headers && <p className="text-sm text-destructive">{errors.headers}</p>}
-            <p className="text-sm text-muted-foreground">
-              {t('form.fields.headers.hint')}
-            </p>
-          </div>
+          <KeyValueEditor
+            id="headers"
+            label={t('form.fields.headers.labelKv')}
+            value={formData.headers}
+            onChange={handleKvChange('headers')}
+            disabled={loading}
+            hint={t('form.fields.headers.hint')}
+            keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
+            valuePlaceholder={t('form.fields.headers.valuePlaceholder')}
+          />
 
-          {(formData.method === 'POST' || formData.method === 'PUT' || formData.method === 'PATCH') && (
-            <div className="space-y-2">
-              <Label htmlFor="body_params">{t('form.fields.bodyParams.label')}</Label>
-              <Textarea
-                id="body_params"
-                value={bodyParamsJson}
-                onChange={e => handleJsonFieldChange('body_params', e.target.value, setBodyParamsJson)}
-                placeholder={t('form.fields.bodyParams.placeholder')}
-                disabled={loading}
-                rows={6}
-                className={`font-mono ${errors.body_params ? 'border-destructive' : ''}`}
-              />
-              {errors.body_params && <p className="text-sm text-destructive">{errors.body_params}</p>}
-              <p className="text-sm text-muted-foreground">
-                {t('form.fields.bodyParams.hint')}
-              </p>
-            </div>
+          {showBodyParams && (
+            <KeyValueEditor
+              id="body_params"
+              label={t('form.fields.bodyParams.labelKv')}
+              value={formData.body_params}
+              onChange={handleKvChange('body_params')}
+              disabled={loading}
+              hint={t('form.fields.bodyParams.hint')}
+              keyPlaceholder={t('form.fields.bodyParams.keyPlaceholder')}
+              valuePlaceholder={t('form.fields.bodyParams.valuePlaceholder')}
+            />
           )}
 
-          <div className="space-y-2">
-            <Label htmlFor="query_params">{t('form.fields.queryParams.label')}</Label>
-            <Textarea
-              id="query_params"
-              value={queryParamsJson}
-              onChange={e => handleJsonFieldChange('query_params', e.target.value, setQueryParamsJson)}
-              placeholder={t('form.fields.queryParams.placeholder')}
-              disabled={loading}
-              rows={6}
-              className={`font-mono ${errors.query_params ? 'border-destructive' : ''}`}
-            />
-            {errors.query_params && <p className="text-sm text-destructive">{errors.query_params}</p>}
-            <p className="text-sm text-muted-foreground">
-              {t('form.fields.queryParams.hint')}
-            </p>
-          </div>
+          <KeyValueEditor
+            id="query_params"
+            label={t('form.fields.queryParams.labelKv')}
+            value={formData.query_params}
+            onChange={handleKvChange('query_params')}
+            disabled={loading}
+            hint={t('form.fields.queryParams.hint')}
+            keyPlaceholder={t('form.fields.queryParams.keyPlaceholder')}
+            valuePlaceholder={t('form.fields.queryParams.valuePlaceholder')}
+          />
 
-          <div className="space-y-2">
-            <Label htmlFor="path_params">{t('form.fields.pathParams.label')}</Label>
-            <Textarea
-              id="path_params"
-              value={pathParamsJson}
-              onChange={e => handleJsonFieldChange('path_params', e.target.value, setPathParamsJson)}
-              placeholder={t('form.fields.pathParams.placeholder')}
-              disabled={loading}
-              rows={6}
-              className={`font-mono ${errors.path_params ? 'border-destructive' : ''}`}
-            />
-            {errors.path_params && <p className="text-sm text-destructive">{errors.path_params}</p>}
-            <p className="text-sm text-muted-foreground">
-              {t('form.fields.pathParams.hint')}
-            </p>
-          </div>
+          <KeyValueEditor
+            id="path_params"
+            label={t('form.fields.pathParams.labelKv')}
+            value={formData.path_params}
+            onChange={handleKvChange('path_params')}
+            disabled={loading}
+            hint={t('form.fields.pathParams.hint')}
+            keyPlaceholder={t('form.fields.pathParams.keyPlaceholder')}
+            valuePlaceholder={t('form.fields.pathParams.valuePlaceholder')}
+          />
 
-          <div className="space-y-2">
-            <Label htmlFor="values">{t('form.fields.values.label')}</Label>
-            <Textarea
-              id="values"
-              value={valuesJson}
-              onChange={e => handleJsonFieldChange('values', e.target.value, setValuesJson)}
-              placeholder={t('form.fields.values.placeholder')}
-              disabled={loading}
-              rows={6}
-              className={`font-mono ${errors.values ? 'border-destructive' : ''}`}
-            />
-            {errors.values && <p className="text-sm text-destructive">{errors.values}</p>}
-            <p className="text-sm text-muted-foreground">
-              {t('form.fields.values.hint')}
-            </p>
-          </div>
+          <TestRequestButton
+            mode={mode === 'create' ? 'create' : 'edit'}
+            toolId={tool?.id}
+            disabled={loading}
+          />
 
-          <div className="space-y-2">
-            <Label htmlFor="error_handling">{t('form.fields.errorHandling.label')}</Label>
-            <Textarea
-              id="error_handling"
-              value={errorHandlingJson}
-              onChange={e => handleJsonFieldChange('error_handling', e.target.value, setErrorHandlingJson)}
-              placeholder={t('form.fields.errorHandling.placeholder')}
-              disabled={loading}
-              rows={6}
-              className={`font-mono ${errors.error_handling ? 'border-destructive' : ''}`}
-            />
-            {errors.error_handling && <p className="text-sm text-destructive">{errors.error_handling}</p>}
-            <p className="text-sm text-muted-foreground">
-              {t('form.fields.errorHandling.hint')}
-            </p>
-          </div>
+          <AdvancedJsonCollapse title={t('advancedConfig.title')}>
+            <div className="space-y-2">
+              <Label htmlFor="values">{t('form.fields.values.label')}</Label>
+              <Textarea
+                id="values"
+                value={valuesJson}
+                onChange={e => handleAdvancedJsonChange('values', e.target.value, setValuesJson)}
+                placeholder={t('form.fields.values.placeholder')}
+                disabled={loading}
+                rows={6}
+                className={`font-mono ${errors.values ? 'border-destructive' : ''}`}
+              />
+              {errors.values && <p className="text-sm text-destructive">{errors.values}</p>}
+              <p className="text-sm text-muted-foreground">{t('form.fields.values.hint')}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="error_handling">{t('form.fields.errorHandling.label')}</Label>
+              <Textarea
+                id="error_handling"
+                value={errorHandlingJson}
+                onChange={e => handleAdvancedJsonChange('error_handling', e.target.value, setErrorHandlingJson)}
+                placeholder={t('form.fields.errorHandling.placeholder')}
+                disabled={loading}
+                rows={6}
+                className={`font-mono ${errors.error_handling ? 'border-destructive' : ''}`}
+              />
+              {errors.error_handling && <p className="text-sm text-destructive">{errors.error_handling}</p>}
+              <p className="text-sm text-muted-foreground">{t('form.fields.errorHandling.hint')}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="input_modes">{t('form.fields.inputModes.label')}</Label>
+              <Textarea
+                id="input_modes"
+                value={inputModesJson}
+                onChange={e => handleModesJsonChange('input_modes', e.target.value, setInputModesJson)}
+                placeholder={t('form.fields.inputModes.placeholder')}
+                disabled={loading}
+                rows={3}
+                className={`font-mono ${errors.input_modes ? 'border-destructive' : ''}`}
+              />
+              {errors.input_modes && <p className="text-sm text-destructive">{errors.input_modes}</p>}
+              <p className="text-sm text-muted-foreground">{t('form.fields.inputModes.hint')}</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="output_modes">{t('form.fields.outputModes.label')}</Label>
+              <Textarea
+                id="output_modes"
+                value={outputModesJson}
+                onChange={e => handleModesJsonChange('output_modes', e.target.value, setOutputModesJson)}
+                placeholder={t('form.fields.outputModes.placeholder')}
+                disabled={loading}
+                rows={3}
+                className={`font-mono ${errors.output_modes ? 'border-destructive' : ''}`}
+              />
+              {errors.output_modes && <p className="text-sm text-destructive">{errors.output_modes}</p>}
+              <p className="text-sm text-muted-foreground">{t('form.fields.outputModes.hint')}</p>
+            </div>
+          </AdvancedJsonCollapse>
         </div>
       </div>
 

--- a/src/components/customTools/CustomToolModal.tsx
+++ b/src/components/customTools/CustomToolModal.tsx
@@ -13,7 +13,11 @@ interface CustomToolModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tool?: CustomTool;
-  mode?: 'create' | 'edit' | 'view';
+  /**
+   * Edit or view existing tools. Create flow is handled by the standalone
+   * wizard page at `/agents/custom-tools/new` (see CustomToolWizardModal embedded mode).
+   */
+  mode?: 'edit' | 'view';
   loading?: boolean;
   onSubmit: (data: CustomToolFormData) => void;
 }
@@ -22,7 +26,7 @@ export default function CustomToolModal({
   open,
   onOpenChange,
   tool,
-  mode = 'create',
+  mode = 'edit',
   loading = false,
   onSubmit,
 }: CustomToolModalProps) {
@@ -32,20 +36,14 @@ export default function CustomToolModal({
     onOpenChange(false);
   };
 
-  const handleSubmit = (data: CustomToolFormData) => {
-    onSubmit(data);
-  };
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[90vh] p-0">
+      <DialogContent className="max-w-2xl max-h-[90vh] p-0">
         <DialogHeader className="px-6 py-4 border-b">
           <DialogTitle className="text-xl">
-            {mode === 'create'
-              ? t('modal.title.create')
-              : mode === 'view'
-                ? (tool?.name ? t('modal.title.view', { name: tool.name }) : t('modal.title.viewFallback'))
-                : (tool?.name ? t('modal.title.edit', { name: tool.name }) : t('modal.title.editFallback'))}
+            {mode === 'view'
+              ? (tool?.name ? t('modal.title.view', { name: tool.name }) : t('modal.title.viewFallback'))
+              : (tool?.name ? t('modal.title.edit', { name: tool.name }) : t('modal.title.editFallback'))}
           </DialogTitle>
         </DialogHeader>
 
@@ -54,7 +52,7 @@ export default function CustomToolModal({
             tool={tool}
             mode={mode}
             loading={loading}
-            onSubmit={handleSubmit}
+            onSubmit={onSubmit}
             onCancel={handleCancel}
           />
         </ScrollArea>

--- a/src/components/customTools/CustomToolTestResultDialog.spec.tsx
+++ b/src/components/customTools/CustomToolTestResultDialog.spec.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CustomToolTestResultDialog from './CustomToolTestResultDialog';
+import type { CustomTool } from '@/types/ai';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+const baseTool: CustomTool = {
+  id: 'tool-1',
+  name: 'My Tool',
+  description: 'desc',
+  method: 'GET',
+  endpoint: 'https://api.example.com/x',
+  headers: {},
+  path_params: {},
+  query_params: {},
+  body_params: {},
+  error_handling: {},
+  values: {},
+  tags: [],
+  examples: [],
+  input_modes: [],
+  output_modes: [],
+  created_at: '2026-06-24T00:00:00Z',
+  updated_at: '2026-06-24T00:00:00Z',
+};
+
+describe('CustomToolTestResultDialog', () => {
+  it('renders success title and metrics when test succeeded', () => {
+    render(
+      <CustomToolTestResultDialog
+        open
+        onOpenChange={() => {}}
+        tool={baseTool}
+        result={{
+          success: true,
+          status_code: 200,
+          response_time: 0.123,
+          headers: { 'content-type': 'application/json' },
+          error: '',
+        }}
+      />,
+    );
+    expect(screen.getByText('testResult.titleSuccess')).toBeTruthy();
+    expect(screen.getByText('200')).toBeTruthy();
+    // Backend sends seconds; UI renders rounded milliseconds.
+    expect(screen.getByText('123ms')).toBeTruthy();
+  });
+
+  it('renders failure title and error message when test failed with DNS error', () => {
+    render(
+      <CustomToolTestResultDialog
+        open
+        onOpenChange={() => {}}
+        tool={baseTool}
+        result={{
+          success: false,
+          status_code: 0 as unknown as number,
+          response_time: 0,
+          headers: {},
+          error: 'HTTP request failed: dial tcp: lookup api.example.com: no such host',
+        }}
+      />,
+    );
+    expect(screen.getByText('testResult.titleError')).toBeTruthy();
+    expect(screen.getByText('testResult.errorLabel')).toBeTruthy();
+    expect(
+      screen.getByText(/HTTP request failed: dial tcp/),
+    ).toBeTruthy();
+    // Both metrics show "—" when status/time absent
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows "no data" hint when failure has neither error nor status', () => {
+    render(
+      <CustomToolTestResultDialog
+        open
+        onOpenChange={() => {}}
+        tool={baseTool}
+        result={{
+          success: false,
+          status_code: 0 as unknown as number,
+          response_time: 0,
+          headers: {},
+          error: '',
+        }}
+      />,
+    );
+    expect(screen.getByText('testResult.noData')).toBeTruthy();
+  });
+
+  it('calls onOpenChange(false) when Close is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <CustomToolTestResultDialog
+        open
+        onOpenChange={onOpenChange}
+        tool={baseTool}
+        result={{
+          success: true,
+          status_code: 200,
+          response_time: 50,
+          headers: {},
+          error: '',
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByText('testResult.close'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/customTools/CustomToolTestResultDialog.tsx
+++ b/src/components/customTools/CustomToolTestResultDialog.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@evoapi/design-system';
+import { CheckCircle2, XCircle, ChevronDown, Clock, Activity } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import type { CustomTool, CustomToolTestResponse } from '@/types/ai';
+
+type TestResult = CustomToolTestResponse['test_result'] & {
+  body?: unknown;
+};
+
+interface CustomToolTestResultDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tool: CustomTool | null;
+  result: TestResult | null;
+}
+
+const statusColor = (code: number | undefined): string => {
+  if (!code) return 'text-muted-foreground';
+  if (code >= 200 && code < 300) return 'text-emerald-600';
+  if (code >= 300 && code < 400) return 'text-sky-600';
+  if (code >= 400 && code < 500) return 'text-amber-600';
+  return 'text-destructive';
+};
+
+const formatBody = (raw: unknown): string => {
+  if (raw === null || raw === undefined) return '';
+  if (typeof raw === 'string') {
+    try {
+      return JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      return raw;
+    }
+  }
+  try {
+    return JSON.stringify(raw, null, 2);
+  } catch {
+    return String(raw);
+  }
+};
+
+export default function CustomToolTestResultDialog({
+  open,
+  onOpenChange,
+  tool,
+  result,
+}: CustomToolTestResultDialogProps) {
+  const { t } = useLanguage('customTools');
+  const [headersOpen, setHeadersOpen] = useState(false);
+
+  const isSuccess = !!result?.success;
+  const hasStatusCode = !!result?.status_code;
+  const hasHeaders =
+    !!result?.headers && Object.keys(result.headers).length > 0;
+  const hasBody = result?.body !== undefined && result?.body !== null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden p-0">
+        <DialogHeader className="px-6 py-4 border-b">
+          <DialogTitle className="text-xl flex items-center gap-2">
+            {isSuccess ? (
+              <CheckCircle2 className="h-6 w-6 text-emerald-500" />
+            ) : (
+              <XCircle className="h-6 w-6 text-destructive" />
+            )}
+            <span>
+              {isSuccess
+                ? t('testResult.titleSuccess')
+                : t('testResult.titleError')}
+            </span>
+          </DialogTitle>
+          {tool && (
+            <p className="text-sm text-muted-foreground pt-1">
+              {tool.method} · {tool.name}
+            </p>
+          )}
+        </DialogHeader>
+
+        <div className="overflow-y-auto max-h-[calc(85vh-100px)] px-6 py-4 space-y-4">
+          {tool && (
+            <div className="text-xs font-mono text-muted-foreground bg-muted/30 rounded px-3 py-2 break-all">
+              {tool.endpoint}
+            </div>
+          )}
+
+          {/* Top metrics */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded border bg-muted/20 px-3 py-2.5">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+                <Activity className="h-3.5 w-3.5" />
+                {t('testResult.statusCode')}
+              </div>
+              <div className={`text-lg font-semibold ${statusColor(result?.status_code)}`}>
+                {hasStatusCode ? result?.status_code : '—'}
+              </div>
+            </div>
+            <div className="rounded border bg-muted/20 px-3 py-2.5">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+                <Clock className="h-3.5 w-3.5" />
+                {t('testResult.responseTime')}
+              </div>
+              <div className="text-lg font-semibold">
+                {result?.response_time !== undefined && result.response_time > 0
+                  ? `${Math.round(result.response_time * 1000)}ms`
+                  : '—'}
+              </div>
+            </div>
+          </div>
+
+          {/* Error message */}
+          {!isSuccess && result?.error && (
+            <div className="rounded border border-destructive/40 bg-destructive/10 p-3">
+              <p className="text-xs font-semibold text-destructive mb-1">
+                {t('testResult.errorLabel')}
+              </p>
+              <p className="text-sm text-destructive break-words">
+                {result.error}
+              </p>
+            </div>
+          )}
+
+          {/* Headers */}
+          {hasHeaders && (
+            <Collapsible open={headersOpen} onOpenChange={setHeadersOpen}>
+              <CollapsibleTrigger className="flex items-center gap-1 text-sm font-medium hover:text-foreground">
+                <ChevronDown
+                  className={`h-4 w-4 transition-transform ${headersOpen ? 'rotate-180' : ''}`}
+                />
+                {t('testResult.responseHeaders')} ({Object.keys(result!.headers).length})
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-2 rounded border bg-muted/20 p-3 font-mono text-xs space-y-1">
+                {Object.entries(result!.headers).map(([k, v]) => (
+                  <div key={k} className="break-all">
+                    <span className="text-muted-foreground">{k}:</span>{' '}
+                    <span>{v}</span>
+                  </div>
+                ))}
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+
+          {/* Body */}
+          {hasBody && (
+            <div>
+              <p className="text-sm font-medium mb-1.5">
+                {t('testResult.responseBody')}
+              </p>
+              <pre className="rounded border bg-muted/20 p-3 font-mono text-xs overflow-x-auto max-h-72">
+                {formatBody(result?.body)}
+              </pre>
+            </div>
+          )}
+
+          {/* No data hint */}
+          {!isSuccess && !result?.error && !hasStatusCode && (
+            <p className="text-sm text-muted-foreground italic">
+              {t('testResult.noData')}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end px-6 py-3 border-t bg-muted/20">
+          <Button onClick={() => onOpenChange(false)}>
+            {t('testResult.close')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/customTools/CustomToolWizardModal.spec.tsx
+++ b/src/components/customTools/CustomToolWizardModal.spec.tsx
@@ -269,6 +269,39 @@ describe('CustomToolWizardModal', () => {
     expect(values.__modes_meta__).toBeUndefined();
   });
 
+  it('dedupes input_modes/output_modes on save (R2 self-review fix)', () => {
+    // Honest scenario: the tool already has a duplicate in input_modes
+    // (could come from a prior bad save, an admin SQL edit, or — the
+    // real motivating case — the user picking a primary mode that was
+    // already in extras). With dedup off, save would re-emit duplicates;
+    // with dedup on, the output collapses to unique entries.
+    const editTool = {
+      id: 'tool-dedup',
+      name: 'Dedup Tool',
+      description: '',
+      method: 'GET',
+      endpoint: 'https://api.example.com/d',
+      headers: {},
+      path_params: {},
+      query_params: {},
+      body_params: {},
+      error_handling: {},
+      values: {},
+      tags: [],
+      examples: [],
+      input_modes: ['text', 'text', 'image'],
+      output_modes: ['json', 'json'],
+      created_at: '2026-06-25T00:00:00Z',
+      updated_at: '2026-06-25T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: editTool, onSubmit })} />);
+    walkToFinishAndSave();
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.input_modes).toEqual(['text', 'image']);
+    expect(payload.output_modes).toEqual(['json']);
+  });
+
   it('keeps unrelated values entries intact when no mode descriptions are set', () => {
     const editTool = {
       id: 'tool-values',

--- a/src/components/customTools/CustomToolWizardModal.spec.tsx
+++ b/src/components/customTools/CustomToolWizardModal.spec.tsx
@@ -1,0 +1,156 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CustomToolWizardModal from './CustomToolWizardModal';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/services/agents/customToolsService', () => ({
+  testCustomTool: vi.fn(),
+}));
+
+const makeProps = (overrides: Record<string, unknown> = {}) => ({
+  open: true,
+  onOpenChange: vi.fn(),
+  onSubmit: vi.fn(),
+  loading: false,
+  ...overrides,
+});
+
+describe('CustomToolWizardModal', () => {
+  it('starts on step 1 (identity) showing name field and continue disabled', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    expect(screen.getByText('wizard.step1.title')).toBeTruthy();
+    const continueBtn = screen.getByRole('button', { name: 'wizard.actions.continue' });
+    expect((continueBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('advances from step 1 to step 2 after filling name', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[0], { target: { value: 'My Tool' } });
+    const continueBtn = screen.getByRole('button', { name: 'wizard.actions.continue' });
+    expect((continueBtn as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(continueBtn);
+    expect(screen.getByText('wizard.step2.title')).toBeTruthy();
+  });
+
+  it('blocks step 2 → step 3 when endpoint is empty or invalid', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    const nameInput = screen.getAllByRole('textbox')[0];
+    fireEvent.change(nameInput, { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+
+    const endpointInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+    fireEvent.change(endpointInput, { target: { value: 'not a url' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+    expect(screen.getByText('form.validation.endpointInvalid')).toBeTruthy();
+    expect(screen.getByText('wizard.step2.title')).toBeTruthy();
+  });
+
+  it('back button returns to previous step', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'X' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+    expect(screen.getByText('wizard.step2.title')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.back' }));
+    expect(screen.getByText('wizard.step1.title')).toBeTruthy();
+  });
+
+  it('prefills wizard from tool prop in edit mode and shows save label on submit', () => {
+    const editTool = {
+      id: 'tool-edit-1',
+      name: 'My Existing Tool',
+      description: 'desc',
+      method: 'POST',
+      endpoint: 'https://api.example.com/v1',
+      headers: { Authorization: 'Bearer abc' },
+      path_params: {},
+      query_params: {},
+      body_params: { name: 'value' },
+      error_handling: { timeout: 45 },
+      values: { __modes_meta__: { input: 'doc image', output: 'json data' } },
+      tags: ['api'],
+      examples: ['ex1'],
+      input_modes: ['image'],
+      output_modes: ['json'],
+      created_at: '2026-06-24T00:00:00Z',
+      updated_at: '2026-06-24T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: editTool, onSubmit })} />);
+    // Name prefilled
+    expect(screen.getByDisplayValue('My Existing Tool')).toBeTruthy();
+    // Tag prefilled as chip
+    expect(screen.getByText('api')).toBeTruthy();
+    // Walk to step 6 to verify save button label
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 1 -> 2
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 2 -> 3
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 3 -> 4
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 4 -> 5
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 5 -> 6
+    // In edit mode, submit button reads "save" instead of "create"
+    expect(screen.getByRole('button', { name: 'wizard.actions.save' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.save' }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0];
+    // input_modes stays as ['image'] (single-element wrap), modes_meta round-trips through values
+    expect(payload.input_modes).toEqual(['image']);
+    expect(payload.output_modes).toEqual(['json']);
+    expect((payload.values as Record<string, unknown>).__modes_meta__).toEqual({
+      input: 'doc image',
+      output: 'json data',
+    });
+    // Other fields preserved
+    expect(payload.name).toBe('My Existing Tool');
+    expect(payload.headers).toEqual({ Authorization: 'Bearer abc' });
+    expect(payload.body_params).toEqual({ name: 'value' });
+  });
+
+  it('renders without a Dialog wrapper when embedded=true', () => {
+    const { container } = render(
+      <CustomToolWizardModal {...makeProps({ embedded: true })} />,
+    );
+    // Embedded mode skips Radix Dialog: no [role="dialog"] portal, content rendered inline
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    // But the wizard content (step 1 header) is still visible
+    expect(screen.getByText('wizard.step1.title')).toBeTruthy();
+  });
+
+  it('submits payload at the end of the flow with collected data', () => {
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ onSubmit })} />);
+
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'My Tool' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+
+    const endpointInput = screen.getAllByRole('textbox')[0] as HTMLInputElement;
+    fireEvent.change(endpointInput, { target: { value: 'https://api.example.com/x' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+
+    // step 3
+    expect(screen.getByText('wizard.step3.title')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+
+    // step 4
+    expect(screen.getByText('wizard.step4.title')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+
+    // step 5 - modes
+    expect(screen.getByText('wizard.step5.title')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+
+    // step 6 - create
+    expect(screen.getByText('wizard.step6.title')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.create' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.name).toBe('My Tool');
+    expect(payload.endpoint).toBe('https://api.example.com/x');
+    expect(payload.method).toBe('GET');
+    expect(payload.headers).toEqual({});
+    expect(payload.examples).toEqual([]);
+  });
+});

--- a/src/components/customTools/CustomToolWizardModal.spec.tsx
+++ b/src/components/customTools/CustomToolWizardModal.spec.tsx
@@ -98,10 +98,14 @@ describe('CustomToolWizardModal', () => {
     // input_modes stays as ['image'] (single-element wrap), modes_meta round-trips through values
     expect(payload.input_modes).toEqual(['image']);
     expect(payload.output_modes).toEqual(['json']);
-    expect((payload.values as Record<string, unknown>).__modes_meta__).toEqual({
+    // Legacy unnamespaced __modes_meta__ is migrated to the namespaced key
+    // on save; the old key must not be re-emitted (or the user could end up
+    // with two divergent copies).
+    expect((payload.values as Record<string, unknown>).__evo_modes_meta__).toEqual({
       input: 'doc image',
       output: 'json data',
     });
+    expect((payload.values as Record<string, unknown>).__modes_meta__).toBeUndefined();
     // Other fields preserved
     expect(payload.name).toBe('My Existing Tool');
     expect(payload.headers).toEqual({ Authorization: 'Bearer abc' });
@@ -152,5 +156,146 @@ describe('CustomToolWizardModal', () => {
     expect(payload.method).toBe('GET');
     expect(payload.headers).toEqual({});
     expect(payload.examples).toEqual([]);
+  });
+
+  // ----- AC6 regression coverage: PUT must NOT erase fields outside what
+  // the wizard UI exposes. The wizard reads them into hidden state on edit
+  // and re-emits them on save.
+
+  const walkToFinishAndSave = () => {
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 1 -> 2
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 2 -> 3
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 3 -> 4
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 4 -> 5
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 5 -> 6
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.save' }));
+  };
+
+  it('preserves error_handling extras across an unmodified edit cycle (AC6)', () => {
+    const editTool = {
+      id: 'tool-eh',
+      name: 'EH Tool',
+      description: '',
+      method: 'POST',
+      endpoint: 'https://api.example.com/y',
+      headers: {},
+      path_params: {},
+      query_params: {},
+      body_params: {},
+      // 3 promoted + 2 extras. Extras MUST survive the round trip.
+      error_handling: {
+        timeout: 30,
+        retry_count: 2,
+        fallback_response: 'static',
+        custom_field: 'kept',
+        on_429: { strategy: 'backoff', wait_seconds: 60 },
+      },
+      values: {},
+      tags: [],
+      examples: [],
+      input_modes: [],
+      output_modes: [],
+      created_at: '2026-06-24T00:00:00Z',
+      updated_at: '2026-06-24T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: editTool, onSubmit })} />);
+    walkToFinishAndSave();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const eh = onSubmit.mock.calls[0][0].error_handling as Record<string, unknown>;
+    expect(eh.timeout).toBe(30);
+    expect(eh.retry_count).toBe(2);
+    expect(eh.fallback_response).toBe('static');
+    expect(eh.custom_field).toBe('kept');
+    expect(eh.on_429).toEqual({ strategy: 'backoff', wait_seconds: 60 });
+  });
+
+  it('preserves trailing input_modes/output_modes beyond the primary (AC6)', () => {
+    const editTool = {
+      id: 'tool-modes',
+      name: 'Modes Tool',
+      description: '',
+      method: 'GET',
+      endpoint: 'https://api.example.com/z',
+      headers: {},
+      path_params: {},
+      query_params: {},
+      body_params: {},
+      error_handling: {},
+      values: {},
+      tags: [],
+      examples: [],
+      input_modes: ['stream', 'batch', 'realtime'],
+      output_modes: ['json', 'csv'],
+      created_at: '2026-06-24T00:00:00Z',
+      updated_at: '2026-06-24T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: editTool, onSubmit })} />);
+    walkToFinishAndSave();
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.input_modes).toEqual(['stream', 'batch', 'realtime']);
+    expect(payload.output_modes).toEqual(['json', 'csv']);
+  });
+
+  it('reads tools written with the namespaced __evo_modes_meta__ key', () => {
+    const editTool = {
+      id: 'tool-ns',
+      name: 'NS Tool',
+      description: '',
+      method: 'GET',
+      endpoint: 'https://api.example.com/n',
+      headers: {},
+      path_params: {},
+      query_params: {},
+      body_params: {},
+      error_handling: {},
+      values: { __evo_modes_meta__: { input: 'foo', output: 'bar' }, real_key: 'kept' },
+      tags: [],
+      examples: [],
+      input_modes: [],
+      output_modes: [],
+      created_at: '2026-06-24T00:00:00Z',
+      updated_at: '2026-06-24T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: editTool, onSubmit })} />);
+    walkToFinishAndSave();
+    const payload = onSubmit.mock.calls[0][0];
+    const values = payload.values as Record<string, unknown>;
+    expect(values.__evo_modes_meta__).toEqual({ input: 'foo', output: 'bar' });
+    expect(values.real_key).toBe('kept');
+    // Legacy key must NOT leak in.
+    expect(values.__modes_meta__).toBeUndefined();
+  });
+
+  it('keeps unrelated values entries intact when no mode descriptions are set', () => {
+    const editTool = {
+      id: 'tool-values',
+      name: 'Values Tool',
+      description: '',
+      method: 'GET',
+      endpoint: 'https://api.example.com/v',
+      headers: {},
+      path_params: {},
+      query_params: {},
+      body_params: {},
+      error_handling: {},
+      values: { alpha: 'a', beta: 'b' },
+      tags: [],
+      examples: [],
+      input_modes: [],
+      output_modes: [],
+      created_at: '2026-06-24T00:00:00Z',
+      updated_at: '2026-06-24T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: editTool, onSubmit })} />);
+    walkToFinishAndSave();
+    const values = onSubmit.mock.calls[0][0].values as Record<string, unknown>;
+    expect(values.alpha).toBe('a');
+    expect(values.beta).toBe('b');
+    expect(values.__evo_modes_meta__).toBeUndefined();
+    expect(values.__modes_meta__).toBeUndefined();
   });
 });

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -25,31 +25,88 @@ interface CustomToolWizardModalProps {
   tool?: CustomTool;
 }
 
-const MODES_META_KEY = '__modes_meta__';
+// Namespaced key for the wizard's mode-description side-channel inside
+// `values`. The legacy unnamespaced key __modes_meta__ is still READ for
+// back-compat (tools saved by older wizard builds) but never WRITTEN, and
+// if the user has a real entry under either key it is preserved in
+// `error_handling_extras`/`values_extras` and round-trips intact.
+const MODES_META_KEY = '__evo_modes_meta__';
+const LEGACY_MODES_META_KEY = '__modes_meta__';
+
+const looksLikeModesMeta = (v: unknown): v is { input?: unknown; output?: unknown } =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
 
 const extractModesMeta = (
   values: Record<string, unknown> | undefined,
-): { input: string; output: string; cleanValues: Record<string, unknown> } => {
+): {
+  input: string;
+  output: string;
+  cleanValues: Record<string, unknown>;
+} => {
   const safeValues = values || {};
-  const meta = safeValues[MODES_META_KEY];
-  const cleanValues = { ...safeValues };
-  delete cleanValues[MODES_META_KEY];
-  if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
-    const m = meta as Record<string, unknown>;
+  const cleanValues: Record<string, unknown> = { ...safeValues };
+  // Prefer the namespaced key; fall back to legacy.
+  const candidate =
+    safeValues[MODES_META_KEY] !== undefined
+      ? safeValues[MODES_META_KEY]
+      : safeValues[LEGACY_MODES_META_KEY];
+
+  if (looksLikeModesMeta(candidate)) {
+    const m = candidate as Record<string, unknown>;
+    // Only strip the key we will rewrite on save (namespaced); the legacy
+    // key, if present, is migrated to the new one on next save — leave the
+    // cleanValues without either so the user's `values` editor in the UI
+    // does not show our internal plumbing.
+    delete cleanValues[MODES_META_KEY];
+    delete cleanValues[LEGACY_MODES_META_KEY];
     return {
-      input: typeof m.input === 'string' ? m.input : '',
-      output: typeof m.output === 'string' ? m.output : '',
+      input: typeof m.input === 'string' ? (m.input as string) : '',
+      output: typeof m.output === 'string' ? (m.output as string) : '',
       cleanValues,
     };
   }
+  // Neither key holds our shape — leave whatever the user wrote intact.
   return { input: '', output: '', cleanValues };
+};
+
+// Promoted error_handling keys edited by the Step4 form. Anything outside
+// this set lives in error_handling_extras and is merged back on submit so
+// edits never erase fields the user (or another integration) wrote.
+const PROMOTED_EH_KEYS = ['timeout', 'retry_count', 'fallback_response'] as const;
+
+const splitErrorHandling = (
+  eh: Record<string, unknown> | undefined,
+): { promoted: ErrorHandling; extras: Record<string, unknown> } => {
+  const safe = eh || {};
+  const extras: Record<string, unknown> = {};
+  for (const k of Object.keys(safe)) {
+    if (!(PROMOTED_EH_KEYS as readonly string[]).includes(k)) {
+      extras[k] = safe[k];
+    }
+  }
+  return {
+    promoted: {
+      timeout: typeof safe.timeout === 'number' ? (safe.timeout as number) : undefined,
+      retry_count:
+        typeof safe.retry_count === 'number' ? (safe.retry_count as number) : undefined,
+      fallback_response:
+        typeof safe.fallback_response === 'string'
+          ? (safe.fallback_response as string)
+          : undefined,
+    },
+    extras,
+  };
 };
 
 const toolToWizardData = (tool: CustomTool): WizardData => {
   const { input, output, cleanValues } = extractModesMeta(
     tool.values as Record<string, unknown>,
   );
-  const eh = (tool.error_handling as Record<string, unknown>) || {};
+  const { promoted, extras } = splitErrorHandling(
+    tool.error_handling as Record<string, unknown>,
+  );
+  const inputModesAll = tool.input_modes || [];
+  const outputModesAll = tool.output_modes || [];
   return {
     name: tool.name || '',
     description: tool.description || '',
@@ -61,15 +118,13 @@ const toolToWizardData = (tool: CustomTool): WizardData => {
     path_params: (tool.path_params as Record<string, unknown>) || {},
     body_params: (tool.body_params as Record<string, unknown>) || {},
     values: cleanValues,
-    error_handling: {
-      timeout: typeof eh.timeout === 'number' ? eh.timeout : undefined,
-      retry_count: typeof eh.retry_count === 'number' ? eh.retry_count : undefined,
-      fallback_response:
-        typeof eh.fallback_response === 'string' ? eh.fallback_response : undefined,
-    },
-    input_mode: tool.input_modes?.[0] || '',
+    error_handling: promoted,
+    error_handling_extras: extras,
+    input_mode: inputModesAll[0] || '',
+    input_modes_extra: inputModesAll.slice(1),
     input_description: input,
-    output_mode: tool.output_modes?.[0] || '',
+    output_mode: outputModesAll[0] || '',
+    output_modes_extra: outputModesAll.slice(1),
     output_description: output,
     examples: tool.examples || [],
   };
@@ -91,10 +146,16 @@ interface WizardData {
   // Step 4
   values: Record<string, unknown>;
   error_handling: ErrorHandling;
+  // Non-promoted error_handling keys preserved verbatim across edit cycles.
+  error_handling_extras: Record<string, unknown>;
   // Step 5
   input_mode: string;
+  // Trailing input_modes beyond [0]; the wizard's single-select UI only
+  // exposes the primary, but the array round-trips intact on save.
+  input_modes_extra: string[];
   input_description: string;
   output_mode: string;
+  output_modes_extra: string[];
   output_description: string;
   // Step 6
   examples: string[];
@@ -112,21 +173,38 @@ const initialWizardData: WizardData = {
   body_params: {},
   values: {},
   error_handling: {},
+  error_handling_extras: {},
   input_mode: '',
+  input_modes_extra: [],
   input_description: '',
   output_mode: '',
+  output_modes_extra: [],
   output_description: '',
   examples: [],
 };
 
 const TOTAL_STEPS = 6;
 
-const errorHandlingToObject = (eh: ErrorHandling): Record<string, unknown> => {
-  const out: Record<string, unknown> = {};
+const mergeErrorHandlingForSave = (
+  eh: ErrorHandling,
+  extras: Record<string, unknown>,
+): Record<string, unknown> => {
+  // Extras first, promoted overrides — user edits in the form always win
+  // but any field the user did not touch (custom_field, on_429, …) is
+  // preserved verbatim from the original tool.
+  const out: Record<string, unknown> = { ...extras };
   if (eh.timeout !== undefined) out.timeout = eh.timeout;
   if (eh.retry_count !== undefined) out.retry_count = eh.retry_count;
   if (eh.fallback_response !== undefined) out.fallback_response = eh.fallback_response;
   return out;
+};
+
+// Re-assemble the input/output mode arrays preserving extras the wizard
+// didn't expose. Empty primary + no extras = empty array (back-compat with
+// pre-wizard tools that had no modes set).
+const composeModes = (primary: string, extras: string[]): string[] => {
+  if (!primary) return extras.length > 0 ? [...extras] : [];
+  return [primary, ...extras];
 };
 
 export default function CustomToolWizardModal({
@@ -189,14 +267,17 @@ export default function CustomToolWizardModal({
   const handleBack = () => setCurrentStep(s => Math.max(s - 1, 1));
 
   const handleSubmit = () => {
-    // Mode descriptions don't map to a backend field; stash them inside `values`
-    // under a reserved key so they round-trip across reads.
+    // Mode descriptions live in `values` under our namespaced key. We
+    // never overwrite an unrelated user-owned `__evo_modes_meta__` key
+    // because cleanValues stripped it on read and the user can't recreate
+    // it (it would have been treated as our meta and migrated out). The
+    // legacy unnamespaced `__modes_meta__` is also never written.
     const modesMeta: Record<string, string> = {};
     if (data.input_description.trim()) modesMeta.input = data.input_description.trim();
     if (data.output_description.trim()) modesMeta.output = data.output_description.trim();
     const valuesWithMeta =
       Object.keys(modesMeta).length > 0
-        ? { ...data.values, __modes_meta__: modesMeta }
+        ? { ...data.values, [MODES_META_KEY]: modesMeta }
         : data.values;
 
     const payload: CustomToolFormData = {
@@ -209,9 +290,12 @@ export default function CustomToolWizardModal({
       path_params: data.path_params,
       body_params: data.body_params,
       values: valuesWithMeta,
-      error_handling: errorHandlingToObject(data.error_handling),
-      input_modes: data.input_mode ? [data.input_mode] : [],
-      output_modes: data.output_mode ? [data.output_mode] : [],
+      error_handling: mergeErrorHandlingForSave(
+        data.error_handling,
+        data.error_handling_extras,
+      ),
+      input_modes: composeModes(data.input_mode, data.input_modes_extra),
+      output_modes: composeModes(data.output_mode, data.output_modes_extra),
       tags: data.tags,
       examples: data.examples,
     };

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -200,11 +200,13 @@ const mergeErrorHandlingForSave = (
 };
 
 // Re-assemble the input/output mode arrays preserving extras the wizard
-// didn't expose. Empty primary + no extras = empty array (back-compat with
-// pre-wizard tools that had no modes set).
+// didn't expose. Dedup because the Select in Step5 lets the user pick a
+// value that was already in extras (e.g. tool had ["text","image"] →
+// primary="text", extras=["image"]; user switches Select to "image" →
+// without dedup we'd emit ["image","image"]).
 const composeModes = (primary: string, extras: string[]): string[] => {
-  if (!primary) return extras.length > 0 ? [...extras] : [];
-  return [primary, ...extras];
+  if (!primary) return extras.length > 0 ? Array.from(new Set(extras)) : [];
+  return Array.from(new Set([primary, ...extras]));
 };
 
 export default function CustomToolWizardModal({

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -1,0 +1,375 @@
+import { useState, useEffect, useRef } from 'react';
+import { Dialog, DialogContent, DialogTitle } from '@evoapi/design-system';
+import { X } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { CustomTool, CustomToolFormData } from '@/types/ai';
+import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
+import {
+  Step1_Identity,
+  Step2_Endpoint,
+  Step3_Parameters,
+  Step4_Advanced,
+  Step5_Modes,
+  Step6_Finish,
+} from './wizard';
+import type { ErrorHandling } from './wizard/Step4_Advanced';
+
+interface CustomToolWizardModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  loading?: boolean;
+  onSubmit: (data: CustomToolFormData) => void;
+  /** Render as a full-page embedded view (sidebar/topbar visible) instead of a Dialog overlay. */
+  embedded?: boolean;
+  /** When provided, the wizard runs in edit mode and prefills its state from this tool. */
+  tool?: CustomTool;
+}
+
+const MODES_META_KEY = '__modes_meta__';
+
+const extractModesMeta = (
+  values: Record<string, unknown> | undefined,
+): { input: string; output: string; cleanValues: Record<string, unknown> } => {
+  const safeValues = values || {};
+  const meta = safeValues[MODES_META_KEY];
+  const cleanValues = { ...safeValues };
+  delete cleanValues[MODES_META_KEY];
+  if (meta && typeof meta === 'object' && !Array.isArray(meta)) {
+    const m = meta as Record<string, unknown>;
+    return {
+      input: typeof m.input === 'string' ? m.input : '',
+      output: typeof m.output === 'string' ? m.output : '',
+      cleanValues,
+    };
+  }
+  return { input: '', output: '', cleanValues };
+};
+
+const toolToWizardData = (tool: CustomTool): WizardData => {
+  const { input, output, cleanValues } = extractModesMeta(
+    tool.values as Record<string, unknown>,
+  );
+  const eh = (tool.error_handling as Record<string, unknown>) || {};
+  return {
+    name: tool.name || '',
+    description: tool.description || '',
+    tags: tool.tags || [],
+    method: tool.method || 'GET',
+    endpoint: tool.endpoint || '',
+    headers: (tool.headers as Record<string, unknown>) || {},
+    query_params: (tool.query_params as Record<string, unknown>) || {},
+    path_params: (tool.path_params as Record<string, unknown>) || {},
+    body_params: (tool.body_params as Record<string, unknown>) || {},
+    values: cleanValues,
+    error_handling: {
+      timeout: typeof eh.timeout === 'number' ? eh.timeout : undefined,
+      retry_count: typeof eh.retry_count === 'number' ? eh.retry_count : undefined,
+      fallback_response:
+        typeof eh.fallback_response === 'string' ? eh.fallback_response : undefined,
+    },
+    input_mode: tool.input_modes?.[0] || '',
+    input_description: input,
+    output_mode: tool.output_modes?.[0] || '',
+    output_description: output,
+    examples: tool.examples || [],
+  };
+};
+
+interface WizardData {
+  // Step 1
+  name: string;
+  description: string;
+  tags: string[];
+  // Step 2
+  method: string;
+  endpoint: string;
+  headers: Record<string, unknown>;
+  // Step 3
+  query_params: Record<string, unknown>;
+  path_params: Record<string, unknown>;
+  body_params: Record<string, unknown>;
+  // Step 4
+  values: Record<string, unknown>;
+  error_handling: ErrorHandling;
+  // Step 5
+  input_mode: string;
+  input_description: string;
+  output_mode: string;
+  output_description: string;
+  // Step 6
+  examples: string[];
+}
+
+const initialWizardData: WizardData = {
+  name: '',
+  description: '',
+  tags: [],
+  method: 'GET',
+  endpoint: '',
+  headers: {},
+  query_params: {},
+  path_params: {},
+  body_params: {},
+  values: {},
+  error_handling: {},
+  input_mode: '',
+  input_description: '',
+  output_mode: '',
+  output_description: '',
+  examples: [],
+};
+
+const TOTAL_STEPS = 6;
+
+const errorHandlingToObject = (eh: ErrorHandling): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+  if (eh.timeout !== undefined) out.timeout = eh.timeout;
+  if (eh.retry_count !== undefined) out.retry_count = eh.retry_count;
+  if (eh.fallback_response !== undefined) out.fallback_response = eh.fallback_response;
+  return out;
+};
+
+export default function CustomToolWizardModal({
+  open,
+  onOpenChange,
+  loading = false,
+  onSubmit,
+  embedded = false,
+  tool,
+}: CustomToolWizardModalProps) {
+  const { t } = useLanguage('customTools');
+  const isEdit = !!tool;
+  const [currentStep, setCurrentStep] = useState(1);
+  const [data, setData] = useState<WizardData>(() =>
+    tool ? toolToWizardData(tool) : initialWizardData,
+  );
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      const timeout = setTimeout(() => {
+        setCurrentStep(1);
+        setData(tool ? toolToWizardData(tool) : initialWizardData);
+      }, 300);
+      return () => clearTimeout(timeout);
+    }
+  }, [open, tool]);
+
+  useEffect(() => {
+    if (open && tool) {
+      setData(toolToWizardData(tool));
+    }
+  }, [tool?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (open && contentRef.current) {
+      contentRef.current.scrollTop = 0;
+    }
+  }, [open, currentStep]);
+
+  const steps = [
+    { id: 1, label: t('wizard.progress.identity') },
+    { id: 2, label: t('wizard.progress.endpoint') },
+    { id: 3, label: t('wizard.progress.parameters') },
+    { id: 4, label: t('wizard.progress.advanced') },
+    { id: 5, label: t('wizard.progress.modes') },
+    { id: 6, label: t('wizard.progress.finish') },
+  ];
+
+  const stepHeader: Record<number, { title: string; subtitle: string }> = {
+    1: { title: t('wizard.step1.title'), subtitle: t('wizard.step1.subtitle') },
+    2: { title: t('wizard.step2.title'), subtitle: t('wizard.step2.subtitle') },
+    3: { title: t('wizard.step3.title'), subtitle: t('wizard.step3.subtitle') },
+    4: { title: t('wizard.step4.title'), subtitle: t('wizard.step4.subtitle') },
+    5: { title: t('wizard.step5.title'), subtitle: t('wizard.step5.subtitle') },
+    6: { title: t('wizard.step6.title'), subtitle: t('wizard.step6.subtitle') },
+  };
+
+  const handleNext = () => setCurrentStep(s => Math.min(s + 1, TOTAL_STEPS));
+  const handleBack = () => setCurrentStep(s => Math.max(s - 1, 1));
+
+  const handleSubmit = () => {
+    // Mode descriptions don't map to a backend field; stash them inside `values`
+    // under a reserved key so they round-trip across reads.
+    const modesMeta: Record<string, string> = {};
+    if (data.input_description.trim()) modesMeta.input = data.input_description.trim();
+    if (data.output_description.trim()) modesMeta.output = data.output_description.trim();
+    const valuesWithMeta =
+      Object.keys(modesMeta).length > 0
+        ? { ...data.values, __modes_meta__: modesMeta }
+        : data.values;
+
+    const payload: CustomToolFormData = {
+      name: data.name.trim(),
+      description: data.description.trim(),
+      method: data.method,
+      endpoint: data.endpoint.trim(),
+      headers: data.headers,
+      query_params: data.query_params,
+      path_params: data.path_params,
+      body_params: data.body_params,
+      values: valuesWithMeta,
+      error_handling: errorHandlingToObject(data.error_handling),
+      input_modes: data.input_mode ? [data.input_mode] : [],
+      output_modes: data.output_mode ? [data.output_mode] : [],
+      tags: data.tags,
+      examples: data.examples,
+    };
+    onSubmit(payload);
+  };
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case 1:
+        return (
+          <Step1_Identity
+            data={{
+              name: data.name,
+              description: data.description,
+              tags: data.tags,
+            }}
+            onChange={d => setData(prev => ({ ...prev, ...d }))}
+            onNext={handleNext}
+          />
+        );
+      case 2:
+        return (
+          <Step2_Endpoint
+            data={{
+              method: data.method,
+              endpoint: data.endpoint,
+              headers: data.headers,
+            }}
+            onChange={d => setData(prev => ({ ...prev, ...d }))}
+            onNext={handleNext}
+            onBack={handleBack}
+          />
+        );
+      case 3:
+        return (
+          <Step3_Parameters
+            data={{
+              method: data.method,
+              query_params: data.query_params,
+              path_params: data.path_params,
+              body_params: data.body_params,
+            }}
+            onChange={d =>
+              setData(prev => ({
+                ...prev,
+                query_params: d.query_params,
+                path_params: d.path_params,
+                body_params: d.body_params,
+              }))
+            }
+            onNext={handleNext}
+            onBack={handleBack}
+          />
+        );
+      case 4:
+        return (
+          <Step4_Advanced
+            data={{
+              values: data.values,
+              error_handling: data.error_handling,
+            }}
+            onChange={d => setData(prev => ({ ...prev, ...d }))}
+            onNext={handleNext}
+            onBack={handleBack}
+          />
+        );
+      case 5:
+        return (
+          <Step5_Modes
+            data={{
+              input_mode: data.input_mode,
+              input_description: data.input_description,
+              output_mode: data.output_mode,
+              output_description: data.output_description,
+            }}
+            onChange={d => setData(prev => ({ ...prev, ...d }))}
+            onNext={handleNext}
+            onBack={handleBack}
+          />
+        );
+      case 6:
+        return (
+          <Step6_Finish
+            data={{ examples: data.examples }}
+            onChange={d => setData(prev => ({ ...prev, examples: d.examples }))}
+            onBack={handleBack}
+            onSubmit={handleSubmit}
+            loading={loading}
+            mode={isEdit ? 'edit' : 'create'}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  const header = stepHeader[currentStep];
+
+  const wizardContent = (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center justify-end px-3 pt-3 pb-0 flex-shrink-0">
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          className="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          aria-label="Close wizard"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="flex flex-col flex-1 min-h-0">
+        <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
+          <div className="text-center">
+            <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
+            {header.subtitle && (
+              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
+                {header.subtitle}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="py-2 px-4 flex-shrink-0 bg-transparent">
+          <WizardProgress
+            currentStep={currentStep}
+            totalSteps={TOTAL_STEPS}
+            steps={steps}
+          />
+        </div>
+
+        <div
+          ref={contentRef}
+          className="flex-1 overflow-y-auto px-3 min-h-0"
+        >
+          {renderStep()}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (embedded) {
+    return (
+      <div className="w-full h-full min-h-0 bg-background overflow-hidden">
+        {wizardContent}
+      </div>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="!w-[72vw] !max-w-[72vw] h-[94vh] max-h-[94vh] overflow-hidden p-0 sm:!max-w-[72vw]"
+      >
+        <DialogTitle className="sr-only">{t('modal.title.create')}</DialogTitle>
+        {wizardContent}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/customTools/index.ts
+++ b/src/components/customTools/index.ts
@@ -3,6 +3,8 @@ export { default as CustomToolsTable } from './CustomToolsTable';
 export { default as CustomToolsPagination } from './CustomToolsPagination';
 export { default as CustomToolCard } from './CustomToolCard';
 export { default as CustomToolModal } from './CustomToolModal';
+export { default as CustomToolWizardModal } from './CustomToolWizardModal';
+export { default as CustomToolTestResultDialog } from './CustomToolTestResultDialog';
 export { default as CustomToolForm } from './CustomToolForm';
 export { default as CustomToolDetails } from './CustomToolDetails';
 export { default as CustomToolsFilter } from './CustomToolsFilter';

--- a/src/components/customTools/wizard/Step1_Identity.tsx
+++ b/src/components/customTools/wizard/Step1_Identity.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Input, Label, Button, Textarea } from '@evoapi/design-system';
+import { ArrowRight } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { TagInput } from '@/components/ai_agents/shared';
+
+export interface Step1Data {
+  name: string;
+  description: string;
+  tags: string[];
+}
+
+interface Step1Props {
+  data: Step1Data;
+  onChange: (data: Step1Data) => void;
+  onNext: () => void;
+}
+
+export default function Step1_Identity({ data, onChange, onNext }: Step1Props) {
+  const { t } = useLanguage('customTools');
+  const [error, setError] = useState('');
+
+  const handleNext = () => {
+    if (!data.name || !data.name.trim()) {
+      setError(t('form.validation.nameRequired'));
+      return;
+    }
+    setError('');
+    onNext();
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 max-w-4xl mx-auto py-2 px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="w-full max-w-2xl mx-auto space-y-4">
+          <div>
+            <Label className="text-sm mb-1.5 block font-semibold">
+              {t('form.fields.name.label')} <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              placeholder={t('form.fields.name.placeholder')}
+              value={data.name}
+              onChange={e => onChange({ ...data, name: e.target.value })}
+              className={`h-10 text-sm ${error ? 'border-red-500' : ''}`}
+              autoFocus
+              onKeyDown={e => {
+                if (e.key === 'Enter' && data.name) handleNext();
+              }}
+            />
+            {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
+          </div>
+
+          <div>
+            <Label className="text-sm mb-1.5 block font-semibold">
+              {t('form.fields.description.label')}
+            </Label>
+            <Textarea
+              placeholder={t('form.fields.description.placeholder')}
+              value={data.description}
+              onChange={e => onChange({ ...data, description: e.target.value })}
+              className="min-h-[80px] text-sm resize-none"
+              maxLength={500}
+            />
+          </div>
+
+          <TagInput
+            id="tags"
+            label={t('form.fields.tags.label')}
+            value={data.tags}
+            onChange={tags => onChange({ ...data, tags })}
+            placeholder={t('form.fields.tags.placeholderTagInput')}
+            hint={t('form.fields.tags.hintTagInput')}
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end flex-shrink-0 pt-2 border-t">
+        <Button className="px-6 gap-2" onClick={handleNext} disabled={!data.name}>
+          {t('wizard.actions.continue')}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customTools/wizard/Step2_Endpoint.tsx
+++ b/src/components/customTools/wizard/Step2_Endpoint.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import {
+  Input,
+  Label,
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { ArrowRight, ArrowLeft } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { KeyValueEditor } from '@/components/ai_agents/shared';
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
+
+export interface Step2Data {
+  method: string;
+  endpoint: string;
+  headers: Record<string, unknown>;
+}
+
+interface Step2Props {
+  data: Step2Data;
+  onChange: (data: Step2Data) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export default function Step2_Endpoint({ data, onChange, onNext, onBack }: Step2Props) {
+  const { t } = useLanguage('customTools');
+  const [error, setError] = useState('');
+
+  const handleNext = () => {
+    if (!data.endpoint || !data.endpoint.trim()) {
+      setError(t('form.validation.endpointRequired'));
+      return;
+    }
+    try {
+      new URL(data.endpoint);
+    } catch {
+      setError(t('form.validation.endpointInvalid'));
+      return;
+    }
+    setError('');
+    onNext();
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 max-w-4xl mx-auto py-2 px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="w-full max-w-2xl mx-auto space-y-4">
+          <div className="grid grid-cols-[140px_1fr] gap-3">
+            <div>
+              <Label className="text-sm mb-1.5 block font-semibold">
+                {t('form.fields.method.label')} <span className="text-red-500">*</span>
+              </Label>
+              <Select
+                value={data.method}
+                onValueChange={value => onChange({ ...data, method: value })}
+              >
+                <SelectTrigger className="h-10">
+                  <SelectValue placeholder={t('form.fields.method.placeholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {HTTP_METHODS.map(method => (
+                    <SelectItem key={method} value={method}>
+                      {method}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div>
+              <Label className="text-sm mb-1.5 block font-semibold">
+                {t('form.fields.endpoint.label')} <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                placeholder={t('form.fields.endpoint.placeholder')}
+                value={data.endpoint}
+                onChange={e => onChange({ ...data, endpoint: e.target.value })}
+                className={`h-10 text-sm ${error ? 'border-red-500' : ''}`}
+              />
+              {error && <p className="text-sm text-red-600 mt-2">{error}</p>}
+            </div>
+          </div>
+
+          <div className="pt-2">
+            <KeyValueEditor
+              id="headers"
+              label={t('form.fields.headers.labelKv')}
+              value={data.headers}
+              onChange={next => onChange({ ...data, headers: next })}
+              hint={t('form.fields.headers.hint')}
+              keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
+              valuePlaceholder={t('form.fields.headers.valuePlaceholder')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-between flex-shrink-0 pt-2 border-t">
+        <Button variant="outline" className="px-6 gap-2" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4" />
+          {t('wizard.actions.back')}
+        </Button>
+        <Button className="px-6 gap-2" onClick={handleNext} disabled={!data.endpoint}>
+          {t('wizard.actions.continue')}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customTools/wizard/Step3_Parameters.tsx
+++ b/src/components/customTools/wizard/Step3_Parameters.tsx
@@ -1,0 +1,76 @@
+import { Button } from '@evoapi/design-system';
+import { ArrowRight, ArrowLeft } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { KeyValueEditor } from '@/components/ai_agents/shared';
+
+export interface Step3Data {
+  method: string;
+  query_params: Record<string, unknown>;
+  path_params: Record<string, unknown>;
+  body_params: Record<string, unknown>;
+}
+
+interface Step3Props {
+  data: Step3Data;
+  onChange: (data: Step3Data) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export default function Step3_Parameters({ data, onChange, onNext, onBack }: Step3Props) {
+  const { t } = useLanguage('customTools');
+
+  const showBody =
+    data.method === 'POST' || data.method === 'PUT' || data.method === 'PATCH';
+
+  return (
+    <div className="flex flex-col h-full min-h-0 max-w-4xl mx-auto py-2 px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="w-full max-w-2xl mx-auto space-y-5">
+          <KeyValueEditor
+            id="query_params"
+            label={t('form.fields.queryParams.labelKv')}
+            value={data.query_params}
+            onChange={next => onChange({ ...data, query_params: next })}
+            hint={t('form.fields.queryParams.hint')}
+            keyPlaceholder={t('form.fields.queryParams.keyPlaceholder')}
+            valuePlaceholder={t('form.fields.queryParams.valuePlaceholder')}
+          />
+
+          <KeyValueEditor
+            id="path_params"
+            label={t('form.fields.pathParams.labelKv')}
+            value={data.path_params}
+            onChange={next => onChange({ ...data, path_params: next })}
+            hint={t('form.fields.pathParams.hint')}
+            keyPlaceholder={t('form.fields.pathParams.keyPlaceholder')}
+            valuePlaceholder={t('form.fields.pathParams.valuePlaceholder')}
+          />
+
+          {showBody && (
+            <KeyValueEditor
+              id="body_params"
+              label={t('form.fields.bodyParams.labelKv')}
+              value={data.body_params}
+              onChange={next => onChange({ ...data, body_params: next })}
+              hint={t('form.fields.bodyParams.hint')}
+              keyPlaceholder={t('form.fields.bodyParams.keyPlaceholder')}
+              valuePlaceholder={t('form.fields.bodyParams.valuePlaceholder')}
+            />
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-between flex-shrink-0 pt-2 border-t">
+        <Button variant="outline" className="px-6 gap-2" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4" />
+          {t('wizard.actions.back')}
+        </Button>
+        <Button className="px-6 gap-2" onClick={onNext}>
+          {t('wizard.actions.continue')}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customTools/wizard/Step4_Advanced.tsx
+++ b/src/components/customTools/wizard/Step4_Advanced.tsx
@@ -1,0 +1,131 @@
+import { Button, Input, Label, Textarea } from '@evoapi/design-system';
+import { ArrowRight, ArrowLeft, SkipForward } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { KeyValueEditor } from '@/components/ai_agents/shared';
+
+export interface ErrorHandling {
+  timeout?: number;
+  retry_count?: number;
+  fallback_response?: string;
+}
+
+export interface Step4Data {
+  values: Record<string, unknown>;
+  error_handling: ErrorHandling;
+}
+
+interface Step4Props {
+  data: Step4Data;
+  onChange: (data: Step4Data) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+export default function Step4_Advanced({ data, onChange, onNext, onBack }: Step4Props) {
+  const { t } = useLanguage('customTools');
+
+  const updateError = (patch: Partial<ErrorHandling>) => {
+    onChange({ ...data, error_handling: { ...data.error_handling, ...patch } });
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 max-w-4xl mx-auto py-2 px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="w-full max-w-2xl mx-auto space-y-5">
+          <p className="text-sm text-muted-foreground bg-muted/40 rounded p-3">
+            {t('wizard.step4.helperText')}
+          </p>
+
+          <KeyValueEditor
+            id="values"
+            label={t('form.fields.values.labelKv')}
+            value={data.values}
+            onChange={next => onChange({ ...data, values: next })}
+            hint={t('form.fields.values.hint')}
+            keyPlaceholder={t('form.fields.values.keyPlaceholder')}
+            valuePlaceholder={t('form.fields.values.valuePlaceholder')}
+          />
+
+          <div className="space-y-3">
+            <Label className="text-sm font-semibold">
+              {t('form.fields.errorHandling.labelVisual')}
+            </Label>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label className="text-xs text-muted-foreground mb-1 block">
+                  {t('form.fields.errorHandling.timeoutLabel')}
+                </Label>
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="30"
+                  value={data.error_handling.timeout ?? ''}
+                  onChange={e =>
+                    updateError({
+                      timeout: e.target.value === '' ? undefined : Number(e.target.value),
+                    })
+                  }
+                  className="h-9 text-sm"
+                />
+              </div>
+              <div>
+                <Label className="text-xs text-muted-foreground mb-1 block">
+                  {t('form.fields.errorHandling.retryLabel')}
+                </Label>
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="3"
+                  value={data.error_handling.retry_count ?? ''}
+                  onChange={e =>
+                    updateError({
+                      retry_count:
+                        e.target.value === '' ? undefined : Number(e.target.value),
+                    })
+                  }
+                  className="h-9 text-sm"
+                />
+              </div>
+            </div>
+            <div>
+              <Label className="text-xs text-muted-foreground mb-1 block">
+                {t('form.fields.errorHandling.fallbackLabel')}
+              </Label>
+              <Textarea
+                value={data.error_handling.fallback_response ?? ''}
+                onChange={e =>
+                  updateError({
+                    fallback_response: e.target.value === '' ? undefined : e.target.value,
+                  })
+                }
+                placeholder={t('form.fields.errorHandling.fallbackPlaceholder')}
+                rows={2}
+                className="text-sm font-mono"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t('form.fields.errorHandling.hint')}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-between flex-shrink-0 pt-2 border-t">
+        <Button variant="outline" className="px-6 gap-2" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4" />
+          {t('wizard.actions.back')}
+        </Button>
+        <div className="flex gap-2">
+          <Button variant="ghost" className="px-6 gap-2" onClick={onNext}>
+            <SkipForward className="h-4 w-4" />
+            {t('wizard.actions.skip')}
+          </Button>
+          <Button className="px-6 gap-2" onClick={onNext}>
+            {t('wizard.actions.continue')}
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customTools/wizard/Step5_Modes.tsx
+++ b/src/components/customTools/wizard/Step5_Modes.tsx
@@ -1,0 +1,142 @@
+import {
+  Button,
+  Badge,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@evoapi/design-system';
+import { ArrowRight, ArrowLeft, SkipForward, LogIn, LogOut } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface Step5Data {
+  input_mode: string;
+  input_description: string;
+  output_mode: string;
+  output_description: string;
+}
+
+interface Step5Props {
+  data: Step5Data;
+  onChange: (data: Step5Data) => void;
+  onNext: () => void;
+  onBack: () => void;
+}
+
+const MODE_OPTIONS = ['text', 'image', 'audio', 'video', 'json', 'file'] as const;
+
+export default function Step5_Modes({ data, onChange, onNext, onBack }: Step5Props) {
+  const { t } = useLanguage('customTools');
+
+  return (
+    <div className="flex flex-col h-full min-h-0 max-w-4xl mx-auto py-2 px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="w-full max-w-3xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {/* Input column */}
+            <div className="space-y-2">
+              <Label className="text-sm font-semibold flex items-center gap-1.5">
+                <LogIn className="h-4 w-4 text-emerald-500" />
+                {t('wizard.step5.input.typeLabel')}
+              </Label>
+              <Select
+                value={data.input_mode || undefined}
+                onValueChange={value => onChange({ ...data, input_mode: value })}
+              >
+                <SelectTrigger className="h-10">
+                  <SelectValue placeholder={t('wizard.step5.selectPlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map(opt => (
+                    <SelectItem key={opt} value={opt}>
+                      {t(`wizard.step5.modeOptions.${opt}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <div className="flex items-center gap-2 pt-1">
+                <Label className="text-sm font-semibold">
+                  {t('wizard.step5.input.descriptionLabel')}
+                </Label>
+                <Badge variant="secondary" className="text-[10px] font-normal">
+                  {t('wizard.step5.input.badge')}
+                </Badge>
+              </div>
+              <Textarea
+                value={data.input_description}
+                onChange={e =>
+                  onChange({ ...data, input_description: e.target.value })
+                }
+                placeholder={t('wizard.step5.input.descriptionPlaceholder')}
+                rows={4}
+                className="text-sm resize-none"
+              />
+            </div>
+
+            {/* Output column */}
+            <div className="space-y-2">
+              <Label className="text-sm font-semibold flex items-center gap-1.5">
+                <LogOut className="h-4 w-4 text-emerald-500" />
+                {t('wizard.step5.output.typeLabel')}
+              </Label>
+              <Select
+                value={data.output_mode || undefined}
+                onValueChange={value => onChange({ ...data, output_mode: value })}
+              >
+                <SelectTrigger className="h-10">
+                  <SelectValue placeholder={t('wizard.step5.selectPlaceholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODE_OPTIONS.map(opt => (
+                    <SelectItem key={opt} value={opt}>
+                      {t(`wizard.step5.modeOptions.${opt}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <div className="flex items-center gap-2 pt-1">
+                <Label className="text-sm font-semibold">
+                  {t('wizard.step5.output.descriptionLabel')}
+                </Label>
+                <Badge variant="secondary" className="text-[10px] font-normal">
+                  {t('wizard.step5.output.badge')}
+                </Badge>
+              </div>
+              <Textarea
+                value={data.output_description}
+                onChange={e =>
+                  onChange({ ...data, output_description: e.target.value })
+                }
+                placeholder={t('wizard.step5.output.descriptionPlaceholder')}
+                rows={4}
+                className="text-sm resize-none"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-between flex-shrink-0 pt-2 border-t">
+        <Button variant="outline" className="px-6 gap-2" onClick={onBack}>
+          <ArrowLeft className="h-4 w-4" />
+          {t('wizard.actions.back')}
+        </Button>
+        <div className="flex gap-2">
+          <Button variant="ghost" className="px-6 gap-2" onClick={onNext}>
+            <SkipForward className="h-4 w-4" />
+            {t('wizard.actions.skip')}
+          </Button>
+          <Button className="px-6 gap-2" onClick={onNext}>
+            {t('wizard.actions.continue')}
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customTools/wizard/Step6_Finish.tsx
+++ b/src/components/customTools/wizard/Step6_Finish.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Button, Input, Label } from '@evoapi/design-system';
+import { ArrowLeft, Plus, X, Check } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+
+export interface Step6Data {
+  examples: string[];
+}
+
+interface Step6Props {
+  data: Step6Data;
+  onChange: (data: Step6Data) => void;
+  onBack: () => void;
+  onSubmit: () => void;
+  loading?: boolean;
+  mode?: 'create' | 'edit';
+}
+
+export default function Step6_Finish({
+  data,
+  onChange,
+  onBack,
+  onSubmit,
+  loading = false,
+  mode = 'create',
+}: Step6Props) {
+  const { t } = useLanguage('customTools');
+  const [newExample, setNewExample] = useState('');
+
+  const handleAdd = () => {
+    if (newExample.trim()) {
+      onChange({ ...data, examples: [...data.examples, newExample.trim()] });
+      setNewExample('');
+    }
+  };
+
+  const handleRemove = (index: number) => {
+    onChange({
+      ...data,
+      examples: data.examples.filter((_, i) => i !== index),
+    });
+  };
+
+  return (
+    <div className="flex flex-col h-full min-h-0 max-w-4xl mx-auto py-2 px-4">
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="w-full max-w-2xl mx-auto space-y-4">
+          <p className="text-sm text-muted-foreground bg-muted/40 rounded p-3">
+            {t('wizard.step6.helperText')}
+          </p>
+
+          <div>
+            <Label className="text-sm mb-1.5 block font-semibold">
+              {t('form.fields.examples.label')}
+            </Label>
+            <div className="flex gap-2">
+              <Input
+                value={newExample}
+                onChange={e => setNewExample(e.target.value)}
+                placeholder={t('form.fields.examples.placeholder')}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    handleAdd();
+                  }
+                }}
+                className="h-10 text-sm"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleAdd}
+                disabled={!newExample.trim()}
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+
+            {data.examples.length > 0 && (
+              <div className="space-y-2 mt-3">
+                {data.examples.map((example, index) => (
+                  <div
+                    key={index}
+                    className="flex items-center gap-2 p-2 bg-muted/30 rounded"
+                  >
+                    <span className="flex-1 text-sm">{example}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleRemove(index)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <p className="text-xs text-muted-foreground bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded p-3">
+            {t('wizard.step6.testHint')}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-between flex-shrink-0 pt-2 border-t">
+        <Button variant="outline" className="px-6 gap-2" onClick={onBack} disabled={loading}>
+          <ArrowLeft className="h-4 w-4" />
+          {t('wizard.actions.back')}
+        </Button>
+        <Button className="px-6 gap-2" onClick={onSubmit} disabled={loading}>
+          <Check className="h-4 w-4" />
+          {loading
+            ? t('form.actions.saving')
+            : t(mode === 'edit' ? 'wizard.actions.save' : 'wizard.actions.create')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/customTools/wizard/index.ts
+++ b/src/components/customTools/wizard/index.ts
@@ -1,0 +1,12 @@
+export { default as Step1_Identity } from './Step1_Identity';
+export type { Step1Data } from './Step1_Identity';
+export { default as Step2_Endpoint } from './Step2_Endpoint';
+export type { Step2Data } from './Step2_Endpoint';
+export { default as Step3_Parameters } from './Step3_Parameters';
+export type { Step3Data } from './Step3_Parameters';
+export { default as Step4_Advanced } from './Step4_Advanced';
+export type { Step4Data } from './Step4_Advanced';
+export { default as Step5_Modes } from './Step5_Modes';
+export type { Step5Data } from './Step5_Modes';
+export { default as Step6_Finish } from './Step6_Finish';
+export type { Step6Data } from './Step6_Finish';

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -79,38 +79,76 @@
       },
       "headers": {
         "label": "Headers HTTP (JSON)",
+        "labelKv": "HTTP Headers",
         "placeholder": "{\"Authorization\": \"Bearer token\", \"Content-Type\": \"application/json\"}",
-        "hint": "Configure the HTTP headers required for authentication and communication"
+        "keyPlaceholder": "Header name (e.g. Authorization)",
+        "valuePlaceholder": "Value (e.g. Bearer token)",
+        "hint": "HTTP headers sent with every request (auth, content-type, etc.)"
       },
       "bodyParams": {
         "label": "Body Parameters (JSON)",
+        "labelKv": "Body Parameters",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
-        "hint": "Configure the request body parameters sent with POST/PUT/PATCH requests"
+        "keyPlaceholder": "Field name",
+        "valuePlaceholder": "Value",
+        "hint": "Body fields sent with POST/PUT/PATCH requests"
       },
       "queryParams": {
         "label": "Query Parameters (JSON)",
+        "labelKv": "Query Parameters",
         "placeholder": "{\"param1\": \"value1\", \"param2\": \"value2\"}",
-        "hint": "Configure URL query string parameters appended to the endpoint"
+        "keyPlaceholder": "Param name",
+        "valuePlaceholder": "Value",
+        "hint": "Query string params appended to the URL (e.g. ?param=value)"
       },
       "pathParams": {
         "label": "Path Parameters (JSON)",
+        "labelKv": "Path Parameters",
         "placeholder": "{\"user_id\": \"{user_id}\", \"resource_id\": \"{resource_id}\"}",
-        "hint": "Configure path parameters that will be substituted in the endpoint URL (e.g., /users/{user_id})"
+        "keyPlaceholder": "Param name (e.g. user_id)",
+        "valuePlaceholder": "Value or placeholder",
+        "hint": "Path placeholders to substitute in the URL (e.g. /users/{user_id})"
       },
       "values": {
         "label": "Default Values (JSON)",
+        "labelKv": "Default Values",
         "placeholder": "{\"default_key\": \"default_value\"}",
-        "hint": "Configure default values used as fallback when parameters are not provided at runtime"
+        "keyPlaceholder": "Key (e.g. default_user)",
+        "valuePlaceholder": "Default value",
+        "hint": "Defaults used as fallback when parameters are missing at runtime"
       },
       "errorHandling": {
         "label": "Error Handling (JSON)",
+        "labelVisual": "Error Handling",
         "placeholder": "{\"timeout\": 30, \"retry_count\": 3, \"fallback_response\": \"{}\"}",
-        "hint": "Configure error handling settings: timeout (seconds), retry_count, and fallback_response"
+        "timeoutLabel": "Timeout (seconds)",
+        "retryLabel": "Retry count",
+        "fallbackLabel": "Fallback response",
+        "fallbackPlaceholder": "JSON to return when all retries fail",
+        "hint": "Configure timeout, retries, and a fallback response for errors"
+      },
+      "inputModes": {
+        "label": "Input Modes (JSON array)",
+        "labelVisual": "Input Modes",
+        "placeholder": "[\"text\", \"image\"]",
+        "placeholderVisual": "Type and press Enter…",
+        "hint": "Supported input MIME types or modes",
+        "hintVisual": "Type and press Enter to add, or pick a suggestion"
+      },
+      "outputModes": {
+        "label": "Output Modes (JSON array)",
+        "labelVisual": "Output Modes",
+        "placeholder": "[\"text\", \"json\"]",
+        "placeholderVisual": "Type and press Enter…",
+        "hint": "Supported output MIME types or modes",
+        "hintVisual": "Type and press Enter to add, or pick a suggestion"
       },
       "tags": {
         "label": "Tags",
         "placeholder": "api, http, webhook",
-        "hint": "Separate the tags with commas to organize and categorize the tool"
+        "placeholderTagInput": "Type and press Enter to add a tag…",
+        "hint": "Separate the tags with commas to organize and categorize the tool",
+        "hintTagInput": "Press Enter or comma to add a tag. Backspace removes the last one."
       },
       "examples": {
         "label": "Examples",
@@ -127,13 +165,122 @@
       "queryParamsInvalid": "Invalid JSON for query parameters",
       "pathParamsInvalid": "Invalid JSON for path parameters",
       "valuesInvalid": "Invalid JSON for default values",
-      "errorHandlingInvalid": "Invalid JSON for error handling"
+      "errorHandlingInvalid": "Invalid JSON for error handling",
+      "inputModesInvalid": "Input modes must be a JSON array of strings",
+      "outputModesInvalid": "Output modes must be a JSON array of strings"
     },
     "actions": {
       "cancel": "Cancel",
       "save": "Save Changes",
       "create": "Create Tool",
       "saving": "Saving..."
+    }
+  },
+  "keyValueEditor": {
+    "keyPlaceholder": "Key",
+    "valuePlaceholder": "Value",
+    "addRow": "Add row",
+    "removeRow": "Remove row",
+    "complexValueBadge": "complex value — edit in advanced mode",
+    "errors": {
+      "emptyKey": "Key cannot be empty",
+      "duplicateKey": "Duplicate key",
+      "emptyValue": "Value is required when key is set"
+    }
+  },
+  "advancedConfig": {
+    "title": "Advanced configuration"
+  },
+  "tagInput": {
+    "placeholder": "Type and press Enter…",
+    "removeTag": "Remove {{tag}}",
+    "suggestions": "Suggestions"
+  },
+  "testResult": {
+    "titleSuccess": "Test successful",
+    "titleError": "Test failed",
+    "statusCode": "Status code",
+    "responseTime": "Response time",
+    "errorLabel": "Error",
+    "responseHeaders": "Response headers",
+    "responseBody": "Response body",
+    "noData": "The request didn't complete and returned no detail.",
+    "close": "Close"
+  },
+  "testRequest": {
+    "button": "Test request",
+    "testing": "Testing...",
+    "success": "Request successful",
+    "error": "Failed to test request",
+    "statusCode": "Status",
+    "responseTime": "Response time",
+    "responseHeaders": "Response headers",
+    "responseBody": "Response body",
+    "disabledTooltipCreateMode": "Save the tool first to be able to test it"
+  },
+  "wizard": {
+    "progress": {
+      "identity": "Identity",
+      "endpoint": "Endpoint",
+      "parameters": "Parameters",
+      "advanced": "Advanced",
+      "modes": "Modes",
+      "finish": "Finish"
+    },
+    "step1": {
+      "title": "Let's identify your tool",
+      "subtitle": "Give it a name, description, and tags so your team can find it later."
+    },
+    "step2": {
+      "title": "What endpoint does it call?",
+      "subtitle": "Pick the HTTP method, the URL, and the headers sent on every request."
+    },
+    "step3": {
+      "title": "Configure the parameters",
+      "subtitle": "Query, path, and body parameters. Body shows only when the method supports it."
+    },
+    "step4": {
+      "title": "Advanced configuration",
+      "subtitle": "Optional. Defaults and error handling.",
+      "helperText": "These fields are optional — skip if you don't need them."
+    },
+    "step5": {
+      "title": "Input and output modes",
+      "subtitle": "Optional. Declare what kind of content this tool accepts and returns.",
+      "selectPlaceholder": "Select a type",
+      "modeOptions": {
+        "text": "Text",
+        "image": "Image",
+        "audio": "Audio",
+        "video": "Video",
+        "json": "JSON",
+        "file": "File"
+      },
+      "input": {
+        "typeLabel": "What it receives",
+        "descriptionLabel": "What should the AI send?",
+        "badge": "instruction for the AI",
+        "descriptionPlaceholder": "Ex: The image of a document or receipt the customer sent that needs to be read."
+      },
+      "output": {
+        "typeLabel": "What it returns",
+        "descriptionLabel": "Describe the return",
+        "badge": "helps the agent interpret",
+        "descriptionPlaceholder": "Ex: The text extracted from the document, in plain prose, ready to be used in the reply."
+      }
+    },
+    "step6": {
+      "title": "Final touches",
+      "subtitle": "Add usage examples that help agents understand when to call this tool.",
+      "helperText": "Examples are short text descriptions of how to use the tool.",
+      "testHint": "After creating, you'll be able to test the tool against the real endpoint."
+    },
+    "actions": {
+      "continue": "Continue",
+      "back": "Back",
+      "skip": "Skip",
+      "create": "Create tool",
+      "save": "Save changes"
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -79,38 +79,76 @@
       },
       "headers": {
         "label": "Headers HTTP (JSON)",
+        "labelKv": "Headers HTTP",
         "placeholder": "{\"Authorization\": \"Bearer token\", \"Content-Type\": \"application/json\"}",
-        "hint": "Configure los headers HTTP necesarios para autenticación y comunicación"
+        "keyPlaceholder": "Nombre del header (ej: Authorization)",
+        "valuePlaceholder": "Valor (ej: Bearer token)",
+        "hint": "Headers HTTP enviados con cada solicitud (auth, content-type, etc.)"
       },
       "bodyParams": {
         "label": "Parámetros del Body (JSON)",
+        "labelKv": "Parámetros del Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
-        "hint": "Configure los parámetros del cuerpo de la solicitud enviados con solicitudes POST/PUT/PATCH"
+        "keyPlaceholder": "Nombre del campo",
+        "valuePlaceholder": "Valor",
+        "hint": "Campos del cuerpo enviados en solicitudes POST/PUT/PATCH"
       },
       "queryParams": {
         "label": "Parámetros de Query (JSON)",
+        "labelKv": "Parámetros de Query",
         "placeholder": "{\"param1\": \"value1\", \"param2\": \"value2\"}",
-        "hint": "Configure los parámetros de la cadena de consulta de la URL anexados al endpoint"
+        "keyPlaceholder": "Nombre del parámetro",
+        "valuePlaceholder": "Valor",
+        "hint": "Parámetros de query string anexados a la URL (ej: ?param=valor)"
       },
       "pathParams": {
         "label": "Parámetros de Path (JSON)",
+        "labelKv": "Parámetros de Path",
         "placeholder": "{\"user_id\": \"{user_id}\", \"resource_id\": \"{resource_id}\"}",
-        "hint": "Configure los parámetros de path que serán sustituidos en la URL del endpoint (ej: /users/{user_id})"
+        "keyPlaceholder": "Nombre del parámetro (ej: user_id)",
+        "valuePlaceholder": "Valor o placeholder",
+        "hint": "Placeholders de path sustituidos en la URL (ej: /users/{user_id})"
       },
       "values": {
         "label": "Valores por Defecto (JSON)",
+        "labelKv": "Valores por Defecto",
         "placeholder": "{\"default_key\": \"default_value\"}",
-        "hint": "Configure valores por defecto usados como respaldo cuando los parámetros no se proporcionan en tiempo de ejecución"
+        "keyPlaceholder": "Clave (ej: default_user)",
+        "valuePlaceholder": "Valor por defecto",
+        "hint": "Valores por defecto usados como respaldo cuando los parámetros no se proporcionan en runtime"
       },
       "errorHandling": {
         "label": "Manejo de Errores (JSON)",
+        "labelVisual": "Manejo de Errores",
         "placeholder": "{\"timeout\": 30, \"retry_count\": 3, \"fallback_response\": \"{}\"}",
-        "hint": "Configure las configuraciones de manejo de errores: timeout (segundos), retry_count y fallback_response"
+        "timeoutLabel": "Timeout (segundos)",
+        "retryLabel": "Número de reintentos",
+        "fallbackLabel": "Respuesta de fallback",
+        "fallbackPlaceholder": "JSON devuelto cuando todos los reintentos fallan",
+        "hint": "Configura timeout, reintentos y una respuesta de fallback para errores"
+      },
+      "inputModes": {
+        "label": "Modos de Entrada (array JSON)",
+        "labelVisual": "Modos de Entrada",
+        "placeholder": "[\"text\", \"image\"]",
+        "placeholderVisual": "Escribe y presiona Enter…",
+        "hint": "Tipos MIME o modos de entrada soportados",
+        "hintVisual": "Escribe y presiona Enter para añadir, o haz clic en una sugerencia"
+      },
+      "outputModes": {
+        "label": "Modos de Salida (array JSON)",
+        "labelVisual": "Modos de Salida",
+        "placeholder": "[\"text\", \"json\"]",
+        "placeholderVisual": "Escribe y presiona Enter…",
+        "hint": "Tipos MIME o modos de salida soportados",
+        "hintVisual": "Escribe y presiona Enter para añadir, o haz clic en una sugerencia"
       },
       "tags": {
         "label": "Etiquetas",
         "placeholder": "api, http, webhook",
-        "hint": "Separe las etiquetas con comas para organizar y categorizar la herramienta"
+        "placeholderTagInput": "Escribe y presiona Enter para añadir una etiqueta…",
+        "hint": "Separe las etiquetas con comas para organizar y categorizar la herramienta",
+        "hintTagInput": "Presiona Enter o coma para añadir una etiqueta. Backspace elimina la última."
       },
       "examples": {
         "label": "Ejemplos",
@@ -127,13 +165,122 @@
       "queryParamsInvalid": "JSON inválido para parámetros de query",
       "pathParamsInvalid": "JSON inválido para parámetros de path",
       "valuesInvalid": "JSON inválido para valores por defecto",
-      "errorHandlingInvalid": "JSON inválido para manejo de errores"
+      "errorHandlingInvalid": "JSON inválido para manejo de errores",
+      "inputModesInvalid": "Modos de entrada deben ser un array JSON de strings",
+      "outputModesInvalid": "Modos de salida deben ser un array JSON de strings"
     },
     "actions": {
       "cancel": "Cancelar",
       "save": "Guardar Cambios",
       "create": "Crear Herramienta",
       "saving": "Guardando..."
+    }
+  },
+  "keyValueEditor": {
+    "keyPlaceholder": "Clave",
+    "valuePlaceholder": "Valor",
+    "addRow": "Agregar fila",
+    "removeRow": "Eliminar fila",
+    "complexValueBadge": "valor complejo — edite en modo avanzado",
+    "errors": {
+      "emptyKey": "La clave no puede estar vacía",
+      "duplicateKey": "Clave duplicada",
+      "emptyValue": "El valor es obligatorio cuando la clave está completada"
+    }
+  },
+  "advancedConfig": {
+    "title": "Configuración avanzada"
+  },
+  "tagInput": {
+    "placeholder": "Escribe y presiona Enter…",
+    "removeTag": "Eliminar {{tag}}",
+    "suggestions": "Sugerencias"
+  },
+  "testResult": {
+    "titleSuccess": "Prueba exitosa",
+    "titleError": "Prueba fallida",
+    "statusCode": "Status code",
+    "responseTime": "Tiempo de respuesta",
+    "errorLabel": "Error",
+    "responseHeaders": "Headers de respuesta",
+    "responseBody": "Cuerpo de respuesta",
+    "noData": "La solicitud no se completó y no devolvió detalles.",
+    "close": "Cerrar"
+  },
+  "testRequest": {
+    "button": "Probar solicitud",
+    "testing": "Probando...",
+    "success": "Solicitud ejecutada con éxito",
+    "error": "Error al probar la solicitud",
+    "statusCode": "Status",
+    "responseTime": "Tiempo de respuesta",
+    "responseHeaders": "Headers de respuesta",
+    "responseBody": "Cuerpo de respuesta",
+    "disabledTooltipCreateMode": "Guarde la herramienta primero para poder probarla"
+  },
+  "wizard": {
+    "progress": {
+      "identity": "Identidad",
+      "endpoint": "Endpoint",
+      "parameters": "Parámetros",
+      "advanced": "Avanzado",
+      "modes": "Modos",
+      "finish": "Finalizar"
+    },
+    "step1": {
+      "title": "Identifiquemos tu herramienta",
+      "subtitle": "Dale un nombre, descripción y etiquetas para que tu equipo la encuentre después."
+    },
+    "step2": {
+      "title": "¿Qué endpoint llama?",
+      "subtitle": "Elige el método HTTP, la URL y los headers enviados en cada solicitud."
+    },
+    "step3": {
+      "title": "Configura los parámetros",
+      "subtitle": "Query, path y body params. Body solo aparece si el método lo permite."
+    },
+    "step4": {
+      "title": "Configuración avanzada",
+      "subtitle": "Opcional. Valores por defecto y manejo de errores.",
+      "helperText": "Estos campos son opcionales — sáltalos si no los necesitas."
+    },
+    "step5": {
+      "title": "Modos de entrada y salida",
+      "subtitle": "Opcional. Declara qué tipo de contenido acepta y devuelve esta herramienta.",
+      "selectPlaceholder": "Selecciona un tipo",
+      "modeOptions": {
+        "text": "Texto",
+        "image": "Imagen",
+        "audio": "Audio",
+        "video": "Vídeo",
+        "json": "JSON",
+        "file": "Archivo"
+      },
+      "input": {
+        "typeLabel": "Lo que recibe",
+        "descriptionLabel": "¿Qué debe enviar la IA?",
+        "badge": "instrucción para la IA",
+        "descriptionPlaceholder": "Ej: La imagen de un documento o comprobante que el cliente envió y necesita ser leído."
+      },
+      "output": {
+        "typeLabel": "Lo que devuelve",
+        "descriptionLabel": "Describe el retorno",
+        "badge": "ayuda al agente a interpretar",
+        "descriptionPlaceholder": "Ej: El texto extraído del documento, en formato corrido, listo para ser usado en la respuesta."
+      }
+    },
+    "step6": {
+      "title": "Toques finales",
+      "subtitle": "Agrega ejemplos de uso que ayuden a los agentes a saber cuándo llamar esta herramienta.",
+      "helperText": "Los ejemplos son descripciones cortas de cómo usar la herramienta.",
+      "testHint": "Después de crear, podrás probar la herramienta contra el endpoint real."
+    },
+    "actions": {
+      "continue": "Continuar",
+      "back": "Volver",
+      "skip": "Saltar",
+      "create": "Crear herramienta",
+      "save": "Guardar cambios"
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -22,7 +22,7 @@
       "basicInfo": "Informations de Base",
       "tags": "Tags",
       "examples": "Exemples",
-      "headers": "En-têtes HTTP",
+      "headers": "Headers HTTP",
       "inputOutput": "Modes d'Entrée et de Sortie"
     },
     "fields": {
@@ -38,7 +38,7 @@
     "empty": {
       "tags": "Aucun tag configuré",
       "examples": "Aucun exemple disponible",
-      "headers": "Aucun en-tête HTTP configuré"
+      "headers": "Aucun header HTTP configuré"
     },
     "actions": {
       "test": "Tester",
@@ -74,43 +74,81 @@
       },
       "endpoint": {
         "label": "Endpoint",
-        "placeholder": "https://api.exemple.com/endpoint",
+        "placeholder": "https://api.example.com/endpoint",
         "required": true
       },
       "headers": {
-        "label": "En-têtes HTTP (JSON)",
+        "label": "Headers HTTP (JSON)",
+        "labelKv": "Headers HTTP",
         "placeholder": "{\"Authorization\": \"Bearer token\", \"Content-Type\": \"application/json\"}",
-        "hint": "Configurez les en-têtes HTTP nécessaires pour l'authentification et la communication"
+        "keyPlaceholder": "Nom du header (ex : Authorization)",
+        "valuePlaceholder": "Valeur (ex : Bearer token)",
+        "hint": "Headers HTTP envoyés à chaque requête (auth, content-type, etc.)"
       },
       "bodyParams": {
         "label": "Paramètres du Body (JSON)",
+        "labelKv": "Paramètres du Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
-        "hint": "Configurez les paramètres du corps de la requête envoyés avec les requêtes POST/PUT/PATCH"
+        "keyPlaceholder": "Nom du champ",
+        "valuePlaceholder": "Valeur",
+        "hint": "Champs du corps envoyés avec les requêtes POST/PUT/PATCH"
       },
       "queryParams": {
         "label": "Paramètres de Query (JSON)",
+        "labelKv": "Paramètres de Query",
         "placeholder": "{\"param1\": \"value1\", \"param2\": \"value2\"}",
-        "hint": "Configurez les paramètres de la chaîne de requête de l'URL ajoutés à l'endpoint"
+        "keyPlaceholder": "Nom du paramètre",
+        "valuePlaceholder": "Valeur",
+        "hint": "Paramètres de query string ajoutés à l'URL (ex : ?param=valeur)"
       },
       "pathParams": {
         "label": "Paramètres de Path (JSON)",
+        "labelKv": "Paramètres de Path",
         "placeholder": "{\"user_id\": \"{user_id}\", \"resource_id\": \"{resource_id}\"}",
-        "hint": "Configurez les paramètres de path qui seront remplacés dans l'URL de l'endpoint (ex: /users/{user_id})"
+        "keyPlaceholder": "Nom du paramètre (ex : user_id)",
+        "valuePlaceholder": "Valeur ou placeholder",
+        "hint": "Placeholders de path substitués dans l'URL (ex : /users/{user_id})"
       },
       "values": {
         "label": "Valeurs par Défaut (JSON)",
+        "labelKv": "Valeurs par Défaut",
         "placeholder": "{\"default_key\": \"default_value\"}",
-        "hint": "Configurez les valeurs par défaut utilisées comme repli lorsque les paramètres ne sont pas fournis à l'exécution"
+        "keyPlaceholder": "Clé (ex : default_user)",
+        "valuePlaceholder": "Valeur par défaut",
+        "hint": "Valeurs par défaut utilisées en repli quand les paramètres ne sont pas fournis à l'exécution"
       },
       "errorHandling": {
         "label": "Gestion des Erreurs (JSON)",
+        "labelVisual": "Gestion des Erreurs",
         "placeholder": "{\"timeout\": 30, \"retry_count\": 3, \"fallback_response\": \"{}\"}",
-        "hint": "Configurez les paramètres de gestion des erreurs: timeout (secondes), retry_count et fallback_response"
+        "timeoutLabel": "Timeout (secondes)",
+        "retryLabel": "Nombre de retries",
+        "fallbackLabel": "Réponse de fallback",
+        "fallbackPlaceholder": "JSON retourné quand tous les retries échouent",
+        "hint": "Configurez timeout, retries et une réponse de fallback pour les erreurs"
+      },
+      "inputModes": {
+        "label": "Modes d'Entrée (tableau JSON)",
+        "labelVisual": "Modes d'Entrée",
+        "placeholder": "[\"text\", \"image\"]",
+        "placeholderVisual": "Tapez et appuyez sur Entrée…",
+        "hint": "Types MIME ou modes d'entrée pris en charge",
+        "hintVisual": "Tapez et appuyez sur Entrée pour ajouter, ou cliquez sur une suggestion"
+      },
+      "outputModes": {
+        "label": "Modes de Sortie (tableau JSON)",
+        "labelVisual": "Modes de Sortie",
+        "placeholder": "[\"text\", \"json\"]",
+        "placeholderVisual": "Tapez et appuyez sur Entrée…",
+        "hint": "Types MIME ou modes de sortie pris en charge",
+        "hintVisual": "Tapez et appuyez sur Entrée pour ajouter, ou cliquez sur une suggestion"
       },
       "tags": {
         "label": "Tags",
         "placeholder": "api, http, webhook",
-        "hint": "Séparez les tags par des virgules pour organiser et catégoriser l'outil"
+        "placeholderTagInput": "Tapez et appuyez sur Entrée pour ajouter un tag…",
+        "hint": "Séparez les tags par des virgules pour organiser et catégoriser l'outil",
+        "hintTagInput": "Appuyez sur Entrée ou virgule pour ajouter un tag. Backspace supprime le dernier."
       },
       "examples": {
         "label": "Exemples",
@@ -122,18 +160,127 @@
       "endpointRequired": "L'endpoint est obligatoire",
       "endpointInvalid": "L'endpoint doit être une URL valide",
       "methodRequired": "La méthode HTTP est obligatoire",
-      "headersInvalid": "JSON des en-têtes invalide",
+      "headersInvalid": "JSON de headers invalide",
       "bodyParamsInvalid": "JSON invalide pour les paramètres du body",
       "queryParamsInvalid": "JSON invalide pour les paramètres de query",
       "pathParamsInvalid": "JSON invalide pour les paramètres de path",
       "valuesInvalid": "JSON invalide pour les valeurs par défaut",
-      "errorHandlingInvalid": "JSON invalide pour la gestion des erreurs"
+      "errorHandlingInvalid": "JSON invalide pour la gestion des erreurs",
+      "inputModesInvalid": "Les modes d'entrée doivent être un tableau JSON de chaînes",
+      "outputModesInvalid": "Les modes de sortie doivent être un tableau JSON de chaînes"
     },
     "actions": {
       "cancel": "Annuler",
       "save": "Enregistrer les Modifications",
       "create": "Créer l'Outil",
       "saving": "Enregistrement..."
+    }
+  },
+  "keyValueEditor": {
+    "keyPlaceholder": "Clé",
+    "valuePlaceholder": "Valeur",
+    "addRow": "Ajouter une ligne",
+    "removeRow": "Supprimer la ligne",
+    "complexValueBadge": "valeur complexe — éditer en mode avancé",
+    "errors": {
+      "emptyKey": "La clé ne peut pas être vide",
+      "duplicateKey": "Clé en double",
+      "emptyValue": "La valeur est obligatoire quand la clé est renseignée"
+    }
+  },
+  "advancedConfig": {
+    "title": "Configuration avancée"
+  },
+  "tagInput": {
+    "placeholder": "Tapez et appuyez sur Entrée…",
+    "removeTag": "Supprimer {{tag}}",
+    "suggestions": "Suggestions"
+  },
+  "testResult": {
+    "titleSuccess": "Test réussi",
+    "titleError": "Test échoué",
+    "statusCode": "Status code",
+    "responseTime": "Temps de réponse",
+    "errorLabel": "Erreur",
+    "responseHeaders": "Headers de réponse",
+    "responseBody": "Corps de réponse",
+    "noData": "La requête n'a pas abouti et n'a renvoyé aucun détail.",
+    "close": "Fermer"
+  },
+  "testRequest": {
+    "button": "Tester la requête",
+    "testing": "Test en cours...",
+    "success": "Requête exécutée avec succès",
+    "error": "Échec du test de la requête",
+    "statusCode": "Status",
+    "responseTime": "Temps de réponse",
+    "responseHeaders": "Headers de réponse",
+    "responseBody": "Corps de réponse",
+    "disabledTooltipCreateMode": "Enregistrez l'outil d'abord pour pouvoir le tester"
+  },
+  "wizard": {
+    "progress": {
+      "identity": "Identité",
+      "endpoint": "Endpoint",
+      "parameters": "Paramètres",
+      "advanced": "Avancé",
+      "modes": "Modes",
+      "finish": "Finaliser"
+    },
+    "step1": {
+      "title": "Identifions votre outil",
+      "subtitle": "Donnez-lui un nom, une description et des tags pour que votre équipe le retrouve plus tard."
+    },
+    "step2": {
+      "title": "Quel endpoint appelle-t-il ?",
+      "subtitle": "Choisissez la méthode HTTP, l'URL et les headers envoyés à chaque requête."
+    },
+    "step3": {
+      "title": "Configurez les paramètres",
+      "subtitle": "Paramètres de query, path et body. Body n'apparaît que si la méthode le permet."
+    },
+    "step4": {
+      "title": "Configuration avancée",
+      "subtitle": "Optionnel. Valeurs par défaut et gestion des erreurs.",
+      "helperText": "Ces champs sont optionnels — passez si vous n'en avez pas besoin."
+    },
+    "step5": {
+      "title": "Modes d'entrée et de sortie",
+      "subtitle": "Optionnel. Déclarez quel type de contenu cet outil accepte et retourne.",
+      "selectPlaceholder": "Sélectionnez un type",
+      "modeOptions": {
+        "text": "Texte",
+        "image": "Image",
+        "audio": "Audio",
+        "video": "Vidéo",
+        "json": "JSON",
+        "file": "Fichier"
+      },
+      "input": {
+        "typeLabel": "Ce qu'il reçoit",
+        "descriptionLabel": "Que doit envoyer l'IA ?",
+        "badge": "instruction pour l'IA",
+        "descriptionPlaceholder": "Ex : L'image d'un document ou justificatif que le client a envoyé et qui doit être lu."
+      },
+      "output": {
+        "typeLabel": "Ce qu'il retourne",
+        "descriptionLabel": "Décrivez le retour",
+        "badge": "aide l'agent à interpréter",
+        "descriptionPlaceholder": "Ex : Le texte extrait du document, en prose continue, prêt à être utilisé dans la réponse."
+      }
+    },
+    "step6": {
+      "title": "Touches finales",
+      "subtitle": "Ajoutez des exemples d'usage pour aider les agents à savoir quand appeler cet outil.",
+      "helperText": "Les exemples sont de courtes descriptions d'utilisation de l'outil.",
+      "testHint": "Après création, vous pourrez tester l'outil contre l'endpoint réel."
+    },
+    "actions": {
+      "continue": "Continuer",
+      "back": "Retour",
+      "skip": "Passer",
+      "create": "Créer l'outil",
+      "save": "Enregistrer les modifications"
     }
   },
   "modal": {

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -8,7 +8,7 @@
   },
   "card": {
     "noDescription": "Nessuna descrizione",
-    "examples": "{{count}} esempio/i",
+    "examples": "{{count}} esempio(i)",
     "createdAt": "Creato il",
     "actions": {
       "test": "Testa",
@@ -17,13 +17,13 @@
     }
   },
   "details": {
-    "title": "Dettagli Strumento",
+    "title": "Dettagli dello Strumento",
     "sections": {
       "basicInfo": "Informazioni di Base",
       "tags": "Tag",
       "examples": "Esempi",
-      "headers": "Header HTTP",
-      "inputOutput": "Modalità Input e Output"
+      "headers": "Headers HTTP",
+      "inputOutput": "Modalità di Input e Output"
     },
     "fields": {
       "name": "Nome",
@@ -31,8 +31,8 @@
       "method": "Metodo HTTP",
       "createdAt": "Creato il",
       "endpoint": "Endpoint",
-      "inputModes": "Modalità Input",
-      "outputModes": "Modalità Output",
+      "inputModes": "Modalità di Input",
+      "outputModes": "Modalità di Output",
       "notSpecified": "Non specificato"
     },
     "empty": {
@@ -78,39 +78,77 @@
         "required": true
       },
       "headers": {
-        "label": "Header HTTP (JSON)",
+        "label": "Headers HTTP (JSON)",
+        "labelKv": "Headers HTTP",
         "placeholder": "{\"Authorization\": \"Bearer token\", \"Content-Type\": \"application/json\"}",
-        "hint": "Configura gli header HTTP necessari per autenticazione e comunicazione"
+        "keyPlaceholder": "Nome header (es. Authorization)",
+        "valuePlaceholder": "Valore (es. Bearer token)",
+        "hint": "Headers HTTP inviati con ogni richiesta (auth, content-type, ecc.)"
       },
       "bodyParams": {
         "label": "Parametri del Body (JSON)",
+        "labelKv": "Parametri del Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
-        "hint": "Configura i parametri del corpo della richiesta inviati con richieste POST/PUT/PATCH"
+        "keyPlaceholder": "Nome campo",
+        "valuePlaceholder": "Valore",
+        "hint": "Campi del corpo inviati con richieste POST/PUT/PATCH"
       },
       "queryParams": {
         "label": "Parametri di Query (JSON)",
+        "labelKv": "Parametri di Query",
         "placeholder": "{\"param1\": \"value1\", \"param2\": \"value2\"}",
-        "hint": "Configura i parametri della query string dell'URL allegati all'endpoint"
+        "keyPlaceholder": "Nome parametro",
+        "valuePlaceholder": "Valore",
+        "hint": "Parametri di query string aggiunti all'URL (es. ?param=valore)"
       },
       "pathParams": {
         "label": "Parametri di Path (JSON)",
+        "labelKv": "Parametri di Path",
         "placeholder": "{\"user_id\": \"{user_id}\", \"resource_id\": \"{resource_id}\"}",
-        "hint": "Configura i parametri di path che saranno sostituiti nell'URL dell'endpoint (es: /users/{user_id})"
+        "keyPlaceholder": "Nome parametro (es. user_id)",
+        "valuePlaceholder": "Valore o placeholder",
+        "hint": "Placeholder di path sostituiti nell'URL (es. /users/{user_id})"
       },
       "values": {
         "label": "Valori Predefiniti (JSON)",
+        "labelKv": "Valori Predefiniti",
         "placeholder": "{\"default_key\": \"default_value\"}",
-        "hint": "Configura valori predefiniti usati come fallback quando i parametri non sono forniti a runtime"
+        "keyPlaceholder": "Chiave (es. default_user)",
+        "valuePlaceholder": "Valore predefinito",
+        "hint": "Valori predefiniti usati come fallback quando i parametri non sono forniti a runtime"
       },
       "errorHandling": {
-        "label": "Gestione Errori (JSON)",
+        "label": "Gestione degli Errori (JSON)",
+        "labelVisual": "Gestione degli Errori",
         "placeholder": "{\"timeout\": 30, \"retry_count\": 3, \"fallback_response\": \"{}\"}",
-        "hint": "Configura le impostazioni di gestione errori: timeout (secondi), retry_count e fallback_response"
+        "timeoutLabel": "Timeout (secondi)",
+        "retryLabel": "Numero di retry",
+        "fallbackLabel": "Risposta di fallback",
+        "fallbackPlaceholder": "JSON restituito quando tutti i retry falliscono",
+        "hint": "Configura timeout, retry e una risposta di fallback per gli errori"
+      },
+      "inputModes": {
+        "label": "Modalità di Input (array JSON)",
+        "labelVisual": "Modalità di Input",
+        "placeholder": "[\"text\", \"image\"]",
+        "placeholderVisual": "Digita e premi Invio…",
+        "hint": "Tipi MIME o modalità di input supportati",
+        "hintVisual": "Digita e premi Invio per aggiungere, o clicca un suggerimento"
+      },
+      "outputModes": {
+        "label": "Modalità di Output (array JSON)",
+        "labelVisual": "Modalità di Output",
+        "placeholder": "[\"text\", \"json\"]",
+        "placeholderVisual": "Digita e premi Invio…",
+        "hint": "Tipi MIME o modalità di output supportati",
+        "hintVisual": "Digita e premi Invio per aggiungere, o clicca un suggerimento"
       },
       "tags": {
         "label": "Tag",
         "placeholder": "api, http, webhook",
-        "hint": "Separa i tag con virgole per organizzare e categorizzare lo strumento"
+        "placeholderTagInput": "Digita e premi Invio per aggiungere un tag…",
+        "hint": "Separa i tag con virgole per organizzare e categorizzare lo strumento",
+        "hintTagInput": "Premi Invio o virgola per aggiungere un tag. Backspace rimuove l'ultimo."
       },
       "examples": {
         "label": "Esempi",
@@ -122,18 +160,127 @@
       "endpointRequired": "L'endpoint è obbligatorio",
       "endpointInvalid": "L'endpoint deve essere un URL valido",
       "methodRequired": "Il metodo HTTP è obbligatorio",
-      "headersInvalid": "JSON degli header non valido",
+      "headersInvalid": "JSON di headers non valido",
       "bodyParamsInvalid": "JSON non valido per i parametri del body",
       "queryParamsInvalid": "JSON non valido per i parametri di query",
       "pathParamsInvalid": "JSON non valido per i parametri di path",
       "valuesInvalid": "JSON non valido per i valori predefiniti",
-      "errorHandlingInvalid": "JSON non valido per la gestione errori"
+      "errorHandlingInvalid": "JSON non valido per la gestione degli errori",
+      "inputModesInvalid": "Le modalità di input devono essere un array JSON di stringhe",
+      "outputModesInvalid": "Le modalità di output devono essere un array JSON di stringhe"
     },
     "actions": {
       "cancel": "Annulla",
       "save": "Salva Modifiche",
       "create": "Crea Strumento",
       "saving": "Salvataggio..."
+    }
+  },
+  "keyValueEditor": {
+    "keyPlaceholder": "Chiave",
+    "valuePlaceholder": "Valore",
+    "addRow": "Aggiungi riga",
+    "removeRow": "Rimuovi riga",
+    "complexValueBadge": "valore complesso — modifica in modalità avanzata",
+    "errors": {
+      "emptyKey": "La chiave non può essere vuota",
+      "duplicateKey": "Chiave duplicata",
+      "emptyValue": "Il valore è obbligatorio quando la chiave è impostata"
+    }
+  },
+  "advancedConfig": {
+    "title": "Configurazione avanzata"
+  },
+  "tagInput": {
+    "placeholder": "Digita e premi Invio…",
+    "removeTag": "Rimuovi {{tag}}",
+    "suggestions": "Suggerimenti"
+  },
+  "testResult": {
+    "titleSuccess": "Test riuscito",
+    "titleError": "Test fallito",
+    "statusCode": "Status code",
+    "responseTime": "Tempo di risposta",
+    "errorLabel": "Errore",
+    "responseHeaders": "Headers della risposta",
+    "responseBody": "Corpo della risposta",
+    "noData": "La richiesta non è stata completata e non ha restituito dettagli.",
+    "close": "Chiudi"
+  },
+  "testRequest": {
+    "button": "Testa richiesta",
+    "testing": "Test in corso...",
+    "success": "Richiesta eseguita con successo",
+    "error": "Errore nel test della richiesta",
+    "statusCode": "Status",
+    "responseTime": "Tempo di risposta",
+    "responseHeaders": "Headers di risposta",
+    "responseBody": "Corpo della risposta",
+    "disabledTooltipCreateMode": "Salva lo strumento prima per poterlo testare"
+  },
+  "wizard": {
+    "progress": {
+      "identity": "Identità",
+      "endpoint": "Endpoint",
+      "parameters": "Parametri",
+      "advanced": "Avanzato",
+      "modes": "Modalità",
+      "finish": "Finalizza"
+    },
+    "step1": {
+      "title": "Identifichiamo il tuo strumento",
+      "subtitle": "Dagli un nome, una descrizione e tag in modo che il tuo team lo trovi in seguito."
+    },
+    "step2": {
+      "title": "Quale endpoint chiama?",
+      "subtitle": "Scegli il metodo HTTP, l'URL e gli headers inviati a ogni richiesta."
+    },
+    "step3": {
+      "title": "Configura i parametri",
+      "subtitle": "Parametri di query, path e body. Body appare solo se il metodo lo permette."
+    },
+    "step4": {
+      "title": "Configurazione avanzata",
+      "subtitle": "Opzionale. Valori predefiniti e gestione degli errori.",
+      "helperText": "Questi campi sono opzionali — salta se non ne hai bisogno."
+    },
+    "step5": {
+      "title": "Modalità di input e output",
+      "subtitle": "Opzionale. Dichiara che tipo di contenuto questo strumento accetta e restituisce.",
+      "selectPlaceholder": "Seleziona un tipo",
+      "modeOptions": {
+        "text": "Testo",
+        "image": "Immagine",
+        "audio": "Audio",
+        "video": "Video",
+        "json": "JSON",
+        "file": "File"
+      },
+      "input": {
+        "typeLabel": "Cosa riceve",
+        "descriptionLabel": "Cosa deve inviare l'IA?",
+        "badge": "istruzione per l'IA",
+        "descriptionPlaceholder": "Es: L'immagine di un documento o ricevuta che il cliente ha inviato e deve essere letta."
+      },
+      "output": {
+        "typeLabel": "Cosa restituisce",
+        "descriptionLabel": "Descrivi il ritorno",
+        "badge": "aiuta l'agente a interpretare",
+        "descriptionPlaceholder": "Es: Il testo estratto dal documento, in prosa continua, pronto per essere usato nella risposta."
+      }
+    },
+    "step6": {
+      "title": "Tocchi finali",
+      "subtitle": "Aggiungi esempi d'uso che aiutino gli agenti a sapere quando chiamare questo strumento.",
+      "helperText": "Gli esempi sono brevi descrizioni di come usare lo strumento.",
+      "testHint": "Dopo la creazione, potrai testare lo strumento contro l'endpoint reale."
+    },
+    "actions": {
+      "continue": "Continua",
+      "back": "Indietro",
+      "skip": "Salta",
+      "create": "Crea strumento",
+      "save": "Salva modifiche"
     }
   },
   "modal": {
@@ -161,8 +308,8 @@
       "createdAt": "Creato il",
       "test": "Test"
     },
-    "noName": "Nessun nome",
-    "noDescription": "Nessuna descrizione",
+    "noName": "Senza nome",
+    "noDescription": "Senza descrizione",
     "noTags": "-",
     "actions": {
       "test": "Testa",
@@ -181,17 +328,17 @@
     "creating": "Creazione...",
     "updating": "Aggiornamento...",
     "deleting": "Eliminazione...",
-    "testing": "Test..."
+    "testing": "Test in corso..."
   },
   "messages": {
-    "loadError": "Errore durante il caricamento degli strumenti personalizzati",
+    "loadError": "Errore nel caricamento degli strumenti personalizzati",
     "createSuccess": "Strumento personalizzato creato con successo",
-    "createError": "Errore durante la creazione dello strumento personalizzato",
+    "createError": "Errore nella creazione dello strumento personalizzato",
     "updateSuccess": "Strumento personalizzato aggiornato con successo",
-    "updateError": "Errore durante l'aggiornamento dello strumento personalizzato",
+    "updateError": "Errore nell'aggiornamento dello strumento personalizzato",
     "deleteSuccess": "Strumento personalizzato eliminato con successo",
-    "deleteError": "Errore durante l'eliminazione dello strumento personalizzato",
+    "deleteError": "Errore nell'eliminazione dello strumento personalizzato",
     "testSuccess": "Test eseguito con successo",
-    "testError": "Errore durante il test dello strumento personalizzato"
+    "testError": "Errore nel test dello strumento personalizzato"
   }
 }

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -79,38 +79,76 @@
       },
       "headers": {
         "label": "Headers HTTP (JSON)",
+        "labelKv": "Headers HTTP",
         "placeholder": "{\"Authorization\": \"Bearer token\", \"Content-Type\": \"application/json\"}",
-        "hint": "Configure os headers HTTP necessários para autenticação e comunicação"
+        "keyPlaceholder": "Nome do header (ex: Authorization)",
+        "valuePlaceholder": "Valor (ex: Bearer token)",
+        "hint": "Headers HTTP enviados em toda requisição (auth, content-type, etc.)"
       },
       "bodyParams": {
         "label": "Parâmetros do Body (JSON)",
+        "labelKv": "Parâmetros do Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
-        "hint": "Configure os parâmetros do corpo da requisição enviados com requisições POST/PUT/PATCH"
+        "keyPlaceholder": "Nome do campo",
+        "valuePlaceholder": "Valor",
+        "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH"
       },
       "queryParams": {
         "label": "Parâmetros de Query (JSON)",
+        "labelKv": "Parâmetros de Query",
         "placeholder": "{\"param1\": \"value1\", \"param2\": \"value2\"}",
-        "hint": "Configure os parâmetros da query string da URL anexados ao endpoint"
+        "keyPlaceholder": "Nome do parâmetro",
+        "valuePlaceholder": "Valor",
+        "hint": "Parâmetros da query string anexados à URL (ex: ?param=valor)"
       },
       "pathParams": {
         "label": "Parâmetros de Path (JSON)",
+        "labelKv": "Parâmetros de Path",
         "placeholder": "{\"user_id\": \"{user_id}\", \"resource_id\": \"{resource_id}\"}",
-        "hint": "Configure os parâmetros de path que serão substituídos na URL do endpoint (ex: /users/{user_id})"
+        "keyPlaceholder": "Nome do parâmetro (ex: user_id)",
+        "valuePlaceholder": "Valor ou placeholder",
+        "hint": "Placeholders de path substituídos na URL (ex: /users/{user_id})"
       },
       "values": {
         "label": "Valores Padrão (JSON)",
+        "labelKv": "Valores Padrão",
         "placeholder": "{\"default_key\": \"default_value\"}",
-        "hint": "Configure valores padrão usados como fallback quando parâmetros não são fornecidos em tempo de execução"
+        "keyPlaceholder": "Chave (ex: default_user)",
+        "valuePlaceholder": "Valor padrão",
+        "hint": "Valores padrão usados como fallback quando parâmetros não são fornecidos em runtime"
       },
       "errorHandling": {
         "label": "Tratamento de Erros (JSON)",
+        "labelVisual": "Tratamento de Erros",
         "placeholder": "{\"timeout\": 30, \"retry_count\": 3, \"fallback_response\": \"{}\"}",
-        "hint": "Configure as configurações de tratamento de erros: timeout (segundos), retry_count e fallback_response"
+        "timeoutLabel": "Timeout (segundos)",
+        "retryLabel": "Número de retries",
+        "fallbackLabel": "Resposta de fallback",
+        "fallbackPlaceholder": "JSON retornado quando todos os retries falham",
+        "hint": "Configure timeout, retries e uma resposta de fallback pra erros"
+      },
+      "inputModes": {
+        "label": "Modos de Entrada (array JSON)",
+        "labelVisual": "Modos de Entrada",
+        "placeholder": "[\"text\", \"image\"]",
+        "placeholderVisual": "Digite e pressione Enter…",
+        "hint": "Tipos MIME ou modos de entrada suportados",
+        "hintVisual": "Digite e pressione Enter pra adicionar, ou clique numa sugestão"
+      },
+      "outputModes": {
+        "label": "Modos de Saída (array JSON)",
+        "labelVisual": "Modos de Saída",
+        "placeholder": "[\"text\", \"json\"]",
+        "placeholderVisual": "Digite e pressione Enter…",
+        "hint": "Tipos MIME ou modos de saída suportados",
+        "hintVisual": "Digite e pressione Enter pra adicionar, ou clique numa sugestão"
       },
       "tags": {
         "label": "Tags",
         "placeholder": "api, http, webhook",
-        "hint": "Separe as tags com vírgulas para organizar e categorizar a ferramenta"
+        "placeholderTagInput": "Digite e pressione Enter pra adicionar uma tag…",
+        "hint": "Separe as tags com vírgulas para organizar e categorizar a ferramenta",
+        "hintTagInput": "Pressione Enter ou vírgula pra adicionar uma tag. Backspace remove a última."
       },
       "examples": {
         "label": "Exemplos",
@@ -127,13 +165,122 @@
       "queryParamsInvalid": "JSON inválido para parâmetros de query",
       "pathParamsInvalid": "JSON inválido para parâmetros de path",
       "valuesInvalid": "JSON inválido para valores padrão",
-      "errorHandlingInvalid": "JSON inválido para tratamento de erros"
+      "errorHandlingInvalid": "JSON inválido para tratamento de erros",
+      "inputModesInvalid": "Modos de entrada devem ser um array JSON de strings",
+      "outputModesInvalid": "Modos de saída devem ser um array JSON de strings"
     },
     "actions": {
       "cancel": "Cancelar",
       "save": "Salvar Alterações",
       "create": "Criar Ferramenta",
       "saving": "Salvando..."
+    }
+  },
+  "keyValueEditor": {
+    "keyPlaceholder": "Chave",
+    "valuePlaceholder": "Valor",
+    "addRow": "Adicionar linha",
+    "removeRow": "Remover linha",
+    "complexValueBadge": "valor complexo — edite no modo avançado",
+    "errors": {
+      "emptyKey": "A chave não pode ser vazia",
+      "duplicateKey": "Chave duplicada",
+      "emptyValue": "Valor é obrigatório quando a chave está preenchida"
+    }
+  },
+  "advancedConfig": {
+    "title": "Configuração avançada"
+  },
+  "tagInput": {
+    "placeholder": "Digite e pressione Enter…",
+    "removeTag": "Remover {{tag}}",
+    "suggestions": "Sugestões"
+  },
+  "testResult": {
+    "titleSuccess": "Teste bem-sucedido",
+    "titleError": "Teste falhou",
+    "statusCode": "Status code",
+    "responseTime": "Tempo de resposta",
+    "errorLabel": "Erro",
+    "responseHeaders": "Headers da resposta",
+    "responseBody": "Corpo da resposta",
+    "noData": "A requisição não completou e não retornou detalhes.",
+    "close": "Fechar"
+  },
+  "testRequest": {
+    "button": "Testar requisição",
+    "testing": "Testando...",
+    "success": "Requisição executada com sucesso",
+    "error": "Falha ao testar a requisição",
+    "statusCode": "Status",
+    "responseTime": "Tempo de resposta",
+    "responseHeaders": "Headers da resposta",
+    "responseBody": "Corpo da resposta",
+    "disabledTooltipCreateMode": "Salve a tool primeiro pra poder testar"
+  },
+  "wizard": {
+    "progress": {
+      "identity": "Identidade",
+      "endpoint": "Endpoint",
+      "parameters": "Parâmetros",
+      "advanced": "Avançado",
+      "modes": "Modos",
+      "finish": "Finalizar"
+    },
+    "step1": {
+      "title": "Vamos identificar sua tool",
+      "subtitle": "Dê um nome, descrição e tags pra sua equipe encontrar depois."
+    },
+    "step2": {
+      "title": "Qual endpoint ela chama?",
+      "subtitle": "Escolha o método HTTP, a URL e os headers enviados em toda requisição."
+    },
+    "step3": {
+      "title": "Configure os parâmetros",
+      "subtitle": "Query, path e body params. Body só aparece se o método permitir."
+    },
+    "step4": {
+      "title": "Configuração avançada",
+      "subtitle": "Opcional. Valores padrão e tratamento de erros.",
+      "helperText": "Esses campos são opcionais — pule se não precisar."
+    },
+    "step5": {
+      "title": "Modos de entrada e saída",
+      "subtitle": "Opcional. Declare que tipo de conteúdo essa tool aceita e devolve.",
+      "selectPlaceholder": "Selecione um tipo",
+      "modeOptions": {
+        "text": "Texto",
+        "image": "Imagem",
+        "audio": "Áudio",
+        "video": "Vídeo",
+        "json": "JSON",
+        "file": "Arquivo"
+      },
+      "input": {
+        "typeLabel": "O que ela recebe",
+        "descriptionLabel": "O que a IA deve enviar?",
+        "badge": "instrução pra IA",
+        "descriptionPlaceholder": "Ex: A imagem de um documento ou comprovante que o cliente enviou e precisa ser lido."
+      },
+      "output": {
+        "typeLabel": "O que ela devolve",
+        "descriptionLabel": "Descreva o retorno",
+        "badge": "ajuda o agente a interpretar",
+        "descriptionPlaceholder": "Ex: O texto extraído do documento, em formato corrido, pronto pra ser usado na resposta."
+      }
+    },
+    "step6": {
+      "title": "Toques finais",
+      "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
+      "helperText": "Exemplos são descrições curtas de como usar a tool.",
+      "testHint": "Após criar, você poderá testar a tool contra o endpoint real."
+    },
+    "actions": {
+      "continue": "Continuar",
+      "back": "Voltar",
+      "skip": "Pular",
+      "create": "Criar tool",
+      "save": "Salvar alterações"
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -79,38 +79,76 @@
       },
       "headers": {
         "label": "Headers HTTP (JSON)",
+        "labelKv": "Headers HTTP",
         "placeholder": "{\"Authorization\": \"Bearer token\", \"Content-Type\": \"application/json\"}",
-        "hint": "Configure os headers HTTP necessários para autenticação e comunicação"
+        "keyPlaceholder": "Nome do header (ex: Authorization)",
+        "valuePlaceholder": "Valor (ex: Bearer token)",
+        "hint": "Headers HTTP enviados em toda requisição (auth, content-type, etc.)"
       },
       "bodyParams": {
         "label": "Parâmetros do Body (JSON)",
+        "labelKv": "Parâmetros do Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
-        "hint": "Configure os parâmetros do corpo da requisição enviados com requisições POST/PUT/PATCH"
+        "keyPlaceholder": "Nome do campo",
+        "valuePlaceholder": "Valor",
+        "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH"
       },
       "queryParams": {
         "label": "Parâmetros de Query (JSON)",
+        "labelKv": "Parâmetros de Query",
         "placeholder": "{\"param1\": \"value1\", \"param2\": \"value2\"}",
-        "hint": "Configure os parâmetros da query string da URL anexados ao endpoint"
+        "keyPlaceholder": "Nome do parâmetro",
+        "valuePlaceholder": "Valor",
+        "hint": "Parâmetros da query string anexados à URL (ex: ?param=valor)"
       },
       "pathParams": {
         "label": "Parâmetros de Path (JSON)",
+        "labelKv": "Parâmetros de Path",
         "placeholder": "{\"user_id\": \"{user_id}\", \"resource_id\": \"{resource_id}\"}",
-        "hint": "Configure os parâmetros de path que serão substituídos na URL do endpoint (ex: /users/{user_id})"
+        "keyPlaceholder": "Nome do parâmetro (ex: user_id)",
+        "valuePlaceholder": "Valor ou placeholder",
+        "hint": "Placeholders de path substituídos na URL (ex: /users/{user_id})"
       },
       "values": {
         "label": "Valores Padrão (JSON)",
+        "labelKv": "Valores Padrão",
         "placeholder": "{\"default_key\": \"default_value\"}",
-        "hint": "Configure valores padrão usados como fallback quando parâmetros não são fornecidos em tempo de execução"
+        "keyPlaceholder": "Chave (ex: default_user)",
+        "valuePlaceholder": "Valor padrão",
+        "hint": "Valores padrão usados como fallback quando parâmetros não são fornecidos em runtime"
       },
       "errorHandling": {
         "label": "Tratamento de Erros (JSON)",
+        "labelVisual": "Tratamento de Erros",
         "placeholder": "{\"timeout\": 30, \"retry_count\": 3, \"fallback_response\": \"{}\"}",
-        "hint": "Configure as configurações de tratamento de erros: timeout (segundos), retry_count e fallback_response"
+        "timeoutLabel": "Timeout (segundos)",
+        "retryLabel": "Número de retries",
+        "fallbackLabel": "Resposta de fallback",
+        "fallbackPlaceholder": "JSON retornado quando todos os retries falham",
+        "hint": "Configure timeout, retries e uma resposta de fallback pra erros"
+      },
+      "inputModes": {
+        "label": "Modos de Entrada (array JSON)",
+        "labelVisual": "Modos de Entrada",
+        "placeholder": "[\"text\", \"image\"]",
+        "placeholderVisual": "Digite e pressione Enter…",
+        "hint": "Tipos MIME ou modos de entrada suportados",
+        "hintVisual": "Digite e pressione Enter pra adicionar, ou clique numa sugestão"
+      },
+      "outputModes": {
+        "label": "Modos de Saída (array JSON)",
+        "labelVisual": "Modos de Saída",
+        "placeholder": "[\"text\", \"json\"]",
+        "placeholderVisual": "Digite e pressione Enter…",
+        "hint": "Tipos MIME ou modos de saída suportados",
+        "hintVisual": "Digite e pressione Enter pra adicionar, ou clique numa sugestão"
       },
       "tags": {
         "label": "Tags",
         "placeholder": "api, http, webhook",
-        "hint": "Separe as tags com vírgulas para organizar e categorizar a ferramenta"
+        "placeholderTagInput": "Digite e pressione Enter pra adicionar uma tag…",
+        "hint": "Separe as tags com vírgulas para organizar e categorizar a ferramenta",
+        "hintTagInput": "Pressione Enter ou vírgula pra adicionar uma tag. Backspace remove a última."
       },
       "examples": {
         "label": "Exemplos",
@@ -127,13 +165,122 @@
       "queryParamsInvalid": "JSON inválido para parâmetros de query",
       "pathParamsInvalid": "JSON inválido para parâmetros de path",
       "valuesInvalid": "JSON inválido para valores padrão",
-      "errorHandlingInvalid": "JSON inválido para tratamento de erros"
+      "errorHandlingInvalid": "JSON inválido para tratamento de erros",
+      "inputModesInvalid": "Modos de entrada devem ser um array JSON de strings",
+      "outputModesInvalid": "Modos de saída devem ser um array JSON de strings"
     },
     "actions": {
       "cancel": "Cancelar",
       "save": "Salvar Alterações",
       "create": "Criar Ferramenta",
       "saving": "Salvando..."
+    }
+  },
+  "keyValueEditor": {
+    "keyPlaceholder": "Chave",
+    "valuePlaceholder": "Valor",
+    "addRow": "Adicionar linha",
+    "removeRow": "Remover linha",
+    "complexValueBadge": "valor complexo — edite no modo avançado",
+    "errors": {
+      "emptyKey": "A chave não pode ser vazia",
+      "duplicateKey": "Chave duplicada",
+      "emptyValue": "Valor é obrigatório quando a chave está preenchida"
+    }
+  },
+  "advancedConfig": {
+    "title": "Configuração avançada"
+  },
+  "tagInput": {
+    "placeholder": "Digite e pressione Enter…",
+    "removeTag": "Remover {{tag}}",
+    "suggestions": "Sugestões"
+  },
+  "testResult": {
+    "titleSuccess": "Teste bem-sucedido",
+    "titleError": "Teste falhou",
+    "statusCode": "Status code",
+    "responseTime": "Tempo de resposta",
+    "errorLabel": "Erro",
+    "responseHeaders": "Headers da resposta",
+    "responseBody": "Corpo da resposta",
+    "noData": "A requisição não completou e não retornou detalhes.",
+    "close": "Fechar"
+  },
+  "testRequest": {
+    "button": "Testar requisição",
+    "testing": "Testando...",
+    "success": "Requisição executada com sucesso",
+    "error": "Falha ao testar a requisição",
+    "statusCode": "Status",
+    "responseTime": "Tempo de resposta",
+    "responseHeaders": "Headers da resposta",
+    "responseBody": "Corpo da resposta",
+    "disabledTooltipCreateMode": "Salve a tool primeiro pra poder testar"
+  },
+  "wizard": {
+    "progress": {
+      "identity": "Identidade",
+      "endpoint": "Endpoint",
+      "parameters": "Parâmetros",
+      "advanced": "Avançado",
+      "modes": "Modos",
+      "finish": "Finalizar"
+    },
+    "step1": {
+      "title": "Vamos identificar sua tool",
+      "subtitle": "Dê um nome, descrição e tags pra sua equipe encontrar depois."
+    },
+    "step2": {
+      "title": "Qual endpoint ela chama?",
+      "subtitle": "Escolha o método HTTP, a URL e os headers enviados em toda requisição."
+    },
+    "step3": {
+      "title": "Configure os parâmetros",
+      "subtitle": "Query, path e body params. Body só aparece se o método permitir."
+    },
+    "step4": {
+      "title": "Configuração avançada",
+      "subtitle": "Opcional. Valores padrão e tratamento de erros.",
+      "helperText": "Esses campos são opcionais — pule se não precisar."
+    },
+    "step5": {
+      "title": "Modos de entrada e saída",
+      "subtitle": "Opcional. Declare que tipo de conteúdo essa tool aceita e devolve.",
+      "selectPlaceholder": "Selecione um tipo",
+      "modeOptions": {
+        "text": "Texto",
+        "image": "Imagem",
+        "audio": "Áudio",
+        "video": "Vídeo",
+        "json": "JSON",
+        "file": "Arquivo"
+      },
+      "input": {
+        "typeLabel": "O que ela recebe",
+        "descriptionLabel": "O que a IA deve enviar?",
+        "badge": "instrução pra IA",
+        "descriptionPlaceholder": "Ex: A imagem de um documento ou comprovante que o cliente enviou e precisa ser lido."
+      },
+      "output": {
+        "typeLabel": "O que ela devolve",
+        "descriptionLabel": "Descreva o retorno",
+        "badge": "ajuda o agente a interpretar",
+        "descriptionPlaceholder": "Ex: O texto extraído do documento, em formato corrido, pronto pra ser usado na resposta."
+      }
+    },
+    "step6": {
+      "title": "Toques finais",
+      "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
+      "helperText": "Exemplos são descrições curtas de como usar a tool.",
+      "testHint": "Após criar, você poderá testar a tool contra o endpoint real."
+    },
+    "actions": {
+      "continue": "Continuar",
+      "back": "Voltar",
+      "skip": "Pular",
+      "create": "Criar tool",
+      "save": "Salvar alterações"
     }
   },
   "modal": {

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -6,7 +7,7 @@ import { AgentsCustomToolsTour } from '@/tours';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Button } from '@evoapi/design-system';
 import { Grid3X3, List, Wand } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
-import { CustomTool, CustomToolsState, CustomToolFormData, CustomToolsListParams } from '@/types/ai';
+import { CustomTool, CustomToolsState, CustomToolFormData, CustomToolsListParams, CustomToolTestResponse } from '@/types/ai';
 import { BaseFilter, AppliedFilter, CUSTOM_TOOL_FILTER_TYPES } from '@/types/core';
 import { buildAppliedFilterChips } from '@/utils/appliedFilterChips';
 import {
@@ -15,11 +16,14 @@ import {
   CustomToolsTable,
   CustomToolsPagination,
   CustomToolModal,
+  CustomToolWizardModal,
+  CustomToolTestResultDialog,
   CustomToolDetails,
   CustomToolsFilter,
 } from '@/components/customTools';
 import {
   listCustomTools,
+  getCustomTool,
   createCustomTool,
   updateCustomTool,
   deleteCustomTool,
@@ -34,6 +38,12 @@ const INITIAL_STATE: CustomToolsState = initialCustomToolsState;
 export default function CustomTools() {
   const { can, isReady: permissionsReady } = useUserPermissions();
   const { t } = useLanguage('customTools');
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { id: editToolId } = useParams<{ id: string }>();
+  const isWizardCreate = location.pathname === '/agents/custom-tools/new';
+  const isWizardEdit = !!editToolId && location.pathname.endsWith('/edit');
+  const isWizardOpen = isWizardCreate || isWizardEdit;
   const [state, setState] = useState<CustomToolsState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -47,6 +57,10 @@ export default function CustomTools() {
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
   const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
   const [testingTool, setTestingTool] = useState<string | null>(null);
+  const [testResultOpen, setTestResultOpen] = useState(false);
+  const [testResultTool, setTestResultTool] = useState<CustomTool | null>(null);
+  const [testResultData, setTestResultData] =
+    useState<CustomToolTestResponse['test_result'] | null>(null);
   const hasLoaded = useRef(false);
 
   // Load tools
@@ -186,7 +200,7 @@ export default function CustomTools() {
       return;
     }
     setEditingTool(null);
-    setToolModalOpen(true);
+    navigate('/agents/custom-tools/new');
   };
 
   const handleEditTool = (tool: CustomTool) => {
@@ -195,8 +209,31 @@ export default function CustomTools() {
       return;
     }
     setEditingTool(tool);
-    setToolModalOpen(true);
+    navigate(`/agents/custom-tools/${tool.id}/edit`);
   };
+
+  useEffect(() => {
+    if (!isWizardEdit || !editToolId) return;
+    if (editingTool?.id === editToolId) return;
+    const cached = state.tools.find(tool => tool.id === editToolId);
+    if (cached) {
+      setEditingTool(cached);
+      return;
+    }
+    let cancelled = false;
+    getCustomTool(editToolId)
+      .then(fetched => {
+        if (!cancelled && fetched) setEditingTool(fetched);
+      })
+      .catch(err => {
+        console.error('Failed to load tool for edit:', err);
+        toast.error(t('errors.loadError'));
+        navigate('/agents/custom-tools');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isWizardEdit, editToolId, state.tools, editingTool?.id, navigate, t]);
 
   const handleDeleteTool = (tool: CustomTool) => {
     if (!can('ai_custom_tools', 'delete')) {
@@ -213,17 +250,9 @@ export default function CustomTools() {
 
     try {
       const result = await testCustomTool(tool.id);
-
-      if (result.test_result.success) {
-        toast.success(
-          t('success.testSuccess', {
-            statusCode: result.test_result.status_code,
-            responseTime: result.test_result.response_time
-          })
-        );
-      } else {
-        toast.error(t('test.failed', { error: result.test_result.error || t('test.unknownError') }));
-      }
+      setTestResultTool(tool);
+      setTestResultData(result.test_result);
+      setTestResultOpen(true);
     } catch (error) {
       console.error('Error testing custom tool:', error);
       toast.error(getErrorMessage(error as Error, t('errors.testError')));
@@ -291,9 +320,12 @@ export default function CustomTools() {
         loadTools();
       }
 
-      // Close modal and clear editing state
+      // Close modal/wizard and clear editing state
       setToolModalOpen(false);
       setEditingTool(null);
+      if (isWizardCreate || isWizardEdit) {
+        navigate('/agents/custom-tools');
+      }
     } catch (error) {
       console.error('Error saving custom tool:', error);
       toast.error(editingTool ? t('errors.updateError') : t('errors.createError'));
@@ -319,6 +351,25 @@ export default function CustomTools() {
       setDetailsTool(null);
     }
   };
+
+  if (isWizardOpen) {
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex-1 min-h-0 animate-slideInFromRight">
+          <CustomToolWizardModal
+            embedded
+            open={isWizardOpen}
+            loading={state.loading.create || state.loading.update}
+            tool={isWizardEdit ? editingTool || undefined : undefined}
+            onOpenChange={(open) => {
+              if (!open) navigate('/agents/custom-tools');
+            }}
+            onSubmit={handleToolFormSubmit}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full flex flex-col p-4" data-tour="agents-custom-tools-page">
@@ -455,13 +506,13 @@ export default function CustomTools() {
         </DialogContent>
       </Dialog>
 
-      {/* Tool Modal */}
+      {/* Tool Modal — edit only; create is handled by the wizard page */}
       <CustomToolModal
         open={toolModalOpen}
         onOpenChange={handleToolModalClose}
         tool={editingTool || undefined}
-        mode={!editingTool ? 'create' : 'edit'}
-        loading={state.loading.create || state.loading.update}
+        mode="edit"
+        loading={state.loading.update}
         onSubmit={handleToolFormSubmit}
       />
 
@@ -487,6 +538,20 @@ export default function CustomTools() {
         onFiltersChange={setActiveFilters}
         onApplyFilters={handleApplyFilters}
         onClearFilters={handleClearFilters}
+      />
+
+      {/* Test Result Dialog */}
+      <CustomToolTestResultDialog
+        open={testResultOpen}
+        onOpenChange={open => {
+          setTestResultOpen(open);
+          if (!open) {
+            setTestResultTool(null);
+            setTestResultData(null);
+          }
+        }}
+        tool={testResultTool}
+        result={testResultData}
       />
     </div>
   );

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -523,8 +523,7 @@ export default function CustomTools() {
         tool={detailsTool}
         onEdit={(tool: CustomTool) => {
           setDetailsModalOpen(false);
-          setEditingTool(tool);
-          setToolModalOpen(true);
+          handleEditTool(tool);
         }}
         onTest={handleTestTool}
         isTestLoading={testingTool === detailsTool?.id}

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -15,7 +15,6 @@ import {
   CustomToolsHeader,
   CustomToolsTable,
   CustomToolsPagination,
-  CustomToolModal,
   CustomToolWizardModal,
   CustomToolTestResultDialog,
   CustomToolDetails,
@@ -49,7 +48,6 @@ export default function CustomTools() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [toolToDelete, setToolToDelete] = useState<CustomTool | null>(null);
 
-  const [toolModalOpen, setToolModalOpen] = useState(false);
   const [editingTool, setEditingTool] = useState<CustomTool | null>(null);
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [detailsTool, setDetailsTool] = useState<CustomTool | null>(null);
@@ -320,8 +318,7 @@ export default function CustomTools() {
         loadTools();
       }
 
-      // Close modal/wizard and clear editing state
-      setToolModalOpen(false);
+      // Clear editing state; the wizard page navigates back below.
       setEditingTool(null);
       if (isWizardCreate || isWizardEdit) {
         navigate('/agents/custom-tools');
@@ -337,13 +334,6 @@ export default function CustomTools() {
     }
   };
 
-  // Handle modal close
-  const handleToolModalClose = (open: boolean) => {
-    if (!open) {
-      setToolModalOpen(false);
-      setEditingTool(null);
-    }
-  };
 
   const handleDetailsModalClose = (open: boolean) => {
     if (!open) {
@@ -505,16 +495,6 @@ export default function CustomTools() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      {/* Tool Modal — edit only; create is handled by the wizard page */}
-      <CustomToolModal
-        open={toolModalOpen}
-        onOpenChange={handleToolModalClose}
-        tool={editingTool || undefined}
-        mode="edit"
-        loading={state.loading.update}
-        onSubmit={handleToolFormSubmit}
-      />
 
       {/* Tool Details Modal */}
       <CustomToolDetails

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1373,6 +1373,36 @@ const AppRouter = () => {
           />
 
           <Route
+            path="/agents/custom-tools/new"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="ai_custom_tools" action="create">
+                      <CustomTools />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/agents/custom-tools/:id/edit"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="ai_custom_tools" action="update">
+                      <CustomTools />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
             path="/dashboard"
             element={
               <PrivateRoute>


### PR DESCRIPTION
## Summary

Refactor completo da UI de Custom Tools — form antigo (575 linhas, 6 textareas JSON cru) substituído por **wizard de 6 steps** em página dedicada, espelhando o padrão do `AgentWizardModal`. Edit também passa pelo mesmo wizard (rota `/agents/custom-tools/:id/edit`) com tool prefilled.

**Scope shift autorizado pelo PM (Davidson) durante execução:** era pra ser refactor de modal, virou wizard tela cheia + página dedicada (consistente com agente). Decisão registrada na story file e no Change Log.

### Wizard
```
Identidade  →  Endpoint  →  Parâmetros  →  Avançado  →  Modos  →  Finalizar
```

### Shared components novos (`ai_agents/shared/`)
- **KeyValueEditor**: substitui textareas de headers/params; validação inline (chave vazia/duplicada, valor obrigatório); valores aninhados renderizam JSON.stringify readonly com badge "valor complexo — edite no modo avançado"
- **AdvancedJsonCollapse**: usado no edit mode (form single-page) e wizard quando aplicável
- **TestRequestButton**: prop `mode='create'|'edit'`; create desabilitado com tooltip explicativo
- **TagInput**: chips removíveis (Enter/vírgula commit, Backspace remove última)

### CustomToolTestResultDialog
Substitui o `toast.error('test.failed')` antigo (key i18n não resolvida). Dialog estruturado com: status colorido por faixa HTTP, response time, erro destacado em box, headers em accordion, body em pretty-print.

### Roteamento
- `/agents/custom-tools/new` → wizard embedded (create)
- `/agents/custom-tools/:id/edit` → wizard embedded prefilled (edit)
- Listing modal antigo (`CustomToolModal`) só usado em view e como fallback de edit em casos pontuais

### Backwards compatibility (AC6)
- Tools criadas antes do refactor abrem sem perda
- `CustomToolsSelectionDialog` (caller secundário) continua usando `CustomToolForm` direto — refactor preserva API pública
- Descrições dos modos round-trippam via `values.__modes_meta__` (chave reservada)

### i18n
6 locales (en, pt-BR, pt, es, fr, it) com ~120 chaves novas no namespace `customTools`.

## ACs

| AC | Status |
|----|--------|
| **AC1** Zero JSON cru no caminho principal + retrocompat nested | ✅ |
| **AC2** values/error/modes em "Avançado" fechado | ✅ (escopo mudou pra wizard) |
| **AC3** Validação inline | ✅ |
| **AC4** Botão Testar (edit funcional + create disabled) | ✅ + CustomToolTestResultDialog |
| **AC5** Sem scroll em 1366×768 | ✅ (wizard 72vw×94vh) |
| **AC6** Retrocompat byte-identical | ✅ |
| **AC7** i18n 6 idiomas | ✅ |
| **AC8** Unit specs | ✅ 43 specs verde |
| **AC9** CustomToolsSelectionDialog sem regressão | ✅ validado E2E em agente real |

## Test plan

- [x] `npx vitest run src/components/customTools/ src/components/ai_agents/shared/ src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.spec.tsx` → 43/43 verde
- [x] Smoke E2E manual contra webhook.site:
  - Cenário A (GET + header X-Evo-Teste): 200 ✅
  - Cenário B (GET + query cliente=marcelo&pedido=123): 200 ✅
  - Cenário C (POST + body {nome,tipo}): 200 ✅
  - Cenário D (GET + path template /usuarios/{user_id}/pedidos/{pedido_id}): 200 ✅
- [x] Smoke AC9: tools criadas no wizard novo adicionáveis em agente real via CustomToolsSelectionDialog — zero regressão
- [x] Backwards compat: tool antiga abre, edita, salva, payload preservado

## Dependências

Bloqueado por (mesma story): backend PR https://github.com/evolution-foundation/evo-ai-core-service-community/pull/10 — fix do endpoint `/test` (content-type-agnostic) + migration `000016` que cria coluna `tenant_id` em 8 tabelas community. Sem backend mergeado, criar/testar tools quebra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)