### PR TITLE
feat(frontend): contacts filter by company picker + readable applied chip (EVO-1887)

### DIFF
--- a/src/components/contacts/ContactsFilter.tsx
+++ b/src/components/contacts/ContactsFilter.tsx
@@ -26,14 +26,16 @@ export default function ContactsFilter({
   onClearFilters,
 }: ContactsFilterProps) {
   const { t } = useLanguage('contacts');
-  const { labels } = useContactFilterOptions({ enabled: open });
+  const { labels, companies } = useContactFilterOptions({ enabled: open });
 
   const enrichedFilterTypes = useMemo(
     () =>
-      CONTACT_FILTER_TYPES.map(filterType =>
-        filterType.attributeKey === 'labels' ? { ...filterType, options: labels } : filterType,
-      ),
-    [labels],
+      CONTACT_FILTER_TYPES.map(filterType => {
+        if (filterType.attributeKey === 'labels') return { ...filterType, options: labels };
+        if (filterType.attributeKey === 'company') return { ...filterType, options: companies };
+        return filterType;
+      }),
+    [labels, companies],
   );
 
   return (

--- a/src/hooks/contacts/useContactFilterOptions.ts
+++ b/src/hooks/contacts/useContactFilterOptions.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { labelsService } from '@/services/contacts/labelsService';
+import { contactsService } from '@/services/contacts/contactsService';
 import type { Label } from '@/types/settings';
 
 interface FilterOption {
@@ -9,6 +10,7 @@ interface FilterOption {
 
 interface ContactFilterOptions {
   labels: FilterOption[];
+  companies: FilterOption[];
   loading: boolean;
 }
 
@@ -17,15 +19,19 @@ interface UseContactFilterOptionsParams {
 }
 
 /**
- * Loads the dynamic options for the Contacts advanced filter. Only labels are
- * dynamic today; mirrors the labels block of useFilterOptions (conversations)
+ * Loads the dynamic options for the Contacts advanced filter (labels and
+ * companies). Mirrors the labels block of useFilterOptions (conversations)
  * but without the conversation-only lists (inboxes/teams/pipelines/contacts).
  */
 export const useContactFilterOptions = (
   params: UseContactFilterOptionsParams = {},
 ): ContactFilterOptions => {
   const { enabled = true } = params;
-  const [options, setOptions] = useState<ContactFilterOptions>({ labels: [], loading: false });
+  const [options, setOptions] = useState<ContactFilterOptions>({
+    labels: [],
+    companies: [],
+    loading: false,
+  });
 
   useEffect(() => {
     if (!enabled) return;
@@ -33,18 +39,30 @@ export const useContactFilterOptions = (
 
     const load = async () => {
       setOptions(prev => ({ ...prev, loading: true }));
-      try {
-        const response = await labelsService.getLabels({ per_page: 200 });
-        const data = response?.data ?? [];
-        // value = label.title to match filter_service tag query (compares tags.name).
-        const labels = Array.isArray(data)
-          ? data.map((label: Label) => ({ label: label.title, value: label.title }))
-          : [];
-        if (active) setOptions({ labels, loading: false });
-      } catch (error) {
-        console.warn('Erro ao carregar labels para o filtro de contatos:', error);
-        if (active) setOptions({ labels: [], loading: false });
+      const [labelsResult, companiesResult] = await Promise.allSettled([
+        labelsService.getLabels({ per_page: 200 }),
+        contactsService.getCompaniesList(),
+      ]);
+
+      // value = label.title to match filter_service tag query (compares tags.name).
+      const labelData = labelsResult.status === 'fulfilled' ? (labelsResult.value?.data ?? []) : [];
+      const labels = Array.isArray(labelData)
+        ? labelData.map((label: Label) => ({ label: label.title, value: label.title }))
+        : [];
+      if (labelsResult.status === 'rejected') {
+        console.warn('Erro ao carregar labels para o filtro de contatos:', labelsResult.reason);
       }
+
+      // value = company id (UUID) to match filter_service company query (contact_companies.company_id).
+      const companyData = companiesResult.status === 'fulfilled' ? companiesResult.value : [];
+      const companies = Array.isArray(companyData)
+        ? companyData.map(company => ({ label: company.name, value: company.id }))
+        : [];
+      if (companiesResult.status === 'rejected') {
+        console.warn('Erro ao carregar empresas para o filtro de contatos:', companiesResult.reason);
+      }
+
+      if (active) setOptions({ labels, companies, loading: false });
     };
 
     load();

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -80,7 +80,11 @@ export default function Contacts() {
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
   const hasCompanyFilter = activeFilters.some(f => f.attributeKey === 'company');
-  const { companies: companyFilterOptions } = useContactFilterOptions({ enabled: hasCompanyFilter });
+  // Preload company options while the filter modal is open so the applied chip
+  // resolves the company name immediately on Apply (no id-then-name flicker).
+  const { companies: companyFilterOptions } = useContactFilterOptions({
+    enabled: filterModalOpen || hasCompanyFilter,
+  });
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [mergeModalOpen, setMergeModalOpen] = useState(false);

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -484,17 +484,9 @@ export default function Contacts() {
     setContactModalOpen(true);
   };
 
-  const handleEditContact = async (contact: Contact) => {
+  const handleEditContact = (contact: Contact) => {
     setEditingContact(contact);
     setContactModalOpen(true);
-    // The list payload omits linked companies (serialized without include_companies),
-    // so re-fetch the full contact to populate the "Linked Companies" picker on edit.
-    try {
-      const fullContact = await contactsService.getContact(contact.id);
-      setEditingContact(fullContact);
-    } catch (error) {
-      console.error('Error loading contact for edit:', error);
-    }
   };
 
   const handleStartConversation = (contact: Contact) => {
@@ -905,7 +897,7 @@ export default function Contacts() {
 
       {/* Pagination */}
       {state.meta.pagination.total > 0 && (
-        <div data-tour="contacts-pagination" className="mt-4 border-t border-border pt-4">
+        <div data-tour="contacts-pagination">
           <ContactsPagination
             currentPage={state.meta.pagination.page}
             totalPages={state.meta.pagination.total_pages}

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -905,7 +905,7 @@ export default function Contacts() {
 
       {/* Pagination */}
       {state.meta.pagination.total > 0 && (
-        <div data-tour="contacts-pagination">
+        <div data-tour="contacts-pagination" className="mt-4 border-t border-border pt-4">
           <ContactsPagination
             currentPage={state.meta.pagination.page}
             totalPages={state.meta.pagination.total_pages}

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -17,7 +17,8 @@ import EmptyState from '@/components/base/EmptyState';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { contactsService } from '@/services/contacts';
 import { Contact, ContactsState, ContactsListParams, ContactFormData } from '@/types/contacts';
-import { BaseFilter, AppliedFilter } from '@/types/core';
+import { BaseFilter, AppliedFilter, CONTACT_FILTER_TYPES } from '@/types/core';
+import { useContactFilterOptions } from '@/hooks/contacts/useContactFilterOptions';
 import { ContactCard } from '@/components/contacts';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 
@@ -78,7 +79,8 @@ export default function Contacts() {
   const [detailsContact, setDetailsContact] = useState<Contact | null>(null);
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
-  const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
+  const hasCompanyFilter = activeFilters.some(f => f.attributeKey === 'company');
+  const { companies: companyFilterOptions } = useContactFilterOptions({ enabled: hasCompanyFilter });
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [mergeModalOpen, setMergeModalOpen] = useState(false);
@@ -269,15 +271,27 @@ export default function Contacts() {
     });
   };
 
+  const resolveFilterAttributeLabel = (attributeKey: string): string => {
+    const filterType = CONTACT_FILTER_TYPES.find(f => f.attributeKey === attributeKey);
+    return filterType?.attributeI18nKey ? t(filterType.attributeI18nKey) : attributeKey;
+  };
+
+  const resolveFilterValueLabel = (filter: BaseFilter): string => {
+    const raw = Array.isArray(filter.values) ? filter.values.join(',') : String(filter.values ?? '');
+    // The company filter submits a company id (UUID); show its name in the chip.
+    if (filter.attributeKey === 'company') {
+      return companyFilterOptions.find(o => o.value === raw)?.label ?? raw;
+    }
+    return raw;
+  };
+
   const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] => {
+    // BaseHeader renders each chip as `{label}: {value}`, so label is the attribute
+    // name and value is the human-readable value (company id resolved to its name).
     return filters.map((filter, index) => ({
       id: `filter-${index}`,
-      label: `${filter.attributeKey}: ${
-        Array.isArray(filter.values) ? filter.values.join(',') : filter.values
-      }`,
-      value: Array.isArray(filter.values)
-        ? String(filter.values.join(','))
-        : (filter.values as string | number),
+      label: resolveFilterAttributeLabel(filter.attributeKey),
+      value: resolveFilterValueLabel(filter),
       onRemove: () => handleRemoveFilter(index),
     }));
   };
@@ -288,7 +302,6 @@ export default function Contacts() {
 
   const handleApplyFilters = async (filters: BaseFilter[]) => {
     setActiveFilters(filters);
-    setAppliedFilters(convertFiltersToApplied(filters));
 
     setState(prev => ({
       ...prev,
@@ -389,7 +402,6 @@ export default function Contacts() {
 
   const handleClearFilters = () => {
     setActiveFilters([]);
-    setAppliedFilters([]);
     loadContacts({ page: 1 });
   };
 
@@ -401,6 +413,13 @@ export default function Contacts() {
       handleApplyFilters(newFilters);
     }
   };
+
+  // Derived so company chips re-resolve their name once the options load async.
+  const appliedFilters = useMemo(
+    () => convertFiltersToApplied(activeFilters),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeFilters, companyFilterOptions, t],
+  );
 
   const handlePageChange = (page: number) => {
     setState(prev => ({
@@ -460,9 +479,17 @@ export default function Contacts() {
     setContactModalOpen(true);
   };
 
-  const handleEditContact = (contact: Contact) => {
+  const handleEditContact = async (contact: Contact) => {
     setEditingContact(contact);
     setContactModalOpen(true);
+    // The list payload omits linked companies (serialized without include_companies),
+    // so re-fetch the full contact to populate the "Linked Companies" picker on edit.
+    try {
+      const fullContact = await contactsService.getContact(contact.id);
+      setEditingContact(fullContact);
+    } catch (error) {
+      console.error('Error loading contact for edit:', error);
+    }
   };
 
   const handleStartConversation = (contact: Contact) => {

--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -277,6 +277,11 @@ export default function Contacts() {
   };
 
   const resolveFilterValueLabel = (filter: BaseFilter): string => {
+    // Presence operators carry no value — show the operator name so the chip
+    // reads "Company: Present" instead of a dangling "Company:".
+    if (filter.filterOperator === 'is_present' || filter.filterOperator === 'is_not_present') {
+      return t(`filter.operators.${filter.filterOperator}`);
+    }
     const raw = Array.isArray(filter.values) ? filter.values.join(',') : String(filter.values ?? '');
     // The company filter submits a company id (UUID); show its name in the chip.
     if (filter.attributeKey === 'company') {

--- a/src/types/core/filters.contacts.spec.ts
+++ b/src/types/core/filters.contacts.spec.ts
@@ -35,4 +35,9 @@ describe('CONTACT_FILTER_TYPES (EVO-1835)', () => {
     expect(byKey('company')?.filterOperators.map(o => o.key)).not.toContain('contains');
     expect(byKey('country_code')?.filterOperators.map(o => o.key)).not.toContain('contains');
   });
+
+  it('company exposes presence operators to match the backend (has-any / has-no company)', () => {
+    const ops = byKey('company')?.filterOperators.map(o => o.key);
+    expect(ops).toEqual(['equal_to', 'not_equal_to', 'is_present', 'is_not_present']);
+  });
 });

--- a/src/types/core/filters.contacts.spec.ts
+++ b/src/types/core/filters.contacts.spec.ts
@@ -17,18 +17,22 @@ describe('CONTACT_FILTER_TYPES (EVO-1835)', () => {
     }
   });
 
-  it('labels is a search_select with a dynamic-options placeholder', () => {
+  it('labels and company are search_selects with a dynamic-options placeholder', () => {
     expect(byKey('labels')?.inputType).toBe('search_select');
     expect(byKey('labels')?.options).toEqual([]);
+    // EVO-1887: company is a picker (select from registered companies), not free text.
+    expect(byKey('company')?.inputType).toBe('search_select');
+    expect(byKey('company')?.options).toEqual([]);
   });
 
   it('blocked offers boolean options', () => {
     expect(byKey('blocked')?.options?.map(o => o.value)).toEqual(['true', 'false']);
   });
 
-  it('city/company allow contains operators, country_code does not', () => {
+  it('city allows contains operators; company and country_code do not', () => {
     expect(byKey('city')?.filterOperators.map(o => o.key)).toContain('contains');
-    expect(byKey('company')?.filterOperators.map(o => o.key)).toContain('contains');
+    // EVO-1887: company filters by association id, so contains is not offered.
+    expect(byKey('company')?.filterOperators.map(o => o.key)).not.toContain('contains');
     expect(byKey('country_code')?.filterOperators.map(o => o.key)).not.toContain('contains');
   });
 });

--- a/src/types/core/filters.ts
+++ b/src/types/core/filters.ts
@@ -133,7 +133,15 @@ export const CONTACT_FILTER_TYPES: FilterType[] = [
     attributeI18nKey: 'filter.attributes.company',
     inputType: 'search_select',
     dataType: 'text',
-    filterOperators: OPERATOR_TYPES_1,
+    // Mirrors the backend contacts.company operators (filter_keys.yml): is/is-not a
+    // company, plus has-any / has-no company. is_present/is_not_present render
+    // without a value input (BaseFilterRow.needsValueInput).
+    filterOperators: [
+      { key: 'equal_to', label: 'filter.operators.equal_to', value: 'equal_to' },
+      { key: 'not_equal_to', label: 'filter.operators.not_equal_to', value: 'not_equal_to' },
+      { key: 'is_present', label: 'filter.operators.is_present', value: 'is_present' },
+      { key: 'is_not_present', label: 'filter.operators.is_not_present', value: 'is_not_present' },
+    ],
     attribute_type: 'standard',
     options: [], // populated dynamically (companies) in ContactsFilter
   },

--- a/src/types/core/filters.ts
+++ b/src/types/core/filters.ts
@@ -129,6 +129,15 @@ export const CONTACT_FILTER_TYPES: FilterType[] = [
     attribute_type: 'standard',
   },
   {
+    attributeKey: 'company',
+    attributeI18nKey: 'filter.attributes.company',
+    inputType: 'search_select',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_1,
+    attribute_type: 'standard',
+    options: [], // populated dynamically (companies) in ContactsFilter
+  },
+  {
     attributeKey: 'blocked',
     attributeI18nKey: 'filter.attributes.blocked',
     inputType: 'search_select',


### PR DESCRIPTION
## Summary
- Re-add **company** to `CONTACT_FILTER_TYPES` as a `search_select` picker whose options load dynamically from `GET /contacts/companies_list` (value = company **id**). Mirrors the labels dynamic-options pattern.
- Operators match the backend: `equal_to` / `not_equal_to` / `is_present` / `is_not_present` (presence operators render without a value input).
- **Applied-filter chip** now resolves the attribute i18n label + the company **id → name** (was showing the raw UUID, and doubled it), and shows the operator name for presence operators (was a dangling "Company:"). Company options preload while the filter modal is open to avoid an id→name flicker.
- Fixes the EVO-1835 `filters.contacts` spec that went red on develop after EVO-1849 removed company.

## Out of scope (relocated)
- Linked-companies-on-edit data-loss fix → **EVO-1943** (PR #200).
- Pagination spacing + mobile toolbar → **EVO-1944** (PR #201).
- Cross-screen chip operator-awareness → **EVO-1937**; `companies_list` pagination → **EVO-1936**.

## Test plan
- `frontend: pnpm exec tsc -b --noEmit` (clean)
- `frontend: pnpm exec vitest run src/types/core/filters.contacts.spec.ts` → 6 passed
- `frontend: pnpm lint` (0 errors)
- Manual smoke: pick a company in the filter → chip reads "Company: <name>" (no UUID/flicker); "is present" → "Company: Present"; results match.

## Changed Files
- `src/types/core/filters.ts`
- `src/types/core/filters.contacts.spec.ts`
- `src/hooks/contacts/useContactFilterOptions.ts`
- `src/components/contacts/ContactsFilter.tsx`
- `src/pages/Customer/Contacts/Contacts.tsx`

## Related PRs
- crm: company filter backend — https://github.com/evolution-foundation/evo-ai-crm-community/pull/177

## Linked Issue
- EVO-1887

🤖 Generated with [Claude Code](https://claude.com/claude-code)