### PR TITLE
fix(journey): treat manual trigger as conversation-indeterminate like webhook (EVO-1946)

### DIFF
--- a/src/utils/journeyValidators/triggerActionContext.spec.ts
+++ b/src/utils/journeyValidators/triggerActionContext.spec.ts
@@ -30,12 +30,15 @@ describe('triggerProvidesConversation (EVO-1744)', () => {
     ).toBe(false);
   });
   it('contact-level trigger types do NOT provide conversation', () => {
-    for (const tt of ['manual', 'segment', 'contactCreated', 'label', 'customAttribute', 'pipelineStageChanged']) {
+    for (const tt of ['segment', 'contactCreated', 'label', 'customAttribute', 'pipelineStageChanged']) {
       expect(triggerProvidesConversation({ triggerType: tt })).toBe(false);
     }
   });
-  it('webhook is treated as provides=true (indeterminate, no-warn)', () => {
+  it('indeterminate triggers (webhook, manual) are provides=true (no-warn)', () => {
+    // Both can carry conversation_id in their payload; the runtime contextSkip
+    // is the real guard, so warning on every manual flow would be noise.
     expect(triggerProvidesConversation({ triggerType: 'webhook' })).toBe(true);
+    expect(triggerProvidesConversation({ triggerType: 'manual' })).toBe(true);
   });
 });
 

--- a/src/utils/journeyValidators/triggerActionContext.ts
+++ b/src/utils/journeyValidators/triggerActionContext.ts
@@ -56,11 +56,14 @@ export function triggerProvidesConversation(
       return category === 'conversation' || category === 'message';
     }
     case 'webhook':
-      // Indeterminate: payload may carry conversation_id and the runtime
-      // contextSkip is the real guard. Treat as provides=true to keep warnings
-      // high-signal (documented design choice).
+    case 'manual':
+      // Indeterminate: a webhook payload OR a manual POST /journeys/trigger/:id
+      // call may carry conversation_id, and the runtime contextSkip is the real
+      // guard. Treat as provides=true to keep warnings high-signal — a manual
+      // trigger legitimately drives conversation-scoped nodes when it passes a
+      // conversation (documented design choice, mirrors webhook).
       return true;
-    // manual, segment, contactCreated, contactUpdated, label, customAttribute,
+    // segment, contactCreated, contactUpdated, label, customAttribute,
     // pipelineStageChanged → contact/pipeline-level, no conversation.
     default:
       return false;


### PR DESCRIPTION
## Summary
A coerência trigger↔ação (EVO-1744) marcava gatilho **Manual** como 'não fornece conversa' (`default: false`), gerando warning falso-positivo (*needs a conversation, but the trigger doesn't provide one*) em nós de conversa (assign-team, assign-agent, send-message, etc.) sob trigger manual.

Manual é tão indeterminado quanto `webhook` (já tratado como `provides=true`): um `POST /journeys/trigger/:id` pode carregar `conversation_id`. Agrupei `manual` com `webhook` → `provides=true`, com o mesmo racional (runtime contextSkip é o guard real).

Gatilhos que realmente nunca fornecem conversa (contactCreated/contactUpdated/label/customAttribute/segment/pipelineStageChanged) seguem avisando corretamente.

## Test plan
- `triggerProvidesConversation({ triggerType: 'manual' })` → true.
- Spec atualizada: manual saiu do grupo 'não fornece' e entrou no teste de indeterminados junto do webhook. `vitest` 7/7 verde.
- `tsc -b` limpo.

## Notas
Trade-off documentado: um trigger Manual que NÃO passe conversation_id deixa de ser avisado — o nó dará contextSkip em runtime (mesmo comportamento já aceito pro webhook).

## Summary by Sourcery

Adjust journey trigger conversation inference to treat manual triggers as conversation-indeterminate like webhooks to avoid noisy validation warnings.

Bug Fixes:
- Stop falsely warning that manual-triggered conversation nodes lack a conversation by recognizing that manual triggers may carry a conversation context.

Tests:
- Update triggerProvidesConversation specs to classify manual as indeterminate alongside webhook and ensure contact-level triggers remain conversation-less.