### PR TITLE
fix(journey): unreachableExit só em ciclos reais, não em cadeias lineares (EVO-1889)

### DIFF
--- a/src/utils/journeyFlowValidation.spec.ts
+++ b/src/utils/journeyFlowValidation.spec.ts
@@ -240,4 +240,26 @@ describe('validateJourney (EVO-1744)', () => {
     ]);
     expect(r.warnings.some((w) => w.rule === 'unreachableExit')).toBe(false);
   });
+
+  // EVO-1889 (follow-up to EVO-1857): a LINEAR dangling chain is not a loop. The
+  // single root cause is the dangling leaf `b` (danglingExit); the intermediate
+  // `a` must NOT be mislabeled with the "stuck in a loop" copy.
+  it('EVO-1889: a linear dangling chain does NOT flag the intermediate node as a loop', () => {
+    const nodes = [
+      node('t', 'journey-trigger-node', {
+        triggerType: 'event',
+        eventName: 'conversation.created',
+      }),
+      sendMsg('a'),
+      sendMsg('b'),
+    ];
+    // trigger → a → b, and b has no outgoing edge (dangling leaf).
+    const r = validateJourney(nodes, [edge('t', 'a'), edge('a', 'b')]);
+    // The intermediate `a` is a linear dead-end, not a cycle: no loop warning.
+    expect(r.warnings.some((w) => w.rule === 'unreachableExit')).toBe(false);
+    // The actual root cause — the dangling leaf `b` — is still surfaced.
+    expect(
+      r.warnings.some((w) => w.rule === 'terminalPath' && w.nodeId === 'b'),
+    ).toBe(true);
+  });
 });

--- a/src/utils/journeyFlowValidation.ts
+++ b/src/utils/journeyFlowValidation.ts
@@ -98,18 +98,42 @@ function terminalPathIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] {
 }
 
 /**
+ * True when `start` lies on a cycle — i.e. it is reachable from itself by
+ * following outgoing edges. Used to scope `unreachableExit` to genuine loops.
+ */
+function isOnCycle(start: string, outgoing: Map<string, string[]>): boolean {
+  const stack = [...(outgoing.get(start) ?? [])];
+  const seen = new Set<string>();
+  while (stack.length > 0) {
+    const id = stack.pop() as string;
+    if (id === start) return true; // walked back to the origin → cycle
+    if (seen.has(id)) continue;
+    seen.add(id);
+    for (const next of outgoing.get(id) ?? []) stack.push(next);
+  }
+  return false;
+}
+
+/**
  * Detects the blind spot `terminalPath` misses (EVO-1857, follow-up to EVO-1744
- * F5): nodes reachable from a trigger that can **never** reach a terminating node
- * (`exit-journey-node`/`transfer-journey-node`) — e.g. a closed loop with no exit
- * (`trigger → A → B → A`). `terminalPath` only flags nodes with *no outgoing
- * edge*, so a node inside a cycle (which always has one) escapes it, yet at
- * runtime its session stays "running" for ~30 days (EVO-1691).
+ * F5): nodes inside a **closed loop with no exit** (`trigger → A → B → A`).
+ * `terminalPath` only flags nodes with *no outgoing edge*, so a node inside a
+ * cycle (which always has one) escapes it, yet at runtime its session stays
+ * "running" for ~30 days (EVO-1691).
  *
- * Algorithm (as specced on the card): one reverse-reachability pass from the
- * terminal nodes yields the set that *can* reach a terminal; any trigger-reachable
- * node outside it is trapped. Linear, no memoization needed. Two exclusions keep
- * it from doubling up with `terminalPath`: trigger nodes (the entry, not the
- * offending step) and no-outgoing nodes (already its `danglingExit` domain).
+ * Algorithm: a reverse-reachability pass from the terminal nodes yields the set
+ * that *can* reach a terminal; a forward pass from the triggers yields the set
+ * that actually executes. A node warns only when it (1) executes, (2) cannot
+ * reach a terminal, and (3) is genuinely on a cycle (`isOnCycle`).
+ *
+ * The cycle guard (EVO-1889) is what makes the "stuck in a loop" copy accurate:
+ * a LINEAR dangling chain (`trigger → a → b`, `b` no exit) has its single root
+ * cause — the dangling leaf `b` — already reported by `terminalPath`/`danglingExit`.
+ * The intermediate `a` cannot reach a terminal either, but it is NOT in a loop,
+ * so flagging it with the loop message mislabels the problem; the cycle guard
+ * suppresses it. Two further exclusions avoid doubling up with `terminalPath`:
+ * trigger nodes (the entry, not the offending step) and no-outgoing nodes
+ * (already its `danglingExit` domain).
  */
 function unreachableExitIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] {
   const nodeById = new Map(nodes.map((node) => [node.id, node]));
@@ -161,6 +185,7 @@ function unreachableExitIssues(nodes: Node[], edges: Edge[]): ValidationIssue[] 
     if (!node) continue;
     if (node.type === TRIGGER_NODE_TYPE) continue; // entry, not the offending step
     if ((outgoing.get(id) ?? []).length === 0) continue; // danglingExit's domain
+    if (!isOnCycle(id, outgoing)) continue; // linear dead-end → danglingExit covers it (EVO-1889)
     issues.push({
       nodeId: id,
       rule: 'unreachableExit',


### PR DESCRIPTION
## Summary

Follow-up da EVO-1857. Numa cadeia **linear pendente** (`trigger → a → b`, com `b` sem aresta de saída), o nó intermediário `a` recebia a regra `unreachableExit`, cuja mensagem afirma literalmente "preso em um ciclo" / "stuck in a loop" (nos 6 locales) — mas `a` não está em ciclo nenhum: é uma cadeia linear que termina numa folha pendente.

A causa raiz real (a folha `b`) já é reportada por `terminalPath` / `danglingExit`. O `unreachableExit` apenas dobrava o problema e o rotulava errado como "loop".

### Fix (opção a — corrige a regra, não só a cópia)

Adiciona um guard `isOnCycle`: o aviso `unreachableExit` só dispara quando o nó está **genuinamente em um ciclo** (alcançável a partir de si mesmo seguindo as arestas de saída). Assim:

- Cadeia linear pendente → só a folha `b` é flagada (`danglingExit`); `a` não recebe o aviso de "loop".
- Ciclo real (`trigger → A → B → A`) → continua flagado como `unreachableExit` (cópia "preso em um ciclo" agora sempre precisa).

A cópia i18n fica **inalterada** — agora ela é correta porque a regra só dispara em ciclos de fato.

## Files
- `src/utils/journeyFlowValidation.ts` — helper `isOnCycle` + guard no `unreachableExitIssues` + JSDoc atualizada.
- `src/utils/journeyFlowValidation.spec.ts` — novo teste para cadeia linear com nó intermediário.

## Test plan
- `npx tsc -b` → OK (exit 0)
- `npx vitest run src/utils/journeyFlowValidation.spec.ts` → 16/16 verdes (inclui o novo teste EVO-1889 e todos os casos de ciclo da EVO-1857 sem regressão).

## AC
Cadeia linear pendente (`trigger → a → b`, `b` sem saída) NÃO mostra mensagem de "ciclo/loop" em `a`; teste cobrindo a cadeia linear com nó intermediário adicionado.

## Summary by Sourcery

Scope unreachableExit validation issues to nodes that are genuinely part of closed loops, avoiding mislabeling linear dangling chains as cycles.

Bug Fixes:
- Prevent intermediate nodes in linear dangling chains from being incorrectly flagged as unreachableExit loop warnings.

Enhancements:
- Introduce a cycle-detection helper to identify nodes that lie on loops and document the updated unreachableExit behavior.

Tests:
- Add a regression test ensuring linear dangling chains only flag the terminal dangling node and not intermediate nodes as loop issues.