### PR TITLE
feat(frontend): conversation-list overhaul (EVO-1960 +4)

### DIFF
--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -204,18 +204,21 @@ const ChatHeader = ({
   const handlePipelineStageSelect = useCallback(
     async (pipeline: Pipeline, stage: PipelineStage) => {
       const currentPipelines = convPipelineData?.pipelines ?? [];
-      const existingInSamePipeline = currentPipelines.find(p => p.id === pipeline.id);
+      const samePipeline = currentPipelines.find(p => p.id === pipeline.id);
       const existingInOtherPipelines = currentPipelines.filter(p => p.id !== pipeline.id);
+      // MOVER vs ADICIONAR por item ATIVO encontrável, não por presença do pipeline
+      // (pipeline com jornada COMPLETED volta sem item ativo → precisa cair no ADD,
+      // senão morre em moveError). Mesmo fix do ChatSidebar.
+      const existingItem = samePipeline
+        ? findItemInPipeline(samePipeline, String(conversation.id))
+        : undefined;
 
-      if (existingInSamePipeline) {
-        const item = findItemInPipeline(existingInSamePipeline, String(conversation.id));
-        const itemId = item?.id;
-        if (!itemId) { toast.error(t('pipeline.moveError')); return; }
+      if (existingItem?.id) {
         try {
           await pipelinesService.moveItem({
             pipeline_id: pipeline.id,
-            item_id: itemId,
-            from_stage_id: item.stage_id,
+            item_id: existingItem.id,
+            from_stage_id: existingItem.stage_id,
             to_stage_id: stage.id,
           });
           toast.success(t('pipeline.moveSuccess'));

--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -136,6 +136,10 @@ const makeMockContext = () => ({
 
 let overrideContext: ReturnType<typeof makeMockContext> | null = null;
 
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({ can: () => true }),
+}));
+
 vi.mock('@/contexts/chat/ChatContext', () => ({
   useChatContext: () => overrideContext ?? makeMockContext(),
 }));
@@ -165,7 +169,7 @@ const defaultProps = {
   selectedConversationIds: new Set<string>(),
   onToggleSelect: vi.fn(),
   onClearSelection: vi.fn(),
-  onBulkResolve: vi.fn().mockResolvedValue(undefined),
+  onBulkSetStatus: vi.fn().mockResolvedValue(undefined),
 };
 
 beforeEach(() => {
@@ -198,6 +202,32 @@ const openContextMenuPipelineStage = async (
 
   await waitFor(() => screen.getByText(stageName), { timeout: 3000 });
   await user.click(screen.getByText(stageName));
+};
+
+const openContextMenuRemoveFromPipeline = async (
+  user: ReturnType<typeof userEvent.setup>,
+  pipelineName: string,
+) => {
+  const row = screen.getByText('Test Contact').closest('div[class*="p-4"]') as HTMLElement;
+  fireEvent.contextMenu(row);
+
+  const addToTrigger = await screen.findByText('pipeline.addTo', {}, { timeout: 2000 });
+  const addToSubTrigger = (
+    addToTrigger.closest('[data-slot="context-menu-sub-trigger"]') ?? addToTrigger
+  ) as HTMLElement;
+  addToSubTrigger.focus();
+  await user.keyboard('{ArrowRight}');
+
+  await waitFor(() => screen.getByText(pipelineName), { timeout: 2000 });
+  const pipelineEl = screen.getByText(pipelineName);
+  const pipelineSubTrigger = (
+    pipelineEl.closest('[data-slot="context-menu-sub-trigger"]') ?? pipelineEl
+  ) as HTMLElement;
+  pipelineSubTrigger.focus();
+  await user.keyboard('{ArrowRight}');
+
+  await waitFor(() => screen.getByText('pipeline.removeFrom'), { timeout: 3000 });
+  await user.click(screen.getByText('pipeline.removeFrom'));
 };
 
 describe('ChatSidebar pipeline', () => {
@@ -398,7 +428,11 @@ describe('ChatSidebar pipeline', () => {
     });
   });
 
-  it('shows moveError toast (no silent return) when the item cannot be resolved', async () => {
+  it('re-adds (ADD) when the pipeline is present but has no active item (completed journey), instead of dead-ending on moveError', async () => {
+    // by_conversation não filtra completed_at, então um pipeline cuja jornada foi
+    // concluída volta na lista MAS com stages sem itens ativos. O branch deve ser
+    // decidido por item ATIVO encontrável → cai no ADD (backend permite reentrada),
+    // não em moveError.
     const pipeline = {
       ...makeNestedPipeline(),
       stages: [
@@ -408,6 +442,8 @@ describe('ChatSidebar pipeline', () => {
     };
     vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [pipeline] } as never);
     vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([pipeline] as never);
+    vi.mocked(pipelinesService.addItemToPipeline).mockResolvedValue({} as never);
+    vi.mocked(chatService.getConversation).mockResolvedValue({ data: makeConversation('42') } as never);
 
     render(<ChatSidebar {...defaultProps} />);
     await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
@@ -416,9 +452,38 @@ describe('ChatSidebar pipeline', () => {
     await openContextMenuPipelineStage(user, 'Pipeline p1', 'Qualified');
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('pipeline.moveError');
-      expect(pipelinesService.moveItem).not.toHaveBeenCalled();
+      expect(pipelinesService.addItemToPipeline).toHaveBeenCalledWith('p1', {
+        item_id: '42',
+        type: 'conversation',
+        pipeline_stage_id: 'stage-2',
+      });
     });
+    expect(pipelinesService.moveItem).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalledWith('pipeline.moveError');
+  });
+
+  it('removes via context menu using the per-conversation item id, even when allPipelines lacks the item', async () => {
+    // allPipelines (getPipelines) = estrutura global SEM o item da conversa; o
+    // item vive só na state por-conversa (getPipelinesByConversation). O handler
+    // de remover deve buscar o item na convPipelineStates, não no pipeline passado
+    // — senão findItemInPipeline volta undefined e dá removeError.
+    const globalPipeline = makePipeline('p1', [{ id: 'stage-1', name: 'Lead' }]);
+    const convPipeline = makePipeline('p1', [{ id: 'stage-1', name: 'Lead' }], [makeItem('item-77', 'p1')]);
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [globalPipeline] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([convPipeline] as never);
+    vi.mocked(pipelinesService.removeItemFromPipeline).mockResolvedValue({ success: true, message: '' });
+    vi.mocked(chatService.getConversation).mockResolvedValue({ data: makeConversation('42') } as never);
+
+    render(<ChatSidebar {...defaultProps} />);
+    await waitFor(() => expect(pipelinesService.getPipelines).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    await openContextMenuRemoveFromPipeline(user, 'Pipeline p1');
+
+    await waitFor(() => {
+      expect(pipelinesService.removeItemFromPipeline).toHaveBeenCalledWith('p1', 'item-77');
+    });
+    expect(toast.error).not.toHaveBeenCalledWith('pipeline.removeError');
   });
 });
 

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -15,10 +15,27 @@ import {
   ContextMenuLabel,
 } from '@evoapi/design-system/context-menu';
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@evoapi/design-system/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@evoapi/design-system/alert-dialog';
+import {
   Search,
   Filter,
   Mail,
   MailOpen,
+  MoreVertical,
   MessageCircle,
   CheckCircle,
   Clock,
@@ -35,11 +52,13 @@ import {
   FileText,
   Pin,
   Archive,
+  ArrowLeft,
   GitBranch,
   Check,
 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useChatContext } from '@/contexts/chat/ChatContext';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { Conversation, ConversationFilter } from '@/types/chat/api';
 import type { Pipeline, PipelineStage } from '@/types/analytics';
 import {
@@ -57,6 +76,7 @@ import { NoConversations } from '../empty-states';
 import ContactAvatar from '../contact/ContactAvatar';
 import ConversationBadges from '../conversation/ConversationBadges';
 import ConversationsFilter from '../conversation/ConversationsFilter';
+import ConversationSegments from './ConversationSegments';
 import GlobalSearchPanel from '../search/GlobalSearchPanel';
 import { BaseFilter } from '@/types/core';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -99,9 +119,13 @@ interface ChatSidebarProps {
   selectedConversationIds: Set<string>;
   onToggleSelect: (displayId: string) => void;
   onClearSelection: () => void;
-  onBulkResolve: () => Promise<void>;
-  isBulkResolving?: boolean;
-  canBulkResolve?: boolean;
+  // Status em lote (resolver/reabrir/pendente) usa o endpoint dedicado
+  // /bulk_actions (1 request, 1 toast, reconcilia via reloadCurrentFilters).
+  // NÃO tem undo: mudar status é deliberado e dispara automações/webhooks/
+  // atividade no backend.
+  onBulkSetStatus: (status: 'open' | 'pending' | 'resolved') => Promise<void>;
+  isBulkUpdatingStatus?: boolean;
+  canBulkUpdateStatus?: boolean;
 }
 
 // Prefetch the next page well before the user reaches the end so the loading
@@ -110,6 +134,35 @@ interface ChatSidebarProps {
 // floor for short viewports. loadMore stays sequential via loadingMoreRef.
 const PREFETCH_VIEWPORT_FACTOR = 2.5;
 const MIN_PREFETCH_DISTANCE_PX = 1000;
+
+// Atributos que são SÓ navegação por chip (Não lidas / Grupos) e NÃO existem no
+// catálogo do modal avançado (CONVERSATION_FILTER_TYPES). Precisam ser excluídos
+// do sync activeFilters -> modal, senão o modal renderiza uma linha quebrada
+// (dropdowns em branco) ao abrir com um desses ativos.
+const CHIP_ONLY_FILTER_KEYS = ['unread', 'is_group'];
+
+// Eixos que são navegação por chip (status + unread + is_group) — não contam
+// como "filtro avançado aplicado" no badge "N filtros".
+const CHIP_NAV_KEYS = ['status', ...CHIP_ONLY_FILTER_KEYS];
+
+// Snapshot mínimo p/ o undo das ações SEM efeito colateral no backend (ler/
+// não-ler). Capturado ANTES de aplicar — o store muta a conversa em seguida,
+// então guardamos só os primitivos (id + estado de leitura anterior).
+interface BulkSnapshot {
+  id: string;
+  wasUnread: boolean;
+}
+
+// Converte um ConversationFilter (estado global) para o BaseFilter do modal
+// avançado. Usado no sync activeFilters->modal e ao remesclar a navegação por
+// chip no apply do modal.
+const conversationFilterToBaseFilter = (f: ConversationFilter): BaseFilter => ({
+  attributeKey: f.attribute_key,
+  filterOperator: f.filter_operator,
+  values: Array.isArray(f.values) ? f.values.join(',') : String(f.values[0] || ''),
+  queryOperator: f.query_operator,
+  attributeModel: 'standard' as const,
+});
 
 const ChatSidebar = ({
   mobileView,
@@ -136,9 +189,9 @@ const ChatSidebar = ({
   selectedConversationIds,
   onToggleSelect,
   onClearSelection,
-  onBulkResolve,
-  isBulkResolving = false,
-  canBulkResolve = true,
+  onBulkSetStatus,
+  isBulkUpdatingStatus = false,
+  canBulkUpdateStatus = true,
 }: ChatSidebarProps) => {
   const { t } = useLanguage('chat');
   const chatContext = useChatContext();
@@ -161,16 +214,24 @@ const ChatSidebar = ({
     loadMoreConversations: () => Promise<void>;
   };
   const filters = chatContext.filters;
+  const { can } = usePermissions();
   const [conversationFilters, setConversationFilters] = useState<BaseFilter[]>([]);
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [isLoadingMoreConversations, setIsLoadingMoreConversations] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
+  // Modo de seleção em lote: default OFF (lista limpa, sem checkbox). O botão
+  // "Selecionar" liga; "Concluir" desliga. Só nesse modo os checkboxes aparecem
+  // e o click na row alterna seleção (em vez de abrir a conversa).
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [bulkRunning, setBulkRunning] = useState(false);
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const sidebarScrollRef = useRef<HTMLDivElement | null>(null);
   const loadingMoreRef = useRef(false);
   const lastScrollTimeRef = useRef<number>(0);
 
   useEffect(() => {
     onClearSelection();
+    setSelectionMode(false);
   }, [showArchived, onClearSelection]);
 
   // Pipeline state
@@ -247,21 +308,22 @@ const ChatSidebar = ({
     async (conversation: Conversation, pipeline: Pipeline, stage: PipelineStage) => {
       const convId = String(conversation.id);
       const currentPipelines = convPipelineStates.get(convId) ?? [];
-      const existingInSamePipeline = currentPipelines.find(p => p.id === pipeline.id);
+      const samePipeline = currentPipelines.find(p => p.id === pipeline.id);
       const existingInOtherPipelines = currentPipelines.filter(p => p.id !== pipeline.id);
+      // MOVER vs ADICIONAR é decidido por ITEM ATIVO encontrável, NÃO por presença
+      // do pipeline: um pipeline com jornada COMPLETED ainda volta em by_conversation
+      // (que não filtra completed_at) mas sem item ativo no serializer → o branch
+      // antigo (`if pipeline presente`) caía no MOVER e morria em moveError. A
+      // reentrada em pipeline com jornada concluída (o backend permite) tem que
+      // cair no ADICIONAR.
+      const existingItem = samePipeline ? findItemInPipeline(samePipeline, convId) : undefined;
 
-      if (existingInSamePipeline) {
-        const item = findItemInPipeline(existingInSamePipeline, convId);
-        const itemId = item?.id;
-        if (!itemId) {
-          toast.error(t('pipeline.moveError'));
-          return;
-        }
+      if (existingItem?.id) {
         try {
           await pipelinesService.moveItem({
             pipeline_id: pipeline.id,
-            item_id: itemId,
-            from_stage_id: item.stage_id,
+            item_id: existingItem.id,
+            from_stage_id: existingItem.stage_id,
             to_stage_id: stage.id,
           });
           toast.success(t('pipeline.moveSuccess'));
@@ -320,7 +382,13 @@ const ChatSidebar = ({
   const handleRemoveFromPipeline = useCallback(
     async (conversation: Conversation, pipeline: Pipeline) => {
       const convId = String(conversation.id);
-      const item = findItemInPipeline(pipeline, convId);
+      // O `pipeline` vem do allPipelines (estrutura global, SEM o item desta
+      // conversa). O item vive na state por-conversa (convPipelineStates, do
+      // by_conversation) — buscar lá, senão findItemInPipeline volta undefined e
+      // dá removeError mesmo com a conversa no pipeline. (Mesma fonte que o assign.)
+      const currentPipelines = convPipelineStates.get(convId) ?? [];
+      const statePipeline = currentPipelines.find(p => p.id === pipeline.id);
+      const item = statePipeline ? findItemInPipeline(statePipeline, convId) : undefined;
       const itemId = item?.id;
       if (!itemId) {
         toast.error(t('pipeline.removeError'));
@@ -329,20 +397,28 @@ const ChatSidebar = ({
       try {
         await pipelinesService.removeItemFromPipeline(pipeline.id, itemId);
         toast.success(t('pipeline.removeSuccess'));
+        // Update otimista LOCAL — remover é determinístico, então evitamos o
+        // refetch pesado do by_conversation (payload gigante: conversa+contato+
+        // mensagens+tasks por item) que deixava uma requisição em pending. Tira o
+        // pipeline da state por-conversa (checkmark do submenu) e do badge
+        // (conversation.pipelines). Reload real acontece ao reabrir o menu.
         setConvPipelineStates(prev => {
           const next = new Map(prev);
-          next.delete(convId);
+          next.set(convId, (next.get(convId) ?? []).filter(p => p.id !== pipeline.id));
           return next;
         });
-        await Promise.all([
-          loadConversationPipelineState(convId),
-          refreshConversationBadge(convId),
-        ]);
+        // Payload MÍNIMO: UPDATE_CONVERSATION faz merge sobre a state atual, então
+        // mandar só {id, pipelines} atualiza o badge sem sobrescrever campos que um
+        // eco de WS concorrente possa ter mudado (não espalhar o objeto do render).
+        chatContext.conversations.updateConversation({
+          id: conversation.id,
+          pipelines: (conversation.pipelines ?? []).filter(p => p.id !== pipeline.id),
+        } as Conversation);
       } catch {
         toast.error(t('pipeline.removeError'));
       }
     },
-    [t, loadConversationPipelineState, refreshConversationBadge],
+    [t, convPipelineStates, chatContext],
   );
 
   const renderPipelineSubContent = useCallback(
@@ -451,32 +527,18 @@ const ChatSidebar = ({
     ],
   );
 
-  // ðŸŽ¯ SYNC: Sincronizar local state com FiltersContext para compatibilidade com o modal
+  // 🎯 SYNC: activeFilters (global) -> estado local do modal avançado.
+  // Exclui TODA navegação por chip (status/unread/is_group): status é dirigido
+  // pelos chips, não pelo modal. Sem isso o default "Ativas" (status != resolved)
+  // abriria uma linha confusa no modal ("Status ... Resolved"). O apply do modal
+  // remescla a navegação (handleApplyAdvancedFilters), então nada se perde.
   useEffect(() => {
-    // Quando filters.state.activeFilters mudar (ex: por applyFilters chamado diretamente),
-    // atualizar o local state tambÃ©m para que o modal mostre os filtros corretos
-    // ConversationFilter (API format) -> BaseFilter (UI format)
-    const currentLocal = JSON.stringify(conversationFilters);
-    const currentContext = JSON.stringify(
-      filters.state.activeFilters.map((f: ConversationFilter) => ({
-        attributeKey: f.attribute_key,
-        filterOperator: f.filter_operator,
-        values: Array.isArray(f.values) ? f.values.join(',') : String(f.values[0] || ''),
-        queryOperator: f.query_operator,
-        attributeModel: 'standard' as const,
-      })),
-    );
+    const modalFilters = filters.state.activeFilters
+      .filter((f: ConversationFilter) => !CHIP_NAV_KEYS.includes(f.attribute_key))
+      .map(conversationFilterToBaseFilter);
 
-    if (currentLocal !== currentContext) {
-      setConversationFilters(
-        filters.state.activeFilters.map((f: ConversationFilter) => ({
-          attributeKey: f.attribute_key,
-          filterOperator: f.filter_operator,
-          values: Array.isArray(f.values) ? f.values.join(',') : String(f.values[0] || ''),
-          queryOperator: f.query_operator,
-          attributeModel: 'standard' as const,
-        })),
-      );
+    if (JSON.stringify(conversationFilters) !== JSON.stringify(modalFilters)) {
+      setConversationFilters(modalFilters);
     }
   }, [filters.state.activeFilters, conversationFilters]);
 
@@ -544,6 +606,26 @@ const ChatSidebar = ({
     onFilterApply(newFilters);
   };
 
+  // Apply do MODAL avançado: status/unread/is_group são navegação por chip e NÃO
+  // aparecem no modal. Preserva SÓ o `status` ao aplicar filtros avançados, pois é
+  // a única navegação por chip que TAMBÉM é atributo válido no POST /filter.
+  // unread/is_group são GET-only (CHIP_ONLY) — incluí-los no POST daria 400; são
+  // descartados ao aplicar um filtro avançado (comportamento original). Se o
+  // usuário adicionou o mesmo atributo no modal, o do modal vence.
+  const handleApplyAdvancedFilters = async (advancedFilters: BaseFilter[]) => {
+    setConversationFilters(advancedFilters);
+    const advancedKeys = new Set(advancedFilters.map(f => f.attributeKey));
+    const chipNav = filters.state.activeFilters
+      .filter(
+        (f: ConversationFilter) =>
+          CHIP_NAV_KEYS.includes(f.attribute_key) &&
+          !CHIP_ONLY_FILTER_KEYS.includes(f.attribute_key) &&
+          !advancedKeys.has(f.attribute_key),
+      )
+      .map(conversationFilterToBaseFilter);
+    onFilterApply([...chipNav, ...advancedFilters]);
+  };
+
   const handleClearFilters = async () => {
     setConversationFilters([]);
     onFilterClear();
@@ -554,16 +636,11 @@ const ChatSidebar = ({
   const totalPages = pagination?.total_pages || 1;
   const hasNextPage = pagination?.has_next_page ?? currentPage < totalPages;
 
-  // EVO-1939: o filtro padrão (status=open) representa a visão default e não
-  // deve contar como filtro aplicado no badge — assim o badge some ao limpar.
+  // Os eixos de chip (status / unread / is_group) são navegação, não filtro
+  // avançado — não contam no badge. Só filtros de verdade (prioridade, data,
+  // label, inbox, canal…) acendem. (Estende a exclusão do EVO-1939.)
   const appliedFilterCount = filters.state.activeFilters.filter(
-    f =>
-      !(
-        f.attribute_key === 'status' &&
-        f.filter_operator === 'equal_to' &&
-        f.values?.length === 1 &&
-        f.values[0] === 'open'
-      ),
+    f => !CHIP_NAV_KEYS.includes(f.attribute_key),
   ).length;
 
   const handleSidebarScroll = useCallback(async () => {
@@ -625,22 +702,19 @@ const ChatSidebar = ({
       return showArchived ? isArchived : !isArchived;
     });
 
-    const getSortTimestamp = (conversation: Conversation) => {
-      if (typeof conversation.timestamp === 'number') {
-        return conversation.timestamp;
-      }
-      const activityTime = Date.parse(conversation.last_activity_at || '');
-      if (!Number.isNaN(activityTime)) {
-        return activityTime;
-      }
-      const updatedTime = Date.parse(conversation.updated_at || '');
-      if (!Number.isNaN(updatedTime)) {
-        return updatedTime;
-      }
-      const createdTime = Date.parse(conversation.created_at || '');
-      if (!Number.isNaN(createdTime)) {
-        return createdTime;
-      }
+    // Ordena por last_activity_at (autoritativo: avança em status/atendente/label/
+    // mensagem e é mantido em sincronia pelo WS). NÃO usa conversation.timestamp
+    // como chave primária — o conversation.updated do WS o deixa defasado, e a
+    // conversa não subia ("bump que não reordena"). Tudo normalizado em ms para
+    // não misturar segundos (timestamp) com milissegundos (Date.parse).
+    const getSortTimestamp = (conversation: Conversation): number => {
+      const activityMs = Date.parse(conversation.last_activity_at || '');
+      if (!Number.isNaN(activityMs)) return activityMs;
+      const updatedMs = Date.parse(conversation.updated_at || '');
+      if (!Number.isNaN(updatedMs)) return updatedMs;
+      const createdMs = Date.parse(conversation.created_at || '');
+      if (!Number.isNaN(createdMs)) return createdMs;
+      if (typeof conversation.timestamp === 'number') return conversation.timestamp * 1000;
       return 0;
     };
 
@@ -650,9 +724,89 @@ const ChatSidebar = ({
       if (aPinned !== bPinned) {
         return aPinned ? -1 : 1;
       }
-      return getSortTimestamp(b) - getSortTimestamp(a);
+      const diff = getSortTimestamp(b) - getSortTimestamp(a);
+      if (diff !== 0) return diff;
+      // Tiebreaker determinístico: evita swaps/duplicatas na borda de página
+      // quando last_activity_at empata.
+      return String(b.id).localeCompare(String(a.id));
     });
   }, [conversations.state.conversations, showArchived]);
+
+  // Best-effort: contagem de arquivadas entre as conversas já carregadas.
+  const archivedCount = useMemo(
+    () =>
+      conversations.state.conversations.filter(c => Boolean(c.custom_attributes?.archived)).length,
+    [conversations.state.conversations],
+  );
+
+  // Conversas selecionadas (map display_id -> conversa) para as ações em lote.
+  const selectedConversations = useMemo(
+    () =>
+      conversations.state.conversations.filter(c =>
+        selectedConversationIds.has(String(c.display_id)),
+      ),
+    [conversations.state.conversations, selectedConversationIds],
+  );
+
+  const exitSelection = useCallback(() => {
+    onClearSelection();
+    setSelectionMode(false);
+  }, [onClearSelection]);
+
+  // Roda uma ação por-conversa em todas as selecionadas (loop no client — v1;
+  // o endpoint bulk dedicado fica como otimização futura). Quando `revert` é
+  // passado (só ler/não-ler, ações sem efeito colateral no backend), captura o
+  // estado de leitura ANTES de aplicar e, ao final, mostra um toast "Desfazer"
+  // (5s) que reaplica o inverso por conversa (cobre seleção mista). O toast e o
+  // undo cobrem APENAS as conversas que a ação aplicou com sucesso. Ações sem
+  // `revert` (arquivar/excluir) não mostram toast nem undo.
+  const runBulk = useCallback(
+    async (
+      action: (conv: Conversation) => Promise<unknown>,
+      revert?: (item: BulkSnapshot) => Promise<unknown>,
+    ) => {
+      if (selectedConversations.length === 0) return;
+      const convs = selectedConversations.slice();
+      // Snapshot dos primitivos que o undo precisa, antes do store mutar as rows.
+      const items: BulkSnapshot[] = convs.map(c => ({
+        id: c.id,
+        wasUnread: (conversations.getUnreadCount(c.id) ?? c.unread_count ?? 0) > 0,
+      }));
+      setBulkRunning(true);
+      let results: PromiseSettledResult<unknown>[] = [];
+      try {
+        results = await Promise.allSettled(convs.map(c => action(c)));
+      } finally {
+        setBulkRunning(false);
+        exitSelection();
+      }
+      if (revert) {
+        // Não oferecer undo (nem o toast de sucesso) para o que falhou.
+        const applied = items.filter((_, i) => results[i]?.status === 'fulfilled');
+        if (applied.length > 0) {
+          toast(t('chatSidebar.bulkApplied', { count: applied.length }), {
+            duration: 5000,
+            action: {
+              label: t('chatSidebar.undo'),
+              onClick: () => {
+                void Promise.allSettled(applied.map(it => revert(it)));
+              },
+            },
+          });
+        }
+      }
+    },
+    [selectedConversations, exitSelection, conversations, t],
+  );
+
+  // Undo só dos eixos SEM efeito colateral no backend: ler/não-ler usam
+  // update_column (sem automação/webhook/atividade). Restaura o estado de
+  // leitura anterior de cada conversa (cobre seleção mista). Status e
+  // arquivamento NÃO têm undo — re-disparariam eventos no backend.
+  const revertRead = (item: BulkSnapshot) =>
+    item.wasUnread
+      ? conversations.markAsUnread(item.id)
+      : conversations.markAsRead(item.id, { silent: true });
 
   const stripHtml = (html: string): string => {
     if (!html) return '';
@@ -945,7 +1099,7 @@ const ChatSidebar = ({
       data-tour="chat-sidebar"
       className={`
         ${mobileView === 'list' ? 'flex' : 'hidden'} md:flex
-        w-full ${selectedConversationIds.size > 0 ? 'md:w-96' : 'md:w-80'} border-r bg-card/50 flex-col h-full
+        w-full md:w-96 border-r bg-card/50 flex-col h-full
       `}
     >
       {/* Search and Filter Header */}
@@ -972,94 +1126,247 @@ const ChatSidebar = ({
           />
         </div>
 
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant={showArchived ? 'ghost' : 'secondary'}
-            size="sm"
-            className="h-8 cursor-pointer"
-            aria-pressed={!showArchived}
-            onClick={() => setShowArchived(false)}
-          >
-            {t('chatSidebar.view.active')}
-          </Button>
-          <Button
-            type="button"
-            variant={showArchived ? 'secondary' : 'ghost'}
-            size="sm"
-            className="h-8 cursor-pointer"
-            aria-pressed={showArchived}
-            onClick={() => setShowArchived(true)}
-          >
-            {t('chatSidebar.view.archived')}
-          </Button>
-        </div>
+        {/* Segments (lab Experimento #1): WhatsApp-style primary views.
+            Reversible — remove this block to restore the prior UX. */}
+        {!showArchived && !selectionMode && (
+          <ConversationSegments
+            activeFilters={filters.state.activeFilters}
+            onSelectSegment={handleApplyFilters}
+            disabled={filters.state.isApplyingFilters}
+          />
+        )}
 
-        {/* Filter Actions */}
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-muted-foreground">
-            {(conversations.state.conversationsPagination?.total || visibleConversations.length)}{' '}
-            {(conversations.state.conversationsPagination?.total || visibleConversations.length) === 1
-              ? t('chatSidebar.conversation')
-              : t('chatSidebar.conversations')}
-          </span>
-          <div className="flex items-center gap-2">
-            {/* Indicador de filtros ativos (ignora o filtro padrão status=open) */}
-            {appliedFilterCount > 0 && (
-              <Badge variant="secondary" className="text-xs">
-                {appliedFilterCount}{' '}
-                {appliedFilterCount === 1
-                  ? t('chatSidebar.filter')
-                  : t('chatSidebar.filters')}
-              </Badge>
-            )}
+        {/* Ações e filtro (apenas na visão normal) */}
+        {!showArchived && !selectionMode && (
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">
+              {(conversations.state.conversationsPagination?.total || visibleConversations.length)}{' '}
+              {(conversations.state.conversationsPagination?.total || visibleConversations.length) === 1
+                ? t('chatSidebar.conversation')
+                : t('chatSidebar.conversations')}
+            </span>
+            <div className="flex items-center gap-2">
+              {/* Indicador de filtros ativos (status é navegação, não conta) */}
+              {appliedFilterCount > 0 && (
+                <Badge variant="secondary" className="text-xs">
+                  {appliedFilterCount}{' '}
+                  {appliedFilterCount === 1
+                    ? t('chatSidebar.filter')
+                    : t('chatSidebar.filters')}
+                </Badge>
+              )}
 
-            {/* Botão de filtros */}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setFilterModalOpen(true)}
-              disabled={filters.state.isApplyingFilters}
-              className="h-8 px-2 cursor-pointer"
-              data-tour="chat-filter-button"
-            >
-              <Filter className="h-4 w-4" />
-              {t('chatSidebar.filtersButton')}
-            </Button>
+              {/* Botão "Selecionar" — entra no modo de seleção em lote */}
+              {!selectionMode && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelectionMode(true)}
+                  className="h-8 px-2 cursor-pointer"
+                >
+                  {t('chatSidebar.select')}
+                </Button>
+              )}
+
+              {/* Botão de filtros */}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setFilterModalOpen(true)}
+                disabled={filters.state.isApplyingFilters}
+                className="h-8 px-2 cursor-pointer"
+                data-tour="chat-filter-button"
+              >
+                <Filter className="h-4 w-4" />
+                {t('chatSidebar.filtersButton')}
+              </Button>
+            </div>
           </div>
-        </div>
-        {showArchived && (
-          <p className="text-xs text-muted-foreground">{t('chatSidebar.archivedNotice')}</p>
+        )}
+
+        {/* Entrada única de Arquivados (visão normal) → abre a "aba" de arquivados */}
+        {!showArchived && !selectionMode && (
+          <button
+            type="button"
+            onClick={() => {
+              setShowArchived(true);
+              // Busca no backend só as arquivadas (archived=true, todos os status),
+              // per_page 100 (cap do backend) = carrega todas numa tacada, sem botão.
+              void conversations.loadConversations({ status: 'all', archived: true, per_page: 100 });
+            }}
+            className="flex w-full items-center justify-between rounded-md px-2 py-2 text-sm hover:bg-muted cursor-pointer"
+          >
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Archive className="h-4 w-4" />
+              {t('chatSidebar.view.archived')}
+            </span>
+            {archivedCount > 0 && (
+              <span className="text-xs text-muted-foreground">{archivedCount}</span>
+            )}
+          </button>
+        )}
+
+        {/* "Aba" de arquivados aberta → cabeçalho com voltar à visão normal */}
+        {showArchived && !selectionMode && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowArchived(false);
+                  // Volta pra visão normal reaplicando o filtro ativo (default/chip).
+                  void filters.applyFilters(
+                    filters.state.activeFilters,
+                    (c, p, q) => conversations.setConversations(c, p, q),
+                    () => {},
+                  );
+                }}
+                className="flex items-center gap-2 text-sm font-medium cursor-pointer hover:text-primary"
+              >
+                <ArrowLeft className="h-4 w-4" />
+                {t('chatSidebar.view.archived')}
+              </button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setSelectionMode(true)}
+                className="h-8 px-2 cursor-pointer"
+              >
+                {t('chatSidebar.select')}
+              </Button>
+            </div>
+          </div>
         )}
       </div>
 
-      {/* Bulk Action Toolbar */}
-      {selectedConversationIds.size > 0 && (
-        <div className="px-3 py-2 border-b bg-primary/5 flex flex-col gap-1.5 flex-shrink-0">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-muted-foreground">
-              {t('chatSidebar.selectedCount', { count: selectedConversationIds.size })}
-            </span>
+      {/* Barra de ações em lote (estilo WhatsApp: ✕ N selecionadas + kebab ⋮) */}
+      {selectionMode && (
+        <div className="px-3 py-2 border-b bg-muted/40 flex items-center justify-between gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 w-7 p-0 cursor-pointer"
-              onClick={onClearSelection}
+              className="h-8 w-8 p-0 cursor-pointer"
+              onClick={exitSelection}
+              aria-label={t('chatSidebar.doneSelection')}
             >
-              <X className="h-3.5 w-3.5" />
+              <X className="h-4 w-4" />
             </Button>
+            <span className="text-sm font-medium truncate">
+              {t('chatSidebar.selectedCount', { count: selectedConversationIds.size })}
+            </span>
           </div>
-          <Button
-            size="sm"
-            className="h-7 w-full cursor-pointer"
-            onClick={onBulkResolve}
-            disabled={isBulkResolving || !canBulkResolve}
-          >
-            <CheckCircle className="h-3.5 w-3.5 mr-1.5" />
-            {t('chatHeader.actions.markAsResolved')}
-          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0 cursor-pointer"
+                disabled={selectedConversationIds.size === 0 || bulkRunning}
+                aria-label={t('chatSidebar.bulkActions')}
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {canBulkUpdateStatus && (
+                <>
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    disabled={isBulkUpdatingStatus}
+                    onClick={() => {
+                      void onBulkSetStatus('resolved').finally(() => setSelectionMode(false));
+                    }}
+                  >
+                    <CheckCircle className="h-4 w-4 mr-2" />
+                    {t('chatHeader.actions.markAsResolved')}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    disabled={isBulkUpdatingStatus}
+                    onClick={() => {
+                      void onBulkSetStatus('open').finally(() => setSelectionMode(false));
+                    }}
+                  >
+                    <MessageCircle className="h-4 w-4 mr-2" />
+                    {t('chatHeader.actions.markAsOpen')}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="cursor-pointer"
+                    disabled={isBulkUpdatingStatus}
+                    onClick={() => {
+                      void onBulkSetStatus('pending').finally(() => setSelectionMode(false));
+                    }}
+                  >
+                    <Clock className="h-4 w-4 mr-2" />
+                    {t('chatHeader.actions.markAsPending')}
+                  </DropdownMenuItem>
+                </>
+              )}
+              {showArchived ? (
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => void runBulk(c => conversations.unarchiveConversation(c.id))}
+                >
+                  <Archive className="h-4 w-4 mr-2" />
+                  {t('chatHeader.actions.unarchiveConversation')}
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  className="cursor-pointer"
+                  onClick={() => void runBulk(c => conversations.archiveConversation(c.id))}
+                >
+                  <Archive className="h-4 w-4 mr-2" />
+                  {t('chatHeader.actions.archiveConversation')}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() =>
+                  void runBulk(c => conversations.markAsRead(c.id, { silent: true }), revertRead)
+                }
+              >
+                <MailOpen className="h-4 w-4 mr-2" />
+                {t('chatHeader.actions.markAsRead')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onClick={() => void runBulk(c => conversations.markAsUnread(c.id), revertRead)}
+              >
+                <Mail className="h-4 w-4 mr-2" />
+                {t('chatHeader.actions.markAsUnread')}
+              </DropdownMenuItem>
+              {can('conversations', 'delete') && (
+                <DropdownMenuItem
+                  className="cursor-pointer text-destructive focus:text-destructive"
+                  onClick={() => setBulkDeleteOpen(true)}
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  {t('chatHeader.actions.deleteConversation')}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       )}
+
+      {/* Confirmação de exclusão em lote */}
+      <AlertDialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('deleteDialog.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('chatSidebar.bulkDeleteDescription', { count: selectedConversationIds.size })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('deleteDialog.cancel')}</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void runBulk(c => conversations.deleteConversation(c.id))}>
+              {t('deleteDialog.confirm')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Conversations List */}
       <div
@@ -1115,6 +1422,8 @@ const ChatSidebar = ({
             {visibleConversations.map((conversation: Conversation) => {
               const isSelected =
                 String(conversations.state.selectedConversationId) === String(conversation.id);
+              const isBulkSelected =
+                selectionMode && selectedConversationIds.has(String(conversation.display_id));
 
               // Usar channel da conversa diretamente, com fallback para inbox
               const channelType =
@@ -1129,30 +1438,38 @@ const ChatSidebar = ({
                 <div
                   key={conversation.id}
                   className={`p-4 hover:bg-accent cursor-pointer transition-colors ${
-                    isSelected
-                      ? 'bg-primary/10 border-l-2 border-l-primary'
-                      : 'border-b border-border/50'
+                    isBulkSelected
+                      ? 'bg-primary/5 border-l-2 border-l-primary'
+                      : isSelected
+                        ? 'bg-primary/10 border-l-2 border-l-primary'
+                        : 'border-b border-border/50'
                   }`}
-                  onClick={() => onConversationSelect(conversation)}
+                  onClick={() =>
+                    selectionMode
+                      ? onToggleSelect(String(conversation.display_id))
+                      : onConversationSelect(conversation)
+                  }
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex items-start gap-3 min-w-0 flex-1">
-                      <div
-                        className="mt-1 flex-shrink-0"
-                        onClick={e => e.stopPropagation()}
-                      >
-                        <Checkbox
-                          checked={selectedConversationIds.has(String(conversation.display_id))}
-                          onCheckedChange={(checked: boolean | 'indeterminate') => {
-                            const isSelected = selectedConversationIds.has(String(conversation.display_id));
-                            if ((checked === true && !isSelected) || (checked === false && isSelected)) {
-                              onToggleSelect(String(conversation.display_id));
-                            }
-                          }}
-                          aria-label={t('chatSidebar.selectConversation')}
-                          className="bg-white dark:bg-zinc-700 border-2 border-zinc-400 dark:border-zinc-500 data-[state=checked]:bg-primary data-[state=checked]:border-primary"
-                        />
-                      </div>
+                      {selectionMode && (
+                        <div
+                          className="mt-1 flex-shrink-0"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          <Checkbox
+                            checked={selectedConversationIds.has(String(conversation.display_id))}
+                            onCheckedChange={(checked: boolean | 'indeterminate') => {
+                              const isSelected = selectedConversationIds.has(String(conversation.display_id));
+                              if ((checked === true && !isSelected) || (checked === false && isSelected)) {
+                                onToggleSelect(String(conversation.display_id));
+                              }
+                            }}
+                            aria-label={t('chatSidebar.selectConversation')}
+                            className="border-muted-foreground/40 data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+                          />
+                        </div>
+                      )}
                       <ContactAvatar
                         contact={conversation.contact}
                         channelType={channelType}
@@ -1239,7 +1556,7 @@ const ChatSidebar = ({
               </div>
             )}
 
-            {!isLoadingMoreConversations && hasNextPage && (
+            {!isLoadingMoreConversations && hasNextPage && !showArchived && (
               <div className="p-3 border-t border-border/40">
                 <Button
                   variant="outline"
@@ -1261,7 +1578,7 @@ const ChatSidebar = ({
         onOpenChange={setFilterModalOpen}
         filters={conversationFilters}
         onFiltersChange={setConversationFilters}
-        onApplyFilters={handleApplyFilters}
+        onApplyFilters={handleApplyAdvancedFilters}
         onClearFilters={handleClearFilters}
       />
     </div>

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -601,9 +601,33 @@ const ChatSidebar = ({
     [navigate, onSearchChange],
   );
 
-  const handleApplyFilters = async (newFilters: BaseFilter[]) => {
-    setConversationFilters(newFilters);
-    onFilterApply(newFilters);
+  // Navegação por chip. Simétrico ao handleApplyAdvancedFilters (que preserva o
+  // status ao aplicar avançado): um chip de STATUS preserva os filtros avançados
+  // ativos (troca só o status). Não-lidas/Grupos são CHIP_ONLY e NÃO combinam com
+  // avançado no backend (POST /filter = 400; é o EVO-1970), então limpam o
+  // avançado — mas avisando, em vez do sumiço silencioso de antes.
+  const handleApplyFilters = async (segmentPreset: BaseFilter[]) => {
+    const advanced = filters.state.activeFilters
+      .filter((f: ConversationFilter) => !CHIP_NAV_KEYS.includes(f.attribute_key))
+      .map(conversationFilterToBaseFilter);
+
+    if (advanced.length === 0) {
+      setConversationFilters([]);
+      onFilterApply(segmentPreset);
+      return;
+    }
+
+    const isChipOnly = segmentPreset.some(f => CHIP_ONLY_FILTER_KEYS.includes(f.attributeKey));
+    if (isChipOnly) {
+      toast.info(t('chatSidebar.advancedFiltersCleared'));
+      setConversationFilters([]);
+      onFilterApply(segmentPreset);
+      return;
+    }
+
+    // Chip de status: mantém o avançado, troca só a navegação de status.
+    setConversationFilters(advanced);
+    onFilterApply([...segmentPreset, ...advanced]);
   };
 
   // Apply do MODAL avançado: status/unread/is_group são navegação por chip e NÃO
@@ -758,12 +782,14 @@ const ChatSidebar = ({
   // passado (só ler/não-ler, ações sem efeito colateral no backend), captura o
   // estado de leitura ANTES de aplicar e, ao final, mostra um toast "Desfazer"
   // (5s) que reaplica o inverso por conversa (cobre seleção mista). O toast e o
-  // undo cobrem APENAS as conversas que a ação aplicou com sucesso. Ações sem
-  // `revert` (arquivar/excluir) não mostram toast nem undo.
+  // undo cobrem APENAS as conversas que a ação aplicou com sucesso. Todas as
+  // ações em massa silenciam o toast por-conversa ({ silent: true }) e mostram
+  // só o consolidado; as sem `revert` (arquivar/excluir) mostram-no sem undo.
   const runBulk = useCallback(
     async (
       action: (conv: Conversation) => Promise<unknown>,
       revert?: (item: BulkSnapshot) => Promise<unknown>,
+      successKey: string = 'chatSidebar.bulkApplied',
     ) => {
       if (selectedConversations.length === 0) return;
       const convs = selectedConversations.slice();
@@ -780,20 +806,31 @@ const ChatSidebar = ({
         setBulkRunning(false);
         exitSelection();
       }
-      if (revert) {
-        // Não oferecer undo (nem o toast de sucesso) para o que falhou.
-        const applied = items.filter((_, i) => results[i]?.status === 'fulfilled');
-        if (applied.length > 0) {
-          toast(t('chatSidebar.bulkApplied', { count: applied.length }), {
-            duration: 5000,
-            action: {
-              label: t('chatSidebar.undo'),
-              onClick: () => {
-                void Promise.allSettled(applied.map(it => revert(it)));
-              },
-            },
-          });
-        }
+      // Toast CONSOLIDADO (1 só): as ações em massa silenciam o toast por-conversa,
+      // então mostramos um único resumo. Conta só o que aplicou com sucesso; o undo
+      // (quando reversível — ler/não-ler) reaplica o inverso por conversa.
+      const applied = items.filter((_, i) => results[i]?.status === 'fulfilled');
+      const failedCount = results.length - applied.length;
+      if (applied.length > 0) {
+        toast(t(successKey, { count: applied.length }), {
+          duration: 5000,
+          ...(revert
+            ? {
+                action: {
+                  label: t('chatSidebar.undo'),
+                  onClick: () => {
+                    void Promise.allSettled(applied.map(it => revert(it)));
+                  },
+                },
+              }
+            : {}),
+        });
+      }
+      // Falhas TAMBÉM consolidadas num único toast (as ações silenciam o erro
+      // por-conversa via { silent: true }), pra não empilhar N erros nem afogar
+      // o toast de sucesso/undo.
+      if (failedCount > 0) {
+        toast.error(t('chatSidebar.bulkFailed', { count: failedCount }));
       }
     },
     [selectedConversations, exitSelection, conversations, t],
@@ -805,7 +842,7 @@ const ChatSidebar = ({
   // arquivamento NÃO têm undo — re-disparariam eventos no backend.
   const revertRead = (item: BulkSnapshot) =>
     item.wasUnread
-      ? conversations.markAsUnread(item.id)
+      ? conversations.markAsUnread(item.id, { silent: true })
       : conversations.markAsRead(item.id, { silent: true });
 
   const stripHtml = (html: string): string => {
@@ -1306,7 +1343,7 @@ const ChatSidebar = ({
               {showArchived ? (
                 <DropdownMenuItem
                   className="cursor-pointer"
-                  onClick={() => void runBulk(c => conversations.unarchiveConversation(c.id))}
+                  onClick={() => void runBulk(c => conversations.unarchiveConversation(c.id, undefined, { silent: true }))}
                 >
                   <Archive className="h-4 w-4 mr-2" />
                   {t('chatHeader.actions.unarchiveConversation')}
@@ -1314,7 +1351,7 @@ const ChatSidebar = ({
               ) : (
                 <DropdownMenuItem
                   className="cursor-pointer"
-                  onClick={() => void runBulk(c => conversations.archiveConversation(c.id))}
+                  onClick={() => void runBulk(c => conversations.archiveConversation(c.id, undefined, { silent: true }))}
                 >
                   <Archive className="h-4 w-4 mr-2" />
                   {t('chatHeader.actions.archiveConversation')}
@@ -1331,7 +1368,7 @@ const ChatSidebar = ({
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
-                onClick={() => void runBulk(c => conversations.markAsUnread(c.id), revertRead)}
+                onClick={() => void runBulk(c => conversations.markAsUnread(c.id, { silent: true }), revertRead)}
               >
                 <Mail className="h-4 w-4 mr-2" />
                 {t('chatHeader.actions.markAsUnread')}
@@ -1361,7 +1398,7 @@ const ChatSidebar = ({
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('deleteDialog.cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={() => void runBulk(c => conversations.deleteConversation(c.id))}>
+            <AlertDialogAction onClick={() => void runBulk(c => conversations.deleteConversation(c.id, { silent: true }), undefined, 'chatSidebar.bulkDeleted')}>
               {t('deleteDialog.confirm')}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/components/chat/chat-sidebar/ConversationSegments.tsx
+++ b/src/components/chat/chat-sidebar/ConversationSegments.tsx
@@ -1,0 +1,175 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Button } from '@evoapi/design-system/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@evoapi/design-system/dropdown-menu';
+import { useLanguage } from '@/hooks/useLanguage';
+import type { BaseFilter } from '@/types/core/filters';
+import type { ConversationFilter } from '@/types/chat/api';
+import { CONVERSATION_SEGMENTS, getActiveSegmentId, ALL_SEGMENT_PRESET } from './conversationSegments';
+
+interface ConversationSegmentsProps {
+  /** Current GLOBAL active filters, used to highlight the matching chip. */
+  activeFilters: ConversationFilter[];
+  /** Applies the segment preset through the existing filter pipeline. */
+  onSelectSegment: (preset: BaseFilter[]) => void;
+  disabled?: boolean;
+}
+
+const GAP = 4; // matches gap-1 (0.25rem)
+// Chips compactos (px-2.5 + text-xs) pra caberem mais na largura da lista. A
+// camada de medição usa a MESMA classe pro cálculo de overflow bater.
+const CHIP_CLASS = 'h-8 shrink-0 cursor-pointer px-2.5 text-xs';
+
+/**
+ * WhatsApp/CRM-style primary navigation for the conversation list. Chips são
+ * mutuamente exclusivos; clicar no ativo volta pro All. Quando os chips não
+ * cabem na largura, os que sobram colapsam num botão "▾" (estilo chip) que abre
+ * um dropdown — responsividade no estilo WhatsApp Web.
+ */
+const ConversationSegments = ({
+  activeFilters,
+  onSelectSegment,
+  disabled = false,
+}: ConversationSegmentsProps) => {
+  const { t } = useLanguage('chat');
+  const activeId = getActiveSegmentId(activeFilters);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(CONVERSATION_SEGMENTS.length);
+
+  // Mede as larguras naturais (camada oculta) e calcula quantos chips cabem,
+  // reservando espaço pro botão de overflow. useLayoutEffect = colapsa antes do
+  // paint (sem flicker). Recalcula no resize (ResizeObserver) e na troca de idioma.
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const measureLayer = measureRef.current;
+    if (!container || !measureLayer) return;
+
+    const compute = () => {
+      const chipEls = measureLayer.querySelectorAll<HTMLElement>('[data-measure-chip]');
+      const widths = Array.from(chipEls).map(el => el.offsetWidth);
+      const moreEl = measureLayer.querySelector<HTMLElement>('[data-measure-more]');
+      const moreWidth = moreEl?.offsetWidth ?? 40;
+      const total = widths.length;
+      if (!total) return;
+
+      const available = container.clientWidth;
+      const sumAll = widths.reduce((acc, w) => acc + w, 0) + GAP * (total - 1);
+      if (sumAll <= available) {
+        setVisibleCount(total);
+        return;
+      }
+
+      // Overflow: reserva o botão "▾" e encaixa o máximo de chips.
+      const budget = available - moreWidth - GAP;
+      let used = 0;
+      let count = 0;
+      for (let i = 0; i < total; i += 1) {
+        const next = used + widths[i] + (count > 0 ? GAP : 0);
+        if (next <= budget) {
+          used = next;
+          count += 1;
+        } else {
+          break;
+        }
+      }
+      setVisibleCount(Math.max(1, count));
+    };
+
+    compute();
+    const observer = new ResizeObserver(compute);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [t]);
+
+  const visible = CONVERSATION_SEGMENTS.slice(0, visibleCount);
+  const overflow = CONVERSATION_SEGMENTS.slice(visibleCount);
+  const overflowHasActive = overflow.some(segment => segment.id === activeId);
+
+  const applySegment = (segmentId: string, preset: BaseFilter[]) => {
+    // Toggle: clicar no chip já ativo desmarca e volta pro All.
+    onSelectSegment(segmentId === activeId ? ALL_SEGMENT_PRESET : preset);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative flex items-center gap-1 overflow-hidden"
+      role="tablist"
+      aria-label={t('chatSidebar.segments.ariaLabel')}
+    >
+      {/* Camada de medição oculta (todos os chips + o botão de overflow). */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        className="pointer-events-none absolute -z-10 flex items-center gap-1 opacity-0"
+      >
+        {CONVERSATION_SEGMENTS.map(segment => (
+          <Button key={segment.id} data-measure-chip variant="ghost" size="sm" className={CHIP_CLASS}>
+            {t(segment.labelKey)}
+          </Button>
+        ))}
+        <Button data-measure-more variant="ghost" size="sm" className="h-8 shrink-0 px-2">
+          <ChevronDown className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Chips visíveis */}
+      {visible.map(segment => {
+        const isActive = segment.id === activeId;
+        return (
+          <Button
+            key={segment.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            variant={isActive ? 'secondary' : 'ghost'}
+            size="sm"
+            className={CHIP_CLASS}
+            disabled={disabled}
+            onClick={() => applySegment(segment.id, segment.preset)}
+          >
+            {t(segment.labelKey)}
+          </Button>
+        );
+      })}
+
+      {/* Botão de overflow (▾) → dropdown com os chips que não couberam */}
+      {overflow.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant={overflowHasActive ? 'secondary' : 'ghost'}
+              size="sm"
+              className="h-8 shrink-0 px-2 cursor-pointer"
+              disabled={disabled}
+              aria-label={t('chatSidebar.segments.ariaLabel')}
+            >
+              <ChevronDown className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {overflow.map(segment => (
+              <DropdownMenuItem
+                key={segment.id}
+                className={`cursor-pointer ${segment.id === activeId ? 'font-semibold' : ''}`}
+                onClick={() => applySegment(segment.id, segment.preset)}
+              >
+                {t(segment.labelKey)}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+};
+
+export default ConversationSegments;

--- a/src/components/chat/chat-sidebar/conversationSegments.ts
+++ b/src/components/chat/chat-sidebar/conversationSegments.ts
@@ -1,0 +1,70 @@
+import { DEFAULT_BASE_FILTER, type BaseFilter } from '@/types/core/filters';
+import type { ConversationFilter } from '@/types/chat/api';
+
+// Lab (Experimento #1): WhatsApp/CRM-style primary navigation modeled as preset
+// filters. Each segment is just a BaseFilter[] fed through the existing
+// applyFilters seam (useFilterHandlers -> FiltersContext.applyFilters), so it
+// persiste, mantém o realtime matcher coerente e roteia pra GET barato. Os chips
+// são mutuamente exclusivos (single-select); clicar no ativo volta pro All.
+
+export type ConversationSegmentId = 'open' | 'pending' | 'resolved' | 'unread' | 'groups';
+
+export interface ConversationSegment {
+  id: ConversationSegmentId;
+  /** i18n key in the `chat` namespace. */
+  labelKey: string;
+  /** Preset applied via the existing filter pipeline when the chip is clicked. */
+  preset: BaseFilter[];
+}
+
+const statusFilter = (value: string): BaseFilter => ({
+  ...DEFAULT_BASE_FILTER,
+  attributeKey: 'status',
+  filterOperator: 'equal_to',
+  values: value,
+});
+
+// unread / is_group: eixos de navegação (não-status) mapeados pra params GET em
+// convertFiltersToUrlParams. status ausente é injetado como 'all' lá, então estas
+// views abrangem todos os status (ex.: "Não lidas" = não lidas em qualquer status).
+const boolFilter = (attributeKey: 'unread' | 'is_group'): BaseFilter => ({
+  ...DEFAULT_BASE_FILTER,
+  attributeKey,
+  filterOperator: 'equal_to',
+  values: 'true',
+});
+
+export const CONVERSATION_SEGMENTS: ConversationSegment[] = [
+  { id: 'open', labelKey: 'chatSidebar.segments.open', preset: [statusFilter('open')] },
+  { id: 'pending', labelKey: 'chatSidebar.segments.pending', preset: [statusFilter('pending')] },
+  { id: 'resolved', labelKey: 'chatSidebar.segments.resolved', preset: [statusFilter('resolved')] },
+  { id: 'unread', labelKey: 'chatSidebar.segments.unread', preset: [boolFilter('unread')] },
+  { id: 'groups', labelKey: 'chatSidebar.segments.groups', preset: [boolFilter('is_group')] },
+];
+
+// "All" = nenhum chip marcado (status=all). Aplicado ao clicar no chip já ativo
+// (toggle-off) e como visão padrão. getActiveSegmentId retorna null aqui.
+export const ALL_SEGMENT_PRESET: BaseFilter[] = [statusFilter('all')];
+
+const hasFilter = (active: ConversationFilter[], key: string, value: string): boolean =>
+  active.some(
+    f =>
+      f.attribute_key === key &&
+      f.filter_operator === 'equal_to' &&
+      (Array.isArray(f.values) ? f.values.map(String).includes(value) : String(f.values) === value),
+  );
+
+/**
+ * Derive which segment the current GLOBAL activeFilters represent so the matching
+ * chip can be highlighted. Single-select / mutually exclusive: cada preset é um
+ * único filtro. Returns null para All (status=all) ou filtro avançado/custom.
+ */
+export const getActiveSegmentId = (active: ConversationFilter[]): ConversationSegmentId | null => {
+  if (!active || active.length === 0) return null;
+  if (active.length === 1 && hasFilter(active, 'unread', 'true')) return 'unread';
+  if (active.length === 1 && hasFilter(active, 'is_group', 'true')) return 'groups';
+  if (active.length === 1 && hasFilter(active, 'status', 'pending')) return 'pending';
+  if (active.length === 1 && hasFilter(active, 'status', 'resolved')) return 'resolved';
+  if (active.length === 1 && hasFilter(active, 'status', 'open')) return 'open';
+  return null;
+};

--- a/src/components/chat/chat-sidebar/conversationSegments.ts
+++ b/src/components/chat/chat-sidebar/conversationSegments.ts
@@ -56,15 +56,19 @@ const hasFilter = (active: ConversationFilter[], key: string, value: string): bo
 
 /**
  * Derive which segment the current GLOBAL activeFilters represent so the matching
- * chip can be highlighted. Single-select / mutually exclusive: cada preset é um
- * único filtro. Returns null para All (status=all) ou filtro avançado/custom.
+ * chip can be highlighted. O eixo STATUS é refletido mesmo quando filtros avançados
+ * o acompanham (Opção 1: chip de status preserva o avançado). unread/groups são
+ * CHIP_ONLY e nunca coexistem com avançado, então exigem seleção única. Returns
+ * null para All (status=all) ou filtro avançado sem status reconhecível.
  */
 export const getActiveSegmentId = (active: ConversationFilter[]): ConversationSegmentId | null => {
   if (!active || active.length === 0) return null;
   if (active.length === 1 && hasFilter(active, 'unread', 'true')) return 'unread';
   if (active.length === 1 && hasFilter(active, 'is_group', 'true')) return 'groups';
-  if (active.length === 1 && hasFilter(active, 'status', 'pending')) return 'pending';
-  if (active.length === 1 && hasFilter(active, 'status', 'resolved')) return 'resolved';
-  if (active.length === 1 && hasFilter(active, 'status', 'open')) return 'open';
+  // status coexiste com avançado — não guardar por length, senão o chip clicado
+  // não acende (e não dá pra desligar) quando há um filtro avançado ativo.
+  if (hasFilter(active, 'status', 'pending')) return 'pending';
+  if (hasFilter(active, 'status', 'resolved')) return 'resolved';
+  if (hasFilter(active, 'status', 'open')) return 'open';
   return null;
 };

--- a/src/components/chat/contact-sidebar/ContactSidebar.spec.tsx
+++ b/src/components/chat/contact-sidebar/ContactSidebar.spec.tsx
@@ -17,6 +17,12 @@ vi.mock('./MacrosList', () => ({ default: () => null }));
 vi.mock('./EditableContactCustomAttributes', () => ({ default: () => null }));
 vi.mock('./EditableConversationCustomAttributes', () => ({ default: () => null }));
 vi.mock('@/components/pipelines/ConversationPipelineItem', () => ({ default: () => null }));
+vi.mock('@/contexts/chat/ChatContext', () => ({
+  useChatContext: () => ({ conversations: { updateConversation: vi.fn() } }),
+}));
+vi.mock('@/services/chat/chatService', () => ({
+  default: { getConversation: vi.fn().mockResolvedValue({ data: {} }) },
+}));
 type WithChildren = { children?: React.ReactNode; onClick?: () => void };
 vi.mock('@evoapi/design-system/button', () => ({ Button: ({ children, onClick }: WithChildren) => <button onClick={onClick}>{children}</button> }));
 vi.mock('@evoapi/design-system/card', () => ({

--- a/src/components/chat/contact-sidebar/ContactSidebar.tsx
+++ b/src/components/chat/contact-sidebar/ContactSidebar.tsx
@@ -22,6 +22,8 @@ import type { Pipeline } from '@/types/analytics';
 import { contactsService } from '@/services/contacts';
 import { Contact, Conversation } from '@/types/chat/api';
 import { mergeFullContact } from '@/utils/chat/contactTimestamp';
+import { useChatContext } from '@/contexts/chat/ChatContext';
+import chatService from '@/services/chat/chatService';
 
 interface ContactSidebarProps {
   isOpen: boolean;
@@ -80,6 +82,7 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
   onFilterReload,
 }) => {
   const { t } = useLanguage('chat');
+  const chatCtx = useChatContext();
 
   // Estados para controlar seções expandidas/colapsadas (padrão Agents.tsx)
   const [showContactDetails, setShowContactDetails] = useState(false);
@@ -167,15 +170,32 @@ const ContactSidebar: React.FC<ContactSidebarProps> = ({
     }
   }, [conversation?.id]);
 
+  // #1 harmonia mesma-aba: recarrega o rich state quando OUTRA superfície (menu de
+  // contexto / header) muta o pipeline. Toda mutação chama updateConversation, que
+  // troca a REFERÊNCIA de conversation.pipelines (badge) — logo, keyar o effect
+  // nela reflete a mudança aqui sem precisar de websocket. selectedConversation é
+  // derivado da state compartilhada, então o prop chega fresco. (Cross-aba/agente
+  // = websocket, camada separada.)
   useEffect(() => {
     loadConversationPipelines();
-  }, [loadConversationPipelines]);
+  }, [loadConversationPipelines, conversation?.pipelines]);
 
   // Handler para recarregar pipelines quando houver atualização
   const handlePipelineUpdated = useCallback(async () => {
     await loadConversationPipelines();
-    onFilterReload?.();
-  }, [loadConversationPipelines, onFilterReload]);
+    // #2: em vez de refetchar a lista INTEIRA (onFilterReload = reloadCurrentFilters),
+    // atualiza só o badge DESTA conversa via getConversation (rápido depois do fix do
+    // include_messages) -> updateConversation. Fallback pro reload amplo se falhar.
+    const id = conversation?.id;
+    if (!id) return;
+    try {
+      const raw = await chatService.getConversation(id);
+      const updated = (raw as { data?: Conversation })?.data ?? (raw as unknown as Conversation);
+      if (updated?.id) chatCtx.conversations.updateConversation(updated);
+    } catch {
+      await onFilterReload?.();
+    }
+  }, [loadConversationPipelines, conversation?.id, chatCtx, onFilterReload]);
 
   const handleContactAttributeUpdate = useCallback(async () => {
     const id = contactRef.current?.id;

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -22,74 +22,7 @@ import { useAppDataStore } from '@/store/appDataStore';
 import { useAuth } from '@/contexts/AuthContext';
 import { playNotificationSound, getAudioSettings } from '@/utils/audioNotificationUtils';
 import { normalizeToUnixSeconds } from '@/utils/time/timeHelpers';
-
-function doesConversationMatchFilters(
-  conversation: Conversation,
-  activeFilters: ConversationFilter[],
-  currentUserId?: string,
-): boolean {
-  if (!activeFilters || activeFilters.length === 0) return true;
-
-  return activeFilters.every(filter => {
-    const { attribute_key, filter_operator, values } = filter;
-    if (!values || values.length === 0) return true;
-    const stringValues = values.map(v => String(v));
-    if (stringValues.some(v => v.toLowerCase() === 'all')) return true;
-
-    let conversationValue: string | null | undefined;
-
-    switch (attribute_key) {
-      case 'status':
-        conversationValue = conversation.status;
-        break;
-      case 'inbox_id':
-        conversationValue = conversation.inbox_id ? String(conversation.inbox_id) : undefined;
-        break;
-      case 'assignee_id': {
-        const val = String(values[0]);
-        if (val === 'me') {
-          const meMatches = currentUserId
-            ? conversation.assignee_id != null && String(conversation.assignee_id) === String(currentUserId)
-            : false;
-          return filter_operator === 'not_equal_to' ? !meMatches : meMatches;
-        }
-        if (val === 'unassigned') {
-          const isUnassigned = !conversation.assignee_id;
-          return filter_operator === 'not_equal_to' ? !isUnassigned : isUnassigned;
-        }
-        if (val === 'assigned') {
-          const isAssigned = !!conversation.assignee_id;
-          return filter_operator === 'not_equal_to' ? !isAssigned : isAssigned;
-        }
-        conversationValue = conversation.assignee_id ? String(conversation.assignee_id) : null;
-        break;
-      }
-      case 'team_id':
-        conversationValue = conversation.team_id ? String(conversation.team_id) : null;
-        break;
-      case 'channel_type':
-        conversationValue = conversation.channel || undefined;
-        break;
-      default:
-        return true;
-    }
-
-    if (filter_operator === 'equal_to') {
-      return conversationValue != null && stringValues.includes(String(conversationValue));
-    }
-    if (filter_operator === 'not_equal_to') {
-      return conversationValue == null || !stringValues.includes(String(conversationValue));
-    }
-    if (filter_operator === 'contains') {
-      return conversationValue != null && stringValues.some(v => String(conversationValue).includes(v));
-    }
-    if (filter_operator === 'does_not_contain') {
-      return conversationValue == null || !stringValues.some(v => String(conversationValue).includes(v));
-    }
-
-    return true;
-  });
-}
+import { doesConversationMatchFilters } from '@/utils/chat/conversationMatch';
 
 interface ChatContextValue {
   // All sub-contexts
@@ -587,23 +520,47 @@ function useChatIntegration() {
           return;
         }
 
-        conversations.updateConversation({
+        const updatedConversation: Conversation = {
           ...existingConversation,
           status,
           ...(updatedAt ? { updated_at: updatedAt } : {}),
-        });
+        };
+
+        // EVO-1960: uma mudança de status via realtime pode tirar a conversa da
+        // view ativa (ex.: reaberta enquanto vejo "Resolvidas"). Reconcilia como
+        // o onConversationUpdated faz — senão a conversa fica pendurada e, se for
+        // fixada, o sort de pinned a joga pro topo da lista errada.
+        if (!doesConversationMatchFilters(updatedConversation, activeFiltersRef.current, currentUser?.id)) {
+          conversations.addHiddenConversation(updatedConversation);
+          conversations.removeConversation(conversationId);
+          return;
+        }
+
+        conversations.updateConversation(updatedConversation);
       },
 
       onConversationRead: (conversationId: string, unreadCount: number) => {
         conversations.updateUnreadCount(conversationId, unreadCount);
 
         const conversation = conversations.getConversation(conversationId);
-        if (conversation) {
-          conversations.updateConversation({
-            ...conversation,
-            unread_count: unreadCount,
-          });
+        if (!conversation) {
+          return;
         }
+
+        const updatedConversation: Conversation = {
+          ...conversation,
+          unread_count: unreadCount,
+        };
+
+        // EVO-1960: zerar não-lidas pode tirar a conversa da view "Não lidas".
+        // Mesma reconciliação do status — evita o vazamento (inclusive de fixadas).
+        if (!doesConversationMatchFilters(updatedConversation, activeFiltersRef.current, currentUser?.id)) {
+          conversations.addHiddenConversation(updatedConversation);
+          conversations.removeConversation(conversationId);
+          return;
+        }
+
+        conversations.updateConversation(updatedConversation);
       },
 
       onConversationLastActivity: (conversationId: string, lastActivityAt: string) => {

--- a/src/contexts/chat/ConversationsContext.tsx
+++ b/src/contexts/chat/ConversationsContext.tsx
@@ -506,7 +506,11 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const archiveConversation = useCallback(
-    async (conversationId: string, onFilterReload?: () => Promise<void>) => {
+    async (
+      conversationId: string,
+      onFilterReload?: () => Promise<void>,
+      options?: { silent?: boolean },
+    ) => {
       try {
         const response = await chatService.archiveConversation(conversationId);
 
@@ -516,7 +520,9 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
           console.warn('archiveConversation: Invalid response', response);
         }
 
-        toast.success(t('contexts.conversations.success.archived'));
+        if (!options?.silent) {
+          toast.success(t('contexts.conversations.success.archived'));
+        }
 
         if (onFilterReload) {
           await onFilterReload();
@@ -525,19 +531,23 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
         return response as unknown as Conversation;
       } catch (error) {
         if (isActionNotSupported(error)) {
-          toast.error(t('contexts.conversations.errors.archiveNotSupported'), {
-            description: t('contexts.conversations.errors.archiveNotSupportedDescription'),
-          });
+          if (!options?.silent) {
+            toast.error(t('contexts.conversations.errors.archiveNotSupported'), {
+              description: t('contexts.conversations.errors.archiveNotSupportedDescription'),
+            });
+          }
           throw error;
         }
 
         console.error('Error archiving conversation:', error);
-        toast.error(t('contexts.conversations.errors.archiveConversation'), {
-          description:
-            error instanceof Error
-              ? error.message
-              : t('contexts.conversations.tryAgainDescription'),
-        });
+        if (!options?.silent) {
+          toast.error(t('contexts.conversations.errors.archiveConversation'), {
+            description:
+              error instanceof Error
+                ? error.message
+                : t('contexts.conversations.tryAgainDescription'),
+          });
+        }
         throw error;
       }
     },
@@ -545,7 +555,11 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const unarchiveConversation = useCallback(
-    async (conversationId: string, onFilterReload?: () => Promise<void>) => {
+    async (
+      conversationId: string,
+      onFilterReload?: () => Promise<void>,
+      options?: { silent?: boolean },
+    ) => {
       try {
         const response = await chatService.unarchiveConversation(conversationId);
 
@@ -555,7 +569,9 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
           console.warn('unarchiveConversation: Invalid response', response);
         }
 
-        toast.success(t('contexts.conversations.success.unarchived'));
+        if (!options?.silent) {
+          toast.success(t('contexts.conversations.success.unarchived'));
+        }
 
         if (onFilterReload) {
           await onFilterReload();
@@ -564,19 +580,23 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
         return response as unknown as Conversation;
       } catch (error) {
         if (isActionNotSupported(error)) {
-          toast.error(t('contexts.conversations.errors.archiveNotSupported'), {
-            description: t('contexts.conversations.errors.archiveNotSupportedDescription'),
-          });
+          if (!options?.silent) {
+            toast.error(t('contexts.conversations.errors.archiveNotSupported'), {
+              description: t('contexts.conversations.errors.archiveNotSupportedDescription'),
+            });
+          }
           throw error;
         }
 
         console.error('Error unarchiving conversation:', error);
-        toast.error(t('contexts.conversations.errors.archiveConversation'), {
-          description:
-            error instanceof Error
-              ? error.message
-              : t('contexts.conversations.tryAgainDescription'),
-        });
+        if (!options?.silent) {
+          toast.error(t('contexts.conversations.errors.archiveConversation'), {
+            description:
+              error instanceof Error
+                ? error.message
+                : t('contexts.conversations.tryAgainDescription'),
+          });
+        }
         throw error;
       }
     },
@@ -666,7 +686,7 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
 
   // Context menu actions
   const deleteConversation = useCallback(
-    async (conversationId: string) => {
+    async (conversationId: string, options?: { silent?: boolean }) => {
       try {
         await conversationAPI.deleteConversation(conversationId);
 
@@ -678,15 +698,19 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
           dispatch({ type: 'SELECT_CONVERSATION', payload: null });
         }
 
-        toast.success(t('contexts.conversations.success.deleted'));
+        if (!options?.silent) {
+          toast.success(t('contexts.conversations.success.deleted'));
+        }
       } catch (error) {
         console.error('Error deleting conversation:', error);
-        toast.error(t('contexts.conversations.errors.deleteConversation'), {
-          description:
-            error instanceof Error
-              ? error.message
-              : t('contexts.conversations.tryAgainDescription'),
-        });
+        if (!options?.silent) {
+          toast.error(t('contexts.conversations.errors.deleteConversation'), {
+            description:
+              error instanceof Error
+                ? error.message
+                : t('contexts.conversations.tryAgainDescription'),
+          });
+        }
         throw error;
       }
     },
@@ -709,12 +733,14 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
         }
       } catch (error) {
         console.error('Error marking conversation as read:', error);
-        toast.error(t('contexts.conversations.errors.markAsRead'), {
-          description:
-            error instanceof Error
-              ? error.message
-              : t('contexts.conversations.tryAgainDescription'),
-        });
+        if (!options?.silent) {
+          toast.error(t('contexts.conversations.errors.markAsRead'), {
+            description:
+              error instanceof Error
+                ? error.message
+                : t('contexts.conversations.tryAgainDescription'),
+          });
+        }
         throw error;
       }
     },
@@ -722,7 +748,7 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
   );
 
   const markAsUnread = useCallback(
-    async (conversationId: string) => {
+    async (conversationId: string, options?: { silent?: boolean }) => {
       try {
         await conversationAPI.markAsUnread(conversationId);
 
@@ -733,15 +759,19 @@ export function ConversationsProvider({ children }: { children: React.ReactNode 
         });
         useUnreadConversationsStore.getState().fetch();
 
-        toast.success(t('contexts.conversations.success.markedAsUnread'));
+        if (!options?.silent) {
+          toast.success(t('contexts.conversations.success.markedAsUnread'));
+        }
       } catch (error) {
         console.error('Error marking conversation as unread:', error);
-        toast.error(t('contexts.conversations.errors.markAsUnread'), {
-          description:
-            error instanceof Error
-              ? error.message
-              : t('contexts.conversations.tryAgainDescription'),
-        });
+        if (!options?.silent) {
+          toast.error(t('contexts.conversations.errors.markAsUnread'), {
+            description:
+              error instanceof Error
+                ? error.message
+                : t('contexts.conversations.tryAgainDescription'),
+          });
+        }
         throw error;
       }
     },

--- a/src/contexts/chat/ConversationsContextReducer.ts
+++ b/src/contexts/chat/ConversationsContextReducer.ts
@@ -412,6 +412,10 @@ export function conversationsReducer(
       const unreadKey = removed ? String(removed.id) : targetId;
       const { [unreadKey]: _removed, ...remainingUnreadCounts } = state.unreadCounts; // eslint-disable-line @typescript-eslint/no-unused-vars
 
+      // O total da paginação é DERIVADO do servidor — não mutamos no client em
+      // remoções (reconcile/realtime). Entre fetches o header pode ficar levemente
+      // alto (mostra 10 com 9 linhas), mas é estável e sem corrida de
+      // double-decrement; self-heals no próximo fetch.
       return {
         ...state,
         conversations: filteredConversations,

--- a/src/contexts/chat/FiltersContext.tsx
+++ b/src/contexts/chat/FiltersContext.tsx
@@ -27,11 +27,13 @@ type FiltersAction =
   | { type: 'SET_SEARCH_TERM'; payload: string }
   | { type: 'SET_APPLYING_FILTERS'; payload: boolean };
 
-// 🎯 FILTRO PADRÃO: Inicializar com filtro "open" desde o início
+// 🎯 FILTRO PADRÃO = "All": todos os status (status=all). EXPLÍCITO (nunca [])
+// para o matcher de realtime fazer match-all sem vazar; status é navegação
+// (chips), não filtro. Baseline do realtime + alvo do "Limpar filtros".
 export const DEFAULT_FILTER: ConversationFilter = {
   attribute_key: 'status',
   filter_operator: 'equal_to',
-  values: ['open'], // Array para API, mas será convertido para string no modal
+  values: ['all'],
   query_operator: 'and',
 };
 

--- a/src/contexts/chat/WebSocketContext.tsx
+++ b/src/contexts/chat/WebSocketContext.tsx
@@ -447,6 +447,10 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
               })),
               unread_count: data.unread_count,
               messages: [], // Será carregado quando selecionado
+              // Grupos: o serializer/preset do chip filtra por is_group; sem popular
+              // aqui, um grupo novo via realtime não casa o matcher e cai no buffer
+              // oculto até refetch. Vem do push_event_data (EventDataPresenter).
+              is_group: data.is_group ?? false,
               custom_attributes: data.custom_attributes || {},
               additional_attributes: data.additional_attributes || {},
               // Campos obrigatórios adicionais da interface Conversation
@@ -531,6 +535,10 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
             assignee_id: data.assignee_id,
             team_id: data.team_id,
             unread_count: data.unread_count,
+            // Grupos: mesmo gap do create — sem copiar is_group, um grupo ainda não
+            // carregado que atualiza via realtime não sobe pro chip Grupos. Spread
+            // condicional pra não sobrescrever um is_group=true já existente no merge.
+            ...(data.is_group !== undefined && { is_group: data.is_group }),
             timestamp: normalizeToUnixSeconds(data.last_activity_at),
             waiting_since: data.waiting_since ?? normalizeToUnixSeconds(data.last_activity_at),
             meta: {

--- a/src/hooks/chat/__tests__/useConversationHandlers.spec.ts
+++ b/src/hooks/chat/__tests__/useConversationHandlers.spec.ts
@@ -12,10 +12,19 @@ const mockConversations = vi.hoisted(() => ({
   unpinConversation: vi.fn(),
   archiveConversation: vi.fn(),
   unarchiveConversation: vi.fn(),
+  addHiddenConversation: vi.fn(),
+  removeConversation: vi.fn(),
 }));
 
+const mockFilters = vi.hoisted(() => ({ state: { activeFilters: [] as any[] } }));
+const mockAuth = vi.hoisted(() => ({ user: { id: 'me-1' } as any }));
+
 vi.mock('@/contexts/chat/ChatContext', () => ({
-  useChatContext: () => ({ conversations: mockConversations }),
+  useChatContext: () => ({ conversations: mockConversations, filters: mockFilters }),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth,
 }));
 
 vi.mock('@/contexts/PermissionsContext', () => ({
@@ -26,25 +35,30 @@ vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+const statusFilter = (value: string) => ({
+  attribute_key: 'status',
+  filter_operator: 'equal_to',
+  values: [value],
+  query_operator: 'and',
+});
+
 const baseConversation = { id: 'conv-1', uuid: 'uuid-conv-1', status: 'open' } as any;
 
 describe('useConversationHandlers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFilters.state.activeFilters = [];
   });
 
   describe('handleMarkAsResolved', () => {
-    it('calls updateConversationStatus with resolved status', async () => {
+    it('calls updateConversationStatus with resolved status and NO list-refetch callback', async () => {
       mockConversations.updateConversationStatus.mockResolvedValueOnce({});
 
       const { result } = renderHook(() => useConversationHandlers());
       await result.current.handleMarkAsResolved(baseConversation);
 
-      expect(mockConversations.updateConversationStatus).toHaveBeenCalledWith(
-        'conv-1',
-        'resolved',
-        undefined,
-      );
+      // Eixo A: the parasite onFilterReload arg is gone — only (id, status).
+      expect(mockConversations.updateConversationStatus).toHaveBeenCalledWith('conv-1', 'resolved');
     });
 
     it('re-throws when updateConversationStatus fails', async () => {
@@ -58,20 +72,39 @@ describe('useConversationHandlers', () => {
       ).rejects.toThrow('API error');
     });
 
-    it('passes onReload callback to updateConversationStatus', async () => {
+    it('drops the conversation from the current view when it no longer matches the active filter (no list refetch)', async () => {
+      // Viewing "Abertas" (status=open); resolving makes it stop matching.
+      mockFilters.state.activeFilters = [statusFilter('open')];
       mockConversations.updateConversationStatus.mockResolvedValueOnce({});
-      const onReload = vi.fn().mockResolvedValue(undefined);
 
       const { result } = renderHook(() => useConversationHandlers());
-      await result.current.handleMarkAsResolved(baseConversation, onReload);
+      await result.current.handleMarkAsResolved(baseConversation);
 
-      expect(mockConversations.updateConversationStatus).toHaveBeenCalledWith(
-        'conv-1',
-        'resolved',
-        onReload,
-      );
+      expect(mockConversations.removeConversation).toHaveBeenCalledWith('conv-1');
+      expect(mockConversations.addHiddenConversation).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps the conversation when it still matches the active filter', async () => {
+      // Viewing "Resolvidas" (status=resolved); resolving keeps it matching.
+      mockFilters.state.activeFilters = [statusFilter('resolved')];
+      mockConversations.updateConversationStatus.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useConversationHandlers());
+      await result.current.handleMarkAsResolved(baseConversation);
+
+      expect(mockConversations.removeConversation).not.toHaveBeenCalled();
+      expect(mockConversations.addHiddenConversation).not.toHaveBeenCalled();
+    });
+
+    it('does not drop the conversation when no filter is active (match-all view)', async () => {
+      mockFilters.state.activeFilters = [];
+      mockConversations.updateConversationStatus.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useConversationHandlers());
+      await result.current.handleMarkAsResolved(baseConversation);
+
+      expect(mockConversations.removeConversation).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleMarkAsResolved — error propagation', () => {
@@ -93,6 +126,41 @@ describe('useConversationHandlers', () => {
 
       expect(navigateMock).not.toHaveBeenCalled();
       expect(navigationCalled).toBe(false);
+    });
+  });
+
+  describe('status siblings + priority (Eixo A)', () => {
+    it('handlePostpone: sets pending without refetch and drops it from an "open" view', async () => {
+      mockFilters.state.activeFilters = [statusFilter('open')];
+      mockConversations.updateConversationStatus.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useConversationHandlers());
+      await result.current.handlePostpone(baseConversation);
+
+      expect(mockConversations.updateConversationStatus).toHaveBeenCalledWith('conv-1', 'pending');
+      expect(mockConversations.removeConversation).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('handleMarkAsOpen: keeps it when viewing "open"', async () => {
+      mockFilters.state.activeFilters = [statusFilter('open')];
+      mockConversations.updateConversationStatus.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useConversationHandlers());
+      await result.current.handleMarkAsOpen(baseConversation);
+
+      expect(mockConversations.updateConversationStatus).toHaveBeenCalledWith('conv-1', 'open');
+      expect(mockConversations.removeConversation).not.toHaveBeenCalled();
+    });
+
+    it('handleSetPriority: never drops from a status view (priority is not a view axis) and sends no refetch arg', async () => {
+      mockFilters.state.activeFilters = [statusFilter('open')];
+      mockConversations.updateConversationPriority.mockResolvedValueOnce({});
+
+      const { result } = renderHook(() => useConversationHandlers());
+      await result.current.handleSetPriority(baseConversation, 'high');
+
+      expect(mockConversations.updateConversationPriority).toHaveBeenCalledWith('conv-1', 'high');
+      expect(mockConversations.removeConversation).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/chat/__tests__/useFilterHandlers.spec.ts
+++ b/src/hooks/chat/__tests__/useFilterHandlers.spec.ts
@@ -3,11 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useFilterHandlers } from '../useFilterHandlers';
 
-// Shape mirrors DEFAULT_FILTER from FiltersContext (status = open).
+// Shape mirrors DEFAULT_FILTER from FiltersContext: "Todas" = status = all.
 const DEFAULT_FILTER = {
   attribute_key: 'status',
   filter_operator: 'equal_to',
-  values: ['open'],
+  values: ['all'],
   query_operator: 'and',
 };
 
@@ -18,7 +18,7 @@ const mockConversations = vi.hoisted(() => ({
 
 const mockFilters = vi.hoisted(() => ({
   setFilters: vi.fn(),
-  applyFilters: vi.fn(),
+  applyFilters: vi.fn().mockResolvedValue(undefined),
   applySearch: vi.fn(),
   state: { activeFilters: [] as any[], searchTerm: '' },
 }));
@@ -36,7 +36,7 @@ vi.mock('@/contexts/chat/FiltersContext', () => ({
   DEFAULT_FILTER: {
     attribute_key: 'status',
     filter_operator: 'equal_to',
-    values: ['open'],
+    values: ['all'],
     query_operator: 'and',
   },
 }));
@@ -52,7 +52,7 @@ describe('useFilterHandlers — handleClearFilters (EVO-1939)', () => {
     vi.clearAllMocks();
   });
 
-  it('resets the GLOBAL activeFilters to the default open filter (so badge + realtime matcher clear)', async () => {
+  it('resets the GLOBAL activeFilters to the default "Todas" filter so badge + realtime matcher clear', async () => {
     const { result } = renderHook(() => useFilterHandlers());
 
     await result.current.handleClearFilters();
@@ -61,12 +61,17 @@ describe('useFilterHandlers — handleClearFilters (EVO-1939)', () => {
     expect(mockFilters.setFilters).toHaveBeenCalledWith([DEFAULT_FILTER]);
   });
 
-  it('clears persisted filters and reloads only open conversations', async () => {
+  it('clears persisted filters and reloads the default view via applyFilters (single pipeline), not a direct loadConversations', async () => {
     const { result } = renderHook(() => useFilterHandlers());
 
     await result.current.handleClearFilters();
 
     expect(mockStorage.clearConversationFilters).toHaveBeenCalledTimes(1);
-    expect(mockConversations.loadConversations).toHaveBeenCalledWith({ status: 'open' });
+    expect(mockFilters.applyFilters).toHaveBeenCalledWith(
+      [DEFAULT_FILTER],
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(mockConversations.loadConversations).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/chat/useConversationHandlers.ts
+++ b/src/hooks/chat/useConversationHandlers.ts
@@ -2,12 +2,29 @@ import { useCallback } from 'react';
 import { toast } from 'sonner';
 import { useChatContext } from '@/contexts/chat/ChatContext';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { useAuth } from '@/contexts/AuthContext';
 import { Conversation } from '@/types/chat/api';
 import { isActionNotSupported } from '@/utils/chat/actionSupport';
+import { doesConversationMatchFilters } from '@/utils/chat/conversationMatch';
 
 export const useConversationHandlers = () => {
   const { can } = usePermissions();
-  const { conversations } = useChatContext();
+  const { conversations, filters } = useChatContext();
+  const { user: currentUser } = useAuth();
+
+  // Após uma mutação, reconcilia SÓ esta conversa contra a view ativa: se ela
+  // não casa mais o filtro atual (ex.: resolvi enquanto via "Abertas"), some da
+  // lista localmente (vai pro buffer hidden) — sem refetch da lista inteira.
+  // Mesma regra que o realtime (WebSocket) já usa.
+  const reconcileWithActiveView = useCallback(
+    (updated: Conversation) => {
+      if (!doesConversationMatchFilters(updated, filters.state.activeFilters, currentUser?.id)) {
+        conversations.addHiddenConversation(updated);
+        conversations.removeConversation(String(updated.id));
+      }
+    },
+    [conversations, filters.state.activeFilters, currentUser?.id],
+  );
 
   const handleMarkAsRead = useCallback(
     async (conversation: Conversation) => {
@@ -32,69 +49,79 @@ export const useConversationHandlers = () => {
   );
 
   const handleMarkAsResolved = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.updateConversationStatus(conversation.id, 'resolved', onReload);
+        await conversations.updateConversationStatus(conversation.id, 'resolved');
+        // Eixo A: em vez de refetch da lista, reconcilia só esta conversa.
+        reconcileWithActiveView({ ...conversation, status: 'resolved' });
       } catch (error) {
         console.error('❌ Error marking as resolved:', error);
         throw error;
       }
     },
-    [conversations],
+    [conversations, reconcileWithActiveView],
   );
 
   const handlePostpone = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.updateConversationStatus(conversation.id, 'pending', onReload);
+        await conversations.updateConversationStatus(conversation.id, 'pending');
+        reconcileWithActiveView({ ...conversation, status: 'pending' });
       } catch (error) {
         console.error('❌ Error marking as pending:', error);
       }
     },
-    [conversations],
+    [conversations, reconcileWithActiveView],
   );
 
   const handleMarkAsOpen = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.updateConversationStatus(conversation.id, 'open', onReload);
+        await conversations.updateConversationStatus(conversation.id, 'open');
+        reconcileWithActiveView({ ...conversation, status: 'open' });
       } catch (error) {
         console.error('❌ Error marking as open:', error);
       }
     },
-    [conversations],
+    [conversations, reconcileWithActiveView],
   );
 
   const handleMarkAsSnoozed = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.updateConversationStatus(conversation.id, 'snoozed', onReload);
+        await conversations.updateConversationStatus(conversation.id, 'snoozed');
+        reconcileWithActiveView({ ...conversation, status: 'snoozed' });
       } catch (error) {
         console.error('❌ Error marking as snoozed:', error);
       }
     },
-    [conversations],
+    [conversations, reconcileWithActiveView],
   );
 
   const handleSetPriority = useCallback(
     async (
       conversation: Conversation,
       priority: 'low' | 'medium' | 'high' | 'urgent' | null,
-      onReload?: () => Promise<void>,
     ) => {
       try {
-        await conversations.updateConversationPriority(conversation.id, priority, onReload);
+        await conversations.updateConversationPriority(conversation.id, priority);
+        // Prioridade não é eixo das views padrão, então o reconcile normalmente
+        // mantém a conversa (correto); mas roda por consistência e p/ filtros avançados.
+        reconcileWithActiveView({ ...conversation, priority });
       } catch (error) {
         console.error('❌ Error updating priority:', error);
       }
     },
-    [conversations],
+    [conversations, reconcileWithActiveView],
   );
 
+  // Pin/arquivar não precisam de reconcile-por-filtro: o memo visibleConversations
+  // já re-ordena por custom_attributes.pinned e filtra por archived. Basta o patch
+  // (UPDATE_CONVERSATION com response.data) e NÃO refetchar a lista.
   const handlePinConversation = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.pinConversation(conversation.id, onReload);
+        await conversations.pinConversation(conversation.id);
       } catch (error) {
         if (isActionNotSupported(error)) {
           return;
@@ -106,9 +133,9 @@ export const useConversationHandlers = () => {
   );
 
   const handleUnpinConversation = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.unpinConversation(conversation.id, onReload);
+        await conversations.unpinConversation(conversation.id);
       } catch (error) {
         if (isActionNotSupported(error)) {
           return;
@@ -120,9 +147,9 @@ export const useConversationHandlers = () => {
   );
 
   const handleArchiveConversation = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.archiveConversation(conversation.id, onReload);
+        await conversations.archiveConversation(conversation.id);
       } catch (error) {
         if (isActionNotSupported(error)) {
           return;
@@ -134,9 +161,9 @@ export const useConversationHandlers = () => {
   );
 
   const handleUnarchiveConversation = useCallback(
-    async (conversation: Conversation, onReload?: () => Promise<void>) => {
+    async (conversation: Conversation) => {
       try {
-        await conversations.unarchiveConversation(conversation.id, onReload);
+        await conversations.unarchiveConversation(conversation.id);
       } catch (error) {
         if (isActionNotSupported(error)) {
           return;

--- a/src/hooks/chat/useFilterHandlers.ts
+++ b/src/hooks/chat/useFilterHandlers.ts
@@ -40,13 +40,22 @@ export const useFilterHandlers = () => {
       // 🗑️ LIMPAR: Remover filtros salvos do localStorage
       clearConversationFilters();
 
-      // EVO-1939: resetar o estado GLOBAL para o filtro padrão (status=open).
-      // Sem isso o badge e o matcher de conversas em tempo real (ChatContext)
-      // continuam usando os filtros antigos — o usuário "limpa" mas a UI não some.
+      // EVO-1939: resetar o estado GLOBAL para o filtro padrão "Todas" (status=all).
+      // Sem isso o badge e o matcher de realtime continuam com os filtros antigos —
+      // o usuário "limpa" mas a UI não some.
       filters.setFilters([DEFAULT_FILTER]);
 
-      // 🎯 FILTRO PADRÃO: Carregar apenas conversas abertas ao limpar filtros
-      await conversations.loadConversations({ status: 'open' });
+      // 🎯 FILTRO PADRÃO: recarregar a visão "Todas" pela MESMA via do pipeline
+      // (applyFilters), mantendo activeFilters e a query em sincronia.
+      await filters.applyFilters(
+        [DEFAULT_FILTER],
+        (conversationsResult, pagination, query) => {
+          conversations.setConversations(conversationsResult, pagination, query);
+        },
+        error => {
+          console.error('❌ Erro ao limpar filtros:', error);
+        },
+      );
     } catch (error) {
       console.error('❌ Erro inesperado ao limpar filtros:', error);
     }
@@ -79,9 +88,17 @@ export const useFilterHandlers = () => {
           },
         );
       }
-      // 🎯 FILTRO PADRÃO: Se não há filtros nem busca, carregar apenas conversas abertas
+      // 🎯 FILTRO PADRÃO: Se não há filtros nem busca, recarregar a visão "Todas".
       else {
-        await conversations.loadConversations({ status: 'open' });
+        await filters.applyFilters(
+          [DEFAULT_FILTER],
+          (conversationsResult, pagination, query) => {
+            conversations.setConversations(conversationsResult, pagination, query);
+          },
+          error => {
+            console.error('❌ Erro ao recarregar filtros:', error);
+          },
+        );
       }
     } catch (error) {
       console.error('❌ Erro inesperado ao recarregar filtros:', error);

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -331,6 +331,9 @@
     "bulkDeleteDescription": "Are you sure you want to delete {{count}} conversation(s)? This action cannot be undone.",
     "undo": "Undo",
     "bulkApplied": "Applied to {{count}} conversation(s)",
+    "bulkDeleted": "{{count}} conversation(s) deleted",
+    "bulkFailed": "{{count}} conversation(s) failed",
+    "advancedFiltersCleared": "Advanced filters cleared — Unread/Groups can't be combined with them",
     "view": {
       "active": "Active",
       "archived": "Archived"

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -294,10 +294,10 @@
       "assignTeam": "Assign Team",
       "assignTag": "Assign Label",
       "deleteConversation": "Delete conversation",
-      "bulkResolveSuccess": "{{count}} conversation(s) resolved",
-      "bulkResolvePartialSuccess": "{{success}} resolved, {{failed}} failed",
-      "bulkResolveError": "Error resolving conversations",
-      "bulkResolveNoPermission": "You do not have permission to resolve conversations"
+      "bulkStatusSuccess": "{{count}} conversation(s) updated",
+      "bulkStatusPartialSuccess": "{{success}} updated, {{failed}} failed",
+      "bulkStatusError": "Error updating conversations",
+      "bulkStatusNoPermission": "You do not have permission to update conversations"
     },
     "contactNoName": "Contact without name",
     "status": "Status:",
@@ -308,6 +308,14 @@
     "closeContactPanel": "Close contact details"
   },
   "chatSidebar": {
+    "segments": {
+      "ariaLabel": "Conversation views",
+      "open": "Open",
+      "pending": "Pending",
+      "resolved": "Resolved",
+      "unread": "Unread",
+      "groups": "Groups"
+    },
     "searchPlaceholder": "Search conversations...",
     "conversation": "conversation",
     "conversations": "conversations",
@@ -317,6 +325,12 @@
     "filter": "filter",
     "filters": "filters",
     "filtersButton": "Filters",
+    "select": "Select",
+    "doneSelection": "Done",
+    "bulkActions": "Bulk actions",
+    "bulkDeleteDescription": "Are you sure you want to delete {{count}} conversation(s)? This action cannot be undone.",
+    "undo": "Undo",
+    "bulkApplied": "Applied to {{count}} conversation(s)",
     "view": {
       "active": "Active",
       "archived": "Archived"

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -326,6 +326,9 @@
     "bulkDeleteDescription": "¿Seguro que deseas eliminar {{count}} conversación(es)? Esta acción no se puede deshacer.",
     "undo": "Deshacer",
     "bulkApplied": "Aplicado a {{count}} conversación(es)",
+    "bulkDeleted": "{{count}} conversación(es) eliminada(s)",
+    "bulkFailed": "{{count}} conversación(es) fallaron",
+    "advancedFiltersCleared": "Filtros avanzados eliminados — No leídas/Grupos no se combinan con ellos",
     "view": {
       "active": "Activas",
       "archived": "Archivadas"

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -289,10 +289,10 @@
       "assignTeam": "Asignar Equipo",
       "assignTag": "Asignar Etiqueta",
       "deleteConversation": "Eliminar conversación",
-      "bulkResolveSuccess": "{{count}} conversación(es) resuelta(s)",
-      "bulkResolvePartialSuccess": "{{success}} resuelta(s), {{failed}} fallida(s)",
-      "bulkResolveError": "Error al resolver conversaciones",
-      "bulkResolveNoPermission": "No tienes permiso para resolver conversaciones"
+      "bulkStatusSuccess": "{{count}} conversación(es) actualizada(s)",
+      "bulkStatusPartialSuccess": "{{success}} actualizada(s), {{failed}} fallida(s)",
+      "bulkStatusError": "Error al actualizar conversaciones",
+      "bulkStatusNoPermission": "No tienes permiso para actualizar conversaciones"
     },
     "contactNoName": "Contacto sin nombre",
     "status": "Estado:",
@@ -303,6 +303,14 @@
     "closeContactPanel": "Cerrar detalles del contacto"
   },
   "chatSidebar": {
+    "segments": {
+      "ariaLabel": "Vistas de conversaciones",
+      "open": "Abiertas",
+      "pending": "Pendientes",
+      "resolved": "Resueltas",
+      "unread": "No leídas",
+      "groups": "Grupos"
+    },
     "searchPlaceholder": "Buscar conversaciones...",
     "conversation": "conversación",
     "conversations": "conversaciones",
@@ -312,6 +320,12 @@
     "filter": "filtro",
     "filters": "filtros",
     "filtersButton": "Filtros",
+    "select": "Seleccionar",
+    "doneSelection": "Listo",
+    "bulkActions": "Acciones en lote",
+    "bulkDeleteDescription": "¿Seguro que deseas eliminar {{count}} conversación(es)? Esta acción no se puede deshacer.",
+    "undo": "Deshacer",
+    "bulkApplied": "Aplicado a {{count}} conversación(es)",
     "view": {
       "active": "Activas",
       "archived": "Archivadas"

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -289,10 +289,10 @@
       "assignTeam": "Assigner une Équipe",
       "assignTag": "Assigner une Étiquette",
       "deleteConversation": "Supprimer la conversation",
-      "bulkResolveSuccess": "{{count}} conversation(s) résolue(s)",
-      "bulkResolvePartialSuccess": "{{success}} résolue(s), {{failed}} échouée(s)",
-      "bulkResolveError": "Erreur lors de la résolution des conversations",
-      "bulkResolveNoPermission": "Vous n'avez pas la permission de résoudre des conversations"
+      "bulkStatusSuccess": "{{count}} conversation(s) mise(s) à jour",
+      "bulkStatusPartialSuccess": "{{success}} mise(s) à jour, {{failed}} échouée(s)",
+      "bulkStatusError": "Erreur lors de la mise à jour des conversations",
+      "bulkStatusNoPermission": "Vous n'avez pas la permission de mettre à jour des conversations"
     },
     "contactNoName": "Contact sans nom",
     "status": "Statut :",
@@ -303,6 +303,14 @@
     "closeContactPanel": "Fermer les détails du contact"
   },
   "chatSidebar": {
+    "segments": {
+      "ariaLabel": "Vues des conversations",
+      "open": "Ouvertes",
+      "pending": "En attente",
+      "resolved": "Résolues",
+      "unread": "Non lues",
+      "groups": "Groupes"
+    },
     "searchPlaceholder": "Rechercher des conversations...",
     "conversation": "conversation",
     "conversations": "conversations",
@@ -312,6 +320,12 @@
     "filter": "filtre",
     "filters": "filtres",
     "filtersButton": "Filtres",
+    "select": "Sélectionner",
+    "doneSelection": "Terminé",
+    "bulkActions": "Actions groupées",
+    "bulkDeleteDescription": "Voulez-vous vraiment supprimer {{count}} conversation(s) ? Cette action est irréversible.",
+    "undo": "Annuler",
+    "bulkApplied": "Appliqué à {{count}} conversation(s)",
     "view": {
       "active": "Actives",
       "archived": "Archivees"

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -326,6 +326,9 @@
     "bulkDeleteDescription": "Voulez-vous vraiment supprimer {{count}} conversation(s) ? Cette action est irréversible.",
     "undo": "Annuler",
     "bulkApplied": "Appliqué à {{count}} conversation(s)",
+    "bulkDeleted": "{{count}} conversation(s) supprimée(s)",
+    "bulkFailed": "{{count}} conversation(s) en échec",
+    "advancedFiltersCleared": "Filtres avancés supprimés — Non lues/Groupes ne se combinent pas avec eux",
     "view": {
       "active": "Actives",
       "archived": "Archivees"

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -289,10 +289,10 @@
       "assignTeam": "Assegna Team",
       "assignTag": "Assegna Etichetta",
       "deleteConversation": "Elimina conversazione",
-      "bulkResolveSuccess": "{{count}} conversazione/i risolta/e",
-      "bulkResolvePartialSuccess": "{{success}} risolta/e, {{failed}} fallita/e",
-      "bulkResolveError": "Errore nella risoluzione delle conversazioni",
-      "bulkResolveNoPermission": "Non hai il permesso di risolvere le conversazioni"
+      "bulkStatusSuccess": "{{count}} conversazione/i aggiornata/e",
+      "bulkStatusPartialSuccess": "{{success}} aggiornata/e, {{failed}} fallita/e",
+      "bulkStatusError": "Errore nell'aggiornamento delle conversazioni",
+      "bulkStatusNoPermission": "Non hai il permesso di aggiornare le conversazioni"
     },
     "contactNoName": "Contatto senza nome",
     "status": "Stato:",
@@ -303,6 +303,14 @@
     "closeContactPanel": "Chiudi dettagli contatto"
   },
   "chatSidebar": {
+    "segments": {
+      "ariaLabel": "Viste delle conversazioni",
+      "open": "Aperte",
+      "pending": "In sospeso",
+      "resolved": "Risolte",
+      "unread": "Non lette",
+      "groups": "Gruppi"
+    },
     "searchPlaceholder": "Cerca conversazioni...",
     "conversation": "conversazione",
     "conversations": "conversazioni",
@@ -312,6 +320,12 @@
     "filter": "filtro",
     "filters": "filtri",
     "filtersButton": "Filtri",
+    "select": "Seleziona",
+    "doneSelection": "Fine",
+    "bulkActions": "Azioni in blocco",
+    "bulkDeleteDescription": "Vuoi davvero eliminare {{count}} conversazione/i? L'azione non può essere annullata.",
+    "undo": "Annulla",
+    "bulkApplied": "Applicato a {{count}} conversazione/i",
     "view": {
       "active": "Attive",
       "archived": "Archiviate"

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -326,6 +326,9 @@
     "bulkDeleteDescription": "Vuoi davvero eliminare {{count}} conversazione/i? L'azione non può essere annullata.",
     "undo": "Annulla",
     "bulkApplied": "Applicato a {{count}} conversazione/i",
+    "bulkDeleted": "{{count}} conversazione/i eliminata/e",
+    "bulkFailed": "{{count}} conversazione/i non riuscite",
+    "advancedFiltersCleared": "Filtri avanzati rimossi — Non lette/Gruppi non si combinano con essi",
     "view": {
       "active": "Attive",
       "archived": "Archiviate"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -331,6 +331,9 @@
     "bulkDeleteDescription": "Tem certeza que deseja excluir {{count}} conversa(s)? Esta ação não pode ser desfeita.",
     "undo": "Desfazer",
     "bulkApplied": "Aplicado a {{count}} conversa(s)",
+    "bulkDeleted": "{{count}} conversa(s) excluída(s)",
+    "bulkFailed": "{{count}} conversa(s) falharam",
+    "advancedFiltersCleared": "Filtros avançados removidos — Não-lidas/Grupos não combinam com eles",
     "view": {
       "active": "Ativas",
       "archived": "Arquivadas"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -294,10 +294,10 @@
       "assignTeam": "Atribuir time",
       "assignTag": "Atribuir etiqueta",
       "deleteConversation": "Deletar conversa",
-      "bulkResolveSuccess": "{{count}} conversa(s) resolvida(s)",
-      "bulkResolvePartialSuccess": "{{success}} resolvida(s), {{failed}} falhada(s)",
-      "bulkResolveError": "Erro ao resolver conversas em lote",
-      "bulkResolveNoPermission": "Você não tem permissão para resolver conversas"
+      "bulkStatusSuccess": "{{count}} conversa(s) atualizada(s)",
+      "bulkStatusPartialSuccess": "{{success}} atualizada(s), {{failed}} falhada(s)",
+      "bulkStatusError": "Erro ao atualizar conversas em lote",
+      "bulkStatusNoPermission": "Você não tem permissão para atualizar conversas"
     },
     "contactNoName": "Contato sem nome",
     "status": "Status:",
@@ -308,6 +308,14 @@
     "closeContactPanel": "Fechar detalhes do contato"
   },
   "chatSidebar": {
+    "segments": {
+      "ariaLabel": "Visões de conversas",
+      "open": "Abertas",
+      "pending": "Pendentes",
+      "resolved": "Resolvidas",
+      "unread": "Não lidas",
+      "groups": "Grupos"
+    },
     "searchPlaceholder": "Buscar conversas...",
     "conversation": "conversa",
     "conversations": "conversas",
@@ -317,6 +325,12 @@
     "filter": "filtro",
     "filters": "filtros",
     "filtersButton": "Filtros",
+    "select": "Selecionar",
+    "doneSelection": "Concluir",
+    "bulkActions": "Ações em lote",
+    "bulkDeleteDescription": "Tem certeza que deseja excluir {{count}} conversa(s)? Esta ação não pode ser desfeita.",
+    "undo": "Desfazer",
+    "bulkApplied": "Aplicado a {{count}} conversa(s)",
     "view": {
       "active": "Ativas",
       "archived": "Arquivadas"

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -289,10 +289,10 @@
       "assignTeam": "Atribuir time",
       "assignTag": "Atribuir etiqueta",
       "deleteConversation": "Deletar conversa",
-      "bulkResolveSuccess": "{{count}} conversa(s) resolvida(s)",
-      "bulkResolvePartialSuccess": "{{success}} resolvida(s), {{failed}} falhada(s)",
-      "bulkResolveError": "Erro ao resolver conversas em lote",
-      "bulkResolveNoPermission": "Não tem permissão para resolver conversas"
+      "bulkStatusSuccess": "{{count}} conversa(s) atualizada(s)",
+      "bulkStatusPartialSuccess": "{{success}} atualizada(s), {{failed}} falhada(s)",
+      "bulkStatusError": "Erro ao atualizar conversas em lote",
+      "bulkStatusNoPermission": "Não tem permissão para atualizar conversas"
     },
     "contactNoName": "Contato sem nome",
     "status": "Status:",
@@ -303,6 +303,14 @@
     "closeContactPanel": "Fechar detalhes do contato"
   },
   "chatSidebar": {
+    "segments": {
+      "ariaLabel": "Vistas de conversas",
+      "open": "Abertas",
+      "pending": "Pendentes",
+      "resolved": "Resolvidas",
+      "unread": "Não lidas",
+      "groups": "Grupos"
+    },
     "searchPlaceholder": "Buscar conversas...",
     "conversation": "conversa",
     "conversations": "conversas",
@@ -312,6 +320,12 @@
     "filter": "filtro",
     "filters": "filtros",
     "filtersButton": "Filtros",
+    "select": "Selecionar",
+    "doneSelection": "Concluir",
+    "bulkActions": "Ações em lote",
+    "bulkDeleteDescription": "Tem certeza que deseja excluir {{count}} conversa(s)? Esta ação não pode ser desfeita.",
+    "undo": "Desfazer",
+    "bulkApplied": "Aplicado a {{count}} conversa(s)",
     "view": {
       "active": "Ativas",
       "archived": "Arquivadas"

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -326,6 +326,9 @@
     "bulkDeleteDescription": "Tem certeza que deseja excluir {{count}} conversa(s)? Esta ação não pode ser desfeita.",
     "undo": "Desfazer",
     "bulkApplied": "Aplicado a {{count}} conversa(s)",
+    "bulkDeleted": "{{count}} conversa(s) excluída(s)",
+    "bulkFailed": "{{count}} conversa(s) falharam",
+    "advancedFiltersCleared": "Filtros avançados removidos — Não-lidas/Grupos não combinam com eles",
     "view": {
       "active": "Ativas",
       "archived": "Arquivadas"

--- a/src/pages/Customer/Chat/Chat.tsx
+++ b/src/pages/Customer/Chat/Chat.tsx
@@ -111,7 +111,7 @@ const Chat = () => {
 
   // Bulk selection state
   const [selectedConversationIds, setSelectedConversationIds] = useState<Set<string>>(new Set());
-  const [isBulkResolving, setIsBulkResolving] = useState(false);
+  const [isBulkUpdatingStatus, setIsBulkUpdatingStatus] = useState(false);
 
   // Dashboard Apps state (lazy loaded, not auto-fetched)
   const [dashboardApps] = useState<DashboardApp[]>([]);
@@ -223,35 +223,38 @@ const Chat = () => {
     setSelectedConversationIds(new Set());
   }, []);
 
-  const handleBulkResolve = useCallback(async () => {
-    if (selectedConversationIds.size === 0) return;
-    if (!can('conversations', 'update')) {
-      toast.error(t('chatHeader.actions.bulkResolveNoPermission'));
-      return;
-    }
-    const displayIds = Array.from(selectedConversationIds);
-    setIsBulkResolving(true);
-    try {
-      const result = await chatService.bulkResolve(displayIds);
-      setSelectedConversationIds(new Set());
-      if (result.failed_ids.length === 0) {
-        toast.success(t('chatHeader.actions.bulkResolveSuccess', { count: result.success_ids.length }));
-      } else if (result.success_ids.length > 0) {
-        toast.warning(t('chatHeader.actions.bulkResolvePartialSuccess', {
-          success: result.success_ids.length,
-          failed: result.failed_ids.length,
-        }));
-      } else {
-        toast.error(t('chatHeader.actions.bulkResolveError'));
+  const handleBulkSetStatus = useCallback(
+    async (status: 'open' | 'pending' | 'resolved') => {
+      if (selectedConversationIds.size === 0) return;
+      if (!can('conversations', 'update')) {
+        toast.error(t('chatHeader.actions.bulkStatusNoPermission'));
+        return;
       }
-      await reloadCurrentFilters();
-    } catch (error) {
-      console.error('Bulk resolve error:', error);
-      toast.error(t('chatHeader.actions.bulkResolveError'));
-    } finally {
-      setIsBulkResolving(false);
-    }
-  }, [selectedConversationIds, can, reloadCurrentFilters, t]);
+      const displayIds = Array.from(selectedConversationIds);
+      setIsBulkUpdatingStatus(true);
+      try {
+        const result = await chatService.bulkUpdateStatus(displayIds, status);
+        setSelectedConversationIds(new Set());
+        if (result.failed_ids.length === 0) {
+          toast.success(t('chatHeader.actions.bulkStatusSuccess', { count: result.success_ids.length }));
+        } else if (result.success_ids.length > 0) {
+          toast.warning(t('chatHeader.actions.bulkStatusPartialSuccess', {
+            success: result.success_ids.length,
+            failed: result.failed_ids.length,
+          }));
+        } else {
+          toast.error(t('chatHeader.actions.bulkStatusError'));
+        }
+        await reloadCurrentFilters();
+      } catch (error) {
+        console.error('Bulk status update error:', error);
+        toast.error(t('chatHeader.actions.bulkStatusError'));
+      } finally {
+        setIsBulkUpdatingStatus(false);
+      }
+    },
+    [selectedConversationIds, can, reloadCurrentFilters, t],
+  );
 
   // 🔄 CARREGAMENTO SIMPLES: Apenas carregar mensagens quando conversa muda
   useEffect(() => {
@@ -464,7 +467,7 @@ const Chat = () => {
     async (conversation: Conversation) => {
       const resolvedId = String(conversation.uuid || conversation.id);
       try {
-        await conversationHandlers.handleMarkAsResolved(conversation, reloadCurrentFilters);
+        await conversationHandlers.handleMarkAsResolved(conversation);
         const liveSelected = selectedConvIdRef.current;
         if (liveSelected != null && String(liveSelected) === resolvedId) {
           await clearSelectionAndGoToList();
@@ -473,63 +476,63 @@ const Chat = () => {
         console.error('[handleMarkAsResolved] failed:', err);
       }
     },
-    [conversationHandlers, reloadCurrentFilters, clearSelectionAndGoToList],
+    [conversationHandlers, clearSelectionAndGoToList],
   );
 
   const handlePostpone = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handlePostpone(conversation, reloadCurrentFilters);
+      await conversationHandlers.handlePostpone(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handleMarkAsOpen = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handleMarkAsOpen(conversation, reloadCurrentFilters);
+      await conversationHandlers.handleMarkAsOpen(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handleMarkAsSnoozed = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handleMarkAsSnoozed(conversation, reloadCurrentFilters);
+      await conversationHandlers.handleMarkAsSnoozed(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handleSetPriority = useCallback(
     async (conversation: Conversation, priority: 'low' | 'medium' | 'high' | 'urgent' | null) => {
-      await conversationHandlers.handleSetPriority(conversation, priority, reloadCurrentFilters);
+      await conversationHandlers.handleSetPriority(conversation, priority);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handlePinConversation = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handlePinConversation(conversation, reloadCurrentFilters);
+      await conversationHandlers.handlePinConversation(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handleUnpinConversation = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handleUnpinConversation(conversation, reloadCurrentFilters);
+      await conversationHandlers.handleUnpinConversation(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handleArchiveConversation = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handleArchiveConversation(conversation, reloadCurrentFilters);
+      await conversationHandlers.handleArchiveConversation(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   const handleUnarchiveConversation = useCallback(
     async (conversation: Conversation) => {
-      await conversationHandlers.handleUnarchiveConversation(conversation, reloadCurrentFilters);
+      await conversationHandlers.handleUnarchiveConversation(conversation);
     },
-    [conversationHandlers, reloadCurrentFilters],
+    [conversationHandlers],
   );
 
   // 🎯 ASSIGNMENT HANDLERS: Usar handlers dos hooks customizados
@@ -789,9 +792,9 @@ const Chat = () => {
           selectedConversationIds={selectedConversationIds}
           onToggleSelect={handleToggleConversationSelection}
           onClearSelection={handleClearSelection}
-          onBulkResolve={handleBulkResolve}
-          isBulkResolving={isBulkResolving}
-          canBulkResolve={can('conversations', 'update')}
+          onBulkSetStatus={handleBulkSetStatus}
+          isBulkUpdatingStatus={isBulkUpdatingStatus}
+          canBulkUpdateStatus={can('conversations', 'update')}
         />
 
         {/* Chat Area */}

--- a/src/pages/Customer/Chat/__tests__/Chat.spec.tsx
+++ b/src/pages/Customer/Chat/__tests__/Chat.spec.tsx
@@ -61,6 +61,9 @@ vi.mock('@/contexts/chat/ChatContext', () => ({
       getConversation: vi.fn().mockReturnValue(null),
       getUnreadCount: vi.fn().mockReturnValue(0),
       loadConversations: vi.fn().mockResolvedValue(undefined),
+      // Chat.tsx:170 auto-marca a conversa selecionada como lida (silencioso) ao
+      // abri-la — o mock precisa expor markAsRead (retorna Promise p/ o .catch).
+      markAsRead: vi.fn().mockResolvedValue(undefined),
     },
     messages: {
       loadMessages: vi.fn(),

--- a/src/services/chat/chatService.ts
+++ b/src/services/chat/chatService.ts
@@ -291,14 +291,24 @@ class ChatService {
     return extractData<Message>(response);
   }
 
-  async bulkResolve(displayIds: string[]): Promise<{ success_ids: number[]; failed_ids: number[] }> {
+  // Atualiza o status de N conversas via o endpoint dedicado /bulk_actions
+  // (1 request, reconcilia a view no chamador). Mudar status é uma ação
+  // deliberada — dispara automações/webhooks/atividade no backend (correto).
+  async bulkUpdateStatus(
+    displayIds: string[],
+    status: 'open' | 'pending' | 'resolved',
+  ): Promise<{ success_ids: number[]; failed_ids: number[] }> {
     const response = await api.post('/bulk_actions', {
       type: 'Conversation',
       ids: displayIds,
-      fields: { status: 'resolved' },
+      fields: { status },
     });
     const data = response.data?.data;
     return data ?? { success_ids: [], failed_ids: [] };
+  }
+
+  async bulkResolve(displayIds: string[]): Promise<{ success_ids: number[]; failed_ids: number[] }> {
+    return this.bulkUpdateStatus(displayIds, 'resolved');
   }
 }
 

--- a/src/services/chat/websocket/ChatActionCableConnector.ts
+++ b/src/services/chat/websocket/ChatActionCableConnector.ts
@@ -176,6 +176,7 @@ export interface ConversationCreatedEvent {
   };
   labels: string[]; // Evolution usa string[] para labels
   unread_count: number;
+  is_group?: boolean;
   additional_attributes?: Record<string, unknown>;
   custom_attributes?: Record<string, unknown>;
   priority?: string | null;
@@ -222,6 +223,7 @@ export interface ConversationUpdatedEvent {
   };
   labels: string[];
   unread_count: number;
+  is_group?: boolean;
   additional_attributes?: Record<string, unknown>;
   custom_attributes?: Record<string, unknown>;
   priority?: string | null;

--- a/src/types/chat/api.ts
+++ b/src/types/chat/api.ts
@@ -51,6 +51,9 @@ export interface Conversation {
   snoozed_until: string | null;
   timestamp: number;
   unread_count: number;
+  /** True quando o contato é um grupo (contact.type === 'group'). Usado pelo
+   *  matcher de realtime da aba "Grupos". */
+  is_group?: boolean;
   waiting_since: number;
   meta: ConversationMeta;
   contact: Contact;
@@ -367,7 +370,7 @@ export interface ConversationListParams {
   page_size?: number;
   pageSize?: number;
   status?: 'open' | 'resolved' | 'pending' | 'snoozed' | 'all';
-  assignee_type?: 'me' | 'unassigned' | 'all';
+  assignee_type?: 'me' | 'unassigned' | 'assigned' | 'all';
   assignee_id?: string;
   inbox_id?: string;
   team_id?: string;
@@ -375,6 +378,9 @@ export interface ConversationListParams {
   q?: string;
   sort_by?: 'last_activity_at' | 'created_at' | 'priority';
   conversation_type?: 'mention' | 'unattended' | 'participating';
+  unread?: boolean;
+  is_group?: boolean;
+  archived?: boolean;
 }
 
 export interface MessageListParams {

--- a/src/types/chat/conversations.ts
+++ b/src/types/chat/conversations.ts
@@ -87,10 +87,12 @@ export interface ConversationsContextValue {
   archiveConversation: (
     conversationId: string,
     onFilterReload?: () => Promise<void>,
+    options?: { silent?: boolean },
   ) => Promise<Conversation>;
   unarchiveConversation: (
     conversationId: string,
     onFilterReload?: () => Promise<void>,
+    options?: { silent?: boolean },
   ) => Promise<Conversation>;
 
   // Direct state manipulation (for WebSocket integration)
@@ -111,9 +113,9 @@ export interface ConversationsContextValue {
   getUnreadCount: (conversationId: string) => number;
 
   // Context menu actions
-  deleteConversation: (conversationId: string) => Promise<void>;
+  deleteConversation: (conversationId: string, options?: { silent?: boolean }) => Promise<void>;
   markAsRead: (conversationId: string, options?: { silent?: boolean }) => Promise<void>;
-  markAsUnread: (conversationId: string) => Promise<void>;
+  markAsUnread: (conversationId: string, options?: { silent?: boolean }) => Promise<void>;
   markAsResolved: (conversationId: string) => Promise<void>;
   markAsPending: (conversationId: string) => Promise<void>;
   assignAgent: (conversationId: string, assigneeId: string | null) => Promise<void>;

--- a/src/types/core/filters.ts
+++ b/src/types/core/filters.ts
@@ -582,9 +582,25 @@ export const CONVERSATION_FILTER_TYPES: FilterType[] = [
   // },
 ];
 
+// Linha-semente do modal avançado (BaseFilter usa quando não há filtros). NÃO
+// pode ser `status` (status é navegação por chip, excluída do modal): senão, na
+// visão padrão (status=all) o modal semeava uma linha-fantasma "Status = Aberta"
+// e só clicar Aplicar jogava a lista pra status=open silenciosamente. Usa um
+// atributo avançado NÃO-chip-nav com valor VAZIO → a linha aparece pronta pra
+// preencher e, se aplicada sem tocar, é descartada (BaseFilter dropa valor vazio).
 export const DEFAULT_CONVERSATION_FILTER: BaseFilter = {
+  ...DEFAULT_BASE_FILTER,
+  attributeKey: 'assignee_type',
+  filterOperator: 'equal_to',
+  values: '',
+};
+
+// "All" = visão padrão da lista (status=all = todos os status). Filtro EXPLÍCITO
+// (nunca []) p/ o matcher de realtime fazer match-all sem vazar e o backend não
+// cair no default implícito status=open. Nenhum chip fica marcado (default).
+export const ALL_CONVERSATION_FILTER: BaseFilter = {
   ...DEFAULT_BASE_FILTER,
   attributeKey: 'status',
   filterOperator: 'equal_to',
-  values: 'open',
+  values: 'all',
 };

--- a/src/utils/chat/conversationMatch.spec.ts
+++ b/src/utils/chat/conversationMatch.spec.ts
@@ -1,0 +1,102 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect } from 'vitest';
+import { doesConversationMatchFilters } from './conversationMatch';
+import { DEFAULT_CONVERSATION_FILTER } from '@/types/core/filters';
+import type { Conversation, ConversationFilter } from '@/types/chat/api';
+
+const conv = (over: Partial<Conversation> = {}): Conversation =>
+  ({
+    id: '1',
+    status: 'open',
+    priority: null,
+    labels: [],
+    unread_count: 0,
+    is_group: false,
+    ...over,
+  } as Conversation);
+
+const filter = (
+  attribute_key: string,
+  values: (string | number)[],
+  filter_operator = 'equal_to',
+): ConversationFilter =>
+  ({ attribute_key, filter_operator, values, query_operator: 'and' } as ConversationFilter);
+
+describe('doesConversationMatchFilters', () => {
+  it('empty filters → match all', () => {
+    expect(doesConversationMatchFilters(conv(), [])).toBe(true);
+  });
+
+  it("status 'all' short-circuits to match (any status)", () => {
+    expect(
+      doesConversationMatchFilters(conv({ status: 'resolved' }), [filter('status', ['all'])]),
+    ).toBe(true);
+  });
+
+  it('status equal_to keeps matching / evicts non-matching', () => {
+    expect(doesConversationMatchFilters(conv({ status: 'open' }), [filter('status', ['open'])])).toBe(true);
+    expect(doesConversationMatchFilters(conv({ status: 'resolved' }), [filter('status', ['open'])])).toBe(false);
+  });
+
+  it('status not_equal_to (the "Ativas"-style filter)', () => {
+    expect(
+      doesConversationMatchFilters(conv({ status: 'open' }), [filter('status', ['resolved'], 'not_equal_to')]),
+    ).toBe(true);
+    expect(
+      doesConversationMatchFilters(conv({ status: 'resolved' }), [filter('status', ['resolved'], 'not_equal_to')]),
+    ).toBe(false);
+  });
+
+  // Regression: advanced priority filter must evict when a row's priority changes.
+  describe('priority (advanced filter eviction)', () => {
+    it('keeps a conversation that still matches', () => {
+      expect(doesConversationMatchFilters(conv({ priority: 'high' }), [filter('priority', ['high'])])).toBe(true);
+    });
+    it('evicts a conversation whose priority no longer matches (incl. cleared)', () => {
+      expect(doesConversationMatchFilters(conv({ priority: 'low' }), [filter('priority', ['high'])])).toBe(false);
+      expect(doesConversationMatchFilters(conv({ priority: null }), [filter('priority', ['high'])])).toBe(false);
+    });
+  });
+
+  // Regression: advanced labels filter must evict when labels change. Value = title.
+  describe('labels (advanced filter eviction)', () => {
+    const withLabels = (titles: string[]) => conv({ labels: titles.map(t => ({ title: t })) as any });
+    it('keeps a conversation that has one of the filtered labels (contains)', () => {
+      expect(doesConversationMatchFilters(withLabels(['VIP', 'Lead']), [filter('labels', ['VIP'])])).toBe(true);
+    });
+    it('evicts a conversation that lost the label / has none', () => {
+      expect(doesConversationMatchFilters(withLabels(['Other']), [filter('labels', ['VIP'])])).toBe(false);
+      expect(doesConversationMatchFilters(withLabels([]), [filter('labels', ['VIP'])])).toBe(false);
+    });
+    it('not_equal_to keeps conversations WITHOUT the label', () => {
+      expect(
+        doesConversationMatchFilters(withLabels(['Other']), [filter('labels', ['VIP'], 'not_equal_to')]),
+      ).toBe(true);
+      expect(
+        doesConversationMatchFilters(withLabels(['VIP']), [filter('labels', ['VIP'], 'not_equal_to')]),
+      ).toBe(false);
+    });
+  });
+
+  describe('chip-nav axes', () => {
+    it('unread', () => {
+      expect(doesConversationMatchFilters(conv({ unread_count: 2 }), [filter('unread', ['true'])])).toBe(true);
+      expect(doesConversationMatchFilters(conv({ unread_count: 0 }), [filter('unread', ['true'])])).toBe(false);
+    });
+    it('is_group', () => {
+      expect(doesConversationMatchFilters(conv({ is_group: true }), [filter('is_group', ['true'])])).toBe(true);
+      expect(doesConversationMatchFilters(conv({ is_group: false }), [filter('is_group', ['true'])])).toBe(false);
+    });
+  });
+});
+
+// Guards the HIGH regression: the advanced-modal seed must NOT be a chip-nav
+// status row (which silently narrowed the default All view to status=open).
+describe('DEFAULT_CONVERSATION_FILTER (advanced modal seed)', () => {
+  it('is not a chip-nav (status/unread/is_group) attribute', () => {
+    expect(['status', 'unread', 'is_group']).not.toContain(DEFAULT_CONVERSATION_FILTER.attributeKey);
+  });
+  it('seeds an empty value so an untouched Apply is dropped (no-op)', () => {
+    expect(DEFAULT_CONVERSATION_FILTER.values).toBe('');
+  });
+});

--- a/src/utils/chat/conversationMatch.ts
+++ b/src/utils/chat/conversationMatch.ts
@@ -1,0 +1,113 @@
+import type { Conversation, ConversationFilter } from '@/types/chat/api';
+
+/**
+ * Single source of truth for "does this conversation still belong to the
+ * currently active view (filters)?". Used by BOTH the realtime (WebSocket) path
+ * and the mutation-reconcile path so a status/assignee change can drop a
+ * conversation from the current view locally — without refetching the list.
+ *
+ * Empty filters = match-all. A 'all' value short-circuits to match.
+ */
+export function doesConversationMatchFilters(
+  conversation: Conversation,
+  activeFilters: ConversationFilter[],
+  currentUserId?: string,
+): boolean {
+  if (!activeFilters || activeFilters.length === 0) return true;
+
+  return activeFilters.every(filter => {
+    const { attribute_key, filter_operator, values } = filter;
+    if (!values || values.length === 0) return true;
+    const stringValues = values.map(v => String(v));
+    if (stringValues.some(v => v.toLowerCase() === 'all')) return true;
+
+    let conversationValue: string | null | undefined;
+
+    switch (attribute_key) {
+      case 'status':
+        conversationValue = conversation.status;
+        break;
+      case 'inbox_id':
+        conversationValue = conversation.inbox_id ? String(conversation.inbox_id) : undefined;
+        break;
+      case 'assignee_id':
+      case 'assignee_type': {
+        // assignee_type (do modal) e assignee_id compartilham os valores
+        // me/unassigned/assigned — mesma lógica de match no realtime.
+        const val = String(values[0]);
+        if (val === 'me') {
+          const meMatches = currentUserId
+            ? conversation.assignee_id != null && String(conversation.assignee_id) === String(currentUserId)
+            : false;
+          return filter_operator === 'not_equal_to' ? !meMatches : meMatches;
+        }
+        if (val === 'unassigned') {
+          const isUnassigned = !conversation.assignee_id;
+          return filter_operator === 'not_equal_to' ? !isUnassigned : isUnassigned;
+        }
+        if (val === 'assigned') {
+          const isAssigned = !!conversation.assignee_id;
+          return filter_operator === 'not_equal_to' ? !isAssigned : isAssigned;
+        }
+        conversationValue = conversation.assignee_id ? String(conversation.assignee_id) : null;
+        break;
+      }
+      case 'team_id':
+        conversationValue = conversation.team_id ? String(conversation.team_id) : null;
+        break;
+      case 'channel_type':
+        conversationValue = conversation.channel || undefined;
+        break;
+      case 'priority':
+        // Filtro avançado de prioridade (POST /filter). Sem este case o matcher
+        // caía no default=true e não expulsava a conversa cuja prioridade mudou
+        // pra fora do filtro ativo (ex.: High -> Low numa view "Prioridade=Alta").
+        conversationValue = conversation.priority ?? null;
+        break;
+      case 'unread': {
+        // Chip "Não lidas" (value 'true'): mantém/insere só conversas com
+        // unread_count > 0; ao ler (unread_count -> 0) o WS remove da view.
+        const isUnread = (conversation.unread_count ?? 0) > 0;
+        return filter_operator === 'not_equal_to' ? !isUnread : isUnread;
+      }
+      case 'is_group': {
+        // Chip "Grupos" (value 'true'): só conversas de grupo (is_group do
+        // serializer). Sem isso o matcher caía no default=true e injetava
+        // conversas não-grupo (ex.: a pinned) na aba Grupos via realtime.
+        const isGroup = conversation.is_group === true;
+        return filter_operator === 'not_equal_to' ? !isGroup : isGroup;
+      }
+      case 'labels': {
+        // Filtro avançado de etiquetas (POST /filter). O valor é o TÍTULO da
+        // etiqueta (useFilterOptions.ts:110); conversation.labels é Label[] (ou
+        // string[] em alguns payloads de realtime) — normaliza pra título.
+        // equal_to = "contém". Sem este case caía no default=true e não expulsava
+        // a conversa cujas etiquetas saíram do filtro.
+        const convLabels = ((conversation.labels ?? []) as Array<{ title?: string } | string>)
+          .map(l => (typeof l === 'string' ? l : l.title))
+          .filter((t): t is string => Boolean(t));
+        if (filter_operator === 'is_present') return convLabels.length > 0;
+        if (filter_operator === 'is_not_present') return convLabels.length === 0;
+        const hasAny = stringValues.some(v => convLabels.includes(v));
+        return filter_operator === 'not_equal_to' ? !hasAny : hasAny;
+      }
+      default:
+        return true;
+    }
+
+    if (filter_operator === 'equal_to') {
+      return conversationValue != null && stringValues.includes(String(conversationValue));
+    }
+    if (filter_operator === 'not_equal_to') {
+      return conversationValue == null || !stringValues.includes(String(conversationValue));
+    }
+    if (filter_operator === 'contains') {
+      return conversationValue != null && stringValues.some(v => String(conversationValue).includes(v));
+    }
+    if (filter_operator === 'does_not_contain') {
+      return conversationValue == null || !stringValues.some(v => String(conversationValue).includes(v));
+    }
+
+    return true;
+  });
+}

--- a/src/utils/chat/filterConverters.ts
+++ b/src/utils/chat/filterConverters.ts
@@ -122,6 +122,15 @@ export const convertFiltersToUrlParams = (
         }
         break;
 
+      // O modal usa attribute_key 'assignee_type' (me/unassigned/assigned/all).
+      // Sem este case ele era DROPADO no GET → "Assigned" mostrava tudo. O finder
+      // (apply_assignee_type_filter) trata me/unassigned/assigned/all direto.
+      case 'assignee_type':
+        if (values.length === 1) {
+          params.assignee_type = values[0] as ConversationListParams['assignee_type'];
+        }
+        break;
+
       case 'inbox_id':
         if (values.length === 1) {
           params.inbox_id = values[0] as string;
@@ -140,6 +149,19 @@ export const convertFiltersToUrlParams = (
         }
         break;
 
+      // Chips "Não lidas" / "Grupos" (eixo de navegação, não status) → GET barato.
+      case 'unread':
+        if (values.length === 1) {
+          params.unread = String(values[0]) === 'true';
+        }
+        break;
+
+      case 'is_group':
+        if (values.length === 1) {
+          params.is_group = String(values[0]) === 'true';
+        }
+        break;
+
       // case 'priority': // Não suportado pela API GET
       //   if (values.length === 1) {
       //     params.priority = values[0] as string;
@@ -147,6 +169,13 @@ export const convertFiltersToUrlParams = (
       //   break;
     }
   });
+
+  // Sem linha de status nos filtros, NÃO deixar o backend cair no default
+  // implícito status=open (footgun: filtrar por inbox/atendente/label sem status
+  // trazia só abertas). status ausente = All, coerente com a visão padrão.
+  if (!params.status) {
+    params.status = 'all';
+  }
 
   return params;
 };

--- a/src/utils/storage/filtersStorage.ts
+++ b/src/utils/storage/filtersStorage.ts
@@ -1,6 +1,9 @@
-import { BaseFilter, DEFAULT_CONVERSATION_FILTER } from '@/types/core';
+import { BaseFilter, ALL_CONVERSATION_FILTER } from '@/types/core';
 
-const STORAGE_KEY = 'evoai:conversation:filters';
+// v2: o default mudou de status=open para status=all ("Todas"). Bumpar a chave
+// força um reset único p/ usuários que tinham o default antigo persistido — senão
+// o filtro salvo os prende no status=open e o novo default nunca se aplica.
+const STORAGE_KEY = 'evoai:conversation:filters:v2';
 
 export const saveConversationFilters = (filters: BaseFilter[]): void => {
   try {
@@ -32,5 +35,6 @@ export const clearConversationFilters = (): void => {
 };
 
 export const getDefaultFilter = (): BaseFilter[] => {
-  return [DEFAULT_CONVERSATION_FILTER];
+  // Visão padrão ao abrir = todos os status (status=all; nenhum chip marcado).
+  return [ALL_CONVERSATION_FILTER];
 };


### PR DESCRIPTION
## Summary

Conversation-list overhaul delivered during the EVO-1960 chat-perf lab. The performance/architecture core is the valuable part; the layout disposition (chips, selection kebab) is an immediate fix, to be re-reviewed under EVO-1965 block C / EVO-1781.

- **EVO-1960** — no-refetch reconcile on status/stage change (patch the single conversation, no full-list refetch); realtime pinned-leak eviction; single-source matcher (`conversationMatch.ts`) shared by the realtime and mutation paths; last_activity ordering.
- **EVO-1975** — WhatsApp-style segment chips (Aberto/Pendente/Resolvido/Não-lidas/Grupos), overflow collapses into a dropdown; advanced-modal seed regression fix (empty `assignee_type` so an untouched Apply no longer narrows Todas→Aberto); `localStorage` key bumped to `:v2` so existing users pick up the new Todas default.
- **EVO-1976** — bulk status actions (reopen/pending) reusing EVO-1011's plumbing; selection kebab; read/unread undo (5s).
- **EVO-1973** — pipeline re-entry into a completed journey ADDs instead of dead-ending on `moveError`; remove resolves the item from per-conversation state with a minimal optimistic payload.
- **EVO-1977** (frontend half) — "Ver arquivadas" toggle.

## Validation

- `pnpm exec tsc -b --noEmit` — clean
- `pnpm exec vitest run` (chat specs) — 49 passing (ChatSidebar, ContactSidebar, useConversationHandlers, useFilterHandlers, conversationMatch, Chat)
- Adversarial code review (core + adjacency risks): EVO-1053 double-evict, EVO-1405 M2 stopPropagation, and EVO-1127 optimistic-vs-partial-failure all verified SAFE.

## Notes

- `src/types/chat/api.ts` carries pre-existing `no-explicit-any` lint errors (lines 148-189) outside the changed hunks — not introduced here.
- Layout disposition (chips, selection kebab) is an immediate fix; final element disposition is tracked under EVO-1965 C / EVO-1781.

## Linked Issues

- EVO-1960, EVO-1975, EVO-1976, EVO-1977, EVO-1973

## Related PRs

- CRM backend (EVO-1960 / EVO-1975 / EVO-1977): sibling PR in `evo-ai-crm-community` (branch `fix/EVO-1960`).
