### PR TITLE
fix(journey): conditional handle prefix (EVO-1902)

### DIFF
--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReactFlowProvider, type Edge } from '@xyflow/react';
+import { ConditionalNode, type ConditionalNodeData } from './ConditionalNode';
+import '@/i18n/config';
+
+// The node reads connected handles via useEdges(); mock it so we can feed the
+// exact edges a saved (legacy) journey would hydrate into the editor.
+const edgesMock = vi.hoisted(() => ({ current: [] as Edge[] }));
+
+vi.mock('@xyflow/react', async importOriginal => {
+  const actual = await importOriginal<typeof import('@xyflow/react')>();
+  return {
+    ...actual,
+    useEdges: () => edgesMock.current,
+  };
+});
+
+function renderNode(data: ConditionalNodeData, edges: Edge[]) {
+  edgesMock.current = edges;
+  return render(
+    <ReactFlowProvider>
+      <ConditionalNode id="cond-1" selected={false} data={data} />
+    </ReactFlowProvider>,
+  );
+}
+
+const data: ConditionalNodeData = {
+  label: 'Conditional',
+  paths: [
+    {
+      id: 'p1',
+      name: 'True branch',
+      logicalOperator: 'AND',
+      conditions: [{ id: 'c1', type: 'contact', field: 'contact.name', operator: 'equals', value: 'x' }],
+    },
+  ],
+};
+
+// EVO-1902: the Handle id stays `path-<id>` so it matches the sourceHandle that
+// legacy journeys already saved. Routing is normalized at runtime by EVO-1922.
+describe('ConditionalNode — handle connectivity (EVO-1902)', () => {
+  it('renders the TRUE branch handle as connected for a legacy edge sourceHandle="path-<id>"', () => {
+    const { container } = renderNode(data, [
+      { id: 'e1', source: 'cond-1', target: 'next', sourceHandle: 'path-p1' } as Edge,
+    ]);
+
+    const handle = container.querySelector('[data-handleid="path-p1"]');
+    expect(handle).not.toBeNull();
+    // connected => green; disconnected => neutral-400 (gray).
+    expect(handle!.className).toContain('!bg-green-500');
+    expect(handle!.className).not.toContain('!bg-neutral-400');
+  });
+
+  it('renders the branch handle as disconnected (gray) when no edge matches', () => {
+    const { container } = renderNode(data, []);
+
+    const handle = container.querySelector('[data-handleid="path-p1"]');
+    expect(handle).not.toBeNull();
+    expect(handle!.className).toContain('!bg-neutral-400');
+    expect(handle!.className).not.toContain('!bg-green-500');
+  });
+
+  it('does NOT mark the branch connected for a raw (un-prefixed) edge sourceHandle="<id>"', () => {
+    // Guards against re-introducing the rejected change (Handle id = raw path.id):
+    // legacy edges are `path-<id>`, so a raw-id handle would render them as gray.
+    const { container } = renderNode(data, [
+      { id: 'e1', source: 'cond-1', target: 'next', sourceHandle: 'p1' } as Edge,
+    ]);
+
+    const handle = container.querySelector('[data-handleid="path-p1"]');
+    expect(handle).not.toBeNull();
+    expect(handle!.className).toContain('!bg-neutral-400');
+  });
+});

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -155,6 +155,15 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
   };
 
   const renderPath = (path: ConditionalPath, index: number) => {
+    // The source Handle id is `path-<id>`, the same value React Flow copies into
+    // a new edge's `sourceHandle`. This MUST stay consistent with the edges that
+    // legacy journeys already have saved (`sourceHandle = 'path-<id>'`) so the
+    // handle renders connected (isHandleConnected compares `sourceHandle === handleId`).
+    // Routing is handled at runtime by EVO-1922 (#99): the backend normalizes the
+    // `path-` prefix on BOTH sides of the match (normalizeConditionalPathHandle),
+    // so `path-<id>` here matches the node's raw `path.id` without a double-strip.
+    // Keeping the prefix mirrors the Split node, which also prefixes both sides.
+    // (EVO-1902.)
     const handleId = `path-${path.id}`;
     const isConnected = isHandleConnected(handleId);
     const colors = getPathColor(path.color);


### PR DESCRIPTION
## Summary

Reworked após review. A versão anterior trocava o id do Handle do nó Conditional de `path-<id>` para o `path.id` cru — o que **regredia jornadas legadas**: as edges salvas têm `sourceHandle = 'path-<id>'`, então contra um handle cru `isHandleConnected()` as renderizava cinza/desconectadas e não se auto-curavam no save.

A decisão canônica é manter `path-<id>` no Handle:

- **Render**: `Handle.id === edge.sourceHandle === 'path-<id>'` tanto para jornadas legadas quanto novas → handle conectado (verde), sem regressão.
- **Roteamento**: já resolvido em runtime pela **EVO-1922 / #99** (já mergeada em develop), que normaliza o prefixo `path-` nos **dois lados** da comparação (`normalizeConditionalPathHandle`). Manter `path-<id>` no FE casa com o `path.id` cru do backend após a normalização **sem double-strip** (a EVO-1922 faz um único strip).
- Consistente com o nó **Split**, que também prefixa nos dois lados.

Não é necessária normalização em load-time: como a forma canônica `path-<id>` já mantém `Handle.id === edge.sourceHandle` para edges legadas e novas, não existem edges fora do padrão para curar.

## Files
- `src/components/journey/nodes/actions/conditional/ConditionalNode.tsx` — reverte o handle para `path-${path.id}` + comentário explicando a relação com a EVO-1922.
- `src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx` — novo teste.

## Test plan
- `npx tsc -b` → OK (exit 0)
- `npx vitest run src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx` → 3/3 verdes:
  - edge legada `sourceHandle='path-<id>'` renderiza conectada (verde)
  - sem edge → desconectada (cinza)
  - edge crua `sourceHandle='<id>'` NÃO conecta (guarda contra reintroduzir a mudança rejeitada)

## AC
Jornada condicional criada no editor roteia o ramo true corretamente quando a condição é satisfeita (EVO-1922 runtime), e jornadas legadas renderizam o ramo como conectado (sem regressão de cinza/desconectado).
