### PR TITLE
feat(frontend): WhatsApp delete/revoke UX — keep content + notices (EVO-1890, EVO-1891)

### DIFF
--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -77,6 +77,8 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
   const isActivity = message.message_type === MESSAGE_TYPE.ACTIVITY;
   const isPrivate = message.private;
   const isDeleted = message.content_attributes?.deleted === true;
+  const isRevokedByContact = message.content_attributes?.revoked_by_contact === true;
+  const isRevokeCrmOnly = message.content_attributes?.revoke_propagated === false;
 
   // Moderation indicators
   const hasPendingModeration = moderation?.status === 'pending';
@@ -344,13 +346,19 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
                 <ReplyPreview message={replyToMessage} isOwn={false} />
               )}
 
-              {isDeleted ? (
-                <div className="italic text-muted-foreground text-sm opacity-70">
-                  {t('messages.messageBubble.deletedPlaceholder', 'This message was deleted')}
-                </div>
-              ) : (
-                <div>{renderMessageContent()}</div>
-              )}
+              <div>
+                {renderMessageContent()}
+                {(isDeleted || isRevokedByContact) && (
+                  <div className="mt-1 text-xs italic text-muted-foreground opacity-80">
+                    {isRevokedByContact
+                      ? t('messages.messageBubble.revokedByContact', 'Deleted by the contact')
+                      : t('messages.messageBubble.deletedPlaceholder', 'This message was deleted')}
+                    {isDeleted && isRevokeCrmOnly && (
+                      <span className="ml-1">· {t('messages.messageBubble.revokeCrmOnly', 'removed only in the CRM')}</span>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>,
           )}
 
@@ -511,13 +519,19 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
               <ReplyPreview message={replyToMessage} isOwn={isOwn} />
             )}
 
-            {isDeleted ? (
-                <div className="italic text-muted-foreground text-sm opacity-70">
-                  {t('messages.messageBubble.deletedPlaceholder', 'This message was deleted')}
+            <div>
+              {renderMessageContent()}
+              {(isDeleted || isRevokedByContact) && (
+                <div className="mt-1 text-xs italic text-muted-foreground opacity-80">
+                  {isRevokedByContact
+                    ? t('messages.messageBubble.revokedByContact', 'Deleted by the contact')
+                    : t('messages.messageBubble.deletedPlaceholder', 'This message was deleted')}
+                  {isDeleted && isRevokeCrmOnly && (
+                    <span className="ml-1">· {t('messages.messageBubble.revokeCrmOnly', 'removed only in the CRM')}</span>
+                  )}
                 </div>
-              ) : (
-                <div>{renderMessageContent()}</div>
               )}
+            </div>
           </div>,
         )}
 

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -41,7 +41,9 @@
         "cancel": "Cancel",
         "confirm": "Delete message"
       },
-      "deletedPlaceholder": "This message was deleted"
+      "deletedPlaceholder": "This message was deleted",
+      "revokedByContact": "Deleted by the contact",
+      "revokeCrmOnly": "removed only in the CRM"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -40,7 +40,9 @@
         "cancel": "Cancelar",
         "confirm": "Eliminar mensaje"
       },
-      "deletedPlaceholder": "Este mensaje fue eliminado"
+      "deletedPlaceholder": "Este mensaje fue eliminado",
+      "revokedByContact": "Eliminado por el contacto",
+      "revokeCrmOnly": "eliminada solo en el CRM"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -40,7 +40,9 @@
         "cancel": "Annuler",
         "confirm": "Supprimer le message"
       },
-      "deletedPlaceholder": "Ce message a été supprimé"
+      "deletedPlaceholder": "Ce message a été supprimé",
+      "revokedByContact": "Supprimé par le contact",
+      "revokeCrmOnly": "supprimée uniquement dans le CRM"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -40,7 +40,9 @@
         "cancel": "Annulla",
         "confirm": "Elimina messaggio"
       },
-      "deletedPlaceholder": "Questo messaggio è stato eliminato"
+      "deletedPlaceholder": "Questo messaggio è stato eliminato",
+      "revokedByContact": "Eliminato dal contatto",
+      "revokeCrmOnly": "rimossa solo nel CRM"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -41,7 +41,9 @@
         "cancel": "Cancelar",
         "confirm": "Excluir mensagem"
       },
-      "deletedPlaceholder": "Esta mensagem foi excluída"
+      "deletedPlaceholder": "Esta mensagem foi excluída",
+      "revokedByContact": "Apagada pelo contato",
+      "revokeCrmOnly": "removida só no CRM"
     },
     "moderation": {
       "banner": {

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -40,7 +40,9 @@
         "cancel": "Cancelar",
         "confirm": "Excluir mensagem"
       },
-      "deletedPlaceholder": "Esta mensagem foi eliminada"
+      "deletedPlaceholder": "Esta mensagem foi eliminada",
+      "revokedByContact": "Apagada pelo contacto",
+      "revokeCrmOnly": "removida só no CRM"
     },
     "moderation": {
       "banner": {

--- a/src/types/notifications/messages.ts
+++ b/src/types/notifications/messages.ts
@@ -21,6 +21,8 @@ export interface BaseMessage {
   content_attributes?: {
     in_reply_to?: string | number | null;
     deleted?: boolean;
+    revoked_by_contact?: boolean;
+    revoke_propagated?: boolean;
     submitted_values?: any[];
     submitted_email?: string;
   };


### PR DESCRIPTION
Frontend for **EVO-1890** (inbound contact-revoke notice) + **EVO-1891** (outbound delete propagation). Pairs with the CRM PR #167.

## Summary
Deleted messages now **keep their content** and show a notice, instead of hiding behind "This message was deleted":
- **EVO-1890:** when `content_attributes.revoked_by_contact` is set (contact deleted for everyone), the bubble shows the original content **plus** a "Deleted by the contact" notice.
- **EVO-1891:** when an agent-deleted message could not propagate to the provider (`content_attributes.revoke_propagated === false`), a "removed only in the CRM" hint is shown next to the notice.
- Agent-deleted messages (the existing `deleted` flag) also keep their content now (product decision) + show the "deleted" notice.

`MessageBubble` updates both render paths (regular + facebook-style); i18n keys `revokedByContact` / `revokeCrmOnly` across all 6 locales; `Message.content_attributes` type gains `revoked_by_contact` / `revoke_propagated`.

## Test plan
- `evo-ai-frontend-community: pnpm exec tsc -b --noEmit` (clean)
- locale JSON valid (6/6)
- Manual smoke (evolution provider): contact revoke → content + "Apagada pelo contato"; agent delete → content + notice.

## Changed Files
- `src/components/chat/messages/MessageBubble.tsx`
- `src/types/notifications/messages.ts`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/chat.json`

## Related PRs
- crm: https://github.com/evolution-foundation/evo-ai-crm-community/pull/167

## Linked Issues
- EVO-1890, EVO-1891

## Summary by Sourcery

Update WhatsApp message bubbles to retain deleted message content while adding contextual deletion notices for agents and contacts.

New Features:
- Display a notice when a message is revoked by the contact while keeping the original message content visible.
- Indicate when an agent-deleted message was removed only in the CRM but not propagated to the provider.

Enhancements:
- Always render message content in bubbles and append deletion or revocation notices instead of replacing the content.
- Extend message content attributes with revoke metadata flags to support new deletion states.
- Add i18n strings for contact revocation and CRM-only deletion notices across supported locales.