### PR TITLE
fix(message-templates): reintroduz example/source e corrige i18n/paridade do template global (EVO-1971)

### DIFF
--- a/src/components/channels/index.ts
+++ b/src/components/channels/index.ts
@@ -31,3 +31,4 @@ export { default as AgentBotConfigurationForm } from './settings/AgentBotConfigu
 export { default as ModerationDashboard } from './settings/ModerationDashboard';
 export { default as ConfigurationForm } from './settings/ConfigurationForm';
 export { default as TemplateFormModal } from './settings/TemplateFormModal';
+export { TemplatePreview } from './settings/TemplatePreview';

--- a/src/components/channels/settings/TemplateFormModal.spec.tsx
+++ b/src/components/channels/settings/TemplateFormModal.spec.tsx
@@ -159,7 +159,7 @@ describe('TemplateFormModal', () => {
     expect(screen.queryByText('{{ab}}')).not.toBeInTheDocument();
   });
 
-  it('lists detected variables read-only (no label/example/source inputs) and keeps the name in the payload', () => {
+  it('shows editable label/example/source inputs per detected variable and persists them (EVO-1971)', () => {
     const onSave = vi.fn();
     render(
       <TemplateFormModal
@@ -178,21 +178,24 @@ describe('TemplateFormModal', () => {
       screen.getByPlaceholderText('settings.messageTemplates.form.bodyTextPlaceholder'),
       { target: { value: 'Oi {{nome}}' } },
     );
-    // The detected variable is shown read-only as a token, with no metadata inputs.
+    // The detected variable is shown as a read-only name token + editable metadata
+    // inputs. The backend preserves these on save (EVO-1971), so they must flow
+    // into the payload.
     expect(screen.getByText('{{nome}}')).toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText('settings.messageTemplates.form.variableLabel'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText('settings.messageTemplates.form.variableExample'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByPlaceholderText('settings.messageTemplates.form.variableSource'),
-    ).not.toBeInTheDocument();
+    fireEvent.change(
+      screen.getByPlaceholderText('settings.messageTemplates.form.variableExample'),
+      { target: { value: 'Maria' } },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText('settings.messageTemplates.form.variableSource'),
+      { target: { value: 'contact.name' } },
+    );
     fireEvent.click(screen.getByText('settings.messageTemplates.form.create'));
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: expect.arrayContaining([expect.objectContaining({ name: 'nome' })]),
+        variables: expect.arrayContaining([
+          expect.objectContaining({ name: 'nome', example: 'Maria', source: 'contact.name' }),
+        ]),
       }),
     );
   });

--- a/src/components/channels/settings/TemplateFormModal.tsx
+++ b/src/components/channels/settings/TemplateFormModal.tsx
@@ -114,6 +114,7 @@ const MessageTextarea: React.FC<{
             isOpen={emojiOpen}
             onClose={() => setEmojiOpen(false)}
             onEmojiSelect={emoji => insertAtCursor(emoji)}
+            placement="bottom"
           />
         </div>
         <Popover>
@@ -328,6 +329,24 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
       ...prev,
       buttons:
         prev.buttons?.map((btn, i) => (i === index ? { ...btn, [field]: value } : btn)) || [],
+    }));
+  };
+
+  // Edit the metadata of a detected variable (the name itself is derived from the
+  // {{token}} in the text and stays read-only). These fields are persisted by the
+  // backend and drive the consumption surfaces (EVO-1971): `example` prefills the
+  // composer / Start-Conversation value, `source` auto-maps automation
+  // `send_template` to `{{contact.x}}`, `label` is the human-readable caption.
+  const updateVariable = (
+    name: string,
+    field: 'label' | 'example' | 'source',
+    value: string,
+  ) => {
+    setFormData(prev => ({
+      ...prev,
+      variables: prev.variables?.map(variable =>
+        variable.name === name ? { ...variable, [field]: value } : variable,
+      ),
     }));
   };
 
@@ -680,13 +699,33 @@ const TemplateFormModal: React.FC<TemplateFormModalProps> = ({
                 <label className="block text-sm font-medium">
                   {t('settings.messageTemplates.form.variables')}
                 </label>
-                {/* Read-only list of the variables detected in the text. We dropped the
-                    label/example/source inputs: the backend re-derives variables from
-                    the content on save (only the name persists), so editing metadata
-                    here had no effect (EVO-1907). */}
-                <div className="flex flex-wrap gap-2">
+                {/* Each variable is detected from a {{token}} in the text (name is
+                    read-only) and carries optional metadata that the backend
+                    PRESERVES on save and feeds back on edit (EVO-1971): `label`
+                    (caption), `example` (composer / Start-Conversation prefill) and
+                    `source` (auto-maps automation send_template to {{contact.x}}). */}
+                <div className="space-y-3">
                   {formData.variables?.map(variable => (
-                    <Badge key={variable.name} variant="secondary">{`{{${variable.name}}}`}</Badge>
+                    <Card key={variable.name} className="p-3 space-y-2">
+                      <Badge variant="secondary">{`{{${variable.name}}}`}</Badge>
+                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                        <Input
+                          value={variable.label ?? ''}
+                          onChange={e => updateVariable(variable.name, 'label', e.target.value)}
+                          placeholder={t('settings.messageTemplates.form.variableLabel')}
+                        />
+                        <Input
+                          value={variable.example ?? ''}
+                          onChange={e => updateVariable(variable.name, 'example', e.target.value)}
+                          placeholder={t('settings.messageTemplates.form.variableExample')}
+                        />
+                        <Input
+                          value={variable.source ?? ''}
+                          onChange={e => updateVariable(variable.name, 'source', e.target.value)}
+                          placeholder={t('settings.messageTemplates.form.variableSource')}
+                        />
+                      </div>
+                    </Card>
                   ))}
                 </div>
               </div>

--- a/src/components/channels/settings/TemplateFormModal.tsx
+++ b/src/components/channels/settings/TemplateFormModal.tsx
@@ -22,12 +22,13 @@ import {
   PopoverTrigger,
 } from '@evoapi/design-system';
 import { Plus, Trash2, Smile, Braces } from 'lucide-react';
+import EmojiPickerReact, { Theme } from 'emoji-picker-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { useIsDarkClass } from '@/hooks/chat/useIsDarkClass';
 import MessageTemplateService, {
   usesStructuredComponents,
   getChannelTemplateConfig,
 } from '@/services/channels/messageTemplatesService';
-import EmojiPicker from '@/components/chat/message-input/EmojiPicker';
 import { TemplatePreview } from './TemplatePreview';
 import { MessageTemplate, TemplateFormData } from '@/types';
 import { detectTemplateFormVariables } from '@/utils/templateVariables';
@@ -57,7 +58,7 @@ const MessageTextarea: React.FC<{
   variableSampleName,
 }) => {
   const ref = useRef<HTMLTextAreaElement>(null);
-  const [emojiOpen, setEmojiOpen] = useState(false);
+  const isDark = useIsDarkClass();
 
   // Insert `snippet` at the caret. If `selFrom`/`selTo` are given, select that
   // sub-range of the inserted text (used to preselect a variable name so the user
@@ -98,25 +99,32 @@ const MessageTextarea: React.FC<{
         className="pr-20"
       />
       <div className="absolute top-2 right-2 flex items-center gap-1">
-        <div className="relative">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 w-7 p-0"
-            aria-label={emojiLabel}
-            title={emojiLabel}
-            onClick={() => setEmojiOpen(open => !open)}
-          >
-            <Smile className="h-4 w-4" />
-          </Button>
-          <EmojiPicker
-            isOpen={emojiOpen}
-            onClose={() => setEmojiOpen(false)}
-            onEmojiSelect={emoji => insertAtCursor(emoji)}
-            placement="bottom"
-          />
-        </div>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              aria-label={emojiLabel}
+              title={emojiLabel}
+            >
+              <Smile className="h-4 w-4" />
+            </Button>
+          </PopoverTrigger>
+          {/* Radix Popover portals + auto-flips, so the panel stays anchored to the
+              button and inside the dialog instead of overflowing off-screen. */}
+          <PopoverContent align="end" className="w-auto p-0 border-none">
+            <EmojiPickerReact
+              onEmojiClick={emojiData => insertAtCursor(emojiData.emoji)}
+              theme={isDark ? Theme.DARK : Theme.LIGHT}
+              width={320}
+              height={380}
+              previewConfig={{ showPreview: false }}
+              lazyLoadEmojis
+            />
+          </PopoverContent>
+        </Popover>
         <Popover>
           <PopoverTrigger asChild>
             <Button

--- a/src/components/channels/settings/index.ts
+++ b/src/components/channels/settings/index.ts
@@ -11,4 +11,5 @@ export { default as PreChatForm } from './PreChatForm';
 export { default as WidgetBuilderForm } from './WidgetBuilderForm';
 export { default as AgentBotConfigurationForm } from './AgentBotConfigurationForm';
 export { default as TemplateFormModal } from './TemplateFormModal';
+export { TemplatePreview } from './TemplatePreview';
 export { default as ConfigurationForm } from './ConfigurationForm';

--- a/src/components/chat/message-input/EmojiPicker.tsx
+++ b/src/components/chat/message-input/EmojiPicker.tsx
@@ -7,21 +7,9 @@ interface EmojiPickerProps {
   onEmojiSelect: (emoji: string) => void;
   onClose: () => void;
   isOpen: boolean;
-  /**
-   * Where the panel opens relative to its trigger. Defaults to `top` (the chat
-   * composer, which sits at the bottom of the screen). Use `bottom` when the
-   * trigger is near the top of a scroll container (e.g. the template form modal)
-   * so the 400px panel does not get clipped above (EVO-1971).
-   */
-  placement?: 'top' | 'bottom';
 }
 
-const EmojiPicker: React.FC<EmojiPickerProps> = ({
-  onEmojiSelect,
-  onClose,
-  isOpen,
-  placement = 'top',
-}) => {
+const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect, onClose, isOpen }) => {
   const { t } = useLanguage('chat');
   const pickerRef = useRef<HTMLDivElement>(null);
 
@@ -84,9 +72,7 @@ const EmojiPicker: React.FC<EmojiPickerProps> = ({
   return (
     <div
       ref={pickerRef}
-      className={`absolute left-0 z-[9999] ${
-        placement === 'bottom' ? 'top-full mt-2' : 'bottom-full mb-2'
-      }`}
+      className="absolute bottom-full left-0 mb-2 z-[9999]"
       style={{
         minWidth: '350px',
         maxWidth: '350px',

--- a/src/components/chat/message-input/EmojiPicker.tsx
+++ b/src/components/chat/message-input/EmojiPicker.tsx
@@ -7,9 +7,21 @@ interface EmojiPickerProps {
   onEmojiSelect: (emoji: string) => void;
   onClose: () => void;
   isOpen: boolean;
+  /**
+   * Where the panel opens relative to its trigger. Defaults to `top` (the chat
+   * composer, which sits at the bottom of the screen). Use `bottom` when the
+   * trigger is near the top of a scroll container (e.g. the template form modal)
+   * so the 400px panel does not get clipped above (EVO-1971).
+   */
+  placement?: 'top' | 'bottom';
 }
 
-const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect, onClose, isOpen }) => {
+const EmojiPicker: React.FC<EmojiPickerProps> = ({
+  onEmojiSelect,
+  onClose,
+  isOpen,
+  placement = 'top',
+}) => {
   const { t } = useLanguage('chat');
   const pickerRef = useRef<HTMLDivElement>(null);
 
@@ -72,7 +84,9 @@ const EmojiPicker: React.FC<EmojiPickerProps> = ({ onEmojiSelect, onClose, isOpe
   return (
     <div
       ref={pickerRef}
-      className="absolute bottom-full left-0 mb-2 z-[9999]"
+      className={`absolute left-0 z-[9999] ${
+        placement === 'bottom' ? 'top-full mt-2' : 'bottom-full mb-2'
+      }`}
       style={{
         minWidth: '350px',
         maxWidth: '350px',

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -643,6 +643,8 @@
         "templateType": "Template Type",
         "templateTypes": {
           "text": "Text",
+          "interactive": "Interactive",
+          "media": "Media",
           "image": "Image",
           "video": "Video",
           "document": "Document",

--- a/src/i18n/locales/en/messageTemplates.json
+++ b/src/i18n/locales/en/messageTemplates.json
@@ -12,7 +12,9 @@
     "language": "Language",
     "actions": "Actions",
     "edit": "Edit",
-    "delete": "Delete"
+    "delete": "Delete",
+    "createdAt": "Created",
+    "preview": "Preview"
   },
   "status": {
     "approved": "Approved",
@@ -61,39 +63,10 @@
     "syncError": "Failed to sync templates."
   },
   "form": {
-    "createTitle": "New Template",
-    "editTitle": "Edit Template",
     "provider": "Provider",
     "providers": {
       "generic": "Generic",
       "email": "Email"
-    },
-    "name": "Name",
-    "namePlaceholder": "e.g. welcome_message",
-    "category": "Category",
-    "categories": {
-      "marketing": "Marketing",
-      "utility": "Utility",
-      "authentication": "Authentication",
-      "transactional": "Transactional"
-    },
-    "language": "Language",
-    "subject": "Subject",
-    "subjectPlaceholder": "Email subject",
-    "content": "Content",
-    "contentPlaceholder": "Type the message content.",
-    "variablesHelp": "Use {{variable}} syntax for dynamic values",
-    "variables": "Variables",
-    "variableLabel": "Label",
-    "variableExample": "Example",
-    "variableSource": "Source",
-    "active": "Active",
-    "activeHelp": "Inactive templates are hidden from selection.",
-    "cancel": "Cancel",
-    "create": "Create",
-    "save": "Save",
-    "errors": {
-      "requiredFields": "Name and content are required."
     },
     "categoryReset": "Category reset to a value supported by the selected provider.",
     "headerNone": "None",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -625,6 +625,8 @@
         "templateType": "Tipo de Plantilla",
         "templateTypes": {
           "text": "Texto",
+          "interactive": "Interactivo",
+          "media": "Multimedia",
           "image": "Imagen",
           "video": "Video",
           "document": "Documento",
@@ -652,6 +654,10 @@
         "footerText": "Texto del Pie de Página",
         "footerTextPlaceholder": "Ingrese el texto del pie de página (opcional)",
         "variablesHelp": "Use la sintaxis {{variable}} para valores dinámicos",
+        "variables": "Variables",
+        "variableLabel": "Etiqueta",
+        "variableExample": "Ejemplo",
+        "variableSource": "Origen, p. ej. contact.name",
         "buttons": "Botones",
         "addButton": "Agregar Botón",
         "buttonTypes": {

--- a/src/i18n/locales/es/messageTemplates.json
+++ b/src/i18n/locales/es/messageTemplates.json
@@ -12,7 +12,9 @@
     "language": "Idioma",
     "actions": "Acciones",
     "edit": "Editar",
-    "delete": "Eliminar"
+    "delete": "Eliminar",
+    "createdAt": "Creado",
+    "preview": "Vista previa"
   },
   "status": {
     "approved": "Aprobada",
@@ -61,39 +63,10 @@
     "syncError": "Error al sincronizar las plantillas."
   },
   "form": {
-    "createTitle": "Nueva Plantilla",
-    "editTitle": "Editar Plantilla",
     "provider": "Proveedor",
     "providers": {
       "generic": "Genérico",
       "email": "Correo electrónico"
-    },
-    "name": "Nombre",
-    "namePlaceholder": "ej.: mensaje_bienvenida",
-    "category": "Categoría",
-    "categories": {
-      "marketing": "Marketing",
-      "utility": "Utilidad",
-      "authentication": "Autenticación",
-      "transactional": "Transaccional"
-    },
-    "language": "Idioma",
-    "subject": "Asunto",
-    "subjectPlaceholder": "Asunto del correo",
-    "content": "Contenido",
-    "contentPlaceholder": "Escribe el contenido del mensaje.",
-    "variablesHelp": "Usa la sintaxis {{variable}} para valores dinámicos",
-    "variables": "Variables",
-    "variableLabel": "Etiqueta",
-    "variableExample": "Ejemplo",
-    "variableSource": "Origen",
-    "active": "Activa",
-    "activeHelp": "Las plantillas inactivas se ocultan en la selección.",
-    "cancel": "Cancelar",
-    "create": "Crear",
-    "save": "Guardar",
-    "errors": {
-      "requiredFields": "El nombre y el contenido son obligatorios."
     },
     "categoryReset": "Categoría restablecida a un valor compatible con el proveedor seleccionado.",
     "headerNone": "Ninguno",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -625,6 +625,8 @@
         "templateType": "Type de Modèle",
         "templateTypes": {
           "text": "Texte",
+          "interactive": "Interactif",
+          "media": "Média",
           "image": "Image",
           "video": "Vidéo",
           "document": "Document",
@@ -652,6 +654,10 @@
         "footerText": "Texte du Pied de Page",
         "footerTextPlaceholder": "Entrez le texte du pied de page (facultatif)",
         "variablesHelp": "Utilisez la syntaxe {{variable}} pour les valeurs dynamiques",
+        "variables": "Variables",
+        "variableLabel": "Libellé",
+        "variableExample": "Exemple",
+        "variableSource": "Source, p. ex. contact.name",
         "buttons": "Boutons",
         "addButton": "Ajouter un Bouton",
         "buttonTypes": {

--- a/src/i18n/locales/fr/messageTemplates.json
+++ b/src/i18n/locales/fr/messageTemplates.json
@@ -12,7 +12,9 @@
     "language": "Langue",
     "actions": "Actions",
     "edit": "Modifier",
-    "delete": "Supprimer"
+    "delete": "Supprimer",
+    "createdAt": "Créé le",
+    "preview": "Aperçu"
   },
   "status": {
     "approved": "Approuvé",
@@ -61,39 +63,10 @@
     "syncError": "Échec de la synchronisation des modèles."
   },
   "form": {
-    "createTitle": "Nouveau Modèle",
-    "editTitle": "Modifier le Modèle",
     "provider": "Fournisseur",
     "providers": {
       "generic": "Générique",
       "email": "E-mail"
-    },
-    "name": "Nom",
-    "namePlaceholder": "ex. : message_bienvenue",
-    "category": "Catégorie",
-    "categories": {
-      "marketing": "Marketing",
-      "utility": "Utilitaire",
-      "authentication": "Authentification",
-      "transactional": "Transactionnel"
-    },
-    "language": "Langue",
-    "subject": "Objet",
-    "subjectPlaceholder": "Objet de l'e-mail",
-    "content": "Contenu",
-    "contentPlaceholder": "Saisissez le contenu du message.",
-    "variablesHelp": "Utilisez la syntaxe {{variable}} pour les valeurs dynamiques",
-    "variables": "Variables",
-    "variableLabel": "Libellé",
-    "variableExample": "Exemple",
-    "variableSource": "Source",
-    "active": "Actif",
-    "activeHelp": "Les modèles inactifs sont masqués de la sélection.",
-    "cancel": "Annuler",
-    "create": "Créer",
-    "save": "Enregistrer",
-    "errors": {
-      "requiredFields": "Le nom et le contenu sont obligatoires."
     },
     "categoryReset": "Catégorie réinitialisée vers une valeur prise en charge par le fournisseur sélectionné.",
     "headerNone": "Aucun",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -625,6 +625,8 @@
         "templateType": "Tipo di Modello",
         "templateTypes": {
           "text": "Testo",
+          "interactive": "Interattivo",
+          "media": "Multimediale",
           "image": "Immagine",
           "video": "Video",
           "document": "Documento",
@@ -652,6 +654,10 @@
         "footerText": "Testo del Piè di Pagina",
         "footerTextPlaceholder": "Inserisci il testo del piè di pagina (facoltativo)",
         "variablesHelp": "Usa la sintassi {{variabile}} per valori dinamici",
+        "variables": "Variabili",
+        "variableLabel": "Etichetta",
+        "variableExample": "Esempio",
+        "variableSource": "Origine, es. contact.name",
         "buttons": "Pulsanti",
         "addButton": "Aggiungi Pulsante",
         "buttonTypes": {

--- a/src/i18n/locales/it/messageTemplates.json
+++ b/src/i18n/locales/it/messageTemplates.json
@@ -12,7 +12,9 @@
     "language": "Lingua",
     "actions": "Azioni",
     "edit": "Modifica",
-    "delete": "Elimina"
+    "delete": "Elimina",
+    "createdAt": "Creato",
+    "preview": "Anteprima"
   },
   "status": {
     "approved": "Approvato",
@@ -61,39 +63,10 @@
     "syncError": "Sincronizzazione dei modelli non riuscita."
   },
   "form": {
-    "createTitle": "Nuovo Modello",
-    "editTitle": "Modifica Modello",
     "provider": "Provider",
     "providers": {
       "generic": "Generico",
       "email": "E-mail"
-    },
-    "name": "Nome",
-    "namePlaceholder": "es. messaggio_benvenuto",
-    "category": "Categoria",
-    "categories": {
-      "marketing": "Marketing",
-      "utility": "Utilità",
-      "authentication": "Autenticazione",
-      "transactional": "Transazionale"
-    },
-    "language": "Lingua",
-    "subject": "Oggetto",
-    "subjectPlaceholder": "Oggetto dell'e-mail",
-    "content": "Contenuto",
-    "contentPlaceholder": "Inserisci il contenuto del messaggio.",
-    "variablesHelp": "Usa la sintassi {{variable}} per i valori dinamici",
-    "variables": "Variabili",
-    "variableLabel": "Etichetta",
-    "variableExample": "Esempio",
-    "variableSource": "Origine",
-    "active": "Attivo",
-    "activeHelp": "I modelli inattivi sono nascosti dalla selezione.",
-    "cancel": "Annulla",
-    "create": "Crea",
-    "save": "Salva",
-    "errors": {
-      "requiredFields": "Nome e contenuto sono obbligatori."
     },
     "categoryReset": "Categoria reimpostata su un valore supportato dal provider selezionato.",
     "headerNone": "Nessuno",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -643,6 +643,8 @@
         "templateType": "Tipo de Template",
         "templateTypes": {
           "text": "Texto",
+          "interactive": "Interativo",
+          "media": "Mídia",
           "image": "Imagem",
           "video": "Vídeo",
           "document": "Documento",

--- a/src/i18n/locales/pt-BR/messageTemplates.json
+++ b/src/i18n/locales/pt-BR/messageTemplates.json
@@ -12,7 +12,9 @@
     "language": "Idioma",
     "actions": "Ações",
     "edit": "Editar",
-    "delete": "Excluir"
+    "delete": "Excluir",
+    "createdAt": "Criado em",
+    "preview": "Visualizar"
   },
   "status": {
     "approved": "Aprovado",
@@ -61,39 +63,10 @@
     "syncError": "Falha ao sincronizar os modelos."
   },
   "form": {
-    "createTitle": "Novo Modelo",
-    "editTitle": "Editar Modelo",
     "provider": "Provedor",
     "providers": {
       "generic": "Genérico",
       "email": "E-mail"
-    },
-    "name": "Nome",
-    "namePlaceholder": "ex.: mensagem_boas_vindas",
-    "category": "Categoria",
-    "categories": {
-      "marketing": "Marketing",
-      "utility": "Utilitário",
-      "authentication": "Autenticação",
-      "transactional": "Transacional"
-    },
-    "language": "Idioma",
-    "subject": "Assunto",
-    "subjectPlaceholder": "Assunto do e-mail",
-    "content": "Conteúdo",
-    "contentPlaceholder": "Digite o conteúdo da mensagem.",
-    "variablesHelp": "Use a sintaxe {{variable}} para valores dinâmicos",
-    "variables": "Variáveis",
-    "variableLabel": "Rótulo",
-    "variableExample": "Exemplo",
-    "variableSource": "Origem",
-    "active": "Ativo",
-    "activeHelp": "Modelos inativos ficam ocultos na seleção.",
-    "cancel": "Cancelar",
-    "create": "Criar",
-    "save": "Salvar",
-    "errors": {
-      "requiredFields": "Nome e conteúdo são obrigatórios."
     },
     "categoryReset": "Categoria redefinida para um valor suportado pelo provedor selecionado.",
     "headerNone": "Nenhum",

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -642,6 +642,8 @@
         "templateType": "Tipo de Template",
         "templateTypes": {
           "text": "Texto",
+          "interactive": "Interativo",
+          "media": "Mídia",
           "image": "Imagem",
           "video": "Vídeo",
           "document": "Documento",
@@ -669,6 +671,10 @@
         "footerText": "Texto do Rodapé",
         "footerTextPlaceholder": "Digite o texto do rodapé (opcional)",
         "variablesHelp": "Use a sintaxe {{variavel}} para valores dinâmicos",
+        "variables": "Variáveis",
+        "variableLabel": "Rótulo",
+        "variableExample": "Exemplo",
+        "variableSource": "Origem, ex.: contact.name",
         "buttons": "Botões",
         "addButton": "Adicionar Botão",
         "buttonTypes": {

--- a/src/i18n/locales/pt/messageTemplates.json
+++ b/src/i18n/locales/pt/messageTemplates.json
@@ -12,7 +12,9 @@
     "language": "Idioma",
     "actions": "Ações",
     "edit": "Editar",
-    "delete": "Excluir"
+    "delete": "Excluir",
+    "createdAt": "Criado em",
+    "preview": "Visualizar"
   },
   "status": {
     "approved": "Aprovado",
@@ -61,39 +63,10 @@
     "syncError": "Falha ao sincronizar os modelos."
   },
   "form": {
-    "createTitle": "Novo Modelo",
-    "editTitle": "Editar Modelo",
     "provider": "Provedor",
     "providers": {
       "generic": "Genérico",
       "email": "E-mail"
-    },
-    "name": "Nome",
-    "namePlaceholder": "ex.: mensagem_boas_vindas",
-    "category": "Categoria",
-    "categories": {
-      "marketing": "Marketing",
-      "utility": "Utilitário",
-      "authentication": "Autenticação",
-      "transactional": "Transacional"
-    },
-    "language": "Idioma",
-    "subject": "Assunto",
-    "subjectPlaceholder": "Assunto do e-mail",
-    "content": "Conteúdo",
-    "contentPlaceholder": "Digite o conteúdo da mensagem.",
-    "variablesHelp": "Use a sintaxe {{variable}} para valores dinâmicos",
-    "variables": "Variáveis",
-    "variableLabel": "Rótulo",
-    "variableExample": "Exemplo",
-    "variableSource": "Origem",
-    "active": "Ativo",
-    "activeHelp": "Modelos inativos ficam ocultos na seleção.",
-    "cancel": "Cancelar",
-    "create": "Criar",
-    "save": "Salvar",
-    "errors": {
-      "requiredFields": "Nome e conteúdo são obrigatórios."
     },
     "categoryReset": "Categoria redefinida para um valor suportado pelo provedor selecionado.",
     "headerNone": "Nenhum",

--- a/src/pages/Customer/Settings/MessageTemplates/MessageTemplates.tsx
+++ b/src/pages/Customer/Settings/MessageTemplates/MessageTemplates.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@evoapi/design-system';
-import { Edit, LayoutTemplate, Plus, RefreshCw, Search, Trash2 } from 'lucide-react';
+import { Edit, Eye, LayoutTemplate, Plus, RefreshCw, Search, Trash2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useUserPermissions } from '@/hooks/useUserPermissions';
 import { useAppDataStore } from '@/store/appDataStore';
@@ -24,7 +24,7 @@ import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 import { extractError } from '@/utils/apiHelpers';
 import BaseTable, { type TableAction, type TableColumn } from '@/components/base/BaseTable';
 import BasePagination from '@/components/base/BasePagination';
-import { TemplateFormModal } from '@/components/channels';
+import { TemplateFormModal, TemplatePreview } from '@/components/channels';
 import MessageTemplateService, {
   supportsTemplateSync,
 } from '@/services/channels/messageTemplatesService';
@@ -60,6 +60,9 @@ const STATUS_STYLE: Record<string, string> = {
 
 export default function MessageTemplates() {
   const { t } = useLanguage('messageTemplates');
+  // The shared <TemplatePreview> renders `settings.messageTemplates.*` keys, which
+  // live in the `channels` namespace (same as the form modal).
+  const { t: tChannels } = useLanguage('channels');
   const navigate = useNavigate();
   const { can, isReady: permissionsReady } = useUserPermissions();
 
@@ -86,6 +89,20 @@ export default function MessageTemplates() {
 
   const [deleteTarget, setDeleteTarget] = useState<MessageTemplate | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Read-only inspection (restores the per-channel tab's eye action, EVO-1971).
+  const [previewTarget, setPreviewTarget] = useState<MessageTemplate | null>(null);
+
+  // Channel type a row should be previewed/edited as: the inbox's own channel in
+  // inbox scope, or the synthetic channel for the template's inferred provider in
+  // Global scope.
+  const channelTypeFor = useCallback(
+    (template: MessageTemplate) =>
+      scope.kind === 'inbox'
+        ? scope.inbox.channel_type
+        : providerToChannelType(inferTemplateProvider(template)),
+    [scope],
+  );
 
   useEffect(() => {
     fetchInboxes();
@@ -315,9 +332,20 @@ export default function MessageTemplates() {
       label: t('table.language'),
       render: template => template.language || '-',
     },
+    {
+      key: 'created_at',
+      label: t('table.createdAt'),
+      render: template =>
+        template.created_at ? new Date(template.created_at).toLocaleDateString() : '-',
+    },
   ];
 
   const actions: TableAction<MessageTemplate>[] = [
+    {
+      label: t('table.preview'),
+      icon: <Eye className="h-4 w-4" />,
+      onClick: setPreviewTarget,
+    },
     ...(can('message_templates', 'update')
       ? [
           {
@@ -448,6 +476,26 @@ export default function MessageTemplates() {
         }}
         onSave={handleSave}
       />
+
+      <Dialog open={!!previewTarget} onOpenChange={open => !open && setPreviewTarget(null)}>
+        <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{previewTarget?.name}</DialogTitle>
+          </DialogHeader>
+          {previewTarget && (
+            <div className="py-2">
+              <TemplatePreview
+                template={MessageTemplateService.transformToFrontendFormat(
+                  previewTarget,
+                  channelTypeFor(previewTarget),
+                )}
+                channelType={channelTypeFor(previewTarget)}
+                t={tChannels}
+              />
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={!!deleteTarget} onOpenChange={open => !open && setDeleteTarget(null)}>
         <DialogContent>

--- a/src/services/channels/__tests__/messageTemplatesService.spec.ts
+++ b/src/services/channels/__tests__/messageTemplatesService.spec.ts
@@ -66,3 +66,90 @@ describe('channel MessageTemplateService — flat endpoint with inbox_id (EVO-17
     expect(apiMock.post).toHaveBeenCalledWith('/inboxes/inbox-1/message_templates/sync');
   });
 });
+
+// EVO-1971: exercise the real transforms (no mocking of the conversion layer) so
+// the structured WhatsApp edit round-trip and the variable metadata that the
+// backend persists are actually covered.
+describe('WhatsApp structured transforms round-trip', () => {
+  const wa = 'Channel::Whatsapp';
+
+  it('transformToBackendFormat skips the HEADER component when headerFormat is NONE', () => {
+    const out = MessageTemplateService.transformToBackendFormat(
+      {
+        name: 'promo',
+        content: '',
+        language: 'pt_BR',
+        category: 'MARKETING',
+        template_type: 'interactive',
+        headerFormat: 'NONE',
+        headerText: '',
+        bodyText: 'Oi {{nome}}',
+        footerText: '',
+        buttons: [],
+      },
+      wa,
+    );
+    const types = (out.components as Array<{ type: string }>).map(c => c.type);
+    expect(types).toContain('BODY');
+    expect(types).not.toContain('HEADER');
+  });
+
+  it('transformToBackendFormat keeps the declared example/source on the persisted variables', () => {
+    const out = MessageTemplateService.transformToBackendFormat(
+      {
+        name: 'promo',
+        content: '',
+        language: 'pt_BR',
+        category: 'MARKETING',
+        template_type: 'interactive',
+        headerFormat: 'NONE',
+        bodyText: 'Oi {{nome}}',
+        variables: [{ name: 'nome', label: 'Nome', example: 'Maria', source: 'contact.name' }],
+      },
+      wa,
+    );
+    const variable = out.variables?.find(v => v.name === 'nome');
+    expect(variable).toMatchObject({ name: 'nome', example: 'Maria', source: 'contact.name' });
+  });
+
+  it('transformToFrontendFormat parses components back (TEXT header) and restores variable metadata', () => {
+    const fe = MessageTemplateService.transformToFrontendFormat(
+      {
+        name: 'promo',
+        content: 'Oi {{nome}}',
+        language: 'pt_BR',
+        category: 'MARKETING',
+        template_type: 'interactive',
+        components: [
+          { type: 'HEADER', format: 'TEXT', text: 'Olá' },
+          { type: 'BODY', text: 'Oi {{nome}}' },
+          { type: 'FOOTER', text: 'tchau' },
+        ],
+        variables: [{ name: 'nome', example: 'Maria', source: 'contact.name' }],
+        active: true,
+      },
+      wa,
+    );
+    expect(fe.headerFormat).toBe('TEXT');
+    expect(fe.headerText).toBe('Olá');
+    expect(fe.bodyText).toBe('Oi {{nome}}');
+    expect(fe.footerText).toBe('tchau');
+    expect(fe.variables?.find(v => v.name === 'nome')).toMatchObject({
+      example: 'Maria',
+      source: 'contact.name',
+    });
+  });
+
+  it('transformToFrontendFormat defaults headerFormat to NONE when there is no HEADER component', () => {
+    const fe = MessageTemplateService.transformToFrontendFormat(
+      {
+        name: 'promo',
+        content: 'Oi {{nome}}',
+        language: 'pt_BR',
+        components: [{ type: 'BODY', text: 'Oi {{nome}}' }],
+      },
+      wa,
+    );
+    expect(fe.headerFormat).toBe('NONE');
+  });
+});

--- a/src/utils/templateVariables.spec.ts
+++ b/src/utils/templateVariables.spec.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { isBalancedExpression } from './templateVariables';
+import {
+  isBalancedExpression,
+  detectTemplateFormVariables,
+  extractTemplateFormVariables,
+} from './templateVariables';
+import type { TemplateFormData } from '@/types/channels/inbox';
 
 // EVO-1267 AC3: basic syntax gate for custom variable expressions.
 describe('isBalancedExpression', () => {
@@ -23,5 +28,40 @@ describe('isBalancedExpression', () => {
   it('rejects closers appearing before openers', () => {
     expect(isBalancedExpression(')(')).toBe(false);
     expect(isBalancedExpression('}{')).toBe(false);
+  });
+});
+
+// EVO-1971: the two form-variable helpers diverge on purpose — `detect` is
+// text-only (drives the live UI without accumulating stale rows) while `extract`
+// re-attaches the declared metadata that the backend persists.
+describe('template form variable helpers', () => {
+  const form = (over: Partial<TemplateFormData>): TemplateFormData => ({
+    name: 't',
+    content: '',
+    language: 'pt_BR',
+    headerFormat: 'NONE',
+    headerText: '',
+    bodyText: '',
+    footerText: '',
+    buttons: [],
+    ...over,
+  });
+
+  it('detectTemplateFormVariables is driven only by the current text', () => {
+    const fd = form({
+      bodyText: 'Oi {{nome}} de {{cidade}}',
+      // A declared-but-no-longer-present variable must NOT resurface.
+      variables: [{ name: 'antigo', example: 'x' }],
+    });
+    expect(detectTemplateFormVariables(fd).map(v => v.name)).toEqual(['nome', 'cidade']);
+  });
+
+  it('extractTemplateFormVariables preserves declared label/example/source for live tokens', () => {
+    const fd = form({
+      bodyText: 'Oi {{nome}}',
+      variables: [{ name: 'nome', label: 'Nome', example: 'Maria', source: 'contact.name' }],
+    });
+    const nome = extractTemplateFormVariables(fd).find(v => v.name === 'nome');
+    expect(nome).toMatchObject({ label: 'Nome', example: 'Maria', source: 'contact.name' });
   });
 });

--- a/src/utils/templateVariables.ts
+++ b/src/utils/templateVariables.ts
@@ -105,10 +105,11 @@ export const extractTemplateFormVariables = (formData: TemplateFormData): Messag
   extractTemplateVariables({ ...formTemplateShape(formData), variables: formData.variables });
 
 /**
- * Variables to DISPLAY/SYNC while editing: driven ONLY by what is currently in the
+ * Variables to DISPLAY while editing: driven ONLY by what is currently in the
  * text. The declared list is intentionally omitted so that renaming a `{{token}}`
- * character-by-character does not accumulate stale rows (the form layer re-attaches
- * any label/example the user already typed, by name).
+ * character-by-character does not accumulate stale rows. The form layer reconciles
+ * this with the declared list by name, re-attaching any label/example/source the
+ * user has already typed for a still-present token (EVO-1971).
  */
 export const detectTemplateFormVariables = (formData: TemplateFormData): MessageTemplateVariable[] =>
   extractTemplateVariables(formTemplateShape(formData));


### PR DESCRIPTION
## Summary

Follow-up da review da EVO-1907 (PR #221). Endereça os 7 pontos do card EVO-1971.

| # | Item | O que mudou |
|---|------|-------------|
| 1 | **example/source removidos (regressão)** | Reintroduz os inputs editáveis `label`/`example`/`source` por variável. A remoção partira de premissa **errada**: `extract_variables_from_content` (`message_template.rb:259-278`) **preserva** as variáveis enviadas que casam com o conteúdo — só adiciona placeholders para nomes novos e remove órfãos. Logo os campos persistem e voltam na edição, e alimentam o consumo: `example` = prefill (`buildInitialVariableParams`, composer, Iniciar Conversa), `source` = auto-map da automação `send_template` → `{{contact.x}}` (`ActionRow.tsx:194`). |
| 2 | **i18n enganoso** | Com os inputs de volta, `form.variableHelp` volta a ser verdade; comentário de `detectTemplateFormVariables` atualizado. |
| 3 | **chave crua** | `channels.json` (6 locais): add `templateTypes.interactive`/`.media`; add `variables`/`variableLabel`/`variableExample`/`variableSource` em es/fr/it/pt. Edits cirúrgicos por texto (sem `json.dump` — o arquivo tem chaves duplicadas que colapsariam). |
| 4 | **subtree i18n órfão** | Remove o `form.*` do editor antigo em `messageTemplates.json` (6 locais), mantendo as 9 chaves ainda referenciadas pela tela. De quebra remove 1 leak de paridade pré-existente. |
| 5 | **paridade** | Repõe o **preview read-only** (ícone de olho, disponível a quem só tem `read`) reaproveitando `<TemplatePreview>` + coluna `created_at`. Ordenação por coluna avaliada e **adiada**: o serviço global já ordena server-side por nome; sort interativo multi-escopo tem suporte incerto no backend de inbox e traria estado/risco desproporcionais para um item "avaliar repor". |
| 6 | **testes** | Round-trip **real** dos transforms (sem mockar o serviço): header WhatsApp, skip de `NONE`, persistência de `example`/`source`; + split de `templateVariables`. |
| 7 | **smoke EmojiPicker** | Prop `placement` (default `top`, chat inalterado); o modal usa `bottom` para o painel de 400px não cortar dentro do `DialogContent overflow-hidden`. |

FE-only, sem mudança de backend.

## Test plan

- `tsc -b` limpo; ESLint limpo nos arquivos alterados.
- `vitest`: TemplateFormModal (7), templateVariables (6), messageTemplatesService (9, inclui os round-trips novos), MessageTemplates (8) — todos verdes.
- i18n-parity: `channels.json`/`messageTemplates.json` sem novos leaks en↔pt-BR (paridade de chaves mantida; 1 leak pré-existente removido). Falhas remanescentes (`products`, `customTools`, e o pré-existente de `channels`) são herdadas da `develop`, não desta PR.
- Smoke manual recomendado: abrir o painel de emoji dentro do modal de template e o preview read-only.

## Notas

- Relacionado: EVO-1907 / PR #221.

## Summary by Sourcery

Restore variable metadata editing and preview capabilities in the message template settings UI while aligning i18n keys and tests with the behaviour of the WhatsApp template transforms and emoji picker.

New Features:
- Add a read-only template preview dialog and created-at column to the message templates table, including an eye action for inspection.
- Expose editable label/example/source fields per detected variable in the template form to drive composer prefill and automation mappings.
- Introduce a placement option on the emoji picker so its panel can open above or below the trigger depending on the container context.

Bug Fixes:
- Ensure WhatsApp template transforms correctly skip headers when configured as NONE and preserve variable metadata across backend/frontend round-trips.
- Fix stale variable rows in the template form by separating text-driven detection from metadata-preserving extraction of variables.

Enhancements:
- Reuse the shared TemplatePreview component and channels i18n namespace from the global templates flow in the per-channel templates screen.
- Clean up legacy message template editor i18n keys while keeping only the strings still referenced by the current UI.
- Align channels/messageTemplates i18n keys across locales for interactive/media template types and variable-related labels.

Tests:
- Expand message template service tests to cover real WhatsApp structured transform round-trips and variable metadata persistence.
- Add unit tests for template variable helpers to verify the divergence between text-only detection and metadata-preserving extraction.
- Update TemplateFormModal tests to assert editable variable metadata fields are persisted on save.