### PR TITLE
fix(frontend): contacts pagination spacing + compact toolbar on mobile (EVO-1944)

### DIFF
--- a/src/components/base/BaseHeader.tsx
+++ b/src/components/base/BaseHeader.tsx
@@ -84,13 +84,13 @@ export default function BaseHeader({
   const visibleMoreActions = moreActions.filter(action => action.show !== false);
 
   return (
-    <div className={`space-y-6 ${className}`}>
-      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+    <div className={`space-y-4 sm:space-y-6 ${className}`}>
+      <div className="flex flex-col gap-3 sm:gap-4 md:flex-row md:items-start md:justify-between">
         {/* Title Section */}
         <div className="flex-1">
-          <h1 className="text-2xl font-bold tracking-tight leading-8 text-sidebar-foreground mb-2">{title}</h1>
+          <h1 className="text-xl sm:text-2xl font-bold tracking-tight leading-7 sm:leading-8 text-sidebar-foreground mb-1 sm:mb-2">{title}</h1>
           {subtitle && (
-            <p className="text-sm leading-5 text-sidebar-foreground/70">{subtitle}</p>
+            <p className="hidden sm:block text-sm leading-5 text-sidebar-foreground/70">{subtitle}</p>
           )}
         </div>
 

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -761,7 +761,7 @@ export default function Contacts() {
   };
 
   return (
-    <div className="h-full flex flex-col p-4">
+    <div className="h-full flex flex-col p-3 sm:p-4">
       <ContactsTour />
       <div data-tour="contacts-header">
       <ContactsHeader
@@ -782,7 +782,7 @@ export default function Contacts() {
       </div>
 
       {/* View Mode Toggle */}
-      <div className="flex items-center justify-end mt-6 mb-3" data-tour="contacts-view-toggle">
+      <div className="flex items-center justify-end mt-3 mb-2 sm:mt-6 sm:mb-3" data-tour="contacts-view-toggle">
         <div className="flex items-center border rounded-lg">
           <Button
             variant={viewMode === 'cards' ? 'default' : 'ghost'}

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -873,7 +873,7 @@ export default function Contacts() {
 
       {/* Pagination */}
       {state.meta.pagination.total > 0 && (
-        <div data-tour="contacts-pagination">
+        <div data-tour="contacts-pagination" className="mt-4 border-t border-border pt-4">
           <ContactsPagination
             currentPage={state.meta.pagination.page}
             totalPages={state.meta.pagination.total_pages}


### PR DESCRIPTION
## Summary
- **AC1 — pagination spacing:** the pagination bar sat flush against the table's last row. Added a top border + spacing so it reads as a distinct footer (`Contacts.tsx`).
- **AC2 — mobile toolbar:** on phone-width the stacked toolbar consumed most of the viewport, leaving a tiny table area. Tightened the **mobile-only** layout so the table gets usable vertical space.

## Mobile compaction (all sm:-gated — desktop & tablet unchanged)
- `BaseHeader` (shared): smaller title, decorative subtitle hidden on phones, reduced section gaps.
- `Contacts`: smaller page padding + view-toggle margins.

> Note: `BaseHeader` is shared, so the mobile compaction applies to every list screen on phone-width (positive density win). Verified on Contacts + a second list screen; desktop/tablet identical (changes revert at >=640px).

## Validation
- `frontend: pnpm exec tsc -b --noEmit` (clean)
- `frontend: pnpm exec eslint <changed files>` (0 errors; 1 pre-existing warning)
- Manual: DevTools device mode @390px (compact, table gains rows) + desktop regression check

## Changed Files
- `src/components/base/BaseHeader.tsx`
- `src/pages/Customer/Contacts/Contacts.tsx`

## Linked Issue
- EVO-1944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust mobile header and contacts layout spacing to improve density and separate pagination from the table footer.

Enhancements:
- Tighten mobile spacing in the shared BaseHeader to reduce vertical gaps and shrink the title on small screens.
- Adjust Contacts page padding and view-toggle margins on mobile to free up vertical space for the table.
- Add visual separation between the contacts table and its pagination bar with top margin and border styling.