### PR TITLE
fix(frontend): load linked companies on contact edit to prevent association wipe (EVO-1943)

### DIFF
--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -460,9 +460,19 @@ export default function Contacts() {
     setContactModalOpen(true);
   };
 
-  const handleEditContact = (contact: Contact) => {
+  const handleEditContact = async (contact: Contact) => {
     setEditingContact(contact);
     setContactModalOpen(true);
+    // The list payload omits linked companies (serialized without include_companies),
+    // so re-fetch the full contact to populate the "Linked Companies" picker on edit
+    // and avoid wiping associations on save.
+    try {
+      const fullContact = await contactsService.getContact(contact.id);
+      // Guard against a newer edit opening before this fetch resolves.
+      setEditingContact(prev => (prev?.id === fullContact.id ? fullContact : prev));
+    } catch (error) {
+      console.error('Error loading contact for edit:', error);
+    }
   };
 
   const handleStartConversation = (contact: Contact) => {


### PR DESCRIPTION
## Summary
- Editing a contact **from the list** opened the form with `company_ids` empty because the list payload omits companies (only `#show` sends `include_companies`).
- The empty `company_ids` meant a plain **Save wiped all linked-company associations** — silent data loss.
- `handleEditContact` now re-fetches the full contact via `getContact` and patches `editingContact` (guarded against a newer edit opening first), so the **Linked Companies** picker reflects existing associations and a save preserves them.

## Validation
- `frontend: pnpm exec tsc -b --noEmit` (clean)
- `frontend: pnpm exec eslint src/pages/Customer/Contacts/Contacts.tsx` (0 errors; 1 pre-existing warning)

## Changed Files
- `src/pages/Customer/Contacts/Contacts.tsx`

## Linked Issue
- EVO-1943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Re-fetch full contact details on edit so the Linked Companies picker is populated and existing company associations are not wiped on save.