### PR TITLE
feat(frontend): wire Custom Tools + Custom MCP Servers list filters (EVO-1953)

### DIFF
--- a/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
+++ b/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
@@ -75,13 +75,28 @@ export default function CustomMCPServers() {
   const [detailsServer, setDetailsServer] = useState<CustomMcpServer | null>(null);
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
+  // EVO-1953: ref synced to activeFilters so the applied-chip "x" removes against
+  // the current list, not the stale snapshot captured when the chips were built.
+  const activeFiltersRef = useRef<BaseFilter[]>([]);
+  activeFiltersRef.current = activeFilters;
   const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
   const [testingServer, setTestingServer] = useState<string | null>(null);
   const hasLoaded = useRef(false);
+  // EVO-1953: debounce the server-side search so typing fires one request after
+  // it settles, not one per keystroke.
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    },
+    [],
+  );
 
   // Load servers
   const loadServers = useCallback(
-    async (params?: Partial<ListCustomMcpServersParams>) => {
+    async (params?: Partial<ListCustomMcpServersParams>, filtersOverride?: BaseFilter[]) => {
       if (!can('ai_custom_mcp_servers', 'read')) {
         toast.error(t('permissions.viewDenied'));
         return;
@@ -95,7 +110,21 @@ export default function CustomMCPServers() {
           ...params,
         };
 
-        const response = await listCustomMcpServers(requestParams);
+        const effectiveFilters = filtersOverride ?? activeFilters;
+        const filterParams = effectiveFilters.reduce((acc, filter, index) => {
+          const prefix = `filters[${index}]`;
+          acc[`${prefix}[attribute_key]`] = filter.attributeKey;
+          acc[`${prefix}[filter_operator]`] = filter.filterOperator;
+          acc[`${prefix}[values]`] = Array.isArray(filter.values)
+            ? filter.values.join(',')
+            : String(filter.values);
+          if (index > 0) {
+            acc[`${prefix}[query_operator]`] = filter.queryOperator;
+          }
+          return acc;
+        }, {} as Record<string, string>);
+
+        const response = await listCustomMcpServers(requestParams, filterParams);
 
         setState(prev => ({
           ...prev,
@@ -116,7 +145,7 @@ export default function CustomMCPServers() {
         setState(prev => ({ ...prev, loading: { ...prev.loading, list: false } }));
       }
     },
-    [can, t],
+    [can, t, activeFilters],
   );
 
   // Initial load
@@ -139,8 +168,12 @@ export default function CustomMCPServers() {
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
     }));
 
-    // TODO: Implement search functionality
-    loadServers({ skip: 0, search: query });
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
+    searchDebounceRef.current = setTimeout(() => {
+      loadServers({ skip: 0, search: query });
+    }, 500);
   };
 
   const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
@@ -161,7 +194,7 @@ export default function CustomMCPServers() {
     }));
 
     try {
-      await loadServers({ skip: 0 });
+      await loadServers({ skip: 0, search: state.searchQuery }, filters);
     } catch (error) {
       console.error('Error applying filters:', error);
       toast.error(t('errors.applyFiltersError'));
@@ -171,11 +204,11 @@ export default function CustomMCPServers() {
   const handleClearFilters = () => {
     setActiveFilters([]);
     setAppliedFilters([]);
-    loadServers({ skip: 0 });
+    loadServers({ skip: 0, search: state.searchQuery }, []);
   };
 
   const handleRemoveFilter = (index: number) => {
-    const newFilters = activeFilters.filter((_, i) => i !== index);
+    const newFilters = activeFiltersRef.current.filter((_, i) => i !== index);
     if (newFilters.length === 0) {
       handleClearFilters();
     } else {
@@ -358,7 +391,7 @@ export default function CustomMCPServers() {
           onFilter={handleOpenFilter}
           onClearSelection={() => setState(prev => ({ ...prev, selectedServerIds: [] }))}
           activeFilters={appliedFilters}
-          showFilters={false}
+          showFilters={true}
         />
       </div>
 

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -53,6 +53,10 @@ export default function CustomTools() {
   const [detailsTool, setDetailsTool] = useState<CustomTool | null>(null);
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
+  // EVO-1953: ref synced to activeFilters so the applied-chip "x" removes against
+  // the current list, not the stale snapshot captured when the chips were built.
+  const activeFiltersRef = useRef<BaseFilter[]>([]);
+  activeFiltersRef.current = activeFilters;
   const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
   const [testingTool, setTestingTool] = useState<string | null>(null);
   const [testResultOpen, setTestResultOpen] = useState(false);
@@ -60,10 +64,21 @@ export default function CustomTools() {
   const [testResultData, setTestResultData] =
     useState<CustomToolTestResponse['test_result'] | null>(null);
   const hasLoaded = useRef(false);
+  // EVO-1953: debounce the server-side search so typing fires one request after
+  // it settles, not one per keystroke.
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    },
+    [],
+  );
 
   // Load tools
   const loadTools = useCallback(
-    async (params?: Partial<CustomToolsListParams>) => {
+    async (params?: Partial<CustomToolsListParams>, filtersOverride?: BaseFilter[]) => {
       if (!can('ai_custom_tools', 'read')) {
         toast.error(t('permissions.viewDenied'));
         return;
@@ -80,7 +95,21 @@ export default function CustomTools() {
           tags: params?.tags,
         };
 
-        const tools = await listCustomTools(searchParams);
+        const effectiveFilters = filtersOverride ?? activeFilters;
+        const filterParams = effectiveFilters.reduce((acc, filter, index) => {
+          const prefix = `filters[${index}]`;
+          acc[`${prefix}[attribute_key]`] = filter.attributeKey;
+          acc[`${prefix}[filter_operator]`] = filter.filterOperator;
+          acc[`${prefix}[values]`] = Array.isArray(filter.values)
+            ? filter.values.join(',')
+            : String(filter.values);
+          if (index > 0) {
+            acc[`${prefix}[query_operator]`] = filter.queryOperator;
+          }
+          return acc;
+        }, {} as Record<string, string>);
+
+        const tools = await listCustomTools(searchParams, filterParams);
 
         setState(prev => ({
           ...prev,
@@ -101,7 +130,7 @@ export default function CustomTools() {
         setState(prev => ({ ...prev, loading: { ...prev.loading, list: false } }));
       }
     },
-    [can, t],
+    [can, t, activeFilters],
   );
 
   // Initial load
@@ -124,7 +153,12 @@ export default function CustomTools() {
       meta: { ...prev.meta, pagination: { ...prev.meta.pagination, page: 1 } },
     }));
 
-    loadTools({ skip: 0, search: query });
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
+    searchDebounceRef.current = setTimeout(() => {
+      loadTools({ skip: 0, search: query });
+    }, 500);
   };
 
   const convertFiltersToApplied = (filters: BaseFilter[]): AppliedFilter[] =>
@@ -145,7 +179,7 @@ export default function CustomTools() {
     }));
 
     try {
-      await loadTools({ skip: 0 });
+      await loadTools({ skip: 0, search: state.searchQuery }, filters);
     } catch (error) {
       console.error('Error applying filters:', error);
       toast.error(getErrorMessage(error as Error, t('errors.applyFiltersError')));
@@ -155,11 +189,11 @@ export default function CustomTools() {
   const handleClearFilters = () => {
     setActiveFilters([]);
     setAppliedFilters([]);
-    loadTools({ skip: 0 });
+    loadTools({ skip: 0, search: state.searchQuery }, []);
   };
 
   const handleRemoveFilter = (index: number) => {
-    const newFilters = activeFilters.filter((_, i) => i !== index);
+    const newFilters = activeFiltersRef.current.filter((_, i) => i !== index);
     if (newFilters.length === 0) {
       handleClearFilters();
     } else {
@@ -375,7 +409,7 @@ export default function CustomTools() {
 
           onClearSelection={() => setState(prev => ({ ...prev, selectedToolIds: [] }))}
           activeFilters={appliedFilters}
-          showFilters={false}
+          showFilters={true}
         />
       </div>
 

--- a/src/services/agents/customMcpServerService.ts
+++ b/src/services/agents/customMcpServerService.ts
@@ -11,15 +11,9 @@ import {
 // List custom MCP servers
 export const listCustomMcpServers = async (
   params?: ListCustomMcpServersParams,
+  filterParams?: Record<string, string>,
 ): Promise<CustomMcpServer[]> => {
-  const queryParams: {
-    skip: number;
-    limit: number;
-    page?: number;
-    pageSize?: number;
-    search?: string;
-    tags?: string;
-  } = {
+  const queryParams: Record<string, unknown> = {
     skip: params?.skip || 0,
     limit: params?.limit || 100,
   };
@@ -35,6 +29,10 @@ export const listCustomMcpServers = async (
   }
   if (params?.tags) {
     queryParams.tags = params.tags;
+  }
+
+  if (filterParams) {
+    Object.assign(queryParams, filterParams);
   }
 
   const response = await evoaiApi.get('/custom-mcp-servers', {

--- a/src/services/agents/customToolsService.ts
+++ b/src/services/agents/customToolsService.ts
@@ -11,8 +11,11 @@ import {
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 
 // Lista ferramentas personalizadas
-export const listCustomTools = async (params?: CustomToolsListParams): Promise<CustomTool[]> => {
-  const queryParams: { skip: number; limit: number; page?: number; pageSize?: number; search?: string; tags?: string } = {
+export const listCustomTools = async (
+  params?: CustomToolsListParams,
+  filterParams?: Record<string, string>,
+): Promise<CustomTool[]> => {
+  const queryParams: Record<string, unknown> = {
     skip: params?.skip || 0,
     limit: params?.limit || 100
   };
@@ -28,6 +31,10 @@ export const listCustomTools = async (params?: CustomToolsListParams): Promise<C
   }
   if (params?.tags) {
     queryParams.tags = params.tags;
+  }
+
+  if (filterParams) {
+    Object.assign(queryParams, filterParams);
   }
 
   const response = await evoaiApi.get('/custom-tools', {

--- a/src/types/core/filters.ts
+++ b/src/types/core/filters.ts
@@ -280,7 +280,9 @@ export const CUSTOM_MCP_SERVER_FILTER_TYPES: FilterType[] = [
     attributeI18nKey: 'Data de Criação',
     inputType: 'date',
     dataType: 'date',
-    filterOperators: OPERATOR_TYPES_5,
+    // Date column: only equality operators (the Go backend matches by DATE();
+    // substring operators are invalid on a timestamp and would 500).
+    filterOperators: OPERATOR_TYPES_1,
     attribute_type: 'standard',
   },
 ];
@@ -379,7 +381,9 @@ export const CUSTOM_TOOL_FILTER_TYPES: FilterType[] = [
     attributeI18nKey: 'Data de Criação',
     inputType: 'date',
     dataType: 'date',
-    filterOperators: OPERATOR_TYPES_5,
+    // Date column: only equality operators (the Go backend matches by DATE();
+    // substring operators are invalid on a timestamp and would 500).
+    filterOperators: OPERATOR_TYPES_1,
     attribute_type: 'standard',
   },
 ];


### PR DESCRIPTION
## Summary

EVO-1953 (EVO-1947 **Fase C1**), frontend half. The **Custom Tools** and **Custom MCP Servers** list screens had a filter modal + `*_FILTER_TYPES` but `loadX` never sent `filters[]` and `showFilters` was false — the advanced filter was dead. Wired end-to-end now that the core-service honors filters.

## Changes

- `CustomTools.tsx` / `CustomMCPServers.tsx`: `loadX(params, filtersOverride?)` serializes + sends `filters[]`; first apply/clear pass the just-applied filters explicitly (no stale closure); applied-chip "x" removes against a ref synced to current filters; re-enable `showFilters`; chips via the shared helper.
- **Search composes with filters**: apply/clear/remove now thread the active `state.searchQuery` (it was being dropped, so the search box showed a term that wasn't applied).
- **Debounce** the server-side search (500ms, cleared on unmount) so typing fires one request after it settles, not one per keystroke.
- `customToolsService` / `customMcpServerService`: forward `filterParams`.
- `filters.ts`: `created_at` restricted to `OPERATOR_TYPES_1` on both `*_FILTER_TYPES` (substring is invalid on a date).

## Security

- No new data exposure; filtering enforced server-side.

## Test plan

- `pnpm exec tsc -b --noEmit` → 0
- `pnpm exec eslint` (changed screens) → 0 (services keep pre-existing `no-explicit-any` on untouched lines)
- Manual smoke (with PM): both screens — filter button opens modal; name/tag/method|url filters change the list server-side; search + filter compose; debounce fires one request; chip "x" removes the correct filter; clear resets.

## Changed Files

- `src/pages/Customer/Agents/CustomTools/CustomTools.tsx`, `CustomMCPServers/CustomMCPServers.tsx`
- `src/services/agents/customToolsService.ts`, `customMcpServerService.ts`
- `src/types/core/filters.ts`

## Deferred (LOW)

- The custom-screen `*_FILTER_TYPES` attribute labels (`'Nome'`, `'Descrição'`, …) are literal PT rather than i18n keys, so non-PT locales show PT on the filter modal/chips. Pre-existing data shared with sibling FILTER_TYPES; cosmetic. A separate i18n cleanup, not this card.

## Related PRs

- core-service (Go, server-side filter): sibling `feat/EVO-1953` PR on evo-ai-core-service-community.

## Linked Issue

- EVO-1953 (EVO-1947 Fase C1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzVxXUXPKJQy4m5WuJEjgz

## Summary by Sourcery

Wire advanced filtering and debounced search for Custom Tools and Custom MCP Servers lists, sending filter parameters to the backend and aligning available filter operators for creation date fields.

New Features:
- Enable advanced filters on Custom Tools and Custom MCP Servers list pages, including visible filter controls and applied filter chips.
- Support combined server-side search and filters so query text and filters are applied together in list requests.

Enhancements:
- Debounce server-side search requests on the Custom Tools and Custom MCP Servers screens to reduce unnecessary calls while typing.
- Propagate structured filter parameters from the frontend list pages through the services to the backend list endpoints.
- Restrict creation date filters for Custom Tools and Custom MCP Servers to equality-style operators compatible with backend date handling.