### PR TITLE
feat(admin-settings): redesign integrations screen as a card directory

### DIFF
--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -518,7 +518,15 @@
     },
     "messages": {
       "loadError": "Failed to load integrations configuration"
-    }
+    },
+    "statusConfigured": "Configured",
+    "statusNotConfigured": "Not configured",
+    "dialogSubtitle": "Enter the OAuth credentials for this integration.",
+    "remove": "Remove",
+    "removing": "Removing...",
+    "removeSuccess": "Configuration removed",
+    "removeError": "Failed to remove configuration",
+    "cancel": "Cancel"
   },
   "inboundEmail": {
     "title": "Inbound email (receive as conversations)",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -518,7 +518,15 @@
     },
     "messages": {
       "loadError": "Error al cargar la configuracion de integraciones"
-    }
+    },
+    "statusConfigured": "Configurado",
+    "statusNotConfigured": "Sin configurar",
+    "dialogSubtitle": "Introduce las credenciales OAuth de esta integración.",
+    "remove": "Eliminar",
+    "removing": "Eliminando...",
+    "removeSuccess": "Configuración eliminada",
+    "removeError": "No se pudo eliminar la configuración",
+    "cancel": "Cancelar"
   },
   "inboundEmail": {
     "title": "Correo entrante (recibir como conversaciones)",
@@ -579,7 +587,9 @@
   "evolutionHub": {
     "title": "Evo Hub",
     "description": "Use Evo Hub como capa de proxy para canales Meta (WhatsApp Cloud, Messenger, Instagram). Cuando se activa, el CRM sustituye las llamadas directas a la Graph API por llamadas vía Hub.",
-    "sections": { "connection": "Conexión" },
+    "sections": {
+      "connection": "Conexión"
+    },
     "fields": {
       "enabled": "Usar Evo Hub",
       "enabledHelp": "Cuando está activado, todas las llamadas Meta pasan por el Hub configurado.",
@@ -590,7 +600,11 @@
       "webhookSecretHelp": "Use una cadena aleatoria fuerte.",
       "secretSet": "configurado"
     },
-    "actions": { "save": "Guardar", "test": "Probar conexión", "generateSecret": "Generar secreto aleatorio" },
+    "actions": {
+      "save": "Guardar",
+      "test": "Probar conexión",
+      "generateSecret": "Generar secreto aleatorio"
+    },
     "messages": {
       "saved": "Configuración guardada",
       "saveError": "Error al guardar",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -517,7 +517,15 @@
     },
     "messages": {
       "loadError": "Echec du chargement de la configuration des integrations"
-    }
+    },
+    "statusConfigured": "Configuré",
+    "statusNotConfigured": "Non configuré",
+    "dialogSubtitle": "Saisissez les identifiants OAuth de cette intégration.",
+    "remove": "Supprimer",
+    "removing": "Suppression...",
+    "removeSuccess": "Configuration supprimée",
+    "removeError": "Échec de la suppression de la configuration",
+    "cancel": "Annuler"
   },
   "inboundEmail": {
     "title": "E-mail entrant (recevoir comme conversations)",

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -517,7 +517,15 @@
     },
     "messages": {
       "loadError": "Errore nel caricamento della configurazione delle integrazioni"
-    }
+    },
+    "statusConfigured": "Configurato",
+    "statusNotConfigured": "Non configurato",
+    "dialogSubtitle": "Inserisci le credenziali OAuth di questa integrazione.",
+    "remove": "Rimuovi",
+    "removing": "Rimozione...",
+    "removeSuccess": "Configurazione rimossa",
+    "removeError": "Impossibile rimuovere la configurazione",
+    "cancel": "Annulla"
   },
   "inboundEmail": {
     "title": "E-mail in entrata (ricevi come conversazioni)",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -518,7 +518,15 @@
     },
     "messages": {
       "loadError": "Falha ao carregar configuracao das integracoes"
-    }
+    },
+    "statusConfigured": "Configurado",
+    "statusNotConfigured": "Não configurado",
+    "dialogSubtitle": "Informe as credenciais OAuth desta integração.",
+    "remove": "Remover",
+    "removing": "Removendo...",
+    "removeSuccess": "Configuração removida",
+    "removeError": "Falha ao remover a configuração",
+    "cancel": "Cancelar"
   },
   "inboundEmail": {
     "title": "E-mail de entrada (receber como conversas)",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -517,7 +517,15 @@
     },
     "messages": {
       "loadError": "Falha ao carregar configuracao das integracoes"
-    }
+    },
+    "statusConfigured": "Configurado",
+    "statusNotConfigured": "Não configurado",
+    "dialogSubtitle": "Informe as credenciais OAuth desta integração.",
+    "remove": "Remover",
+    "removing": "Removendo...",
+    "removeSuccess": "Configuração removida",
+    "removeError": "Falha ao remover a configuração",
+    "cancel": "Cancelar"
   },
   "inboundEmail": {
     "title": "E-mail de entrada (receber como conversas)",

--- a/src/pages/Admin/Settings/IntegrationsConfig.spec.tsx
+++ b/src/pages/Admin/Settings/IntegrationsConfig.spec.tsx
@@ -7,25 +7,22 @@ import { INTEGRATIONS } from './integrationsCatalog';
 const stableT = (key: string) => key;
 
 vi.mock('@/hooks/useLanguage', () => ({
-  useLanguage: () => ({
-    t: stableT,
-  }),
+  useLanguage: () => ({ t: stableT }),
 }));
 
 vi.mock('sonner', () => ({
-  toast: {
-    error: vi.fn(),
-    success: vi.fn(),
-  },
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 const mockGetConfig = vi.fn();
 const mockSaveConfig = vi.fn();
+const mockClearConfig = vi.fn();
 
 vi.mock('@/services/admin/adminConfigService', () => ({
   adminConfigService: {
     getConfig: (...args: unknown[]) => mockGetConfig(...args),
     saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+    clearConfig: (...args: unknown[]) => mockClearConfig(...args),
   },
 }));
 
@@ -34,19 +31,13 @@ vi.mock('@/utils/apiHelpers', () => ({
 }));
 
 // The non-OAuth front-end services section self-loads its own config; stub it out
-// so these tests cover only the OAuth catalog (its own behavior is covered in
-// FrontendServicesSection.spec.tsx).
-vi.mock('./FrontendServicesSection', () => ({
-  default: () => null,
-}));
+// so these tests cover only the OAuth catalog (covered in FrontendServicesSection.spec.tsx).
+vi.mock('./FrontendServicesSection', () => ({ default: () => null }));
 
-// Build fixtures from the catalog so the suite scales with INTEGRATIONS instead
-// of hard-coding the original 4. Keyed by configType (what getConfig receives).
+// Fixtures built from the catalog so the suite scales with INTEGRATIONS. Keyed by
+// configType (what getConfig receives).
 const EMPTY_DATA: Record<string, Record<string, unknown>> = Object.fromEntries(
-  INTEGRATIONS.map((def) => [
-    def.configType,
-    { [def.clientIdKey]: '', [def.clientSecretKey]: null },
-  ]),
+  INTEGRATIONS.map((def) => [def.configType, { [def.clientIdKey]: '', [def.clientSecretKey]: null }]),
 );
 
 const CONFIGURED_DATA: Record<string, Record<string, unknown>> = Object.fromEntries(
@@ -57,15 +48,20 @@ const CONFIGURED_DATA: Record<string, Record<string, unknown>> = Object.fromEntr
 );
 
 const TOTAL = INTEGRATIONS.length;
-const hubspotDef = INTEGRATIONS.find((d) => d.key === 'hubspot')!;
 
 async function renderAndWait(data: Record<string, Record<string, unknown>> = EMPTY_DATA) {
-  mockGetConfig.mockImplementation((type: string) => {
-    return Promise.resolve(data[type] ?? {});
-  });
+  mockGetConfig.mockImplementation((type: string) => Promise.resolve(data[type] ?? {}));
   await act(async () => {
     render(<IntegrationsConfig />);
   });
+}
+
+// Open the configure dialog for an integration key and return its form element.
+async function openDialog(key: string) {
+  await act(async () => {
+    fireEvent.click(screen.getByTestId(`${key}-card`));
+  });
+  return screen.getByTestId(`${key}-form`);
 }
 
 describe('IntegrationsConfig', () => {
@@ -81,7 +77,6 @@ describe('IntegrationsConfig', () => {
 
   it('loads config from every catalog integration endpoint', async () => {
     await renderAndWait();
-
     INTEGRATIONS.forEach((def) => {
       expect(mockGetConfig).toHaveBeenCalledWith(def.configType);
     });
@@ -90,63 +85,49 @@ describe('IntegrationsConfig', () => {
 
   it('renders title and description', async () => {
     await renderAndWait();
-
     expect(screen.getByText('integrations.title')).toBeInTheDocument();
     expect(screen.getByText('integrations.description')).toBeInTheDocument();
   });
 
-  it('renders all 4 section card titles', async () => {
-    await renderAndWait();
-
+  it('renders one card per catalog integration', async () => {
+    const { container } = await act(async () => {
+      mockGetConfig.mockImplementation((type: string) => Promise.resolve(EMPTY_DATA[type] ?? {}));
+      return render(<IntegrationsConfig />);
+    });
+    expect(container.querySelectorAll('[data-testid$="-card"]')).toHaveLength(TOTAL);
     expect(screen.getByText('integrations.linear.cardTitle')).toBeInTheDocument();
-    expect(screen.getByText('integrations.hubspot.cardTitle')).toBeInTheDocument();
-    expect(screen.getByText('integrations.shopify.cardTitle')).toBeInTheDocument();
-    expect(screen.getByText('integrations.slack.cardTitle')).toBeInTheDocument();
+    expect(screen.getByText('integrations.github.cardTitle')).toBeInTheDocument();
   });
 
-  it('renders 8 form fields (2 per integration x 4)', async () => {
-    await renderAndWait();
+  it('shows configured status on every card when secrets are masked', async () => {
+    await renderAndWait(CONFIGURED_DATA);
+    expect(screen.getAllByText('integrations.statusConfigured')).toHaveLength(TOTAL);
+  });
 
+  it('shows not-configured status on every card when empty', async () => {
+    await renderAndWait(EMPTY_DATA);
+    expect(screen.getAllByText('integrations.statusNotConfigured')).toHaveLength(TOTAL);
+  });
+
+  it('does not render any form until a card is clicked', async () => {
+    await renderAndWait();
+    expect(screen.queryByTestId('linear-form')).not.toBeInTheDocument();
+  });
+
+  it('opens a focused dialog with both fields when a card is clicked', async () => {
+    await renderAndWait();
+    await openDialog('linear');
     expect(screen.getByLabelText('integrations.linear.fields.clientId')).toBeInTheDocument();
     expect(screen.getByLabelText('integrations.linear.fields.clientSecret')).toBeInTheDocument();
-    expect(screen.getByLabelText('integrations.hubspot.fields.clientId')).toBeInTheDocument();
-    expect(screen.getByLabelText('integrations.hubspot.fields.clientSecret')).toBeInTheDocument();
-    expect(screen.getByLabelText('integrations.shopify.fields.clientId')).toBeInTheDocument();
-    expect(screen.getByLabelText('integrations.shopify.fields.clientSecret')).toBeInTheDocument();
-    expect(screen.getByLabelText('integrations.slack.fields.clientId')).toBeInTheDocument();
-    expect(screen.getByLabelText('integrations.slack.fields.clientSecret')).toBeInTheDocument();
   });
 
-  it('shows secret configured status for masked secrets', async () => {
-    await renderAndWait(CONFIGURED_DATA);
-
-    const configured = screen.getAllByText('integrations.secretConfigured');
-    expect(configured).toHaveLength(TOTAL);
-  });
-
-  it('shows secret not configured when secrets are empty', async () => {
-    await renderAndWait(EMPTY_DATA);
-
-    const notConfigured = screen.getAllByText('integrations.secretNotConfigured');
-    expect(notConfigured).toHaveLength(TOTAL);
-  });
-
-  it('renders one independent save button per integration', async () => {
-    await renderAndWait();
-
-    const saveButtons = screen.getAllByText('integrations.save');
-    expect(saveButtons).toHaveLength(TOTAL);
-  });
-
-  it('saves Linear section independently', async () => {
+  it('saves the open integration with its client id', async () => {
     await renderAndWait(CONFIGURED_DATA);
     mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.linear);
 
-    const linearForm = screen.getByTestId('linear-form');
-    const saveBtn = within(linearForm).getByText('integrations.save');
-
+    const form = await openDialog('linear');
     await act(async () => {
-      fireEvent.click(saveBtn);
+      fireEvent.click(within(form).getByText('integrations.save'));
     });
 
     await waitFor(() => {
@@ -156,69 +137,13 @@ describe('IntegrationsConfig', () => {
     });
   });
 
-  it('saves HubSpot section independently', async () => {
-    await renderAndWait(CONFIGURED_DATA);
-    mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.hubspot);
-
-    const hubspotForm = screen.getByTestId('hubspot-form');
-    const saveBtn = within(hubspotForm).getByText('integrations.save');
-
-    await act(async () => {
-      fireEvent.click(saveBtn);
-    });
-
-    await waitFor(() => {
-      expect(mockSaveConfig).toHaveBeenCalledWith('hubspot', expect.objectContaining({
-        [hubspotDef.clientIdKey]: 'hubspot-id',
-      }));
-    });
-  });
-
-  it('saves Shopify section independently', async () => {
-    await renderAndWait(CONFIGURED_DATA);
-    mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.shopify);
-
-    const shopifyForm = screen.getByTestId('shopify-form');
-    const saveBtn = within(shopifyForm).getByText('integrations.save');
-
-    await act(async () => {
-      fireEvent.click(saveBtn);
-    });
-
-    await waitFor(() => {
-      expect(mockSaveConfig).toHaveBeenCalledWith('shopify', expect.objectContaining({
-        SHOPIFY_CLIENT_ID: 'shopify-id',
-      }));
-    });
-  });
-
-  it('saves Slack section independently', async () => {
-    await renderAndWait(CONFIGURED_DATA);
-    mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.slack);
-
-    const slackForm = screen.getByTestId('slack-form');
-    const saveBtn = within(slackForm).getByText('integrations.save');
-
-    await act(async () => {
-      fireEvent.click(saveBtn);
-    });
-
-    await waitFor(() => {
-      expect(mockSaveConfig).toHaveBeenCalledWith('slack', expect.objectContaining({
-        SLACK_CLIENT_ID: 'slack-id',
-      }));
-    });
-  });
-
-  it('sends null for unmodified secrets on save', async () => {
+  it('sends null for an unmodified secret on save', async () => {
     await renderAndWait(CONFIGURED_DATA);
     mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.linear);
 
-    const linearForm = screen.getByTestId('linear-form');
-    const saveBtn = within(linearForm).getByText('integrations.save');
-
+    const form = await openDialog('linear');
     await act(async () => {
-      fireEvent.click(saveBtn);
+      fireEvent.click(within(form).getByText('integrations.save'));
     });
 
     await waitFor(() => {
@@ -228,15 +153,54 @@ describe('IntegrationsConfig', () => {
     });
   });
 
+  it('sends the modified secret value on save after typing', async () => {
+    await renderAndWait(CONFIGURED_DATA);
+    mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.linear);
+
+    await openDialog('linear');
+    const secretInput = screen.getByLabelText('integrations.linear.fields.clientSecret');
+    await act(async () => {
+      fireEvent.change(secretInput, { target: { value: 'new-secret' } });
+    });
+    const form = screen.getByTestId('linear-form');
+    await act(async () => {
+      fireEvent.click(within(form).getByText('integrations.save'));
+    });
+
+    await waitFor(() => {
+      expect(mockSaveConfig).toHaveBeenCalledWith('linear', expect.objectContaining({
+        LINEAR_CLIENT_SECRET: 'new-secret',
+      }));
+    });
+  });
+
+  it('removes the configuration via clearConfig', async () => {
+    await renderAndWait(CONFIGURED_DATA);
+    mockClearConfig.mockResolvedValue(undefined);
+
+    const form = await openDialog('linear');
+    await act(async () => {
+      fireEvent.click(within(form).getByText('integrations.remove'));
+    });
+
+    await waitFor(() => {
+      expect(mockClearConfig).toHaveBeenCalledWith('linear');
+    });
+  });
+
+  it('hides the remove action for unconfigured integrations', async () => {
+    await renderAndWait(EMPTY_DATA);
+    const form = await openDialog('linear');
+    expect(within(form).queryByText('integrations.remove')).not.toBeInTheDocument();
+  });
+
   it('shows error toast when save fails', async () => {
     await renderAndWait(CONFIGURED_DATA);
     mockSaveConfig.mockRejectedValue(new Error('Network error'));
 
-    const linearForm = screen.getByTestId('linear-form');
-    const saveBtn = within(linearForm).getByText('integrations.save');
-
+    const form = await openDialog('linear');
     await act(async () => {
-      fireEvent.click(saveBtn);
+      fireEvent.click(within(form).getByText('integrations.save'));
     });
 
     await waitFor(() => {
@@ -248,51 +212,11 @@ describe('IntegrationsConfig', () => {
 
   it('shows error toast when config loading fails', async () => {
     mockGetConfig.mockRejectedValue(new Error('Network error'));
-
     await act(async () => {
       render(<IntegrationsConfig />);
     });
-
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('integrations.messages.loadError');
     });
-  });
-
-  it('sends modified secret value on save after typing', async () => {
-    await renderAndWait(CONFIGURED_DATA);
-    mockSaveConfig.mockResolvedValue(CONFIGURED_DATA.linear);
-
-    const secretInput = screen.getByLabelText('integrations.linear.fields.clientSecret');
-
-    await act(async () => {
-      fireEvent.change(secretInput, { target: { value: 'new-secret' } });
-    });
-
-    const linearForm = screen.getByTestId('linear-form');
-    const saveBtn = within(linearForm).getByText('integrations.save');
-
-    await act(async () => {
-      fireEvent.click(saveBtn);
-    });
-
-    await waitFor(() => {
-      expect(mockSaveConfig).toHaveBeenCalledWith('linear', expect.objectContaining({
-        LINEAR_CLIENT_SECRET: 'new-secret',
-      }));
-    });
-  });
-
-  it('clear secret button marks secret as modified', async () => {
-    await renderAndWait(CONFIGURED_DATA);
-
-    const clearButtons = screen.getAllByTitle('integrations.clearSecret');
-    expect(clearButtons).toHaveLength(TOTAL);
-
-    await act(async () => {
-      fireEvent.click(clearButtons[0]);
-    });
-
-    const configured = screen.getAllByText('integrations.secretConfigured');
-    expect(configured).toHaveLength(TOTAL - 1);
   });
 });

--- a/src/pages/Admin/Settings/IntegrationsConfig.tsx
+++ b/src/pages/Admin/Settings/IntegrationsConfig.tsx
@@ -6,17 +6,20 @@ import {
   Input,
   Label,
   Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from '@evoapi/design-system';
 import { toast } from 'sonner';
-import { Loader2, Lock, LockOpen, X } from 'lucide-react';
+import { Loader2, Lock, LockOpen, X, Check, ChevronRight, Trash2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { adminConfigService } from '@/services/admin/adminConfigService';
 import { extractError } from '@/utils/apiHelpers';
 import type { AdminConfigData } from '@/types/admin/adminConfig';
+import BrandIcon, { getBrandIcon } from '@/components/BrandIcon';
 import { INTEGRATIONS, type IntegrationDef } from './integrationsCatalog';
 import FrontendServicesSection from './FrontendServicesSection';
 
@@ -29,16 +32,16 @@ const integrationSchema = z.object({
 
 type IntegrationFormData = z.infer<typeof integrationSchema>;
 
-const DEFAULTS: IntegrationFormData = {
-  clientId: '',
-  clientSecret: null,
-};
-
 function isSecretMasked(value: unknown): boolean {
   return typeof value === 'string' && value.includes('••••');
 }
 
-function buildFormValues(data: Record<string, unknown>, def: IntegrationDef): IntegrationFormData {
+function isConfigured(data: AdminConfigData, def: IntegrationDef): boolean {
+  const id = data[def.clientIdKey];
+  return (typeof id === 'string' && id.length > 0) || isSecretMasked(data[def.clientSecretKey]);
+}
+
+function buildFormValues(data: AdminConfigData, def: IntegrationDef): IntegrationFormData {
   const secretValue = data[def.clientSecretKey];
   return {
     clientId: (data[def.clientIdKey] as string) ?? '',
@@ -46,10 +49,58 @@ function buildFormValues(data: Record<string, unknown>, def: IntegrationDef): In
   };
 }
 
+function emptyData(def: IntegrationDef): AdminConfigData {
+  return { [def.clientIdKey]: '', [def.clientSecretKey]: null };
+}
+
+// Brand accent per integration — drives the monogram tile (no logo assets shipped).
+const ACCENT: Record<string, string> = {
+  linear: 'bg-indigo-500',
+  hubspot: 'bg-orange-500',
+  shopify: 'bg-green-600',
+  slack: 'bg-purple-600',
+  github: 'bg-neutral-800',
+  notion: 'bg-neutral-900',
+  asana: 'bg-rose-500',
+  canva: 'bg-sky-500',
+  google_calendar: 'bg-blue-500',
+  google_sheets: 'bg-emerald-600',
+  monday: 'bg-red-500',
+  paypal: 'bg-blue-700',
+  atlassian: 'bg-blue-600',
+};
+
+function accent(key: string): string {
+  return ACCENT[key] ?? 'bg-primary';
+}
+
+function monogram(title: string): string {
+  const parts = title.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return title.slice(0, 2).toUpperCase();
+}
+
+// Brand logo (simple-icons via BrandIcon) with a monogram-tile fallback for any
+// integration that has no glyph in the brand set.
+function IntegrationLogo({ integrationKey, title }: { integrationKey: string; title: string }) {
+  const box = 'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg';
+  if (getBrandIcon(integrationKey)) {
+    return (
+      <span className={`${box} bg-muted`} aria-hidden="true">
+        <BrandIcon id={integrationKey} size={22} />
+      </span>
+    );
+  }
+  return (
+    <span className={`${box} text-sm font-semibold text-white ${accent(integrationKey)}`} aria-hidden="true">
+      {monogram(title)}
+    </span>
+  );
+}
+
 // --- SecretField subcomponent ---
 
 interface SecretFieldProps {
-  fieldName: 'clientSecret';
   label: string;
   placeholder: string;
   register: UseFormRegister<IntegrationFormData>;
@@ -62,7 +113,6 @@ interface SecretFieldProps {
 }
 
 function SecretField({
-  fieldName,
   label,
   placeholder,
   register,
@@ -76,7 +126,7 @@ function SecretField({
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between">
-        <Label htmlFor={`${sectionKey}-${fieldName}`}>{label}</Label>
+        <Label htmlFor={`${sectionKey}-clientSecret`}>{label}</Label>
         {!secretModified && (
           secretConfigured ? (
             <span className="inline-flex items-center gap-1 text-xs text-green-600">
@@ -93,11 +143,13 @@ function SecretField({
       </div>
       <div className="relative">
         <Input
-          id={`${sectionKey}-${fieldName}`}
+          id={`${sectionKey}-clientSecret`}
           type="password"
-          autoComplete="off"
+          // new-password (not "off"): Chrome ignores "off" on password inputs and
+          // fills saved credentials anyway. See the decoy pair in the form too.
+          autoComplete="new-password"
           placeholder={placeholder}
-          {...register(fieldName, {
+          {...register('clientSecret', {
             onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
               onSecretModifiedChange(e.target.value.length > 0),
           })}
@@ -118,106 +170,137 @@ function SecretField({
   );
 }
 
-// --- Integration Section (self-contained: owns its own form + state) ---
-//
-// One `useForm` lives here, per rendered section. This is what lets the page
-// scale to any number of INTEGRATIONS without N hand-written useForm calls in
-// the parent (which would violate the Rules of Hooks if generated dynamically).
+// --- Configure dialog (mounted only for the open integration) ---
 
-interface IntegrationSectionProps {
+interface IntegrationDialogProps {
   def: IntegrationDef;
   initialData: AdminConfigData;
+  onClose: () => void;
+  onSaved: (updated: AdminConfigData) => void;
   t: (key: string) => string;
 }
 
-function IntegrationSection({ def, initialData, t }: IntegrationSectionProps) {
+function IntegrationDialogContent({ def, initialData, onClose, onSaved, t }: IntegrationDialogProps) {
   const form = useForm<IntegrationFormData>({
     resolver: zodResolver(integrationSchema),
-    defaultValues: DEFAULTS,
+    defaultValues: buildFormValues(initialData, def),
   });
   const [saving, setSaving] = useState(false);
+  const [removing, setRemoving] = useState(false);
   const [secretModified, setSecretModified] = useState(false);
-  const [secretConfigured, setSecretConfigured] = useState(false);
-
-  // Re-seed the form whenever the parent (re)loads config from the backend.
-  useEffect(() => {
-    const secretValue = initialData[def.clientSecretKey];
-    setSecretConfigured(isSecretMasked(secretValue));
-    setSecretModified(false);
-    form.reset(buildFormValues(initialData, def));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- form is a stable useForm instance
-  }, [initialData, def]);
+  const secretConfigured = isSecretMasked(initialData[def.clientSecretKey]);
+  const configured = isConfigured(initialData, def);
+  const title = t(`integrations.${def.key}.cardTitle`);
 
   const onSave = async (formData: IntegrationFormData) => {
     setSaving(true);
     try {
-      const payload: Record<string, unknown> = {
-        [def.clientIdKey]: formData.clientId,
-      };
+      const payload: AdminConfigData = { [def.clientIdKey]: formData.clientId ?? '' };
+      payload[def.clientSecretKey] =
+        !secretModified || formData.clientSecret === '' ? null : formData.clientSecret;
 
-      if (!secretModified || formData.clientSecret === '') {
-        payload[def.clientSecretKey] = null;
-      } else {
-        payload[def.clientSecretKey] = formData.clientSecret;
-      }
-
-      const data = await adminConfigService.saveConfig(def.configType, payload as AdminConfigData);
-      const secretValue = data[def.clientSecretKey];
-      setSecretConfigured(isSecretMasked(secretValue));
-      setSecretModified(false);
-      form.reset(buildFormValues(data, def));
+      const data = await adminConfigService.saveConfig(def.configType, payload);
+      onSaved(data);
       toast.success(t(`integrations.${def.key}.saveSuccess`));
+      onClose();
     } catch (error) {
-      const errorInfo = extractError(error);
       toast.error(t(`integrations.${def.key}.saveError`), {
-        description: errorInfo.message,
+        description: extractError(error).message,
       });
     } finally {
       setSaving(false);
     }
   };
 
+  const onRemove = async () => {
+    setRemoving(true);
+    try {
+      await adminConfigService.clearConfig(def.configType);
+      onSaved(emptyData(def));
+      toast.success(t('integrations.removeSuccess'));
+      onClose();
+    } catch (error) {
+      toast.error(t('integrations.removeError'), { description: extractError(error).message });
+    } finally {
+      setRemoving(false);
+    }
+  };
+
   return (
-    <Card className="mb-6">
-      <CardHeader>
-        <CardTitle className="text-base">{t(`integrations.${def.key}.cardTitle`)}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <form data-testid={`${def.key}-form`} onSubmit={form.handleSubmit(onSave)} className="space-y-5">
-          <div className="space-y-2">
-            <Label htmlFor={`${def.key}-clientId`}>{t(`integrations.${def.key}.fields.clientId`)}</Label>
-            <Input
-              id={`${def.key}-clientId`}
-              placeholder={t(`integrations.${def.key}.placeholders.clientId`)}
-              {...form.register('clientId')}
-            />
+    <DialogContent>
+      <DialogHeader>
+        <div className="flex items-center gap-3">
+          <IntegrationLogo integrationKey={def.key} title={title} />
+          <div className="space-y-1 text-left">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{t('integrations.dialogSubtitle')}</DialogDescription>
           </div>
+        </div>
+      </DialogHeader>
 
-          <SecretField
-            fieldName="clientSecret"
-            label={t(`integrations.${def.key}.fields.clientSecret`)}
-            placeholder={t(`integrations.${def.key}.placeholders.clientSecret`)}
-            register={form.register}
-            secretModified={secretModified}
-            onSecretModifiedChange={setSecretModified}
-            secretConfigured={secretConfigured}
-            onClear={() => {
-              form.setValue('clientSecret', '');
-              setSecretModified(true);
-            }}
-            sectionKey={def.key}
-            t={t}
+      <form
+        data-testid={`${def.key}-form`}
+        onSubmit={form.handleSubmit(onSave)}
+        autoComplete="off"
+        className="space-y-5"
+      >
+        {/* Decoy credential pair: absorbs the browser's autofill so the real
+            Client ID / Secret fields are left untouched. Off-screen, not focusable. */}
+        <input type="text" name="_decoy_user" autoComplete="username" tabIndex={-1} aria-hidden="true" className="absolute h-0 w-0 opacity-0" />
+        <input type="password" name="_decoy_pass" autoComplete="new-password" tabIndex={-1} aria-hidden="true" className="absolute h-0 w-0 opacity-0" />
+
+        <div className="space-y-2">
+          <Label htmlFor={`${def.key}-clientId`}>{t(`integrations.${def.key}.fields.clientId`)}</Label>
+          <Input
+            id={`${def.key}-clientId`}
+            autoComplete="off"
+            placeholder={t(`integrations.${def.key}.placeholders.clientId`)}
+            {...form.register('clientId')}
           />
+        </div>
 
-          <div className="pt-2">
-            <Button type="submit" disabled={saving}>
+        <SecretField
+          label={t(`integrations.${def.key}.fields.clientSecret`)}
+          placeholder={t(`integrations.${def.key}.placeholders.clientSecret`)}
+          register={form.register}
+          secretModified={secretModified}
+          onSecretModifiedChange={setSecretModified}
+          secretConfigured={secretConfigured}
+          onClear={() => {
+            form.setValue('clientSecret', '');
+            setSecretModified(true);
+          }}
+          sectionKey={def.key}
+          t={t}
+        />
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          {configured ? (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onRemove}
+              disabled={removing || saving}
+              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              {removing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Trash2 className="mr-2 h-4 w-4" />}
+              {removing ? t('integrations.removing') : t('integrations.remove')}
+            </Button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={onClose} disabled={saving || removing}>
+              {t('integrations.cancel')}
+            </Button>
+            <Button type="submit" disabled={saving || removing}>
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {saving ? t('integrations.saving') : t('integrations.save')}
             </Button>
           </div>
-        </form>
-      </CardContent>
-    </Card>
+        </DialogFooter>
+      </form>
+    </DialogContent>
   );
 }
 
@@ -227,6 +310,7 @@ export default function IntegrationsConfig() {
   const { t } = useLanguage('adminSettings');
   const [loading, setLoading] = useState(true);
   const [configs, setConfigs] = useState<Record<string, AdminConfigData>>({});
+  const [activeKey, setActiveKey] = useState<string | null>(null);
 
   const loadConfig = useCallback(async () => {
     setLoading(true);
@@ -258,29 +342,68 @@ export default function IntegrationsConfig() {
     );
   }
 
+  const activeDef = activeKey ? INTEGRATIONS.find((d) => d.key === activeKey) ?? null : null;
+  const activeData = activeDef ? configs[activeDef.key] : undefined;
+
   return (
-    <div className="max-w-2xl">
+    <div className="max-w-5xl">
       <div className="mb-6">
         <h2 className="text-xl font-semibold text-sidebar-foreground">{t('integrations.title')}</h2>
         <p className="text-sm text-sidebar-foreground/70 mt-1">{t('integrations.description')}</p>
       </div>
 
-      {INTEGRATIONS.map((def) => {
-        const initialData = configs[def.key];
-        if (!initialData) return null;
-        return (
-          <IntegrationSection
-            key={def.key}
-            def={def}
-            initialData={initialData}
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {INTEGRATIONS.map((def) => {
+          const data = configs[def.key];
+          if (!data) return null;
+          const configured = isConfigured(data, def);
+          const title = t(`integrations.${def.key}.cardTitle`);
+          return (
+            <button
+              key={def.key}
+              type="button"
+              data-testid={`${def.key}-card`}
+              onClick={() => setActiveKey(def.key)}
+              className="group flex items-center gap-3 rounded-lg border border-sidebar-border bg-card p-4 text-left transition hover:border-primary/50 hover:shadow-sm"
+            >
+              <IntegrationLogo integrationKey={def.key} title={title} />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-sidebar-foreground">{title}</span>
+                {configured ? (
+                  <span className="mt-0.5 inline-flex items-center gap-1 text-xs text-green-600">
+                    <Check className="h-3 w-3" />
+                    {t('integrations.statusConfigured')}
+                  </span>
+                ) : (
+                  <span className="mt-0.5 inline-flex items-center gap-1 text-xs text-sidebar-foreground/50">
+                    {t('integrations.statusNotConfigured')}
+                  </span>
+                )}
+              </span>
+              <ChevronRight className="h-4 w-4 shrink-0 text-sidebar-foreground/30 transition group-hover:text-sidebar-foreground/60" />
+            </button>
+          );
+        })}
+      </div>
+
+      <Dialog open={!!activeDef} onOpenChange={(open) => { if (!open) setActiveKey(null); }}>
+        {activeDef && activeData && (
+          <IntegrationDialogContent
+            key={activeDef.key}
+            def={activeDef}
+            initialData={activeData}
+            onClose={() => setActiveKey(null)}
+            onSaved={(updated) => setConfigs((prev) => ({ ...prev, [activeDef.key]: updated }))}
             t={t}
           />
-        );
-      })}
+        )}
+      </Dialog>
 
       {/* Non-OAuth front-end service keys (reCAPTCHA, Clarity) — own section, not
           part of the OAuth catalog above. Self-loads its own config. */}
-      <FrontendServicesSection />
+      <div className="mt-8">
+        <FrontendServicesSection />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

Reworks the super-admin **Integrations** screen from a stacked column of per-integration forms into a **card directory**.

- Responsive grid of cards: brand logo + name + **Configured / Not configured** status.
- Clicking a card opens a **focused dialog** with the Client ID / Secret form, plus a **Remove** action for already-configured integrations (DELETE `/admin/app_configs/:type`).
- Logos reuse the shared `BrandIcon` (simple-icons), same source as the Agents → MCP servers screen. The three with no glyph in that set (Slack, Canva, Monday) fall back to a colored monogram tile — consistent with MCP, which also renders them without a logo.

## Autofill fix

The OAuth fields were being pre-filled by the browser with the operator's saved login/password. Addressed with three layers: the form now lives inside a dialog (no longer reads as a page login form), the secret input uses `autocomplete=new-password` (Chrome ignores `off` on password inputs), and an off-screen decoy credential pair absorbs the autofill.

## i18n

Adds 8 generic keys under `integrations` (status labels, dialog subtitle, remove/cancel, success/error toasts) across all 6 locales.

## Validation

- Production build (`vite build`) passes clean.
- Manually verified in the browser: no more autofilled credentials; cards + dialog behave as expected.
- `IntegrationsConfig.spec.tsx` was rewritten for the new card→dialog model. Note: the unit suite was **not executed in this environment** (no local `node_modules`; the front is built in Docker and installing pulls private `@evoapi` packages), so the rewritten spec is provided but unrun here — worth a CI run.