### PR TITLE
fix(frontend): reset global filters on "clear filters" so the badge clears (EVO-1939)

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -554,6 +554,18 @@ const ChatSidebar = ({
   const totalPages = pagination?.total_pages || 1;
   const hasNextPage = pagination?.has_next_page ?? currentPage < totalPages;
 
+  // EVO-1939: o filtro padrão (status=open) representa a visão default e não
+  // deve contar como filtro aplicado no badge — assim o badge some ao limpar.
+  const appliedFilterCount = filters.state.activeFilters.filter(
+    f =>
+      !(
+        f.attribute_key === 'status' &&
+        f.filter_operator === 'equal_to' &&
+        f.values?.length === 1 &&
+        f.values[0] === 'open'
+      ),
+  ).length;
+
   const handleSidebarScroll = useCallback(async () => {
     const now = Date.now();
     if (now - lastScrollTimeRef.current < 150) return;
@@ -992,11 +1004,11 @@ const ChatSidebar = ({
               : t('chatSidebar.conversations')}
           </span>
           <div className="flex items-center gap-2">
-            {/* Indicador de filtros ativos */}
-            {filters.state.activeFilters.length > 0 && (
+            {/* Indicador de filtros ativos (ignora o filtro padrão status=open) */}
+            {appliedFilterCount > 0 && (
               <Badge variant="secondary" className="text-xs">
-                {filters.state.activeFilters.length}{' '}
-                {filters.state.activeFilters.length === 1
+                {appliedFilterCount}{' '}
+                {appliedFilterCount === 1
                   ? t('chatSidebar.filter')
                   : t('chatSidebar.filters')}
               </Badge>

--- a/src/contexts/chat/FiltersContext.tsx
+++ b/src/contexts/chat/FiltersContext.tsx
@@ -28,7 +28,7 @@ type FiltersAction =
   | { type: 'SET_APPLYING_FILTERS'; payload: boolean };
 
 // 🎯 FILTRO PADRÃO: Inicializar com filtro "open" desde o início
-const DEFAULT_FILTER: ConversationFilter = {
+export const DEFAULT_FILTER: ConversationFilter = {
   attribute_key: 'status',
   filter_operator: 'equal_to',
   values: ['open'], // Array para API, mas será convertido para string no modal

--- a/src/hooks/chat/__tests__/useFilterHandlers.spec.ts
+++ b/src/hooks/chat/__tests__/useFilterHandlers.spec.ts
@@ -1,0 +1,72 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFilterHandlers } from '../useFilterHandlers';
+
+// Shape mirrors DEFAULT_FILTER from FiltersContext (status = open).
+const DEFAULT_FILTER = {
+  attribute_key: 'status',
+  filter_operator: 'equal_to',
+  values: ['open'],
+  query_operator: 'and',
+};
+
+const mockConversations = vi.hoisted(() => ({
+  setConversations: vi.fn(),
+  loadConversations: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockFilters = vi.hoisted(() => ({
+  setFilters: vi.fn(),
+  applyFilters: vi.fn(),
+  applySearch: vi.fn(),
+  state: { activeFilters: [] as any[], searchTerm: '' },
+}));
+
+const mockStorage = vi.hoisted(() => ({
+  clearConversationFilters: vi.fn(),
+  saveConversationFilters: vi.fn(),
+}));
+
+vi.mock('@/contexts/chat/ChatContext', () => ({
+  useChatContext: () => ({ conversations: mockConversations, filters: mockFilters }),
+}));
+
+vi.mock('@/contexts/chat/FiltersContext', () => ({
+  DEFAULT_FILTER: {
+    attribute_key: 'status',
+    filter_operator: 'equal_to',
+    values: ['open'],
+    query_operator: 'and',
+  },
+}));
+
+vi.mock('@/utils/storage/filtersStorage', () => mockStorage);
+
+vi.mock('@/utils/chat/filterAdapters', () => ({
+  convertBaseFiltersToConversationFilters: vi.fn((f: any) => f),
+}));
+
+describe('useFilterHandlers — handleClearFilters (EVO-1939)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resets the GLOBAL activeFilters to the default open filter (so badge + realtime matcher clear)', async () => {
+    const { result } = renderHook(() => useFilterHandlers());
+
+    await result.current.handleClearFilters();
+
+    expect(mockFilters.setFilters).toHaveBeenCalledTimes(1);
+    expect(mockFilters.setFilters).toHaveBeenCalledWith([DEFAULT_FILTER]);
+  });
+
+  it('clears persisted filters and reloads only open conversations', async () => {
+    const { result } = renderHook(() => useFilterHandlers());
+
+    await result.current.handleClearFilters();
+
+    expect(mockStorage.clearConversationFilters).toHaveBeenCalledTimes(1);
+    expect(mockConversations.loadConversations).toHaveBeenCalledWith({ status: 'open' });
+  });
+});

--- a/src/hooks/chat/useFilterHandlers.ts
+++ b/src/hooks/chat/useFilterHandlers.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useChatContext } from '@/contexts/chat/ChatContext';
+import { DEFAULT_FILTER } from '@/contexts/chat/FiltersContext';
 import { BaseFilter } from '@/types/core';
 import { convertBaseFiltersToConversationFilters } from '@/utils/chat/filterAdapters';
 import { saveConversationFilters, clearConversationFilters } from '@/utils/storage/filtersStorage';
@@ -39,12 +40,17 @@ export const useFilterHandlers = () => {
       // 🗑️ LIMPAR: Remover filtros salvos do localStorage
       clearConversationFilters();
 
+      // EVO-1939: resetar o estado GLOBAL para o filtro padrão (status=open).
+      // Sem isso o badge e o matcher de conversas em tempo real (ChatContext)
+      // continuam usando os filtros antigos — o usuário "limpa" mas a UI não some.
+      filters.setFilters([DEFAULT_FILTER]);
+
       // 🎯 FILTRO PADRÃO: Carregar apenas conversas abertas ao limpar filtros
       await conversations.loadConversations({ status: 'open' });
     } catch (error) {
       console.error('❌ Erro inesperado ao limpar filtros:', error);
     }
-  }, [conversations]);
+  }, [conversations, filters]);
 
   // 🔄 FUNÇÃO PARA RECARREGAR FILTROS: Reaplicar filtros atuais após mudanças
   const reloadCurrentFilters = useCallback(async () => {


### PR DESCRIPTION
## Summary

On the conversations sidebar, clicking **"Clear filters"** reloaded open conversations but the filter **badge kept showing the stale count** — the filter looked like it was never removed (symptom B, reported by a builder's customer).

Root cause: `handleClearFilters` (`useFilterHandlers.ts`) only cleared local component state + localStorage; it never reset the **global** `FiltersContext.state.activeFilters`. The badge (`ChatSidebar`) reads that global state, and the sync effect even re-mirrored the old filters back into the modal.

## Fix

`handleClearFilters` now resets the global filters to the default open filter (`[DEFAULT_FILTER]`).

**Why reset to the default and not to `[]`:** the realtime conversation matcher (`doesConversationMatchFilters`, `ChatContext`) treats an empty filter list as **match-all** — resetting to `[]` would let non-open conversations leak into the list on websocket updates. Keeping `[status=open]` preserves the existing open-only behavior everywhere (matcher, search re-scoping, reload). The only behavior that changes is the badge.

The badge now counts only **non-default** filters, so it disappears at the default state (and no longer shows a spurious "1 filter" on a fresh load).

## Changes

- `src/contexts/chat/FiltersContext.tsx` — export `DEFAULT_FILTER`
- `src/hooks/chat/useFilterHandlers.ts` — reset global filters in `handleClearFilters`
- `src/components/chat/chat-sidebar/ChatSidebar.tsx` — badge counts only non-default filters
- `src/hooks/chat/__tests__/useFilterHandlers.spec.ts` — covers the global reset on clear

## Validation

- `frontend: pnpm exec tsc -b --noEmit` → 0 errors
- `frontend: pnpm exec eslint` (changed files) → 0 errors (2 pre-existing react-refresh warnings on the context file)
- `frontend: pnpm exec vitest run` (useFilterHandlers + ChatSidebar specs) → 18 passed
- **Manual smoke:** apply → clear hides the badge, shows open conversations, modal resets to default; F5 does not restore old filters; applying a real filter still works; realtime stays scoped to open.

## Acceptance Criteria

- [x] AC1 (scroll keeps the filter) — already covered by EVO-1671 (loadMore preserves the query) on develop
- [x] AC2 — "Clear filters" resets `activeFilters` to default, badge disappears immediately, list shows open conversations
- [x] AC3 — after clear + F5, no previous filter is restored
- [x] AC4 — vitest covers the apply→clear reset

## Linked Issue

- EVO-1939

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzVxXUXPKJQy4m5WuJEjgz
