### PR TITLE
feat(admin-settings): clarify Storage "Amazon S3" vs "S3-compatible"

### DIFF
--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -72,13 +72,16 @@
       "label": "Storage Provider",
       "local": "Local Storage",
       "amazon": "Amazon S3",
-      "s3Compatible": "S3-Compatible"
+      "amazonHelp": "AWS S3 — uses Region and your AWS credentials. No custom endpoint needed.",
+      "s3CompatibleHelp": "Any S3-compatible provider that isn't AWS (MinIO, Cloudflare R2, DigitalOcean Spaces…). Requires a custom Endpoint.",
+      "s3Compatible": "S3-Compatible (MinIO, Cloudflare R2, DigitalOcean Spaces…)"
     },
     "fields": {
       "bucketName": "Bucket Name",
       "accessKeyId": "Access Key ID",
       "accessSecret": "Secret Access Key",
       "region": "Region",
+      "endpointHelp": "URL of your S3-compatible provider's endpoint. Only for S3-Compatible — leave blank for AWS.",
       "endpoint": "Endpoint"
     },
     "placeholders": {

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -72,13 +72,16 @@
       "label": "Proveedor de Almacenamiento",
       "local": "Almacenamiento Local",
       "amazon": "Amazon S3",
-      "s3Compatible": "Compatible con S3"
+      "amazonHelp": "AWS S3 — usa la Región y tus credenciales de AWS. No necesita endpoint personalizado.",
+      "s3CompatibleHelp": "Cualquier proveedor compatible con S3 que no sea AWS (MinIO, Cloudflare R2, DigitalOcean Spaces…). Requiere un Endpoint personalizado.",
+      "s3Compatible": "Compatible con S3 (MinIO, Cloudflare R2, DigitalOcean Spaces…)"
     },
     "fields": {
       "bucketName": "Nombre del Bucket",
       "accessKeyId": "ID de Clave de Acceso",
       "accessSecret": "Clave de Acceso Secreta",
       "region": "Region",
+      "endpointHelp": "URL del endpoint de tu proveedor compatible con S3. Solo para Compatible con S3 — déjalo vacío para AWS.",
       "endpoint": "Endpoint"
     },
     "placeholders": {

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -71,13 +71,16 @@
       "label": "Fournisseur de Stockage",
       "local": "Stockage Local",
       "amazon": "Amazon S3",
-      "s3Compatible": "Compatible S3"
+      "amazonHelp": "AWS S3 — utilise la Région et vos identifiants AWS. Aucun endpoint personnalisé requis.",
+      "s3CompatibleHelp": "Tout fournisseur compatible S3 qui n'est pas AWS (MinIO, Cloudflare R2, DigitalOcean Spaces…). Nécessite un Endpoint personnalisé.",
+      "s3Compatible": "Compatible S3 (MinIO, Cloudflare R2, DigitalOcean Spaces…)"
     },
     "fields": {
       "bucketName": "Nom du Bucket",
       "accessKeyId": "ID de Cle d'Acces",
       "accessSecret": "Cle d'Acces Secrete",
       "region": "Region",
+      "endpointHelp": "URL de l'endpoint de votre fournisseur compatible S3. Uniquement pour Compatible S3 — laissez vide pour AWS.",
       "endpoint": "Endpoint"
     },
     "placeholders": {

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -71,13 +71,16 @@
       "label": "Provider di Archiviazione",
       "local": "Archiviazione Locale",
       "amazon": "Amazon S3",
-      "s3Compatible": "Compatibile con S3"
+      "amazonHelp": "AWS S3 — usa la Regione e le tue credenziali AWS. Nessun endpoint personalizzato necessario.",
+      "s3CompatibleHelp": "Qualsiasi provider compatibile con S3 che non sia AWS (MinIO, Cloudflare R2, DigitalOcean Spaces…). Richiede un Endpoint personalizzato.",
+      "s3Compatible": "Compatibile con S3 (MinIO, Cloudflare R2, DigitalOcean Spaces…)"
     },
     "fields": {
       "bucketName": "Nome del Bucket",
       "accessKeyId": "ID Chiave di Accesso",
       "accessSecret": "Chiave di Accesso Segreta",
       "region": "Regione",
+      "endpointHelp": "URL dell'endpoint del tuo provider compatibile con S3. Solo per Compatibile con S3 — lascia vuoto per AWS.",
       "endpoint": "Endpoint"
     },
     "placeholders": {

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -72,13 +72,16 @@
       "label": "Provedor de Armazenamento",
       "local": "Armazenamento Local",
       "amazon": "Amazon S3",
-      "s3Compatible": "Compativel com S3"
+      "amazonHelp": "AWS S3 — usa a Região e suas credenciais AWS. Não precisa de endpoint personalizado.",
+      "s3CompatibleHelp": "Qualquer provedor compatível com S3 que não seja AWS (MinIO, Cloudflare R2, DigitalOcean Spaces…). Requer um Endpoint personalizado.",
+      "s3Compatible": "Compativel com S3 (MinIO, Cloudflare R2, DigitalOcean Spaces…)"
     },
     "fields": {
       "bucketName": "Nome do Bucket",
       "accessKeyId": "ID da Chave de Acesso",
       "accessSecret": "Chave de Acesso Secreta",
       "region": "Regiao",
+      "endpointHelp": "URL do endpoint do seu provedor compatível com S3. Apenas para Compatível com S3 — deixe vazio para AWS.",
       "endpoint": "Endpoint"
     },
     "placeholders": {

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -71,13 +71,16 @@
       "label": "Fornecedor de Armazenamento",
       "local": "Armazenamento Local",
       "amazon": "Amazon S3",
-      "s3Compatible": "Compativel com S3"
+      "amazonHelp": "AWS S3 — usa a Região e as suas credenciais AWS. Não precisa de endpoint personalizado.",
+      "s3CompatibleHelp": "Qualquer fornecedor compatível com S3 que não seja AWS (MinIO, Cloudflare R2, DigitalOcean Spaces…). Requer um Endpoint personalizado.",
+      "s3Compatible": "Compativel com S3 (MinIO, Cloudflare R2, DigitalOcean Spaces…)"
     },
     "fields": {
       "bucketName": "Nome do Bucket",
       "accessKeyId": "ID da Chave de Acesso",
       "accessSecret": "Chave de Acesso Secreta",
       "region": "Regiao",
+      "endpointHelp": "URL do endpoint do seu fornecedor compatível com S3. Apenas para Compatível com S3 — deixe vazio para AWS.",
       "endpoint": "Endpoint"
     },
     "placeholders": {

--- a/src/pages/Admin/Settings/StorageConfig.tsx
+++ b/src/pages/Admin/Settings/StorageConfig.tsx
@@ -164,7 +164,7 @@ export default function StorageConfig() {
       const type = (data.ACTIVE_STORAGE_SERVICE as StorageServiceType) || 'local';
       updateSecretStatus(data);
       reset(buildFormValues(data, type));
-    } catch (error) {
+    } catch {
       toast.error(t('storage.messages.loadError'));
     } finally {
       setLoading(false);
@@ -329,6 +329,13 @@ export default function StorageConfig() {
                   </Select>
                 )}
               />
+              {storageService !== 'local' && (
+                <p className="text-xs text-sidebar-foreground/60">
+                  {storageService === 'amazon'
+                    ? t('storage.provider.amazonHelp')
+                    : t('storage.provider.s3CompatibleHelp')}
+                </p>
+              )}
             </div>
 
             {/* Cloud storage fields */}
@@ -385,6 +392,7 @@ export default function StorageConfig() {
                       placeholder={t('storage.placeholders.endpoint')}
                       {...register('STORAGE_ENDPOINT' as StorageFieldKey)}
                     />
+                    <p className="text-xs text-sidebar-foreground/60">{t('storage.fields.endpointHelp')}</p>
                     {storageService === 's3_compatible' && (errors as Record<string, { message?: string }>).STORAGE_ENDPOINT && (
                       <p className="text-xs text-destructive">{(errors as Record<string, { message?: string }>).STORAGE_ENDPOINT?.message}</p>
                     )}


### PR DESCRIPTION
## O quê

A tela de Storage oferece 3 tipos (`local` / `amazon` / `s3_compatible`) com rótulos que confundem — "S3" e "S3-compatível" pareciam a mesma coisa. **São diferentes:**
- **Amazon S3** (`amazon`) = AWS S3 de verdade — usa Região + credenciais AWS, **sem endpoint custom** (a AWS resolve).
- **S3-compatível** (`s3_compatible`) = storage que fala a API S3 mas **não é AWS** (MinIO, Cloudflare R2, DigitalOcean Spaces…) — **exige `STORAGE_ENDPOINT`** custom.

(Confirmado no schema: `amazon` valida `STORAGE_REGION`; `s3_compatible` valida `STORAGE_ENDPOINT`.)

## Mudanças (só labels + helper, sem tocar lógica/validação/keys)
- Rótulo "S3-compatível" agora lista exemplos: **(MinIO, Cloudflare R2, DigitalOcean Spaces…)**.
- **Helper dinâmico** sob o seletor: explica AWS (região + creds) vs provedor S3-compatível (endpoint custom).
- **Helper no campo Endpoint**: deixa claro que é só para S3-compatível (deixar vazio para AWS).
- i18n nas 6 línguas (pt-BR, pt, en, es, fr, it).

> `amazon` já estava rotulado "Amazon S3" em todos os locales — mantido.

## Verificação
`tsc -b` ✅ · `vitest` 12/12 ✅ · `eslint` ✅ · i18n parity nos 6 locales ✅.

## Summary by Sourcery

Clarify cloud storage provider options in the admin storage settings UI and improve helper text for S3 vs S3-compatible configurations.

Enhancements:
- Add contextual helper text under the storage provider selector to explain the difference between Amazon S3 and S3-compatible backends.
- Add helper text to the storage endpoint field to specify that it is only required for S3-compatible providers and should be left empty for Amazon S3.
- Update storage configuration labels and helper copy across all supported locales to better describe S3-compatible providers (e.g., MinIO, Cloudflare R2, DigitalOcean Spaces).