### PR TITLE
fix(journey): remove auto-persist effect causing infinite render loop in assign panels (EVO-1945)

### DIFF
--- a/src/components/journey/nodes/actions/assign-agent/AssignAgentPanel.tsx
+++ b/src/components/journey/nodes/actions/assign-agent/AssignAgentPanel.tsx
@@ -64,16 +64,6 @@ export function AssignAgentPanel({ nodeId, data, onUpdate, onClose }: AssignAgen
     onClose();
   };
 
-  useEffect(() => {
-    if (formDataOptions.agents.length > 0) {
-      const updatedData: AssignAgentNodeData = {
-        ...data,
-        formDataOptions,
-      };
-      onUpdate(nodeId, updatedData);
-    }
-  }, [formDataOptions, data, nodeId, onUpdate]);
-
   const dirty = useMemo(() => agentId !== originalAgentId, [agentId, originalAgentId]);
   const isValid = Boolean(agentId);
 

--- a/src/components/journey/nodes/actions/assign-team/AssignTeamPanel.tsx
+++ b/src/components/journey/nodes/actions/assign-team/AssignTeamPanel.tsx
@@ -64,16 +64,6 @@ export function AssignTeamPanel({ nodeId, data, onUpdate, onClose }: AssignTeamP
     onClose();
   };
 
-  useEffect(() => {
-    if (formDataOptions.teams.length > 0) {
-      const updatedData: AssignTeamNodeData = {
-        ...data,
-        formDataOptions,
-      };
-      onUpdate(nodeId, updatedData);
-    }
-  }, [formDataOptions, data, nodeId, onUpdate]);
-
   const dirty = useMemo(() => teamId !== originalTeamId, [teamId, originalTeamId]);
   const isValid = Boolean(teamId);
 


### PR DESCRIPTION
## Summary
Abrir um passo **assign-team** (ou assign-agent) no editor de jornadas disparava `Maximum update depth exceeded` (loop infinito de render) e derrubava o flow.

Causa: um `useEffect` de auto-persist em `AssignTeamPanel`/`AssignAgentPanel` chamava `onUpdate(nodeId, { ...data, formDataOptions })` com `[formDataOptions, data, nodeId, onUpdate]` nas deps. Ao carregar times/agentes, `onUpdate` recriava `data` → nova prop → effect re-dispara → loop.

Fix: remover esse effect nos 2 painéis. `formDataOptions` já é persistido no `handleSave`; o display do nó usa `team_name`/`agent_name` (gravados no save) com `formDataOptions` só como fallback; abrir o painel deixa de mutar o nó.

Irmãos `assign-to-pipeline`/`assign-bot` não têm o effect → não tocados.

## Test plan
- `tsc -b` limpo (exit 0).
- Manual: abrir/selecionar time e agente nos painéis não dispara mais o erro; Save persiste team_id/team_name e agent_id/agent_name normalmente.

## Notas
Padrão 'autosave fantasma por effect [data, onUpdate]' já conhecido neste FE.

## Summary by Sourcery

Bug Fixes:
- Remove the auto-persist effect from AssignAgentPanel and AssignTeamPanel that caused an infinite render loop when loading agents or teams.