### PR TITLE
feat(frontend): wire the Agents list advanced filter end-to-end (EVO-1952)

### DIFF
--- a/src/components/agents/AgentsFilter.tsx
+++ b/src/components/agents/AgentsFilter.tsx
@@ -1,0 +1,34 @@
+import BaseFilter from '@/components/base/BaseFilter';
+import { AGENT_FILTER_TYPES, DEFAULT_AGENT_FILTER } from '@/types/agents';
+import { BaseFilter as AgentFilter } from '@/types/core';
+
+interface AgentsFilterProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  filters: AgentFilter[];
+  onFiltersChange: (filters: AgentFilter[]) => void;
+  onApplyFilters: (filters: AgentFilter[]) => void;
+  onClearFilters: () => void;
+}
+
+export default function AgentsFilter({
+  open,
+  onOpenChange,
+  filters,
+  onFiltersChange,
+  onApplyFilters,
+  onClearFilters,
+}: AgentsFilterProps) {
+  return (
+    <BaseFilter
+      open={open}
+      onOpenChange={onOpenChange}
+      filters={filters}
+      onFiltersChange={onFiltersChange}
+      onApplyFilters={onApplyFilters}
+      onClearFilters={onClearFilters}
+      filterTypes={AGENT_FILTER_TYPES}
+      defaultFilter={DEFAULT_AGENT_FILTER}
+    />
+  );
+}

--- a/src/components/agents/AgentsHeader.tsx
+++ b/src/components/agents/AgentsHeader.tsx
@@ -18,6 +18,7 @@ interface AgentsHeaderProps {
   onManageApiKeys: () => void;
   onBulkDelete: () => void;
   onClearSelection: () => void;
+  onFilter?: () => void;
   activeFilters?: HeaderFilter[];
   showFilters?: boolean;
 }
@@ -32,6 +33,7 @@ export default function AgentsHeader({
   onManageApiKeys,
   onBulkDelete,
   onClearSelection,
+  onFilter,
   activeFilters = [],
   showFilters = true,
 }: AgentsHeaderProps) {
@@ -83,7 +85,7 @@ export default function AgentsHeader({
       secondaryActions={secondaryActions}
       bulkActions={bulkActions}
       filters={activeFilters}
-      onFilterClick={() => {}} // TODO: Implement filter functionality
+      onFilterClick={onFilter ?? (() => {})}
       showFilters={showFilters}
       onClearSelection={onClearSelection}
     />

--- a/src/components/agents/index.ts
+++ b/src/components/agents/index.ts
@@ -1,5 +1,6 @@
 export { default as AgentsTable } from './AgentsTable';
 export { default as AgentsHeader } from './AgentsHeader';
+export { default as AgentsFilter } from './AgentsFilter';
 export { default as AgentsPagination } from './AgentsPagination';
 export { default as AgentCard } from './AgentCard';
 export { default as AgentActionsDropdown } from './AgentActionsDropdown';

--- a/src/pages/Customer/Agents/Agents.tsx
+++ b/src/pages/Customer/Agents/Agents.tsx
@@ -1,13 +1,15 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@evoapi/design-system';
-import { AgentsTable, AgentsHeader, AgentsPagination, AgentCard as AgentCardItem, AgentWizardModal } from '@/components/agents';
+import { AgentsTable, AgentsHeader, AgentsPagination, AgentCard as AgentCardItem, AgentWizardModal, AgentsFilter } from '@/components/agents';
 import { EmptyState } from '@/components/base';
 import { Bot, Search, Grid3X3, List } from 'lucide-react';
 import { toast } from 'sonner';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { getAccessibleAgents, deleteAgent } from '@/services/agents';
-import { Agent } from '@/types/agents';
+import { Agent, AGENT_FILTER_TYPES } from '@/types/agents';
+import { buildAppliedFilterChips } from '@/utils/appliedFilterChips';
+import type { BaseFilter, AppliedFilter } from '@/types/core';
 import { useLanguage } from '@/hooks/useLanguage';
 import { ApiKeysModal } from '@/components/ApiKeysModal';
 import { AgentsTour } from '@/tours';
@@ -52,6 +54,13 @@ const Agentes = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [sortBy, setSortBy] = useState<string>('name');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  const [filterModalOpen, setFilterModalOpen] = useState(false);
+  const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
+  const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
+  // EVO-1952: ref synced to activeFilters so the applied-chip "x" removes against
+  // the current list, not the stale snapshot captured when the chips were built.
+  const activeFiltersRef = useRef<BaseFilter[]>([]);
+  activeFiltersRef.current = activeFilters;
 
   const loadingRef = useRef(false);
   const loadAgentsRef = useRef<((params?: { page?: number; per_page?: number }) => Promise<void>) | null>(null);
@@ -62,7 +71,7 @@ const Agentes = () => {
   const isWizardOpen = location.pathname === '/agents/new';
 
   const loadAgents = useCallback(
-    async (params?: { page?: number; per_page?: number }) => {
+    async (params?: { page?: number; per_page?: number }, filtersOverride?: BaseFilter[]) => {
       if (loadingRef.current || permissionsLoading || !permissionsReady) {
         return;
       }
@@ -78,7 +87,22 @@ const Agentes = () => {
       try {
         const currentPage = params?.page ?? 1;
         const currentPageSize = params?.per_page ?? 24;
-        const response = await getAccessibleAgents(currentPage, currentPageSize);
+
+        const effectiveFilters = filtersOverride ?? activeFilters;
+        const filterParams = effectiveFilters.reduce((acc, filter, index) => {
+          const prefix = `filters[${index}]`;
+          acc[`${prefix}[attribute_key]`] = filter.attributeKey;
+          acc[`${prefix}[filter_operator]`] = filter.filterOperator;
+          acc[`${prefix}[values]`] = Array.isArray(filter.values)
+            ? filter.values.join(',')
+            : String(filter.values);
+          if (index > 0) {
+            acc[`${prefix}[query_operator]`] = filter.queryOperator;
+          }
+          return acc;
+        }, {} as Record<string, string>);
+
+        const response = await getAccessibleAgents(currentPage, currentPageSize, { filterParams });
 
         const total = response.meta?.pagination?.total || 0;
         const pageSize = response.meta?.pagination?.page_size || DEFAULT_PAGE_SIZE;
@@ -112,7 +136,7 @@ const Agentes = () => {
         loadingRef.current = false;
       }
     },
-    [permissionsReady, permissionsLoading, can, t],
+    [permissionsReady, permissionsLoading, can, t, activeFilters],
   );
 
   useEffect(() => {
@@ -241,6 +265,32 @@ const Agentes = () => {
     toast.info(t('bulkDelete'));
   };
 
+  const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
+    buildAppliedFilterChips(filters, AGENT_FILTER_TYPES, t, handleRemoveFilter);
+
+  const handleOpenFilter = () => setFilterModalOpen(true);
+
+  const handleApplyFilters = (filters: BaseFilter[]) => {
+    setActiveFilters(filters);
+    setAppliedFilters(convertFiltersToApplied(filters));
+    loadAgents({ page: 1 }, filters);
+  };
+
+  const handleClearFilters = () => {
+    setActiveFilters([]);
+    setAppliedFilters([]);
+    loadAgents({ page: 1 }, []);
+  };
+
+  const handleRemoveFilter = (index: number) => {
+    const newFilters = activeFiltersRef.current.filter((_, i) => i !== index);
+    if (newFilters.length === 0) {
+      handleClearFilters();
+    } else {
+      handleApplyFilters(newFilters);
+    }
+  };
+
   const filteredAgents = state.agents.filter(
     agent =>
       agent.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -279,10 +329,20 @@ const Agentes = () => {
               onManageApiKeys={() => setIsApiKeysModalOpen(true)}
               onBulkDelete={handleBulkDelete}
               onClearSelection={() => setState(prev => ({ ...prev, selectedAgents: [] }))}
-              activeFilters={[]}
-              showFilters={false}
+              onFilter={handleOpenFilter}
+              activeFilters={appliedFilters}
+              showFilters={true}
             />
             </div>
+
+            <AgentsFilter
+              open={filterModalOpen}
+              onOpenChange={setFilterModalOpen}
+              filters={activeFilters}
+              onFiltersChange={setActiveFilters}
+              onApplyFilters={handleApplyFilters}
+              onClearFilters={handleClearFilters}
+            />
 
             <div className="flex items-center justify-end" data-tour="agents-view-toggle">
               <div className="flex items-center border rounded-lg">

--- a/src/services/agents/agentService.ts
+++ b/src/services/agents/agentService.ts
@@ -24,10 +24,21 @@ class AgentsService {
     return extractData<Agent>(response);
   }
 
-  async listAgents(page = 1, pageSize = 100, folderId?: string): Promise<AgentListResponse> {
+  async listAgents(
+    page = 1,
+    pageSize = 100,
+    folderId?: string,
+    options?: { search?: string; filterParams?: Record<string, string> },
+  ): Promise<AgentListResponse> {
     const params: any = buildPaginationParams(page, pageSize);
     if (folderId) {
       params.folder_id = folderId;
+    }
+    if (options?.search) {
+      params.search = options.search;
+    }
+    if (options?.filterParams) {
+      Object.assign(params, options.filterParams);
     }
 
     const response = await evoaiApi.get('/agents', {
@@ -146,9 +157,13 @@ class AgentsService {
     }));
   }
 
-  async getAccessibleAgents(page = 1, pageSize = 100) {
+  async getAccessibleAgents(
+    page = 1,
+    pageSize = 100,
+    options?: { search?: string; filterParams?: Record<string, string> },
+  ) {
     try {
-      return await this.listAgents(page, pageSize);
+      return await this.listAgents(page, pageSize, undefined, options);
     } catch (error) {
       console.error('Error getting accessible agents:', error);
       throw error;
@@ -178,6 +193,10 @@ export const deleteApiKey = (keyId: string) => agentsService.deleteApiKey(keyId)
 
 export const assignAgentToFolder = (agentId: string, folderId: string | null) => agentsService.assignFolder(agentId, folderId);
 export const getAccessibleFolders = (page?: number, pageSize?: number) => agentsService.getAccessibleFolders(page, pageSize);
-export const getAccessibleAgents = (page?: number, pageSize?: number) => agentsService.getAccessibleAgents(page, pageSize);
+export const getAccessibleAgents = (
+  page?: number,
+  pageSize?: number,
+  options?: { search?: string; filterParams?: Record<string, string> },
+) => agentsService.getAccessibleAgents(page, pageSize, options);
 export const shareAgent = (agentId: string) => agentsService.shareAgent(agentId);
 export const getAgentIntegrations = (agentId: string) => agentsService.getAgentIntegrations(agentId);

--- a/src/types/agents/agents-filters.ts
+++ b/src/types/agents/agents-filters.ts
@@ -1,0 +1,66 @@
+import { BaseFilter, FilterType, OPERATOR_TYPES_1, OPERATOR_TYPES_3 } from '@/types/core';
+
+// Advanced-filter attributes exposed on the Agents list screen. Keys must match
+// the whitelist the core-service applies (pkg/agent/repository/agent_filter.go).
+export const AGENT_FILTER_TYPES: FilterType[] = [
+  {
+    attributeKey: 'name',
+    attributeI18nKey: 'Nome',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_3,
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'description',
+    attributeI18nKey: 'Descrição',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_3,
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'type',
+    attributeI18nKey: 'Tipo',
+    inputType: 'search_select',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_1,
+    attribute_type: 'standard',
+    options: [
+      { label: 'LLM', value: 'llm' },
+      { label: 'A2A', value: 'a2a' },
+      { label: 'Sequential', value: 'sequential' },
+      { label: 'Parallel', value: 'parallel' },
+      { label: 'Loop', value: 'loop' },
+      { label: 'Workflow', value: 'workflow' },
+      { label: 'Task', value: 'task' },
+      { label: 'External', value: 'external' },
+    ],
+  },
+  {
+    attributeKey: 'model',
+    attributeI18nKey: 'Modelo',
+    inputType: 'plain_text',
+    dataType: 'text',
+    filterOperators: OPERATOR_TYPES_3,
+    attribute_type: 'standard',
+  },
+  {
+    attributeKey: 'created_at',
+    attributeI18nKey: 'Data de Criação',
+    inputType: 'date',
+    dataType: 'date',
+    // Date column: only equality operators (the Go backend matches by DATE());
+    // substring/ILIKE operators are invalid on a timestamp and would 500.
+    filterOperators: OPERATOR_TYPES_1,
+    attribute_type: 'standard',
+  },
+];
+
+export const DEFAULT_AGENT_FILTER: BaseFilter = {
+  attributeKey: 'name',
+  filterOperator: 'equal_to',
+  values: '',
+  queryOperator: 'and',
+  attributeModel: 'standard',
+};

--- a/src/types/agents/index.ts
+++ b/src/types/agents/index.ts
@@ -3,3 +3,4 @@
 
 // Agent types
 export * from './agent';
+export * from './agents-filters';


### PR DESCRIPTION
## Summary

EVO-1952 (EVO-1947 **Fase B — Agents**), frontend half. The Agents (AI Agents) list filter button was a literal no-op with no advanced-filter UI. Wired end-to-end now that the core-service honors filters.

## Changes

- `src/types/agents/agents-filters.ts` (new) — `AGENT_FILTER_TYPES` (name/description/type/model/created_at) + `DEFAULT_AGENT_FILTER`.
- `src/components/agents/AgentsFilter.tsx` (new) — thin `BaseFilter` wrapper.
- `src/pages/Customer/Agents/Agents.tsx` — build `filters[]` in `loadAgents` and send them; first apply/clear pass the just-applied filters explicitly (no stale closure); applied-chip "x" removes against a ref synced to current filters; chips via shared helper; re-enable the filter button.
- `src/components/agents/AgentsHeader.tsx` — `onFilter` prop wired to the (previously no-op) filter button.
- `src/services/agents/agentService.ts` — `listAgents`/`getAccessibleAgents` forward filter (and search) params.

## Security

- No new data exposure; filtering is enforced server-side (core-service).
- `created_at` offers only equal/not-equal operators (substring operators are invalid on a date column and would 500 the Go backend).

## Test plan

- `pnpm exec tsc -b --noEmit` → 0 errors
- `pnpm exec eslint` (changed files) → no new errors (pre-existing `no-explicit-any` on untouched lines only)
- Manual smoke (with PM): filter button opens the modal; apply Tipo=LLM / Nome contains changes the list server-side; first apply works; chip "x" removes the correct filter; clear resets.

## Changed Files

- `src/types/agents/agents-filters.ts` (new), `src/types/agents/index.ts`
- `src/components/agents/AgentsFilter.tsx` (new), `src/components/agents/AgentsHeader.tsx`, `src/components/agents/index.ts`
- `src/pages/Customer/Agents/Agents.tsx`
- `src/services/agents/agentService.ts`

## Related PRs

- core-service (Go, server-side filter): sibling `feat/EVO-1952` PR on evo-ai-core-service-community.

## Linked Issue

- EVO-1952 (EVO-1947 Fase B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzVxXUXPKJQy4m5WuJEjgz
