### PR TITLE
feat(frontend): centralize filter chip rendering + operator i18n + hide non-functional filters (EVO-1937)

### DIFF
--- a/src/components/base/BaseFilterRow.tsx
+++ b/src/components/base/BaseFilterRow.tsx
@@ -45,6 +45,15 @@ export default function BaseFilterRow<T extends BaseFilter>({
   const [calendarOpen, setCalendarOpen] = useState(false);
   const currentFilterType = filterTypes.find(ft => ft.attributeKey === filter.attributeKey);
 
+  // Operator labels live either in the screen namespace (Contacts/Conversations)
+  // or in the shared `common` namespace (other list screens). Resolve
+  // namespace-first, then fall back to common so every screen shows a
+  // translated operator instead of the raw key.
+  const translateOperatorLabel = (label: string): string => {
+    const fromNamespace = t(label);
+    return fromNamespace === label ? tCommon(label) : fromNamespace;
+  };
+
   const handleDateSelect = (date: Date | undefined) => {
     if (date) {
       onUpdate(index, 'values' as keyof T, format(date, 'yyyy-MM-dd'));
@@ -204,7 +213,7 @@ export default function BaseFilterRow<T extends BaseFilter>({
                 value={operator.key}
                 className="text-sidebar-foreground focus:bg-sidebar-accent"
               >
-                {t(operator.label)}
+                {translateOperatorLabel(operator.label)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,4 +1,10 @@
 {
+  "filter": {
+    "operators": {
+      "is_present": "Present",
+      "is_not_present": "Not present"
+    }
+  },
   "loading": "Loading...",
   "error": "Error",
   "success": "Success",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,6 +1,10 @@
 {
   "filter": {
     "operators": {
+      "equal_to": "Equal to",
+      "not_equal_to": "Not equal to",
+      "contains": "Contains",
+      "does_not_contain": "Does not contain",
       "is_present": "Present",
       "is_not_present": "Not present"
     }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1,6 +1,10 @@
 {
   "filter": {
     "operators": {
+      "equal_to": "Igual a",
+      "not_equal_to": "Diferente de",
+      "contains": "Contiene",
+      "does_not_contain": "No contiene",
       "is_present": "Presente",
       "is_not_present": "No presente"
     }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1,4 +1,10 @@
 {
+  "filter": {
+    "operators": {
+      "is_present": "Presente",
+      "is_not_present": "No presente"
+    }
+  },
   "base": {
     "noResults": {
       "title": "Sin resultados",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1,4 +1,10 @@
 {
+  "filter": {
+    "operators": {
+      "is_present": "Présent",
+      "is_not_present": "Non présent"
+    }
+  },
   "base": {
     "noResults": {
       "title": "Aucun résultat",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1,6 +1,10 @@
 {
   "filter": {
     "operators": {
+      "equal_to": "Égal à",
+      "not_equal_to": "Différent de",
+      "contains": "Contient",
+      "does_not_contain": "Ne contient pas",
       "is_present": "Présent",
       "is_not_present": "Non présent"
     }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -1,4 +1,10 @@
 {
+  "filter": {
+    "operators": {
+      "is_present": "Presente",
+      "is_not_present": "Non presente"
+    }
+  },
   "base": {
     "noResults": {
       "title": "Nessun risultato",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -1,6 +1,10 @@
 {
   "filter": {
     "operators": {
+      "equal_to": "Uguale a",
+      "not_equal_to": "Diverso da",
+      "contains": "Contiene",
+      "does_not_contain": "Non contiene",
       "is_present": "Presente",
       "is_not_present": "Non presente"
     }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -1,4 +1,10 @@
 {
+  "filter": {
+    "operators": {
+      "is_present": "Presente",
+      "is_not_present": "Não presente"
+    }
+  },
   "loading": "Carregando...",
   "error": "Erro",
   "success": "Sucesso",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -1,6 +1,10 @@
 {
   "filter": {
     "operators": {
+      "equal_to": "Igual a",
+      "not_equal_to": "Diferente de",
+      "contains": "Contém",
+      "does_not_contain": "Não contém",
       "is_present": "Presente",
       "is_not_present": "Não presente"
     }

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1,4 +1,10 @@
 {
+  "filter": {
+    "operators": {
+      "is_present": "Presente",
+      "is_not_present": "Não presente"
+    }
+  },
   "base": {
     "noResults": {
       "title": "Nenhum resultado encontrado",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1,6 +1,10 @@
 {
   "filter": {
     "operators": {
+      "equal_to": "Igual a",
+      "not_equal_to": "Diferente de",
+      "contains": "Contém",
+      "does_not_contain": "Não contém",
       "is_present": "Presente",
       "is_not_present": "Não presente"
     }

--- a/src/pages/Customer/Agents/Agents.tsx
+++ b/src/pages/Customer/Agents/Agents.tsx
@@ -280,7 +280,7 @@ const Agentes = () => {
               onBulkDelete={handleBulkDelete}
               onClearSelection={() => setState(prev => ({ ...prev, selectedAgents: [] }))}
               activeFilters={[]}
-              showFilters={true}
+              showFilters={false}
             />
             </div>
 

--- a/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
+++ b/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
@@ -20,7 +20,8 @@ import {
   ListCustomMcpServersParams,
   CustomMcpServerFormData,
 } from '@/types/ai';
-import { BaseFilter, AppliedFilter } from '@/types/core';
+import { BaseFilter, AppliedFilter, CUSTOM_MCP_SERVER_FILTER_TYPES } from '@/types/core';
+import { buildAppliedFilterChips } from '@/utils/appliedFilterChips';
 import { CustomMCPServerCard } from '@/components/customMcpServers';
 
 import CustomMCPServersHeader from '@/components/customMcpServers/CustomMCPServersHeader';
@@ -142,18 +143,8 @@ export default function CustomMCPServers() {
     loadServers({ skip: 0, search: query });
   };
 
-  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] => {
-    return filters.map((filter, index) => ({
-      id: `filter-${index}`,
-      label: `${filter.attributeKey}: ${
-        Array.isArray(filter.values) ? filter.values.join(',') : filter.values
-      }`,
-      value: Array.isArray(filter.values)
-        ? String(filter.values.join(','))
-        : (filter.values as string | number),
-      onRemove: () => handleRemoveFilter(index),
-    }));
-  };
+  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
+    buildAppliedFilterChips(filters, CUSTOM_MCP_SERVER_FILTER_TYPES, t, handleRemoveFilter);
 
   const handleOpenFilter = () => {
     setFilterModalOpen(true);

--- a/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
+++ b/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
@@ -358,7 +358,7 @@ export default function CustomMCPServers() {
           onFilter={handleOpenFilter}
           onClearSelection={() => setState(prev => ({ ...prev, selectedServerIds: [] }))}
           activeFilters={appliedFilters}
-          showFilters={true}
+          showFilters={false}
         />
       </div>
 

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -334,7 +334,7 @@ export default function CustomTools() {
 
           onClearSelection={() => setState(prev => ({ ...prev, selectedToolIds: [] }))}
           activeFilters={appliedFilters}
-          showFilters={true}
+          showFilters={false}
         />
       </div>
 

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -7,7 +7,8 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Grid3X3, List, Wand } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 import { CustomTool, CustomToolsState, CustomToolFormData, CustomToolsListParams } from '@/types/ai';
-import { BaseFilter, AppliedFilter } from '@/types/core';
+import { BaseFilter, AppliedFilter, CUSTOM_TOOL_FILTER_TYPES } from '@/types/core';
+import { buildAppliedFilterChips } from '@/utils/appliedFilterChips';
 import {
   CustomToolCard,
   CustomToolsHeader,
@@ -114,16 +115,8 @@ export default function CustomTools() {
     loadTools({ skip: 0, search: query });
   };
 
-  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] => {
-    return filters.map((filter, index) => ({
-      id: `filter-${index}`,
-      label: `${filter.attributeKey}: ${Array.isArray(filter.values) ? filter.values.join(',') : filter.values}`,
-      value: Array.isArray(filter.values)
-        ? String(filter.values.join(','))
-        : (filter.values as string | number),
-      onRemove: () => handleRemoveFilter(index),
-    }));
-  };
+  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
+    buildAppliedFilterChips(filters, CUSTOM_TOOL_FILTER_TYPES, t, handleRemoveFilter);
 
   const handleOpenFilter = () => {
     setFilterModalOpen(true);

--- a/src/pages/Customer/Agents/Tools/Tools.tsx
+++ b/src/pages/Customer/Agents/Tools/Tools.tsx
@@ -8,7 +8,8 @@ import EmptyState from '@/components/base/EmptyState';
 
 import { listTools } from '@/services/agents/toolsService';
 import type { Tool, ToolsResponse, ToolsState, ToolsListParams } from '@/types/ai';
-import { BaseFilter, AppliedFilter } from '@/types/core';
+import { BaseFilter, AppliedFilter, TOOL_FILTER_TYPES } from '@/types/core';
+import { buildAppliedFilterChips } from '@/utils/appliedFilterChips';
 import { ToolCard } from '@/components/tools';
 
 import ToolsHeader from '@/components/tools/ToolsHeader';
@@ -126,18 +127,8 @@ export default function Tools() {
     loadTools({ skip: 0, search: query });
   };
 
-  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] => {
-    return filters.map((filter, index) => ({
-      id: `filter-${index}`,
-      label: `${filter.attributeKey}: ${
-        Array.isArray(filter.values) ? filter.values.join(',') : filter.values
-      }`,
-      value: Array.isArray(filter.values)
-        ? String(filter.values.join(','))
-        : (filter.values as string | number),
-      onRemove: () => handleRemoveFilter(index),
-    }));
-  };
+  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
+    buildAppliedFilterChips(filters, TOOL_FILTER_TYPES, t, handleRemoveFilter);
 
   const handleOpenFilter = () => {
     setFilterModalOpen(true);

--- a/src/pages/Customer/Agents/Tools/Tools.tsx
+++ b/src/pages/Customer/Agents/Tools/Tools.tsx
@@ -219,7 +219,7 @@ export default function Tools() {
         onFilter={handleOpenFilter}
         onClearSelection={() => setState(prev => ({ ...prev, selectedToolIds: [] }))}
         activeFilters={appliedFilters}
-        showFilters={true}
+        showFilters={false}
       />
 
       {/* View Mode Toggle */}

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -395,7 +395,7 @@ export default function Users() {
           onBulkDelete={handleBulkDelete}
           onClearSelection={() => setState(prev => ({ ...prev, selectedUserIds: [] }))}
           activeFilters={appliedFilters}
-          showFilters={true}
+          showFilters={false}
         />
       </div>
 

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -17,7 +17,8 @@ import EmptyState from '@/components/base/EmptyState';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { useAuthStore } from '@/store/authStore';
 import { usersService } from '@/services/users';
-import { User, UsersListParams, UsersState } from '@/types/users';
+import { User, UsersListParams, UsersState, USER_FILTER_TYPES } from '@/types/users';
+import { buildAppliedFilterChips } from '@/utils/appliedFilterChips';
 import { BaseFilter } from '@/types/core';
 import { AppliedFilter } from '@/types/core';
 
@@ -164,18 +165,8 @@ export default function Users() {
   };
 
   // Funções para o sistema de filtros
-  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] => {
-    return filters.map((filter, index) => ({
-      id: `filter-${index}`,
-      label: `${filter.attributeKey}: ${
-        Array.isArray(filter.values) ? filter.values.join(',') : filter.values
-      }`,
-      value: Array.isArray(filter.values)
-        ? String(filter.values.join(','))
-        : (filter.values as string | number),
-      onRemove: () => handleRemoveFilter(index),
-    }));
-  };
+  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
+    buildAppliedFilterChips(filters, USER_FILTER_TYPES, t, handleRemoveFilter);
 
   const handleOpenFilter = () => {
     setFilterModalOpen(true);

--- a/src/utils/appliedFilterChips.spec.ts
+++ b/src/utils/appliedFilterChips.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildAppliedFilterChips } from './appliedFilterChips';
+import type { BaseFilter, FilterType } from '@/types/core';
+
+const t = (key: string): string => {
+  const map: Record<string, string> = {
+    'filter.attributes.name': 'Name',
+    'common:filter.operators.is_present': 'Present',
+    'common:filter.operators.is_not_present': 'Not present',
+    'filter.options.blocked.true': 'Blocked',
+  };
+  return map[key] ?? key;
+};
+
+const FILTER_TYPES: FilterType[] = [
+  {
+    attributeKey: 'name',
+    attributeI18nKey: 'filter.attributes.name',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: [],
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'role',
+    attributeI18nKey: 'Função',
+    inputType: 'search_select',
+    dataType: 'text',
+    filterOperators: [],
+    attribute_type: 'standard',
+    options: [{ label: 'Admin', value: 'admin' }],
+  },
+  {
+    attributeKey: 'blocked',
+    attributeI18nKey: 'filter.attributes.blocked',
+    inputType: 'search_select',
+    dataType: 'text',
+    filterOperators: [],
+    attribute_type: 'standard',
+    options: [{ label: 'filter.options.blocked.true', value: 'true' }],
+  },
+];
+
+const mkFilter = (over: Partial<BaseFilter>): BaseFilter => ({
+  attributeKey: 'name',
+  filterOperator: 'equal_to',
+  values: '',
+  queryOperator: 'and',
+  attributeModel: 'standard',
+  ...over,
+});
+
+describe('buildAppliedFilterChips', () => {
+  it('separates attribute label and value (no doubling)', () => {
+    const [chip] = buildAppliedFilterChips(
+      [mkFilter({ attributeKey: 'name', values: 'John' })],
+      FILTER_TYPES,
+      t,
+      () => {},
+    );
+    expect(chip.label).toBe('Name');
+    expect(chip.value).toBe('John');
+  });
+
+  it('translates the attribute label instead of the raw key', () => {
+    const [chip] = buildAppliedFilterChips([mkFilter({ attributeKey: 'name' })], FILTER_TYPES, t, () => {});
+    expect(chip.label).toBe('Name');
+    expect(chip.label).not.toBe('name');
+  });
+
+  it('falls back to the raw attributeKey when there is no filter type', () => {
+    const [chip] = buildAppliedFilterChips([mkFilter({ attributeKey: 'unknown' })], FILTER_TYPES, t, () => {});
+    expect(chip.label).toBe('unknown');
+  });
+
+  it('shows the operator name for valueless operators', () => {
+    const [chip] = buildAppliedFilterChips(
+      [mkFilter({ attributeKey: 'role', filterOperator: 'is_present', values: '' })],
+      FILTER_TYPES,
+      t,
+      () => {},
+    );
+    expect(chip.value).toBe('Present');
+  });
+
+  it('resolves option-backed values to their label', () => {
+    const [chip] = buildAppliedFilterChips(
+      [mkFilter({ attributeKey: 'role', values: 'admin' })],
+      FILTER_TYPES,
+      t,
+      () => {},
+    );
+    expect(chip.value).toBe('Admin');
+  });
+
+  it('translates i18n option labels', () => {
+    const [chip] = buildAppliedFilterChips(
+      [mkFilter({ attributeKey: 'blocked', values: 'true' })],
+      FILTER_TYPES,
+      t,
+      () => {},
+    );
+    expect(chip.value).toBe('Blocked');
+  });
+
+  it('joins multiple raw values', () => {
+    const [chip] = buildAppliedFilterChips(
+      [mkFilter({ attributeKey: 'name', values: ['a', 'b'] })],
+      FILTER_TYPES,
+      t,
+      () => {},
+    );
+    expect(chip.value).toBe('a, b');
+  });
+
+  it('wires onRemove by index', () => {
+    const onRemove = vi.fn();
+    const [chip] = buildAppliedFilterChips([mkFilter({})], FILTER_TYPES, t, onRemove);
+    chip.onRemove();
+    expect(onRemove).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/utils/appliedFilterChips.ts
+++ b/src/utils/appliedFilterChips.ts
@@ -1,0 +1,55 @@
+import type { AppliedFilter, BaseFilter, FilterType } from '@/types/core';
+
+type TranslateFn = (key: string) => string;
+
+const VALUELESS_OPERATORS = ['is_present', 'is_not_present'];
+
+const resolveAttributeLabel = (
+  filter: BaseFilter,
+  filterType: FilterType | undefined,
+  t: TranslateFn,
+): string => (filterType?.attributeI18nKey ? t(filterType.attributeI18nKey) : filter.attributeKey);
+
+const resolveValueLabel = (
+  filter: BaseFilter,
+  filterType: FilterType | undefined,
+  t: TranslateFn,
+): string => {
+  // Presence operators carry no value — show the operator name so the chip
+  // reads "Attribute: Present" instead of a dangling "Attribute:".
+  if (VALUELESS_OPERATORS.includes(filter.filterOperator)) {
+    return t(`common:filter.operators.${filter.filterOperator}`);
+  }
+
+  const values = Array.isArray(filter.values) ? filter.values : [filter.values];
+  return values
+    .map(value => {
+      const raw = String(value ?? '');
+      // Option-backed values store an id/code; show the option's human label.
+      const option = filterType?.options?.find(o => String(o.value) === raw);
+      return option ? t(option.label) : raw;
+    })
+    .join(', ');
+};
+
+/**
+ * Builds the applied-filter chips for `BaseHeader` (which renders each chip as
+ * `{label}: {value}`). `label` is the attribute's i18n label and `value` is the
+ * human-readable value (option label) or the operator name for valueless
+ * operators — never the raw attributeKey and never a doubled value.
+ */
+export const buildAppliedFilterChips = (
+  filters: BaseFilter[],
+  filterTypes: FilterType[],
+  t: TranslateFn,
+  onRemove: (index: number) => void,
+): AppliedFilter[] =>
+  filters.map((filter, index) => {
+    const filterType = filterTypes.find(f => f.attributeKey === filter.attributeKey);
+    return {
+      id: `filter-${index}`,
+      label: resolveAttributeLabel(filter, filterType, t),
+      value: resolveValueLabel(filter, filterType, t),
+      onRemove: () => onRemove(index),
+    };
+  });


### PR DESCRIPTION
## Summary
- **Shared chip helper** (`utils/appliedFilterChips.ts`): resolves the attribute i18n label, option-backed value names, and the operator name for valueless operators — so chips read `Attribute: Value` (no doubling, no raw attributeKey, no dangling `Attribute:`). Migrated Users/Tools/CustomTools/CustomMCPServers to it.
- **Operator i18n** (`BaseFilterRow`): the condition dropdown resolves operators namespace-first then falls back to the `common` namespace, so screens without `filter.operators.*` no longer show the raw key. Full operator set added to `common` (6 locales). Contacts/Conversations keep their own keys — no regression.
- **Stopgap — hide non-functional filters** (`showFilters={false}`): the advanced filter on Agents/Users/Tools/CustomTools/CustomMCPServers is a no-op (Agents button is a TODO; Users backend ignores `filters[]`; the others never send them). Hidden so users aren't shown a dead control. Real server-side filtering is tracked in **EVO-1947**, which re-enables each screen and reuses this chip helper.

## Security
- No new endpoints/inputs; pure display + i18n + visibility toggle.

## Test plan
- `frontend: pnpm exec tsc -b --noEmit` (clean)
- `frontend: pnpm exec vitest run src/utils/appliedFilterChips.spec.ts` → 8/8
- `frontend: pnpm lint` on changed files (clean; pre-existing `any` errors in Users.tsx are unrelated)
- Note: `filters.contacts.spec.ts` is red on `develop` (EVO-1835 spec vs EVO-1849 removal) — unrelated to this PR; fixed by EVO-1887 (PR #202).

## Changed Files
- `src/utils/appliedFilterChips.ts` (+ spec)
- `src/components/base/BaseFilterRow.tsx`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/common.json`
- `src/pages/Customer/Agents/{Agents,Tools/Tools,CustomTools/CustomTools,CustomMCPServers/CustomMCPServers}.tsx`
- `src/pages/Customer/Settings/Users/Users.tsx`

## Linked Issue
- EVO-1937

🤖 Generated with [Claude Code](https://claude.com/claude-code)