### PR TITLE
feat(admin-settings): mover credenciais de provedor de e-mail + recebimento (inbound) para a aba E-mail de Canais

### DIFF
--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -3,12 +3,10 @@
   "navigation": {
     "email": "Email",
     "storage": "Storage",
-    "socialLogin": "Authentication Providers",
     "channels": "Channels",
     "openai": "OpenAI",
     "integrations": "Integrations",
     "evolutionHub": "Evo Hub",
-    "inboundEmail": "Inbound Email",
     "frontendRuntime": "Frontend Runtime"
   },
   "email": {
@@ -117,8 +115,8 @@
     }
   },
   "socialLogin": {
-    "title": "Authentication Providers",
-    "description": "Configure OAuth credentials for SSO authentication providers so users can sign in with Google or Microsoft.",
+    "title": "Email provider credentials (OAuth)",
+    "description": "OAuth app credentials (Google / Microsoft) used to connect Gmail and Outlook email channels.",
     "google": {
       "cardTitle": "Google OAuth",
       "fields": {
@@ -165,6 +163,9 @@
     "saving": "Saving..."
   },
   "channels": {
+    "email": {
+      "tabTitle": "Email"
+    },
     "title": "Channel Integrations",
     "description": "Configure credentials for messaging channels and integrations.",
     "secretConfigured": "Configured",
@@ -404,8 +405,8 @@
     }
   },
   "inboundEmail": {
-    "title": "Inbound Email Configuration",
-    "description": "Configure the inbound email provider and credentials used for receiving and processing incoming emails.",
+    "title": "Inbound email (receive as conversations)",
+    "description": "Lets the CRM receive emails as conversations. Requires an external receiving service (relay, Mailgun or Mandrill) configured for your domain.",
     "provider": {
       "label": "Inbound Email Service",
       "relay": "Relay (Exim / Postfix / Qmail)",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -3,12 +3,10 @@
   "navigation": {
     "email": "Correo electronico",
     "storage": "Almacenamiento",
-    "socialLogin": "Proveedores de Autenticación",
     "channels": "Canales",
     "openai": "OpenAI",
     "integrations": "Integraciones",
     "evolutionHub": "Evo Hub",
-    "inboundEmail": "Correo Entrante",
     "frontendRuntime": "Frontend Runtime"
   },
   "email": {
@@ -117,8 +115,8 @@
     }
   },
   "socialLogin": {
-    "title": "Proveedores de Autenticación",
-    "description": "Configure las credenciales OAuth de los proveedores de autenticación SSO para que los usuarios puedan iniciar sesion con Google o Microsoft.",
+    "title": "Credenciales de proveedor de correo (OAuth)",
+    "description": "Credenciales de app OAuth (Google / Microsoft) usadas para conectar canales de correo Gmail y Outlook.",
     "google": {
       "cardTitle": "Google OAuth",
       "fields": {
@@ -165,6 +163,9 @@
     "saving": "Guardando..."
   },
   "channels": {
+    "email": {
+      "tabTitle": "Correo"
+    },
     "title": "Integraciones de Canales",
     "description": "Configure las credenciales para los canales de mensajeria e integraciones.",
     "secretConfigured": "Configurado",
@@ -404,8 +405,8 @@
     }
   },
   "inboundEmail": {
-    "title": "Configuracion de Correo Entrante",
-    "description": "Configure el proveedor de correo entrante y las credenciales utilizadas para recibir y procesar correos electronicos entrantes.",
+    "title": "Correo entrante (recibir como conversaciones)",
+    "description": "Permite que el CRM reciba correos como conversaciones. Requiere un servicio externo de recepción (relay, Mailgun o Mandrill) configurado para tu dominio.",
     "provider": {
       "label": "Servicio de Correo Entrante",
       "relay": "Relay (Exim / Postfix / Qmail)",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -3,11 +3,9 @@
   "navigation": {
     "email": "E-mail",
     "storage": "Stockage",
-    "socialLogin": "Fournisseurs d'authentification",
     "channels": "Canaux",
     "openai": "OpenAI",
     "integrations": "Integrations",
-    "inboundEmail": "E-mail Entrant",
     "frontendRuntime": "Frontend Runtime"
   },
   "email": {
@@ -116,8 +114,8 @@
     }
   },
   "socialLogin": {
-    "title": "Fournisseurs d'authentification",
-    "description": "Configurez les identifiants OAuth des fournisseurs d'authentification SSO pour que les utilisateurs puissent se connecter avec Google ou Microsoft.",
+    "title": "Identifiants du fournisseur d'e-mail (OAuth)",
+    "description": "Identifiants d'application OAuth (Google / Microsoft) utilisés pour connecter les canaux e-mail Gmail et Outlook.",
     "google": {
       "cardTitle": "Google OAuth",
       "fields": {
@@ -164,6 +162,9 @@
     "saving": "Enregistrement..."
   },
   "channels": {
+    "email": {
+      "tabTitle": "E-mail"
+    },
     "title": "Integrations de Canaux",
     "description": "Configurez les identifiants pour les canaux de messagerie et integrations.",
     "secretConfigured": "Configure",
@@ -403,8 +404,8 @@
     }
   },
   "inboundEmail": {
-    "title": "Configuration E-mail Entrant",
-    "description": "Configurez le fournisseur de messagerie entrante et les identifiants utilises pour recevoir et traiter les e-mails entrants.",
+    "title": "E-mail entrant (recevoir comme conversations)",
+    "description": "Permet au CRM de recevoir des e-mails sous forme de conversations. Nécessite un service de réception externe (relay, Mailgun ou Mandrill) configuré pour votre domaine.",
     "provider": {
       "label": "Service d'E-mail Entrant",
       "relay": "Relay (Exim / Postfix / Qmail)",

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -3,11 +3,9 @@
   "navigation": {
     "email": "E-mail",
     "storage": "Archiviazione",
-    "socialLogin": "Provider di autenticazione",
     "channels": "Canali",
     "openai": "OpenAI",
     "integrations": "Integrazioni",
-    "inboundEmail": "E-mail in Entrata",
     "frontendRuntime": "Frontend Runtime"
   },
   "email": {
@@ -116,8 +114,8 @@
     }
   },
   "socialLogin": {
-    "title": "Provider di autenticazione",
-    "description": "Configura le credenziali OAuth dei provider di autenticazione SSO per consentire agli utenti di accedere con Google o Microsoft.",
+    "title": "Credenziali del provider e-mail (OAuth)",
+    "description": "Credenziali dell'app OAuth (Google / Microsoft) usate per collegare i canali e-mail Gmail e Outlook.",
     "google": {
       "cardTitle": "Google OAuth",
       "fields": {
@@ -164,6 +162,9 @@
     "saving": "Salvataggio..."
   },
   "channels": {
+    "email": {
+      "tabTitle": "Email"
+    },
     "title": "Integrazioni Canali",
     "description": "Configura le credenziali per i canali di messaggistica e integrazioni.",
     "secretConfigured": "Configurato",
@@ -403,8 +404,8 @@
     }
   },
   "inboundEmail": {
-    "title": "Configurazione E-mail in Entrata",
-    "description": "Configura il provider di posta elettronica in entrata e le credenziali utilizzate per ricevere ed elaborare le e-mail in arrivo.",
+    "title": "E-mail in entrata (ricevi come conversazioni)",
+    "description": "Permette al CRM di ricevere e-mail come conversazioni. Richiede un servizio di ricezione esterno (relay, Mailgun o Mandrill) configurato per il tuo dominio.",
     "provider": {
       "label": "Servizio E-mail in Entrata",
       "relay": "Relay (Exim / Postfix / Qmail)",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -3,12 +3,10 @@
   "navigation": {
     "email": "E-mail",
     "storage": "Armazenamento",
-    "socialLogin": "Provedores de Autenticação",
     "channels": "Canais",
     "openai": "OpenAI",
     "integrations": "Integracoes",
     "evolutionHub": "Evo Hub",
-    "inboundEmail": "E-mail de Entrada",
     "frontendRuntime": "Frontend Runtime"
   },
   "email": {
@@ -117,8 +115,8 @@
     }
   },
   "socialLogin": {
-    "title": "Provedores de Autenticação",
-    "description": "Configure as credenciais OAuth dos provedores de autenticação SSO para que os usuarios possam entrar com Google ou Microsoft.",
+    "title": "Credenciais de provedor de e-mail (OAuth)",
+    "description": "Credenciais de app OAuth (Google / Microsoft) usadas para conectar canais de e-mail Gmail e Outlook.",
     "google": {
       "cardTitle": "Google OAuth",
       "fields": {
@@ -165,6 +163,9 @@
     "saving": "Salvando..."
   },
   "channels": {
+    "email": {
+      "tabTitle": "E-mail"
+    },
     "title": "Integracoes de Canais",
     "description": "Configure as credenciais para os canais de mensagens e integracoes.",
     "secretConfigured": "Configurado",
@@ -404,8 +405,8 @@
     }
   },
   "inboundEmail": {
-    "title": "Configuracao de E-mail de Entrada",
-    "description": "Configure o provedor de e-mail de entrada e as credenciais usadas para receber e processar e-mails recebidos.",
+    "title": "E-mail de entrada (receber como conversas)",
+    "description": "Permite que o CRM receba e-mails como conversas. Requer um serviço externo de recebimento (relay, Mailgun ou Mandrill) configurado para o seu domínio.",
     "provider": {
       "label": "Servico de E-mail de Entrada",
       "relay": "Relay (Exim / Postfix / Qmail)",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -3,11 +3,9 @@
   "navigation": {
     "email": "E-mail",
     "storage": "Armazenamento",
-    "socialLogin": "Provedores de Autenticação",
     "channels": "Canais",
     "openai": "OpenAI",
     "integrations": "Integracoes",
-    "inboundEmail": "E-mail de Entrada",
     "frontendRuntime": "Frontend Runtime"
   },
   "email": {
@@ -116,8 +114,8 @@
     }
   },
   "socialLogin": {
-    "title": "Provedores de Autenticação",
-    "description": "Configure as credenciais OAuth dos fornecedores de autenticação SSO para que os utilizadores possam iniciar sessao com Google ou Microsoft.",
+    "title": "Credenciais de provedor de e-mail (OAuth)",
+    "description": "Credenciais de app OAuth (Google / Microsoft) usadas para ligar canais de e-mail Gmail e Outlook.",
     "google": {
       "cardTitle": "Google OAuth",
       "fields": {
@@ -164,6 +162,9 @@
     "saving": "A guardar..."
   },
   "channels": {
+    "email": {
+      "tabTitle": "E-mail"
+    },
     "title": "Integracoes de Canais",
     "description": "Configure as credenciais para os canais de mensagens e integracoes.",
     "secretConfigured": "Configurado",
@@ -403,8 +404,8 @@
     }
   },
   "inboundEmail": {
-    "title": "Configuracao de E-mail de Entrada",
-    "description": "Configure o fornecedor de e-mail de entrada e as credenciais usadas para receber e processar e-mails recebidos.",
+    "title": "E-mail de entrada (receber como conversas)",
+    "description": "Permite que o CRM receba e-mails como conversas. Requer um serviço externo de receção (relay, Mailgun ou Mandrill) configurado para o seu domínio.",
     "provider": {
       "label": "Servico de E-mail de Entrada",
       "relay": "Relay (Exim / Postfix / Qmail)",

--- a/src/pages/Admin/Settings/ChannelConfig.spec.tsx
+++ b/src/pages/Admin/Settings/ChannelConfig.spec.tsx
@@ -187,7 +187,7 @@ describe('ChannelConfig', () => {
     expect(screen.getByText('channels.description')).toBeInTheDocument();
   });
 
-  it('renders all 6 tab triggers', async () => {
+  it('renders the visible tab triggers (twitter hidden)', async () => {
     await renderAndWait();
 
     expect(screen.getByText('channels.facebook.tabTitle')).toBeInTheDocument();
@@ -195,7 +195,9 @@ describe('ChannelConfig', () => {
     expect(screen.getByText('channels.instagram.tabTitle')).toBeInTheDocument();
     expect(screen.getByText('channels.evolution.tabTitle')).toBeInTheDocument();
     expect(screen.getByText('channels.evolutionGo.tabTitle')).toBeInTheDocument();
-    expect(screen.getByText('channels.twitter.tabTitle')).toBeInTheDocument();
+    expect(screen.getByText('channels.email.tabTitle')).toBeInTheDocument();
+    // Twitter tab intentionally hidden (deprecated) — no trigger rendered.
+    expect(screen.queryByText('channels.twitter.tabTitle')).not.toBeInTheDocument();
   });
 
   it('renders Facebook tab fields by default', async () => {
@@ -491,41 +493,20 @@ describe('ChannelConfig', () => {
     });
   });
 
-  // --- Twitter Tab Tests ---
+  // --- Email Tab Tests (B1 provider OAuth + B4 inbound) ---
 
-  it('renders Twitter tab fields when tab is clicked', async () => {
+  it('renders the Email tab with provider OAuth and inbound sections', async () => {
     await renderAndWait();
     const user = userEvent.setup();
 
-    await user.click(screen.getByText('channels.twitter.tabTitle'));
+    await user.click(screen.getByText('channels.email.tabTitle'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText('channels.twitter.fields.appId')).toBeInTheDocument();
+      // B1: Google/Microsoft provider OAuth credentials section
+      expect(screen.getByText('socialLogin.title')).toBeInTheDocument();
     });
-    expect(screen.getByLabelText('channels.twitter.fields.consumerKey')).toBeInTheDocument();
-    expect(screen.getByLabelText('channels.twitter.fields.consumerSecret')).toBeInTheDocument();
-    expect(screen.getByLabelText('channels.twitter.fields.environment')).toBeInTheDocument();
-  });
-
-  it('saves Twitter tab independently via twitter config type', async () => {
-    await renderAndWait({ fbData: CONFIGURED_FACEBOOK, wpData: CONFIGURED_WHATSAPP, igData: CONFIGURED_INSTAGRAM, evoData: CONFIGURED_EVOLUTION, evoGoData: CONFIGURED_EVOLUTION_GO, twData: CONFIGURED_TWITTER });
-    mockSaveConfig.mockResolvedValue(CONFIGURED_TWITTER);
-    const user = userEvent.setup();
-
-    await user.click(screen.getByText('channels.twitter.tabTitle'));
-
-    await waitFor(() => {
-      expect(screen.getByLabelText('channels.twitter.fields.appId')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText('channels.save'));
-
-    await waitFor(() => {
-      expect(mockSaveConfig).toHaveBeenCalledWith('twitter', expect.objectContaining({
-        TWITTER_APP_ID: 'test-twitter-app-id',
-        TWITTER_CONSUMER_KEY: 'test-consumer-key',
-      }));
-    });
+    // B4: inbound email receiving section
+    expect(screen.getByText('inboundEmail.title')).toBeInTheDocument();
   });
 
   it('sends null for unmodified secrets on Evolution Go save', async () => {
@@ -584,23 +565,6 @@ describe('ChannelConfig', () => {
     });
   });
 
-  it('shows error toast when Twitter save fails', async () => {
-    await renderAndWait({ twData: CONFIGURED_TWITTER });
-    mockSaveConfig.mockRejectedValue(new Error('Network error'));
-    const user = userEvent.setup();
-
-    await user.click(screen.getByText('channels.twitter.tabTitle'));
-    await waitFor(() => {
-      expect(screen.getByLabelText('channels.twitter.fields.appId')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText('channels.save'));
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Test error');
-    });
-  });
-
   // --- Clear secret tests for new tabs ---
 
   it('clear secret on Evolution tab marks secret as modified', async () => {
@@ -633,38 +597,18 @@ describe('ChannelConfig', () => {
       expect(screen.getByLabelText('channels.evolutionGo.fields.adminSecret')).toBeInTheDocument();
     });
 
-    // Evolution Go has 2 configured secrets
+    // Evolution Go has 1 configured secret (EVOLUTION_GO_ADMIN_SECRET)
     const configuredBefore = screen.getAllByText('channels.secretConfigured');
-    expect(configuredBefore.length).toBe(2);
+    expect(configuredBefore.length).toBe(1);
 
     const clearButtons = screen.getAllByTitle('channels.clearSecret');
     await act(async () => {
       fireEvent.click(clearButtons[0]);
     });
 
-    // One fewer configured indicator
-    const configuredAfter = screen.getAllByText('channels.secretConfigured');
-    expect(configuredAfter.length).toBe(1);
-  });
-
-  it('clear secret on Twitter tab marks secret as modified', async () => {
-    await renderAndWait({ twData: CONFIGURED_TWITTER });
-    const user = userEvent.setup();
-
-    await user.click(screen.getByText('channels.twitter.tabTitle'));
-    await waitFor(() => {
-      expect(screen.getByLabelText('channels.twitter.fields.consumerSecret')).toBeInTheDocument();
-    });
-
-    const clearButtons = screen.getAllByTitle('channels.clearSecret');
-    expect(clearButtons.length).toBeGreaterThanOrEqual(1);
-
-    await act(async () => {
-      fireEvent.click(clearButtons[0]);
-    });
-
-    const remaining = screen.queryAllByText('channels.secretConfigured');
-    expect(remaining.length).toBe(0);
+    // Cleared → no configured indicator remains
+    const configuredAfter = screen.queryAllByText('channels.secretConfigured');
+    expect(configuredAfter.length).toBe(0);
   });
 
   describe('required enforcement', () => {

--- a/src/pages/Admin/Settings/ChannelConfig.tsx
+++ b/src/pages/Admin/Settings/ChannelConfig.tsx
@@ -22,6 +22,8 @@ import { extractError } from '@/utils/apiHelpers';
 import { refreshGlobalConfig } from '@/contexts/GlobalConfigContext';
 import { ClearConfigButton } from '@/components/admin/ClearConfigButton';
 import type { AdminConfigData } from '@/types/admin/adminConfig';
+import SocialLoginConfig from './SocialLoginConfig';
+import InboundEmailConfig from './InboundEmailConfig';
 
 // Sentinel used when the backend reports a secret as "configured" (masked).
 // The form stores this placeholder so zod's .min(1) required validation passes
@@ -717,6 +719,7 @@ export default function ChannelConfig() {
           <TabsTrigger value="instagram">{t('channels.instagram.tabTitle')}</TabsTrigger>
           <TabsTrigger value="evolution">{t('channels.evolution.tabTitle')}</TabsTrigger>
           <TabsTrigger value="evolution_go">{t('channels.evolutionGo.tabTitle')}</TabsTrigger>
+          <TabsTrigger value="email">{t('channels.email.tabTitle')}</TabsTrigger>
           {/* Twitter tab intentionally hidden — channel deprecated in customer-facing flow.
               Form, schema and submit handler are kept below so any installation that already
               has Twitter credentials configured can still load the page without runtime errors. */}
@@ -1021,6 +1024,16 @@ export default function ChannelConfig() {
               required
             />
           </ChannelFormCard>
+        </TabsContent>
+
+        {/* Email Tab — provider OAuth credentials (B1: Google/Microsoft) + inbound
+            email receiving (B4). Both relocated here from standalone Admin Settings
+            menus; each section self-loads its own config_type. */}
+        <TabsContent value="email" className="mt-4">
+          <div className="space-y-10">
+            <SocialLoginConfig />
+            <InboundEmailConfig />
+          </div>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/pages/Admin/Settings/InboundEmailConfig.tsx
+++ b/src/pages/Admin/Settings/InboundEmailConfig.tsx
@@ -154,7 +154,7 @@ export default function InboundEmailConfig() {
       const svc = (data.RAILS_INBOUND_EMAIL_SERVICE as InboundService) || 'relay';
       updateSecretStatus(data);
       reset(buildFormValues(data, svc));
-    } catch (error) {
+    } catch {
       toast.error(t('inboundEmail.messages.loadError'));
     } finally {
       setLoading(false);
@@ -259,9 +259,9 @@ export default function InboundEmailConfig() {
   }
 
   return (
-    <div className="max-w-2xl">
+    <section>
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-sidebar-foreground">{t('inboundEmail.title')}</h2>
+        <h3 className="text-lg font-semibold text-sidebar-foreground">{t('inboundEmail.title')}</h3>
         <p className="text-sm text-sidebar-foreground/70 mt-1">{t('inboundEmail.description')}</p>
       </div>
 
@@ -339,6 +339,6 @@ export default function InboundEmailConfig() {
           </form>
         </CardContent>
       </Card>
-    </div>
+    </section>
   );
 }

--- a/src/pages/Admin/Settings/SocialLoginConfig.tsx
+++ b/src/pages/Admin/Settings/SocialLoginConfig.tsx
@@ -209,7 +209,7 @@ export default function SocialLoginConfig() {
       googleForm.reset(buildGoogleFormValues(googleData));
       updateMicrosoftSecretStatus(microsoftData);
       microsoftForm.reset(buildMicrosoftFormValues(microsoftData));
-    } catch (error) {
+    } catch {
       toast.error(t('socialLogin.messages.loadError'));
     } finally {
       setLoading(false);
@@ -299,9 +299,9 @@ export default function SocialLoginConfig() {
   }
 
   return (
-    <div className="max-w-2xl">
+    <section>
       <div className="mb-6">
-        <h2 className="text-xl font-semibold text-sidebar-foreground">{t('socialLogin.title')}</h2>
+        <h3 className="text-lg font-semibold text-sidebar-foreground">{t('socialLogin.title')}</h3>
         <p className="text-sm text-sidebar-foreground/70 mt-1">{t('socialLogin.description')}</p>
       </div>
 
@@ -400,6 +400,6 @@ export default function SocialLoginConfig() {
           </form>
         </CardContent>
       </Card>
-    </div>
+    </section>
   );
 }

--- a/src/pages/Admin/Settings/index.tsx
+++ b/src/pages/Admin/Settings/index.tsx
@@ -1,16 +1,14 @@
 import { NavLink, Outlet, Navigate, useLocation } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
-import { Mail, MailOpen, HardDrive, KeyRound, MessageSquare, Sparkles, Puzzle, Globe, Cable } from 'lucide-react';
+import { Mail, HardDrive, MessageSquare, Sparkles, Puzzle, Globe, Cable } from 'lucide-react';
 
 const navItems = [
   { key: 'email', path: '/settings/admin/email', icon: Mail },
   { key: 'storage', path: '/settings/admin/storage', icon: HardDrive },
-  { key: 'socialLogin', path: '/settings/admin/social-login', icon: KeyRound },
   { key: 'channels', path: '/settings/admin/channels', icon: MessageSquare },
   { key: 'openai', path: '/settings/admin/openai', icon: Sparkles },
   { key: 'integrations', path: '/settings/admin/integrations', icon: Puzzle },
   { key: 'evolutionHub', path: '/settings/admin/evolution-hub', icon: Cable },
-  { key: 'inboundEmail', path: '/settings/admin/inbound-email', icon: MailOpen },
   { key: 'frontendRuntime', path: '/settings/admin/frontend-runtime', icon: Globe },
 ] as const;
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -84,12 +84,10 @@ const RolesList = React.lazy(() => import('@/pages/Admin/Roles/RolesList'));
 const RoleDetail = React.lazy(() => import('@/pages/Admin/Roles/RoleDetail'));
 const SmtpConfig = React.lazy(() => import('@/pages/Admin/Settings/SmtpConfig'));
 const StorageConfig = React.lazy(() => import('@/pages/Admin/Settings/StorageConfig'));
-const SocialLoginConfig = React.lazy(() => import('@/pages/Admin/Settings/SocialLoginConfig'));
 const ChannelConfig = React.lazy(() => import('@/pages/Admin/Settings/ChannelConfig'));
 const OpenAIConfig = React.lazy(() => import('@/pages/Admin/Settings/OpenAIConfig'));
 const IntegrationsConfig = React.lazy(() => import('@/pages/Admin/Settings/IntegrationsConfig'));
 const EvolutionHubConfig = React.lazy(() => import('@/pages/Admin/Settings/EvolutionHubConfig'));
-const InboundEmailConfig = React.lazy(() => import('@/pages/Admin/Settings/InboundEmailConfig'));
 const FrontendRuntimeConfig = React.lazy(() => import('@/pages/Admin/Settings/FrontendRuntimeConfig'));
 
 // Página de tutoriais
@@ -1392,14 +1390,6 @@ const AppRouter = () => {
               }
             />
             <Route
-              path="social-login"
-              element={
-                <Suspense fallback={<div className="flex items-center justify-center h-full"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" /></div>}>
-                  <SocialLoginConfig />
-                </Suspense>
-              }
-            />
-            <Route
               path="channels"
               element={
                 <Suspense fallback={<div className="flex items-center justify-center h-full"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" /></div>}>
@@ -1428,14 +1418,6 @@ const AppRouter = () => {
               element={
                 <Suspense fallback={<div className="flex items-center justify-center h-full"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" /></div>}>
                   <EvolutionHubConfig />
-                </Suspense>
-              }
-            />
-            <Route
-              path="inbound-email"
-              element={
-                <Suspense fallback={<div className="flex items-center justify-center h-full"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" /></div>}>
-                  <InboundEmailConfig />
                 </Suspense>
               }
             />


### PR DESCRIPTION
## O quê

Reorganização de IA/UX das Admin Settings: dois menus soltos e opacos viram **uma aba "E-mail" na tela de Canais**. Pure-front, **sem mudança de backend**.

### Credenciais de provedor de e-mail (antes: menu "Provedores de Autenticação")
Aquele menu **não era login social** (não existe login social no produto). Ele guarda as **credenciais de app OAuth (Google/Microsoft)** que conectam **canais de e-mail Gmail/Outlook**. Reapresentado como "Credenciais de provedor de e-mail (OAuth)".

### Recebimento de e-mail (antes: menu "Inbound Email")
Receber e-mail como conversa é, na prática, infra do canal de e-mail. Movido pra junto, com o **pré-requisito explícito** no texto (requer serviço externo de recebimento: relay/Mailgun/Mandrill).

## Como
- `ChannelConfig` ganha uma aba **"E-mail"** com 3 seções empilhadas: Google OAuth + Microsoft, e recebimento (domínio + serviço).
- As duas telas viram **seções embeddable** (sem o page-chrome). Lógica de save/load e env keys (`google_oauth`, `microsoft`, `inbound_email`) **intocadas**.
- Remove os menus soltos + suas rotas standalone. i18n nas 6 línguas.

## ⚠️ Drive-by no `ChannelConfig.spec` (mesmo arquivo)
A suíte tinha **6 falhas pré-existentes no `main`** (não introduzidas aqui). Como editei o arquivo, alinhei: testes de UI do tab **Twitter** (já oculto/deprecado, sem trigger) removidos + assere ausência do trigger; contagem de secrets do **Evolution Go** corrigida (tem 1, não 2). Resultado: **67/67 verde**.

## Verificação
`tsc -b` ✅ · `vitest` 67/67 ✅ · `eslint` ✅ · i18n parity nos 6 locales ✅ · sem refs órfãs às rotas removidas.