### PR TITLE
fix(journey): create-pipeline-task contract (EVO-1903)

### DIFF
--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskNode.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskNode.tsx
@@ -17,6 +17,7 @@ export interface CreatePipelineTaskNodeData {
   label?: string;
   title?: string;
   description?: string;
+  task_type?: string;
   priority?: string;
   assigned_to_id?: string;
   assigned_to_name?: string;

--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.spec.tsx
@@ -75,9 +75,33 @@ describe('CreatePipelineTaskPanel', () => {
       expect.objectContaining({
         title: 'Call the lead',
         priority: 'medium',
+        task_type: 'call',
         due_date: null,
       }),
     );
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('persists the configured task_type so the backend receives a valid type', async () => {
+    mockGetFormData.mockResolvedValueOnce({ agents: AGENTS });
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+    renderPanel({
+      onUpdate,
+      data: makeData({ title: 'Send recap', task_type: 'email' }),
+    });
+
+    await waitFor(() => expect(mockGetFormData).toHaveBeenCalled());
+
+    // Dirty the form so Save enables, then persist.
+    await user.type(screen.getByRole('textbox', { name: TITLE_RE }), '!');
+    const saveBtn = screen.getByRole('button', { name: SAVE_RE });
+    await waitFor(() => expect(saveBtn).not.toBeDisabled());
+    await user.click(saveBtn);
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      'n1',
+      expect.objectContaining({ task_type: 'email' }),
+    );
   });
 });

--- a/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.tsx
+++ b/src/components/journey/nodes/actions/create-pipeline-task/CreatePipelineTaskPanel.tsx
@@ -29,6 +29,12 @@ interface CreatePipelineTaskPanelProps {
 
 const PRIORITIES = ['low', 'medium', 'high', 'urgent'];
 
+// Mirrors the PipelineTask `task_type` enum in the CRM
+// (call/email/meeting/follow_up/note/other). The executor forwards this value
+// verbatim and the CRM defaults to `call` when blank, so we default the same.
+const TASK_TYPES = ['call', 'email', 'meeting', 'follow_up', 'note', 'other'];
+const DEFAULT_TASK_TYPE = 'call';
+
 const DUE_PRESETS: { key: string; due: CreatePipelineTaskDueDate | null }[] = [
   { key: 'none', due: null },
   { key: 'in1h', due: { value: 1, unit: 'hours' } },
@@ -50,6 +56,7 @@ export function CreatePipelineTaskPanel({
   const { t } = useLanguage('journey');
   const [title, setTitle] = useState<string>(data.title || '');
   const [description, setDescription] = useState<string>(data.description || '');
+  const [taskType, setTaskType] = useState<string>(data.task_type || DEFAULT_TASK_TYPE);
   const [assignedToId, setAssignedToId] = useState<string>(data.assigned_to_id?.toString() || '');
   const [priority, setPriority] = useState<string>(data.priority || 'medium');
   const [duePreset, setDuePreset] = useState<string>(dueKey(data.due_date));
@@ -85,6 +92,7 @@ export function CreatePipelineTaskPanel({
       ...data,
       title: title.trim(),
       description: description.trim() || undefined,
+      task_type: taskType,
       priority,
       assigned_to_id: assignedToId || undefined,
       assigned_to_name: selectedAgent?.name || undefined,
@@ -101,10 +109,11 @@ export function CreatePipelineTaskPanel({
     () =>
       title.trim() !== (data.title || '') ||
       description.trim() !== (data.description || '') ||
+      taskType !== (data.task_type || DEFAULT_TASK_TYPE) ||
       assignedToId !== (data.assigned_to_id?.toString() || '') ||
       priority !== (data.priority || 'medium') ||
       duePreset !== dueKey(data.due_date),
-    [title, description, assignedToId, priority, duePreset, data],
+    [title, description, taskType, assignedToId, priority, duePreset, data],
   );
 
   return (
@@ -156,6 +165,27 @@ export function CreatePipelineTaskPanel({
             placeholder={t('panels.createPipelineTask.descriptionPlaceholder')}
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
           />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sidebar-foreground font-medium">
+            {t('panels.createPipelineTask.taskType')}
+          </Label>
+          <Select value={taskType} onValueChange={setTaskType}>
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-label={t('panels.createPipelineTask.taskType')}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="bg-sidebar border-sidebar-border">
+              {TASK_TYPES.map(type => (
+                <SelectItem key={type} value={type} className="text-sidebar-foreground">
+                  {t(`panels.createPipelineTask.taskTypes.${type}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         <div className="space-y-2">

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1015,6 +1015,15 @@
       "variablesHint": "Supports variables like {contact.name}.",
       "description": "Description",
       "descriptionPlaceholder": "Optional details",
+      "taskType": "Task type",
+      "taskTypes": {
+        "call": "Call",
+        "email": "Email",
+        "meeting": "Meeting",
+        "follow_up": "Follow-up",
+        "note": "Note",
+        "other": "Other"
+      },
       "assignee": "Assignee",
       "noAssignee": "No assignee",
       "dueDate": "Due date",

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -152,6 +152,9 @@ describe('journey i18n parity (EVO-1260)', () => {
     // block (Template de mensagem, Escolha um template, …) — kept identical
     // to EN by design, so the labels match the surrounding copy.
     'Template', 'Template:',
+    // "Follow-up" is the established pt-BR loanword for the pipeline task type
+    // (kept identical to EN by design).
+    'Follow-up',
     // strings whose only "language" content is the variable placeholder
     'Webhook {{method}}', 'Basic auth: {{username}}', 'Timeout: {{timeout}}s',
     // sample literals used as placeholders in form fields

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1015,6 +1015,15 @@
       "variablesHint": "Suporta variáveis como {contact.name}.",
       "description": "Descrição",
       "descriptionPlaceholder": "Detalhes opcionais",
+      "taskType": "Tipo da tarefa",
+      "taskTypes": {
+        "call": "Ligação",
+        "email": "E-mail",
+        "meeting": "Reunião",
+        "follow_up": "Follow-up",
+        "note": "Anotação",
+        "other": "Outro"
+      },
       "assignee": "Responsável",
       "noAssignee": "Sem responsável",
       "dueDate": "Vencimento",


### PR DESCRIPTION
## Resumo

Corrige o descasamento de contrato FE↔backend (D14) no painel `CreatePipelineTaskPanel` (nó create-pipeline-task de jornadas). O painel não gravava `task_type`, então tarefas criadas via jornada chegavam ao CRM sem tipo configurável.

### Mudanças
- Adiciona seletor **Tipo da tarefa** ao painel, gravando `task_type` no node data.
- Tipos válidos espelham o enum `PipelineTask` do CRM: `call`, `email`, `meeting`, `follow_up`, `note`, `other` (default `call`, igual ao default do CRM).
- `task_type` adicionado ao tipo `CreatePipelineTaskNodeData`, ao rastreio de `dirty` e ao payload de save.
- i18n: chaves `taskType` + `taskTypes.*` em en e pt-BR (lock-step). "Follow-up" adicionado ao whitelist de leakage (loanword idêntico em pt-BR).

## Contrato confirmado (lido em evo-flow + CRM)
- **task_type**: o executor `create-pipeline-task.node.ts` lê `nodeData.task_type` e o repassa verbatim ao CRM (`createPipelineTask`). O CRM (`pipeline_tasks_controller#create_conversation_task`) usa `params[:task_type].presence || 'call'` e valida contra o enum `call/email/meeting/follow_up/note/other`. → **antes faltava** no FE; agora gravado.
- **due_date**: o executor JÁ lê o objeto relativo `{ value, unit }` e o converte (`toDueIn`) para `"<value>.<unit>"` (`due_in`), que o CRM parseia em `calculate_due_date`. → contrato JÁ alinhado no backend; o formato `{value,unit}` do painel está correto, **nenhuma mudança necessária** nessa parte.

## Test plan
- `tsc -b` (project refs): verde.
- vitest `CreatePipelineTaskPanel.spec.tsx` (3) + `journey-parity.spec.ts` (24): 27/27 verde. Novo teste assert que `task_type` é emitido (default `call` e tipo configurado `email`).

EVO-1903