### PR TITLE
fix(journey): validate attributeName not attributeId (EVO-1905)

### DIFF
--- a/src/utils/journeyValidators/nodeValidators.spec.ts
+++ b/src/utils/journeyValidators/nodeValidators.spec.ts
@@ -45,4 +45,24 @@ describe('validateNodeConfig (EVO-1744)', () => {
     });
     expect(issues[0].params?.fields).toBe('stage_id');
   });
+
+  // EVO-1905: validate attributeName (the attribute_key the executor reads),
+  // not the UI-only attributeId.
+  it('requires attributeName, not attributeId, for update-custom-attribute', () => {
+    // attributeId present but attributeName missing must still fail.
+    const onlyId = validateNodeConfig('update-custom-attribute-node', {
+      attributeId: 'a1',
+      newValue: 'x',
+    });
+    expect(onlyId).toHaveLength(1);
+    expect(onlyId[0].params?.fields).toBe('attributeName');
+
+    // attributeName + newValue is enough; attributeId is irrelevant.
+    expect(
+      validateNodeConfig('update-custom-attribute-node', {
+        attributeName: 'plan',
+        newValue: 'pro',
+      }),
+    ).toEqual([]);
+  });
 });

--- a/src/utils/journeyValidators/nodeValidators.ts
+++ b/src/utils/journeyValidators/nodeValidators.ts
@@ -80,8 +80,11 @@ export const nodeValidators: Record<string, Validator> = {
   'update-contact-node': (d) =>
     requiredConfig(absent(d, ['fieldToUpdate', 'newValue'])),
 
+  // attributeName carries the attribute_key (slug) the executor actually reads
+  // (evo-flow update-custom-attribute.node.ts) — validate it, not the UI-only
+  // attributeId (EVO-1905).
   'update-custom-attribute-node': (d) =>
-    requiredConfig(absent(d, ['attributeId', 'newValue'])),
+    requiredConfig(absent(d, ['attributeName', 'newValue'])),
 
   'set-variable-node': (d) =>
     requiredConfig(absent(d, ['variableName', 'operation'])),


### PR DESCRIPTION
## Resumo

Defeito D16 (e2e jornadas, BAIXO). O validador de pré-ativação `nodeValidators.ts` para o nó `update-custom-attribute` exigia `attributeId`, mas o executor do backend (evo-flow `update-custom-attribute.node.ts`) lê `attributeName` (o `attribute_key`/slug). Hoje só passava porque o painel grava ambos os campos; se o painel parasse de gravar `attributeId`, o validador bloquearia indevidamente um campo que o backend nem consome.

## Mudança

- `nodeValidators.ts`: troca a validação de `update-custom-attribute-node` de `attributeId` para `attributeName` (o campo load-bearing lido pelo executor), mantendo `newValue`.
- `nodeValidators.spec.ts`: teste novo cobrindo que `attributeId` sozinho falha (exige `attributeName`) e que `attributeName` + `newValue` passa.

## Testes

- `tsc -b` limpo.
- `vitest` journeyValidators (15) + journeyFlowValidation (15) verdes.

EVO-1905