### PR TITLE
feat(chat): botão Devolver ao bot no dropdown da conversa (EVO-1680)

### DIFF
--- a/src/components/chat/conversation/ConversationActionsDropdown.spec.tsx
+++ b/src/components/chat/conversation/ConversationActionsDropdown.spec.tsx
@@ -4,6 +4,7 @@ import ConversationActionsDropdown from './ConversationActionsDropdown';
 
 const mockConversations = vi.hoisted(() => ({
   updateConversationStatus: vi.fn(),
+  returnConversationToBot: vi.fn().mockResolvedValue({}),
   updateConversationPriority: vi.fn(),
   pinConversation: vi.fn().mockResolvedValue({}),
   unpinConversation: vi.fn().mockResolvedValue({}),
@@ -90,6 +91,65 @@ describe('ConversationActionsDropdown', () => {
     fireEvent.click(screen.getByText('conversationActionsDropdown.markAsUnread'));
 
     expect(onMarkAsUnread).toHaveBeenCalledWith(expect.objectContaining({ id: 'conversation-1' }));
+  });
+
+  // EVO-1680 — reverse human→bot handoff item replaces "Mark as Pending" when
+  // the inbox has an active AgentBot and the conversation is open.
+  describe('Devolver ao bot (EVO-1680)', () => {
+    const openWithBot = {
+      ...baseConversation,
+      status: 'open',
+      inbox: { agent_bot_active: true },
+    } as any;
+    const openWithoutBot = {
+      ...baseConversation,
+      status: 'open',
+      inbox: { agent_bot_active: false },
+    } as any;
+    const resolvedWithBot = {
+      ...baseConversation,
+      status: 'resolved',
+      inbox: { agent_bot_active: true },
+    } as any;
+
+    it('renders "Return to bot" when status=open and inbox has active agent bot', () => {
+      render(<ConversationActionsDropdown conversation={openWithBot} />);
+      expect(screen.getByText('conversationActionsDropdown.returnToBot')).toBeTruthy();
+    });
+
+    it('hides "Return to bot" when status is not open', () => {
+      render(<ConversationActionsDropdown conversation={resolvedWithBot} />);
+      expect(screen.queryByText('conversationActionsDropdown.returnToBot')).toBeNull();
+    });
+
+    it('hides "Return to bot" when inbox has no active agent bot', () => {
+      render(<ConversationActionsDropdown conversation={openWithoutBot} />);
+      expect(screen.queryByText('conversationActionsDropdown.returnToBot')).toBeNull();
+    });
+
+    it('hides legacy "Mark as Pending" when bot is active and status=open (collision fix)', () => {
+      render(<ConversationActionsDropdown conversation={openWithBot} />);
+      expect(screen.queryByText('conversationActionsDropdown.markAsPending')).toBeNull();
+    });
+
+    it('preserves legacy "Mark as Pending" when bot is NOT active and status=open', () => {
+      render(<ConversationActionsDropdown conversation={openWithoutBot} />);
+      expect(screen.getByText('conversationActionsDropdown.markAsPending')).toBeTruthy();
+    });
+
+    it('invokes returnConversationToBot exactly once when clicked', async () => {
+      render(<ConversationActionsDropdown conversation={openWithBot} />);
+
+      fireEvent.click(screen.getByText('conversationActionsDropdown.returnToBot'));
+
+      await waitFor(() => {
+        expect(mockConversations.returnConversationToBot).toHaveBeenCalledTimes(1);
+        expect(mockConversations.returnConversationToBot).toHaveBeenCalledWith(
+          'conversation-1',
+          undefined,
+        );
+      });
+    });
   });
 
   it('pins conversation when not pinned', async () => {

--- a/src/components/chat/conversation/ConversationActionsDropdown.tsx
+++ b/src/components/chat/conversation/ConversationActionsDropdown.tsx
@@ -32,6 +32,7 @@ import {
   GitBranch,
   Check,
   X,
+  Bot,
 } from 'lucide-react';
 import { Conversation } from '@/types/chat/api';
 import type { Pipeline, PipelineStage } from '@/types/analytics';
@@ -101,6 +102,21 @@ const ConversationActionsDropdown: React.FC<ConversationActionsDropdownProps> = 
     }
   };
 
+  // EVO-1680 — reverse human→bot handoff. Hits a dedicated endpoint that, on
+  // top of the pending transition, clears assignee_id and persists a timeline
+  // activity so the BotProcessorService picks it up on the next incoming msg.
+  const handleReturnToBot = async () => {
+    setIsUpdatingStatus(true);
+    try {
+      await conversations.returnConversationToBot(conversation.id, onFilterReload);
+      setOpen(false);
+    } catch (error) {
+      console.error('❌ Error returning conversation to bot:', error);
+    } finally {
+      setIsUpdatingStatus(false);
+    }
+  };
+
   const handlePriorityChange = async (newPriority: 'low' | 'medium' | 'high' | 'urgent' | null) => {
     setIsUpdatingPriority(true);
     try {
@@ -151,6 +167,12 @@ const ConversationActionsDropdown: React.FC<ConversationActionsDropdownProps> = 
   const currentStatus = conversation.status;
   const currentPriority = conversation.priority;
   const hasUnreadMessages = (conversation.unread_count ?? 0) > 0;
+  // EVO-1680 — gate for the "Devolver ao bot" item. The backend serializer
+  // exposes inbox.agent_bot_active reflecting Inbox#active_bot?. When true and
+  // the conversation is open, we replace the legacy "Mark as Pending" with the
+  // dedicated reverse handoff action; otherwise the legacy item is preserved.
+  const agentBotActive = Boolean(conversation.inbox?.agent_bot_active);
+  const canReturnToBot = currentStatus === 'open' && agentBotActive;
 
   const getPriorityColor = (priority: string) => {
     const colors = {
@@ -241,7 +263,7 @@ const ConversationActionsDropdown: React.FC<ConversationActionsDropdownProps> = 
           </DropdownMenuItem>
         )}
 
-        {currentStatus !== 'pending' && (
+        {currentStatus !== 'pending' && !canReturnToBot && (
           <DropdownMenuItem
             onClick={() => handleStatusChange('pending')}
             disabled={isUpdatingStatus}
@@ -249,6 +271,17 @@ const ConversationActionsDropdown: React.FC<ConversationActionsDropdownProps> = 
           >
             <Clock className="h-4 w-4" />
             {t('conversationActionsDropdown.markAsPending')}
+          </DropdownMenuItem>
+        )}
+
+        {canReturnToBot && (
+          <DropdownMenuItem
+            onClick={handleReturnToBot}
+            disabled={isUpdatingStatus}
+            className="flex items-center gap-2"
+          >
+            <Bot className="h-4 w-4" />
+            {t('conversationActionsDropdown.returnToBot')}
           </DropdownMenuItem>
         )}
 

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -348,6 +348,43 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
     [t],
   );
 
+  // EVO-1680 — mirror of updateConversationStatus but targets the dedicated
+  // return_to_bot endpoint which clears the assignee and persists a
+  // human_to_bot activity in addition to the pending transition.
+  const returnConversationToBot = useCallback(
+    async (conversationId: string, onFilterReload?: () => Promise<void>) => {
+      try {
+        const response = await chatService.returnConversationToBot(conversationId);
+
+        if (response && response.data && response.data.id) {
+          dispatch({ type: 'UPDATE_CONVERSATION', payload: response.data });
+        } else {
+          console.warn('returnConversationToBot: Invalid response', response);
+        }
+
+        useUnreadConversationsStore.getState().fetch();
+
+        toast.success(t('contexts.conversations.success.returnedToBot'));
+
+        if (onFilterReload) {
+          await onFilterReload();
+        }
+
+        return response as unknown as Conversation;
+      } catch (error) {
+        console.error('Error returning conversation to bot:', error);
+        toast.error(t('contexts.conversations.errors.returnToBot'), {
+          description:
+            error instanceof Error
+              ? error.message
+              : t('contexts.conversations.tryAgainDescription'),
+        });
+        throw error;
+      }
+    },
+    [t],
+  );
+
   const updateConversationPriority = useCallback(
     async (
       conversationId: string,
@@ -907,6 +944,7 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
     loadSpecificConversation,
     selectConversation,
     updateConversationStatus,
+    returnConversationToBot,
     updateConversationPriority,
     pinConversation,
     unpinConversation,

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -572,6 +572,7 @@
         "loadConversation": "Error loading conversation",
         "conversationNotFound": "Conversation not found",
         "updateStatus": "Error updating conversation status",
+        "returnToBot": "Error returning conversation to bot",
         "updatePriority": "Error updating conversation priority",
         "deleteConversation": "Error deleting conversation",
         "markAsRead": "Error marking as read",
@@ -590,6 +591,7 @@
       },
       "success": {
         "statusChanged": "Status changed to: {{status}}",
+        "returnedToBot": "Conversation returned to bot",
         "priorityChanged": "Priority changed to: {{priority}}",
         "deleted": "Conversation deleted successfully",
         "markedAsRead": "Conversation marked as read",
@@ -832,6 +834,7 @@
     "markAsOpen": "Mark as open",
     "markAsResolved": "Mark as resolved",
     "markAsPending": "Mark as pending",
+    "returnToBot": "Return to bot",
     "pauseConversation": "Pause conversation",
     "priority": "Priority",
     "priorityLabels": {

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -550,6 +550,7 @@
         "loadConversation": "Error al cargar conversación",
         "conversationNotFound": "Conversación no encontrada",
         "updateStatus": "Error al actualizar estado de la conversación",
+        "returnToBot": "Error al devolver la conversación al bot",
         "updatePriority": "Error al actualizar prioridad de la conversación",
         "deleteConversation": "Error al eliminar conversación",
         "markAsRead": "Error al marcar como leída",
@@ -562,6 +563,7 @@
       },
       "success": {
         "statusChanged": "Estado cambiado a: {{status}}",
+        "returnedToBot": "Conversación devuelta al bot",
         "priorityChanged": "Prioridad cambiada a: {{priority}}",
         "deleted": "Conversación eliminada con éxito",
         "markedAsRead": "Conversación marcada como leída",
@@ -793,6 +795,7 @@
     "markAsOpen": "Marcar como abierta",
     "markAsResolved": "Marcar como resuelta",
     "markAsPending": "Marcar como pendiente",
+    "returnToBot": "Devolver al bot",
     "pauseConversation": "Pausar conversación",
     "priority": "Prioridad",
     "priorityLabels": {

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -550,6 +550,7 @@
         "loadConversation": "Erreur lors du chargement de la conversation",
         "conversationNotFound": "Conversation introuvable",
         "updateStatus": "Erreur lors de la mise à jour du statut de la conversation",
+        "returnToBot": "Erreur lors du renvoi de la conversation au bot",
         "updatePriority": "Erreur lors de la mise à jour de la priorité de la conversation",
         "deleteConversation": "Erreur lors de la suppression de la conversation",
         "markAsRead": "Erreur lors du marquage comme lue",
@@ -562,6 +563,7 @@
       },
       "success": {
         "statusChanged": "Statut changé en: {{status}}",
+        "returnedToBot": "Conversation renvoyée au bot",
         "priorityChanged": "Priorité changée en: {{priority}}",
         "deleted": "Conversation supprimée avec succès",
         "markedAsRead": "Conversation marquée comme lue",
@@ -793,6 +795,7 @@
     "markAsOpen": "Marquer comme ouverte",
     "markAsResolved": "Marquer comme résolue",
     "markAsPending": "Marquer comme en attente",
+    "returnToBot": "Renvoyer au bot",
     "pauseConversation": "Mettre en pause la conversation",
     "priority": "Priorité",
     "priorityLabels": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -550,6 +550,7 @@
         "loadConversation": "Errore nel caricamento della conversazione",
         "conversationNotFound": "Conversazione non trovata",
         "updateStatus": "Errore nell'aggiornamento dello stato della conversazione",
+        "returnToBot": "Errore nella restituzione della conversazione al bot",
         "updatePriority": "Errore nell'aggiornamento della priorità della conversazione",
         "deleteConversation": "Errore nell'eliminazione della conversazione",
         "markAsRead": "Errore nel marcare come letta",
@@ -562,6 +563,7 @@
       },
       "success": {
         "statusChanged": "Stato cambiato in: {{status}}",
+        "returnedToBot": "Conversazione restituita al bot",
         "priorityChanged": "Priorità cambiata in: {{priority}}",
         "deleted": "Conversazione eliminata con successo",
         "markedAsRead": "Conversazione marcata come letta",
@@ -793,6 +795,7 @@
     "markAsOpen": "Segna come aperta",
     "markAsResolved": "Segna come risolta",
     "markAsPending": "Segna come in sospeso",
+    "returnToBot": "Restituire al bot",
     "pauseConversation": "Metti in pausa la conversazione",
     "priority": "Priorità",
     "priorityLabels": {

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -572,6 +572,7 @@
         "loadConversation": "Erro ao carregar conversa",
         "conversationNotFound": "Conversa não encontrada",
         "updateStatus": "Erro ao atualizar status da conversa",
+        "returnToBot": "Erro ao devolver conversa ao bot",
         "updatePriority": "Erro ao atualizar prioridade da conversa",
         "deleteConversation": "Erro ao deletar conversa",
         "markAsRead": "Erro ao marcar como lida",
@@ -590,6 +591,7 @@
       },
       "success": {
         "statusChanged": "Status alterado para: {{status}}",
+        "returnedToBot": "Conversa devolvida ao bot",
         "priorityChanged": "Prioridade alterada para: {{priority}}",
         "deleted": "Conversa deletada com sucesso",
         "markedAsRead": "Conversa marcada como lida",
@@ -835,6 +837,7 @@
     "markAsOpen": "Marcar como aberta",
     "markAsResolved": "Marcar como resolvida",
     "markAsPending": "Marcar como pendente",
+    "returnToBot": "Devolver ao bot",
     "pauseConversation": "Pausar conversa",
     "priority": "Prioridade",
     "priorityLabels": {

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -550,6 +550,7 @@
         "loadConversation": "Erro ao carregar conversa",
         "conversationNotFound": "Conversa não encontrada",
         "updateStatus": "Erro ao atualizar status da conversa",
+        "returnToBot": "Erro ao devolver conversa ao bot",
         "updatePriority": "Erro ao atualizar prioridade da conversa",
         "deleteConversation": "Erro ao deletar conversa",
         "markAsRead": "Erro ao marcar como lida",
@@ -562,6 +563,7 @@
       },
       "success": {
         "statusChanged": "Status alterado para: {{status}}",
+        "returnedToBot": "Conversa devolvida ao bot",
         "priorityChanged": "Prioridade alterada para: {{priority}}",
         "deleted": "Conversa deletada com sucesso",
         "markedAsRead": "Conversa marcada como lida",
@@ -796,6 +798,7 @@
     "markAsOpen": "Marcar como aberta",
     "markAsResolved": "Marcar como resolvida",
     "markAsPending": "Marcar como pendente",
+    "returnToBot": "Devolver ao bot",
     "pauseConversation": "Pausar conversa",
     "priority": "Prioridade",
     "priorityLabels": {

--- a/src/services/chat/chatService.ts
+++ b/src/services/chat/chatService.ts
@@ -114,6 +114,15 @@ class ChatService {
     return response.data;
   }
 
+  // EVO-1680 — reverse human→bot handoff. Backend moves the conversation to
+  // pending, clears the assignee, persists a timeline activity, and dispatches
+  // CONVERSATION_HUMAN_HANDOFF so the BotProcessorService picks it up on the
+  // next incoming message.
+  async returnConversationToBot(conversationId: string): Promise<ConversationResponse> {
+    const response = await api.post(`/conversations/${conversationId}/return_to_bot`);
+    return response.data;
+  }
+
   async updateConversationPriority(
     conversationId: string,
     priority: 'low' | 'medium' | 'high' | 'urgent' | null,

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -56,6 +56,9 @@ export interface Inbox {
   lock_to_single_conversation?: boolean;
   // Auth/status
   reauthorization_required?: boolean;
+  // EVO-1680 — true when an AgentBot is connected and its AgentBotInbox.status
+  // is :active. Gates the "Devolver ao bot" UI control in ConversationActionsDropdown.
+  agent_bot_active?: boolean;
   // Live channel health (EVO-1674)
   connection_state?: InboxConnectionState;
   health_source?: InboxHealthSource;

--- a/src/types/chat/conversations.ts
+++ b/src/types/chat/conversations.ts
@@ -67,6 +67,10 @@ export interface ConversationsContextValue {
     status: 'open' | 'resolved' | 'pending' | 'snoozed',
     onFilterReload?: () => Promise<void>,
   ) => Promise<Conversation>;
+  returnConversationToBot: (
+    conversationId: string,
+    onFilterReload?: () => Promise<void>,
+  ) => Promise<Conversation>;
   updateConversationPriority: (
     conversationId: string,
     priority: 'low' | 'medium' | 'high' | 'urgent' | null,


### PR DESCRIPTION
## Summary
- Novo `DropdownMenuItem` "Devolver ao bot" em `ConversationActionsDropdown`, visível só quando `inbox.agent_bot_active && status === 'open'`
- Hide do "Mark as pending" legado quando o novo botão está disponível (evita ambiguidade — pending sem clear/sem activity é versão pior do return_to_bot)
- `chatService.returnConversationToBot` + `ConversationsContext.returnConversationToBot` wireados; tipo `Inbox.agent_bot_active` adicionado
- i18n nos 6 locales (en/es/fr/it/pt/pt-BR): label do botão + toast success + toast error

Companion do backend evo-ai-crm-community#183 — depende daquele PR pra payload `inbox.agent_bot_active` chegar do serializer e o endpoint POST `/return_to_bot` existir.

## Test plan
- [x] `vitest run ConversationActionsDropdown.spec.tsx` — 10/10 verde (4 existentes + 6 novos: visibilidade por status/bot, colisão Mark-as-Pending hide/preserve, click callback)
- [x] `tsc --noEmit` limpo nos arquivos novos
- [ ] CI: rodar suite completa de vitest
- [ ] Smoke manual no browser (depende do backend mergeado em develop): conversa em inbox com bot ativo → header dropdown mostra "Devolver ao bot" → click → toast success → conversa some da lista de "open" e aparece em "pending"

🤖 Generated with [Claude Code](https://claude.com/claude-code)