### PR TITLE
fix(frontend): theme-aware conversation-list scrollbar (EVO-1974)

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -240,8 +240,10 @@
     border-radius: 4px;
   }
 
+  /* Tema claro (default): thumb escuro p/ ficar visível sobre fundo claro.
+     Tema escuro sobrescreve com thumb claro abaixo (.dark). */
   *::-webkit-scrollbar-thumb {
-    background-color: rgba(255, 255, 255, 0.15);
+    background-color: rgba(0, 0, 0, 0.22);
     border-radius: 4px;
     border: 2px solid transparent;
     background-clip: content-box;
@@ -249,16 +251,33 @@
   }
 
   *::-webkit-scrollbar-thumb:hover {
-    background-color: rgba(255, 255, 255, 0.25);
+    background-color: rgba(0, 0, 0, 0.32);
   }
 
   *::-webkit-scrollbar-thumb:active {
+    background-color: rgba(0, 0, 0, 0.42);
+  }
+
+  /* Tema escuro: thumb claro sobre fundo escuro */
+  .dark *::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.15);
+  }
+
+  .dark *::-webkit-scrollbar-thumb:hover {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+
+  .dark *::-webkit-scrollbar-thumb:active {
     background-color: rgba(255, 255, 255, 0.35);
   }
 
-  /* Firefox - otimizado para tema escuro */
+  /* Firefox */
   * {
     scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.22) transparent;
+  }
+
+  .dark * {
     scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
   }
 


### PR DESCRIPTION
## Summary

Theme-aware conversation-list scrollbar. The thumb was white-on-white in the light theme (invisible unless hovered); the dark theme was fine. Adds a dark thumb for the light theme, a `.dark` override that keeps the light thumb, and Firefox `scrollbar-color` for both.

## Validation

- `pnpm exec tsc -b --noEmit` — clean (CSS-only change)

## Linked Issues

- EVO-1974

## Summary by Sourcery

Adjust scrollbar styling to be theme-aware so scroll thumbs remain visible in both light and dark modes.

Enhancements:
- Update default scrollbar thumb colors to be darker for visibility on light backgrounds.
- Add dark-theme overrides for scrollbar thumb colors and interaction states.
- Align Firefox scrollbar-color settings with the theme-specific scrollbar styles.