### PR TITLE
fix(campaigns): evita crash de tela preta quando a API não retorna data (EVO-1966)

### DIFF
--- a/src/pages/Customer/Campaigns/Campaigns.tsx
+++ b/src/pages/Customer/Campaigns/Campaigns.tsx
@@ -93,7 +93,7 @@ export default function Campaigns() {
 
         setState(prev => ({
           ...prev,
-          campaigns: response.data,
+          campaigns: response.data ?? [],
           meta: {
             pagination: {
               page: response.meta?.pagination?.page || 1,


### PR DESCRIPTION
## Problema

A tela de campanhas (`/campaigns`) quebra com **tela preta**:
```
Uncaught TypeError: can't access property "length", state.campaigns is undefined
```
Em `Campaigns.tsx`, o fetch faz `setState({ campaigns: response.data })` sem default. Quando a API responde **2xx mas sem `data`** (`response.data === undefined`), `state.campaigns` vira `undefined`, e o render (`state.campaigns.length`) estoura. (O `catch` só cobre erro de rede/HTTP — um 2xx sem `data` passa reto.)

## Fix

`campaigns: response.data ?? []` — a lista sempre cai em `[]` quando a API não devolve `data`. A página passa a renderizar (lista vazia) em vez de crashar.

## Escopo

Isto corrige **só o crash de front**. A causa de a API devolver `data` vazio (campanhas não aparecem) é **separada** (backend/wiring evo-flow) e não faz parte deste PR.

## Validação

Rebuild do `evo-frontend` num clean-room + teste manual: a tela `/campaigns` **abre sem crash** (lista vazia), confirmado. Descoberto no bring-up de checkout limpo do `evo-crm-community` (EVO-1966).

## Summary by Sourcery

Bug Fixes:
- Ensure the campaigns state falls back to an empty list when the API response has no data to avoid runtime errors on render.