### PR TITLE
feat(journey): exit-journey config panel (EVO-1904)

### DIFF
--- a/src/components/journey/nodes/actions/exit-journey/ExitJourneyNode.tsx
+++ b/src/components/journey/nodes/actions/exit-journey/ExitJourneyNode.tsx
@@ -5,6 +5,11 @@ import { useLanguage } from '@/hooks/useLanguage';
 export interface ExitJourneyNodeData {
   label: string;
   description?: string;
+  /** Reason recorded when the contact leaves the journey. Read by the
+   * exit-journey executor (defaults to 'completed' on the backend). */
+  exitReason?: string;
+  /** Optional human-readable message stored alongside the exit reason. */
+  exitMessage?: string;
 }
 
 export interface ExitJourneyNodeType {

--- a/src/components/journey/nodes/actions/exit-journey/ExitJourneyPanel.tsx
+++ b/src/components/journey/nodes/actions/exit-journey/ExitJourneyPanel.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from 'react';
+import {
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@evoapi/design-system';
+import { LogOut } from 'lucide-react';
+import { ExitJourneyNodeData } from './ExitJourneyNode';
+import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
+import { FlowFeedbackBanner } from '@/components/journey/_ui';
+import { useLanguage } from '@/hooks/useLanguage';
+
+interface ExitJourneyPanelProps {
+  nodeId: string;
+  data: ExitJourneyNodeData;
+  onUpdate: (nodeId: string, newData: ExitJourneyNodeData) => void;
+  onClose: () => void;
+}
+
+// Preset reasons. The exit-journey executor stores `exitReason` as free
+// text (defaulting to 'completed'); presets keep analytics consistent
+// while `custom` lets the author record an arbitrary value.
+const PRESET_REASONS = ['completed', 'abandoned', 'transferred', 'error'] as const;
+const CUSTOM = '__custom__';
+
+export function ExitJourneyPanel({ nodeId, data, onUpdate, onClose }: ExitJourneyPanelProps) {
+  const { t } = useLanguage('journey');
+
+  const initialReason = (data.exitReason || 'completed').trim();
+  const isPreset = (PRESET_REASONS as readonly string[]).includes(initialReason);
+
+  const [selectedReason, setSelectedReason] = useState<string>(
+    isPreset ? initialReason : CUSTOM,
+  );
+  const [customReason, setCustomReason] = useState<string>(isPreset ? '' : initialReason);
+  const [exitMessage, setExitMessage] = useState<string>(data.exitMessage || '');
+
+  const [originalReason] = useState<string>(initialReason);
+  const [originalMessage] = useState<string>(() => data.exitMessage || '');
+
+  const resolvedReason = useMemo(
+    () => (selectedReason === CUSTOM ? customReason.trim() : selectedReason),
+    [selectedReason, customReason],
+  );
+
+  const isValid = resolvedReason.length > 0;
+  const dirty = useMemo(
+    () => resolvedReason !== originalReason || exitMessage !== originalMessage,
+    [resolvedReason, originalReason, exitMessage, originalMessage],
+  );
+
+  const handleSave = () => {
+    const updatedData: ExitJourneyNodeData = {
+      ...data,
+      exitReason: resolvedReason,
+      // Keep the key absent when blank so the backend default applies.
+      exitMessage: exitMessage.trim() ? exitMessage.trim() : undefined,
+    };
+    onUpdate(nodeId, updatedData);
+    onClose();
+  };
+
+  return (
+    <NodeConfigModal
+      open
+      variant="simple"
+      title={t('panels.exitJourney.title')}
+      icon={<LogOut className="h-5 w-5 text-flow-node-exit-fg" />}
+      onCancel={onClose}
+      onSave={handleSave}
+      dirty={dirty}
+      saveDisabled={!isValid}
+      saveLabel={t('panels.actions.save')}
+      cancelLabel={t('panels.actions.cancel')}
+    >
+      <div className="space-y-4">
+        <FlowFeedbackBanner variant="info">
+          <p className="text-xs">{t('panels.exitJourney.intro')}</p>
+        </FlowFeedbackBanner>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">{t('panels.exitJourney.reasonLabel')}</Label>
+          <Select value={selectedReason} onValueChange={setSelectedReason}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={t('panels.exitJourney.reasonPlaceholder')} />
+            </SelectTrigger>
+            <SelectContent>
+              {PRESET_REASONS.map(reason => (
+                <SelectItem key={reason} value={reason}>
+                  {t(`panels.exitJourney.reasons.${reason}`)}
+                </SelectItem>
+              ))}
+              <SelectItem value={CUSTOM}>{t('panels.exitJourney.reasons.custom')}</SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">{t('panels.exitJourney.reasonHint')}</p>
+        </div>
+
+        {selectedReason === CUSTOM && (
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">
+              {t('panels.exitJourney.customReasonLabel')}
+            </Label>
+            <Input
+              value={customReason}
+              onChange={e => setCustomReason(e.target.value)}
+              placeholder={t('panels.exitJourney.customReasonPlaceholder')}
+            />
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">{t('panels.exitJourney.messageLabel')}</Label>
+          <Textarea
+            value={exitMessage}
+            onChange={e => setExitMessage(e.target.value)}
+            placeholder={t('panels.exitJourney.messagePlaceholder')}
+            rows={3}
+          />
+          <p className="text-xs text-muted-foreground">{t('panels.exitJourney.messageHint')}</p>
+        </div>
+
+        {!isValid && (
+          <FlowFeedbackBanner variant="warn">
+            <p className="text-xs">{t('panels.exitJourney.reasonRequired')}</p>
+          </FlowFeedbackBanner>
+        )}
+      </div>
+    </NodeConfigModal>
+  );
+}

--- a/src/components/journey/nodes/actions/exit-journey/index.ts
+++ b/src/components/journey/nodes/actions/exit-journey/index.ts
@@ -1,1 +1,2 @@
 export * from './ExitJourneyNode';
+export * from './ExitJourneyPanel';

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1237,7 +1237,24 @@
     "exitJourney": {
       "title": "Exit Journey",
       "description": "Remove the contact from the journey",
-      "finalStepMessage": "This is a final step - there are no more steps"
+      "finalStepMessage": "This is a final step - there are no more steps",
+      "intro": "Choose the reason recorded when the contact leaves the journey. It is saved to the session variables and logs.",
+      "reasonLabel": "Exit reason",
+      "reasonPlaceholder": "Select a reason",
+      "reasonHint": "Used in analytics and session reports.",
+      "reasonRequired": "An exit reason is required.",
+      "customReasonLabel": "Custom reason",
+      "customReasonPlaceholder": "e.g. opted_out",
+      "messageLabel": "Exit message (optional)",
+      "messagePlaceholder": "e.g. Journey completed successfully",
+      "messageHint": "A human-readable note stored alongside the reason.",
+      "reasons": {
+        "completed": "Completed",
+        "abandoned": "Abandoned",
+        "transferred": "Transferred",
+        "error": "Error",
+        "custom": "Custom…"
+      }
     },
     "resolveConversation": {
       "title": "Configure Conversation Resolution",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -1176,7 +1176,24 @@
     "exitJourney": {
       "title": "Exit Journey",
       "description": "Remove the contact from the journey",
-      "finalStepMessage": "This is a final step - there are no more steps"
+      "finalStepMessage": "This is a final step - there are no more steps",
+      "intro": "Elige el motivo registrado cuando el contacto sale del recorrido. Se guarda en las variables y registros de la sesión.",
+      "reasonLabel": "Motivo de salida",
+      "reasonPlaceholder": "Selecciona un motivo",
+      "reasonHint": "Se usa en analítica e informes de sesión.",
+      "reasonRequired": "Es obligatorio indicar un motivo de salida.",
+      "customReasonLabel": "Motivo personalizado",
+      "customReasonPlaceholder": "p. ej. opted_out",
+      "messageLabel": "Mensaje de salida (opcional)",
+      "messagePlaceholder": "p. ej. Recorrido completado correctamente",
+      "messageHint": "Una nota legible almacenada junto al motivo.",
+      "reasons": {
+        "completed": "Completado",
+        "abandoned": "Abandonado",
+        "transferred": "Transferido",
+        "error": "Error",
+        "custom": "Personalizado…"
+      }
     },
     "resolveConversation": {
       "title": "Configure Conversation Resolution",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -1176,7 +1176,24 @@
     "exitJourney": {
       "title": "Exit Journey",
       "description": "Remove the contact from the journey",
-      "finalStepMessage": "This is a final step - there are no more steps"
+      "finalStepMessage": "This is a final step - there are no more steps",
+      "intro": "Choisissez le motif enregistré lorsque le contact quitte le parcours. Il est enregistré dans les variables et journaux de la session.",
+      "reasonLabel": "Motif de sortie",
+      "reasonPlaceholder": "Sélectionnez un motif",
+      "reasonHint": "Utilisé dans les analyses et les rapports de session.",
+      "reasonRequired": "Un motif de sortie est requis.",
+      "customReasonLabel": "Motif personnalisé",
+      "customReasonPlaceholder": "ex. opted_out",
+      "messageLabel": "Message de sortie (facultatif)",
+      "messagePlaceholder": "ex. Parcours terminé avec succès",
+      "messageHint": "Une note lisible enregistrée avec le motif.",
+      "reasons": {
+        "completed": "Terminé",
+        "abandoned": "Abandonné",
+        "transferred": "Transféré",
+        "error": "Erreur",
+        "custom": "Personnalisé…"
+      }
     },
     "resolveConversation": {
       "title": "Configure Conversation Resolution",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -1188,7 +1188,24 @@
     "exitJourney": {
       "title": "Exit Journey",
       "description": "Remove the contact from the journey",
-      "finalStepMessage": "This is a final step - there are no more steps"
+      "finalStepMessage": "This is a final step - there are no more steps",
+      "intro": "Scegli il motivo registrato quando il contatto esce dal percorso. Viene salvato nelle variabili e nei log della sessione.",
+      "reasonLabel": "Motivo di uscita",
+      "reasonPlaceholder": "Seleziona un motivo",
+      "reasonHint": "Usato in analisi e report di sessione.",
+      "reasonRequired": "È obbligatorio indicare un motivo di uscita.",
+      "customReasonLabel": "Motivo personalizzato",
+      "customReasonPlaceholder": "es. opted_out",
+      "messageLabel": "Messaggio di uscita (facoltativo)",
+      "messagePlaceholder": "es. Percorso completato con successo",
+      "messageHint": "Una nota leggibile salvata insieme al motivo.",
+      "reasons": {
+        "completed": "Completato",
+        "abandoned": "Abbandonato",
+        "transferred": "Trasferito",
+        "error": "Errore",
+        "custom": "Personalizzato…"
+      }
     },
     "resolveConversation": {
       "title": "Configure Conversation Resolution",

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -132,6 +132,43 @@ describe('journey i18n parity (EVO-1260)', () => {
     expect(offenders).toEqual([]);
   });
 
+  // EVO-1904: the exit-journey config-panel keys (exitReason / exitMessage)
+  // were added to ALL six locales. The strict en↔pt-BR mirror covers those
+  // two; assert presence + non-empty across every shipped locale so
+  // pt/es/fr/it can't silently drift (same pattern as EVO-1260 above).
+  const evo1904Keys = [
+    'panels.exitJourney.intro',
+    'panels.exitJourney.reasonLabel',
+    'panels.exitJourney.reasonPlaceholder',
+    'panels.exitJourney.reasonHint',
+    'panels.exitJourney.reasonRequired',
+    'panels.exitJourney.customReasonLabel',
+    'panels.exitJourney.customReasonPlaceholder',
+    'panels.exitJourney.messageLabel',
+    'panels.exitJourney.messagePlaceholder',
+    'panels.exitJourney.messageHint',
+    'panels.exitJourney.reasons.completed',
+    'panels.exitJourney.reasons.abandoned',
+    'panels.exitJourney.reasons.transferred',
+    'panels.exitJourney.reasons.error',
+    'panels.exitJourney.reasons.custom',
+  ];
+
+  it.each([
+    ['en', en],
+    ['pt-BR', ptBR],
+    ['pt', pt],
+    ['es', es],
+    ['fr', fr],
+    ['it', itLocale],
+  ])('%s contains every EVO-1904 exit-journey key, non-empty', (_name, locale) => {
+    const offenders = evo1904Keys.filter((k) => {
+      const v = getAtPath(locale, k);
+      return typeof v !== 'string' || v.trim() === '';
+    });
+    expect(offenders).toEqual([]);
+  });
+
   // Anti-leakage: catches the EVO-1260 review finding class — pt-BR
   // values byte-identical to EN that are NOT legitimate tech terms,
   // sample literals, or pure-interpolation strings. Uses the shared

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1237,7 +1237,24 @@
     "exitJourney": {
       "title": "Sair da Jornada",
       "description": "Remove o contato da jornada",
-      "finalStepMessage": "Esta é uma etapa final — não há mais etapas"
+      "finalStepMessage": "Esta é uma etapa final — não há mais etapas",
+      "intro": "Escolha o motivo registrado quando o contato sai da jornada. Ele é salvo nas variáveis e logs da sessão.",
+      "reasonLabel": "Motivo de saída",
+      "reasonPlaceholder": "Selecione um motivo",
+      "reasonHint": "Usado em analytics e relatórios de sessão.",
+      "reasonRequired": "É obrigatório informar um motivo de saída.",
+      "customReasonLabel": "Motivo personalizado",
+      "customReasonPlaceholder": "ex.: opted_out",
+      "messageLabel": "Mensagem de saída (opcional)",
+      "messagePlaceholder": "ex.: Jornada concluída com sucesso",
+      "messageHint": "Uma nota legível armazenada junto ao motivo.",
+      "reasons": {
+        "completed": "Concluída",
+        "abandoned": "Abandonada",
+        "transferred": "Transferida",
+        "error": "Erro",
+        "custom": "Personalizado…"
+      }
     },
     "resolveConversation": {
       "title": "Configurar Resolução da Conversa",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -1176,7 +1176,24 @@
     "exitJourney": {
       "title": "Exit Journey",
       "description": "Remove the contact from the journey",
-      "finalStepMessage": "This is a final step - there are no more steps"
+      "finalStepMessage": "This is a final step - there are no more steps",
+      "intro": "Escolha o motivo registado quando o contacto sai da jornada. É guardado nas variáveis e registos da sessão.",
+      "reasonLabel": "Motivo de saída",
+      "reasonPlaceholder": "Selecione um motivo",
+      "reasonHint": "Usado em analytics e relatórios de sessão.",
+      "reasonRequired": "É obrigatório indicar um motivo de saída.",
+      "customReasonLabel": "Motivo personalizado",
+      "customReasonPlaceholder": "ex.: opted_out",
+      "messageLabel": "Mensagem de saída (opcional)",
+      "messagePlaceholder": "ex.: Jornada concluída com sucesso",
+      "messageHint": "Uma nota legível guardada junto ao motivo.",
+      "reasons": {
+        "completed": "Concluída",
+        "abandoned": "Abandonada",
+        "transferred": "Transferida",
+        "error": "Erro",
+        "custom": "Personalizado…"
+      }
     },
     "resolveConversation": {
       "title": "Configure Conversation Resolution",

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -44,6 +44,7 @@ import {
   ScheduledActionNode,
   SplitNode,
   ExitJourneyNode,
+  ExitJourneyPanel,
   SendWebhookNode,
   AddLabelNode,
   RemoveLabelNode,
@@ -583,6 +584,8 @@ function JourneyFlowEditor() {
           return <UpdateCustomAttributePanel {...commonProps} />;
         case 'transfer-journey-node':
           return <TransferJourneyPanel {...commonProps} />;
+        case 'exit-journey-node':
+          return <ExitJourneyPanel {...commonProps} />;
         case 'send-message-node':
           return <SendMessagePanel {...commonProps} />;
         case 'set-variable-node':


### PR DESCRIPTION
## Resumo

O nó **exit-journey** não tinha painel de configuração (não havia `case 'exit-journey-node'` em `renderConfigPanel`), então `exitReason` nunca era gravado e o backend caía no default `'completed'` (D15 do e2e de jornadas).

Este PR adiciona um painel de config para o exit-journey, seguindo o padrão dos painéis irmãos (Transfer/Change-Priority + `NodeConfigModal variant=simple`):

- **Campo `exitReason`** via Select com presets (`completed`, `abandoned`, `transferred`, `error`) + opção *Custom…* com input livre.
- **Campo opcional `exitMessage`** (textarea); fica ausente quando em branco para preservar o default do backend.
- Registro do `case 'exit-journey-node'` em `renderConfigPanel` no `JourneyFlowEditor`.
- `ExitJourneyNodeData` estendido com `exitReason`/`exitMessage`.
- i18n nas 6 locales (en, pt-BR, pt, es, fr, it), com en↔pt-BR em lock-step e guarda na `journey-parity.spec.ts`.

## Campo confirmado

Lido o executor `evo-flow/src/modules/temporal/activities/nodes/exit-journey.node.ts`: ele lê `input.nodeData.exitReason` (texto livre, default `'completed'`) e `input.nodeData.exitMessage` (default `'Journey completed successfully'`), expondo-os como variáveis de sessão (`journey_exit_reason`, `journey_exit_message`). O painel grava exatamente esses dois campos em `nodeData`.

## Testes

- `tsc -b` ✓
- `vitest run journey-parity.spec.ts` → 30/30 ✓ (inclui bloco EVO-1904)
- eslint do `ExitJourneyPanel.tsx` limpo (erros remanescentes em `JourneyFlowEditor.tsx` são pré-existentes em develop)

EVO-1904