### PR TITLE
fix(frontend): gate Atendentes on users.manage + clear permission cache on logout (EVO-1938)

### DIFF
--- a/src/components/layout/config/menuItems.spec.ts
+++ b/src/components/layout/config/menuItems.spec.ts
@@ -62,3 +62,48 @@ describe('menuItems — Settings > Atendentes gating (AC4)', () => {
     expect(visible).toBe(true);
   });
 });
+
+// EVO-1938: the default agent no longer holds the administrative Settings reads
+// (dropped from the auth seed), so the existing `.read` gate hides those items —
+// no menu change needed. These lock in that behavior.
+describe('menuItems — EVO-1938 admin Settings gating for the default agent', () => {
+  // Representative post-fix agent set: operational reads (incl. teams.read for the
+  // in-chat assign-team picker), none of the admin Settings resources.
+  const agentGranted = [
+    'conversations.read',
+    'contacts.read',
+    'pipelines.read',
+    'inboxes.read',
+    'users.read',
+    'labels.read',
+    'canned_responses.read',
+    'macros.read',
+    'message_templates.read',
+    'teams.read',
+  ];
+
+  const isVisible = (item: SubMenuItem, granted: string[]) =>
+    shouldShowMenuItem(item, canFrom(granted), canAnyFrom(granted), canAllFrom(granted));
+
+  it.each(['/settings/integrations', '/settings/segments'])(
+    'hides the admin Settings item %s from the default agent',
+    href => {
+      expect(isVisible(findSubItem(href), agentGranted)).toBe(false);
+    },
+  );
+
+  // teams stays visible (teams.read kept for the chat picker); the Teams Settings
+  // use-vs-manage split is deferred to EVO-1955, like labels/canned/macros.
+  it.each(['/settings/labels', '/settings/canned-responses', '/settings/teams'])(
+    'keeps the operational Settings item %s visible to the agent',
+    href => {
+      expect(isVisible(findSubItem(href), agentGranted)).toBe(true);
+    },
+  );
+
+  it('shows the admin Settings items to an administrator that holds the reads', () => {
+    const adminGranted = [...agentGranted, 'integrations.read', 'segments.read'];
+    expect(isVisible(findSubItem('/settings/integrations'), adminGranted)).toBe(true);
+    expect(isVisible(findSubItem('/settings/segments'), adminGranted)).toBe(true);
+  });
+});

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -191,9 +191,12 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         href: '/settings/users',
         icon: Users2,
         resource: 'users',
-        // read, not manage: there is no `users.manage` permission (users has only
-        // granular actions); the manage gate hid the menu for everyone. Like Teams.
-        action: 'read',
+        // EVO-1938: gate the Users (Atendentes) screen on the administrative
+        // users.manage. The earlier revert to users.read predated users.manage
+        // being registered in the auth ResourceActionsConfig; it now is, so the
+        // manage gate resolves for admins (who hold it) and hides the screen from
+        // the default agent (who holds only the operational users.read).
+        action: 'manage',
       },
       {
         name: t('menu.settings.teams'),

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import { useAppDataStore } from '@/store/appDataStore';
 import { getReconnectService } from '@/services/core';
 import { verifyMfa, logout as authServiceLogout } from '@/services/auth/authService';
 import { profileService } from '@/services/profile/profileService';
+import { permissionsService } from '@/services/permissions';
 import { markBootstrapPhaseEnd, markBootstrapPhaseStart } from '@/utils/requestMonitor';
 
 interface MfaState {
@@ -121,6 +122,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     clearUser();
     useAppDataStore.getState().clearAppData();
+    // EVO-1938: drop the cached permission set on logout. Without this the
+    // permissionsService keeps the previous user's permissions for its 30-min TTL,
+    // so the next user to log in on the same browser sees a menu built from the
+    // prior (possibly admin) permissions until the cache expires.
+    permissionsService.clearCache();
     setMfaState(null);
   };
 

--- a/src/routes/PermissionRoute.spec.tsx
+++ b/src/routes/PermissionRoute.spec.tsx
@@ -26,17 +26,18 @@ function permissions(granted: string[]) {
   };
 }
 
-// /settings/users gates on users.read (no users.manage permission exists).
-describe('PermissionRoute — /settings/users gated on users.read', () => {
+// EVO-1938: /settings/users gates on the administrative users.manage (not the
+// operational users.read the default agent holds for the Conversations screen).
+describe('PermissionRoute — /settings/users gated on users.manage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('redirects a profile without users.read (e.g. Conversas-only) away from /settings/users', async () => {
-    mockUsePermissions.mockReturnValue(permissions(['conversations.read']));
+  it('redirects the default agent (holds users.read but not users.manage) away from /settings/users', async () => {
+    mockUsePermissions.mockReturnValue(permissions(['users.read', 'conversations.read']));
 
     render(
-      <PermissionRoute resource="users" action="read">
+      <PermissionRoute resource="users" action="manage">
         <div data-testid="users-panel">Users Panel</div>
       </PermissionRoute>,
     );
@@ -47,11 +48,11 @@ describe('PermissionRoute — /settings/users gated on users.read', () => {
     expect(screen.queryByTestId('users-panel')).toBeNull();
   });
 
-  it('renders the panel for a profile that has users.read (admin roles)', () => {
-    mockUsePermissions.mockReturnValue(permissions(['users.read']));
+  it('renders the panel for an administrator that holds users.manage', () => {
+    mockUsePermissions.mockReturnValue(permissions(['users.read', 'users.manage']));
 
     render(
-      <PermissionRoute resource="users" action="read">
+      <PermissionRoute resource="users" action="manage">
         <div data-testid="users-panel">Users Panel</div>
       </PermissionRoute>,
     );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -677,8 +677,8 @@ const AppRouter = () => {
               <PrivateRoute>
                 <CustomerRoute>
                   <MainLayout>
-                    {/* read, not the non-existent `users.manage` (see menuItems.ts) */}
-                    <PermissionRoute resource="users" action="read">
+                    {/* EVO-1938: users.manage (admin) — agents hold users.read but not manage */}
+                    <PermissionRoute resource="users" action="manage">
                       <Users />
                     </PermissionRoute>
                   </MainLayout>


### PR DESCRIPTION
## Summary

EVO-1938 — the default `agent` (support attendant) role could see and in many cases manage admin-only Settings screens. This closes the **user-facing** leak end-to-end (menu + route + the segments backend) and fixes the permission-cache-on-logout that made it look unfixed when switching users.

The fix spans three repos (cross-linked below). The core change is the **auth seed/migration** (the agent role no longer holds the admin resources); the frontend/CRM gates already read those permissions, so they hide/403 automatically.

## What changed (per repo)
- **auth:** `db/seeds/rbac.rb` trims the agent role to operational resources only; idempotent data-migration strips the admin keys from the existing system `agent` role; RSpec for both.
- **frontend:** Atendentes (`/settings/users`) re-gated on `users.manage`; `permissionsService.clearCache()` on logout (was leaking the prior user's permissions for 30 min); vitest for menu + route gating.
- **crm:** `Api::V1::EvoFlow::SegmentsController` given `require_permissions` (it proxied to evo-flow with no gate); controller spec for the 403.

## Kept by design (deferred to EVO-1955)
`labels`, `canned_responses`, `macros`, `message_templates`, `teams`/`team_members` stay with the agent — their `.read` powers in-chat features (quick-replies, labels, macros, the "Assign team" picker). Their Settings use-vs-manage split is EVO-1955.

## Validation
- auth: `RAILS_ENV=test bundle exec rspec spec/db/seeds/rbac_spec.rb spec/db/migrate/revoke_admin_settings_permissions_from_agent_role_spec.rb` → 41 examples, 0 failures
- crm: `RAILS_ENV=test bundle exec rspec spec/controllers/api/v1/evo_flow/segments_controller_spec.rb` → 23 examples, 0 failures
- frontend: `pnpm exec vitest run` (menuItems + PermissionRoute) → 11 passed · `pnpm exec tsc -b --noEmit` → 0
- Manual smoke (with PM): default agent — admin Settings screens gone from menu + "Access Denied" on direct URL + 403 from API; Conversations works incl. "Assign team"; admin sees everything.

## QA / audit
A multi-agent adversarial review caught + fixed two issues before ship (teams broke the in-chat picker → kept; segments had no backend gate → added). A follow-up exhaustive RBAC audit found other **pre-existing** backend-only enforcement gaps (integration/oauth/AI endpoints missing permission gates) — tracked in **EVO-1956** (frontend is clean; those are direct-API only).

## Related PRs / Issues
- EVO-1938 (this) · EVO-1955 (use-vs-manage split) · EVO-1956 (backend enforcement audit gaps)
- Cross-repo: auth + frontend + crm PRs on `fix/EVO-1938`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzVxXUXPKJQy4m5WuJEjgz

## Summary by Sourcery

Tighten frontend access control for admin-only Settings screens and ensure permissions are correctly reset on logout for EVO-1938.

New Features:
- Add explicit tests verifying admin Settings menu visibility for default agent versus administrator profiles.

Bug Fixes:
- Restrict the Atendentes (/settings/users) screen to users.manage instead of users.read so default agents can no longer access admin-only user management.
- Clear the cached permission set on logout to prevent newly logged-in users from inheriting the previous user’s permissions until cache expiry.

Tests:
- Extend PermissionRoute and menuItems test coverage to validate the new users.manage gate and agent/admin-specific Settings visibility.