### PR TITLE
feat(journey): validação de expressão nos pickers compartilhados (EVO-1872)

### DIFF
--- a/src/components/journey/environment-manager/VariableInput.spec.tsx
+++ b/src/components/journey/environment-manager/VariableInput.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { VariableInput } from './VariableInput';
+import '@/i18n/config';
+
+// The picker reads custom variables from this hook; a stub keeps the tests
+// focused on the EVO-1872 validation behavior.
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({ variables: [], loading: false, error: null }),
+}));
+
+describe('VariableInput — expression validation (EVO-1872)', () => {
+  it('flags an unbalanced value: aria-invalid true + inline error wired to the input', () => {
+    render(<VariableInput journeyId="j1" validateExpression value="{{contact.name" readOnly />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+
+    // The error <p> is associated to the field via aria-describedby.
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toBeInTheDocument();
+  });
+
+  it('treats a balanced value as valid: aria-invalid false, no inline error', () => {
+    render(<VariableInput journeyId="j1" validateExpression value="{{contact.name}}" readOnly />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('aria-invalid', 'false');
+    expect(input.getAttribute('aria-describedby')).toBeFalsy();
+  });
+
+  it('does not validate when validateExpression is off (opt-in)', () => {
+    render(<VariableInput journeyId="j1" value="{{contact.name" readOnly />);
+
+    const input = screen.getByRole('textbox');
+    // No expression guard → no aria-invalid asserted by the component.
+    expect(input.getAttribute('aria-invalid')).toBeFalsy();
+    expect(input.getAttribute('aria-describedby')).toBeFalsy();
+  });
+
+  // CR4: the PhoneInput branch (type=tel, no closing braces so it is not treated
+  // as containing a variable) must still forward the expression aria to its input.
+  it('forwards aria-invalid to the PhoneInput branch (CR4)', () => {
+    render(
+      <VariableInput
+        journeyId="j1"
+        validateExpression
+        type="tel"
+        value="{{contact.phone"
+        readOnly
+      />,
+    );
+
+    const phoneInput = screen.getByRole('textbox');
+    expect(phoneInput).toHaveAttribute('aria-invalid', 'true');
+    expect(phoneInput.getAttribute('aria-describedby')).toBeTruthy();
+  });
+});

--- a/src/components/journey/environment-manager/VariableInput.tsx
+++ b/src/components/journey/environment-manager/VariableInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, forwardRef } from 'react';
+import React, { useState, useRef, useId, forwardRef } from 'react';
 import {
   Input,
   Button,
@@ -13,6 +13,7 @@ import { getSystemVariables, VariableOption } from './EnvironmentManager';
 import { useJourneyVariables } from '@/hooks/useJourneyVariables';
 import { useLanguage } from '@/hooks/useLanguage';
 import { PhoneInput } from '@/components/shared/PhoneInput';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 
 export interface VariableInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   // Optional: contexts without a journey (campaigns, automations) omit it, so the
@@ -21,6 +22,12 @@ export interface VariableInputProps extends React.InputHTMLAttributes<HTMLInputE
   onVariableInsert?: (variable: string) => void;
   showVariableButton?: boolean;
   variableButtonTooltip?: string;
+  // EVO-1872: opt-in guard for free-text expression fields. When on, an unbalanced
+  // {{ }} value renders an inline error and wires aria-invalid/aria-describedby to
+  // the field (also on the PhoneInput branch). Off by default so literal fields
+  // (URLs, headers) never false-positive. Panels aggregate validity for Save via
+  // isExpressionFieldValid over their own data.
+  validateExpression?: boolean;
 }
 
 const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
@@ -31,6 +38,7 @@ const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
       onVariableInsert,
       showVariableButton = true,
       variableButtonTooltip,
+      validateExpression = false,
       ...props
     },
     ref,
@@ -38,6 +46,7 @@ const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
     const { t } = useLanguage('journey');
     const [open, setOpen] = useState(false);
     const inputRef = useRef<HTMLInputElement>(null);
+    const generatedId = useId();
     const { variables } = useJourneyVariables(journeyId);
 
     // Usar a ref passada ou a ref interna
@@ -163,11 +172,23 @@ const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
     // Usar PhoneInput apenas se for tipo tel E não tiver variáveis
     const shouldUsePhoneInput = isPhoneType && !hasVariables;
 
+    // EVO-1872: derive the inline expression error and merge aria wiring. When
+    // validateExpression is off we defer to whatever aria the caller passed.
+    const isExpressionInvalid = validateExpression && !isExpressionFieldValid(currentValue);
+    const errorId = `${generatedId}-expr-error`;
+    const ariaInvalid = validateExpression ? isExpressionInvalid : props['aria-invalid'];
+    const ariaDescribedBy =
+      [props['aria-describedby'], isExpressionInvalid ? errorId : null]
+        .filter(Boolean)
+        .join(' ') || undefined;
+
     return (
       <div className="relative">
         {shouldUsePhoneInput ? (
           <PhoneInput
             value={currentValue}
+            aria-invalid={ariaInvalid}
+            aria-describedby={ariaDescribedBy}
             onChange={value => {
               // Converter string do PhoneInput para formato de evento para manter compatibilidade
               if (props.onChange) {
@@ -194,11 +215,13 @@ const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
             className={cn(className)}
           />
         ) : (
-          <Input 
-            ref={finalRef} 
-            className={cn('pr-10', className)} 
+          <Input
+            ref={finalRef}
+            className={cn('pr-10', className)}
             type={isPhoneType ? 'tel' : props.type}
-            {...props} 
+            {...props}
+            aria-invalid={ariaInvalid}
+            aria-describedby={ariaDescribedBy}
           />
         )}
 
@@ -290,6 +313,12 @@ const VariableInput = forwardRef<HTMLInputElement, VariableInputProps>(
               </PopoverContent>
             </Popover>
           </div>
+        )}
+
+        {isExpressionInvalid && (
+          <p id={errorId} className="mt-1 text-xs text-flow-feedback-error-fg">
+            {t('environmentManager.invalidExpression')}
+          </p>
         )}
       </div>
     );

--- a/src/components/journey/environment-manager/VariableTextarea.spec.tsx
+++ b/src/components/journey/environment-manager/VariableTextarea.spec.tsx
@@ -52,6 +52,34 @@ describe('VariableTextarea — accessibility', () => {
   });
 });
 
+describe('VariableTextarea — expression validation (EVO-1872)', () => {
+  it('flags an unbalanced value: aria-invalid true + inline error wired to the field', () => {
+    render(<VariableTextarea journeyId="j1" validateExpression value="{{order_id" readOnly />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+    const describedBy = textarea.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toBeInTheDocument();
+  });
+
+  it('treats a balanced value as valid: aria-invalid false, no inline error', () => {
+    render(<VariableTextarea journeyId="j1" validateExpression value="{{order_id}}" readOnly />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('aria-invalid', 'false');
+    expect(textarea.getAttribute('aria-describedby')).toBeFalsy();
+  });
+
+  it('does not validate when validateExpression is off (opt-in)', () => {
+    render(<VariableTextarea journeyId="j1" value="{{order_id" readOnly />);
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea.getAttribute('aria-invalid')).toBeFalsy();
+    expect(textarea.getAttribute('aria-describedby')).toBeFalsy();
+  });
+});
+
 describe('VariableTextarea — variable insertion (EVO-1855 item 4)', () => {
   // Capture synchronously inside the handler: the panels are controlled, so a
   // spy that doesn't write state back lets React reset the DOM value after the

--- a/src/components/journey/environment-manager/VariableTextarea.tsx
+++ b/src/components/journey/environment-manager/VariableTextarea.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, forwardRef } from 'react';
+import React, { useState, useRef, useId, forwardRef } from 'react';
 import {
   Textarea,
   Button,
@@ -12,12 +12,15 @@ import { cn } from '@/lib/utils';
 import { getSystemVariables, VariableOption } from './EnvironmentManager';
 import { useJourneyVariables } from '@/hooks/useJourneyVariables';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 
 export interface VariableTextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   journeyId?: string;
   onVariableInsert?: (variable: string) => void;
   showVariableButton?: boolean;
   variableButtonTooltip?: string;
+  // EVO-1872: opt-in guard for free-text expression fields — see VariableInput.
+  validateExpression?: boolean;
 }
 
 const VariableTextarea = forwardRef<HTMLTextAreaElement, VariableTextareaProps>(
@@ -28,6 +31,7 @@ const VariableTextarea = forwardRef<HTMLTextAreaElement, VariableTextareaProps>(
       onVariableInsert,
       showVariableButton = true,
       variableButtonTooltip,
+      validateExpression = false,
       ...props
     },
     ref,
@@ -35,6 +39,7 @@ const VariableTextarea = forwardRef<HTMLTextAreaElement, VariableTextareaProps>(
     const { t } = useLanguage('journey');
     const [open, setOpen] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const generatedId = useId();
     const { variables } = useJourneyVariables(journeyId);
 
     // Usar a ref passada ou a ref interna
@@ -123,9 +128,25 @@ const VariableTextarea = forwardRef<HTMLTextAreaElement, VariableTextareaProps>(
       return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
     });
 
+    // EVO-1872: derive the inline expression error and merge aria wiring.
+    const currentValue = typeof props.value === 'string' ? props.value : '';
+    const isExpressionInvalid = validateExpression && !isExpressionFieldValid(currentValue);
+    const errorId = `${generatedId}-expr-error`;
+    const ariaInvalid = validateExpression ? isExpressionInvalid : props['aria-invalid'];
+    const ariaDescribedBy =
+      [props['aria-describedby'], isExpressionInvalid ? errorId : null]
+        .filter(Boolean)
+        .join(' ') || undefined;
+
     return (
       <div className="relative">
-        <Textarea ref={finalRef} className={cn('pr-10', className)} {...props} />
+        <Textarea
+          ref={finalRef}
+          className={cn('pr-10', className)}
+          {...props}
+          aria-invalid={ariaInvalid}
+          aria-describedby={ariaDescribedBy}
+        />
 
         {showVariableButton && (
           <div className="absolute right-2 top-2">
@@ -211,6 +232,12 @@ const VariableTextarea = forwardRef<HTMLTextAreaElement, VariableTextareaProps>(
               </PopoverContent>
             </Popover>
           </div>
+        )}
+
+        {isExpressionInvalid && (
+          <p id={errorId} className="mt-1 text-xs text-flow-feedback-error-fg">
+            {t('environmentManager.invalidExpression')}
+          </p>
         )}
       </div>
     );

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -27,7 +27,7 @@ import { VariableInput, VariableSelect } from '@/components/journey/environment-
 import { v4 as uuidv4 } from 'uuid';
 import { useLanguage } from '@/hooks/useLanguage';
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
-import { isBalancedExpression } from '@/utils/templateVariables';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 
 const PIPELINE_STAGE_OPERATORS = ['equals', 'not_equals'];
 
@@ -247,9 +247,7 @@ export function ConditionalPanel({
   const isConditionValueBalanced = (condition: Condition) => {
     if (condition.field === PIPELINE_STAGE_FIELD) return true;
     if (!needsValue(condition.operator)) return true;
-    const value = condition.value;
-    if (typeof value !== 'string' || value.trim() === '') return true;
-    return isBalancedExpression(value);
+    return isExpressionFieldValid(condition.value);
   };
 
   // Cheap derived traversal (a handful of conditions) — recompute on each
@@ -290,9 +288,6 @@ export function ConditionalPanel({
     const operatorOptions = isPipelineStageField
       ? OPERATORS.filter(option => PIPELINE_STAGE_OPERATORS.includes(option.value))
       : OPERATORS;
-
-    const valueBalanced = isConditionValueBalanced(condition);
-    const exprErrorId = `conditional-expr-error-${condition.id}`;
 
     return (
       <div
@@ -377,27 +372,19 @@ export function ConditionalPanel({
                 </SelectContent>
               </Select>
             ) : needsValue(condition.operator) ? (
-              <>
-                <VariableInput
-                  value={condition.value || ''}
-                  onChange={e =>
-                    updateCondition(pathId, condition.id, {
-                      value: e.target.value,
-                      valueLabel: undefined,
-                    })
-                  }
-                  placeholder={t('panels.conditional.value')}
-                  className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-                  journeyId={journeyId}
-                  aria-invalid={!valueBalanced}
-                  aria-describedby={valueBalanced ? undefined : exprErrorId}
-                />
-                {!valueBalanced && (
-                  <p id={exprErrorId} className="mt-1 text-xs text-flow-feedback-error-fg">
-                    {t('environmentManager.invalidExpression')}
-                  </p>
-                )}
-              </>
+              <VariableInput
+                value={condition.value || ''}
+                onChange={e =>
+                  updateCondition(pathId, condition.id, {
+                    value: e.target.value,
+                    valueLabel: undefined,
+                  })
+                }
+                placeholder={t('panels.conditional.value')}
+                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                journeyId={journeyId}
+                validateExpression
+              />
             ) : (
               <div className="h-10 flex items-center text-xs text-muted-foreground italic px-3">
                 {t('panels.conditional.notNecessary')}

--- a/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
+++ b/src/components/journey/nodes/actions/send-message/SendMessagePanel.tsx
@@ -30,7 +30,7 @@ import {
   TemplateVariableMapping,
   TemplateVariableSource,
 } from './SendMessageNode';
-import { isBalancedExpression } from '@/utils/templateVariables';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { automationService } from '@/services/automation/automationService';
@@ -491,7 +491,7 @@ export function SendMessagePanel({
       case 'fixed':
         return !!(mapping.value ?? '').trim();
       case 'expression':
-        return !!(mapping.expression ?? '').trim() && isBalancedExpression(mapping.expression!);
+        return !!(mapping.expression ?? '').trim() && isExpressionFieldValid(mapping.expression);
       default:
         return !!mapping.path;
     }
@@ -507,7 +507,7 @@ export function SendMessagePanel({
       mapping =>
         mapping.source === 'expression' &&
         !!(mapping.expression ?? '').trim() &&
-        !isBalancedExpression(mapping.expression!),
+        !isExpressionFieldValid(mapping.expression),
     );
   const missingRequiredVariables = isTemplateMode
     ? (selectedTemplate?.variables ?? []).filter(
@@ -782,11 +782,6 @@ export function SendMessagePanel({
                       mapping.source === 'contact' ||
                       mapping.source === 'conversation' ||
                       mapping.source === 'pipeline';
-                    const expressionInvalid =
-                      mapping.source === 'expression' &&
-                      !!(mapping.expression ?? '').trim() &&
-                      !isBalancedExpression(mapping.expression!);
-                    const exprErrorId = `send-message-expr-error-${variable.name}`;
 
                     return (
                       <div key={variable.name} className="space-y-1">
@@ -857,7 +852,7 @@ export function SendMessagePanel({
                           )}
 
                           {mapping.source === 'expression' && (
-                            <div className="w-full space-y-1">
+                            <div className="w-full">
                               <VariableTextarea
                                 value={mapping.expression ?? ''}
                                 onChange={e =>
@@ -868,17 +863,8 @@ export function SendMessagePanel({
                                 placeholder={t('panels.sendMessage.expressionPlaceholder')}
                                 className="min-h-[40px] resize-none"
                                 journeyId={journeyId}
-                                aria-invalid={expressionInvalid}
-                                aria-describedby={expressionInvalid ? exprErrorId : undefined}
+                                validateExpression
                               />
-                              {expressionInvalid && (
-                                <p
-                                  id={exprErrorId}
-                                  className="text-xs text-flow-feedback-error-fg"
-                                >
-                                  {t('panels.sendMessage.invalidExpression')}
-                                </p>
-                              )}
                             </div>
                           )}
                         </div>

--- a/src/components/journey/nodes/actions/send-webhook/SendWebhookPanel.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/SendWebhookPanel.tsx
@@ -6,6 +6,7 @@ import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableSelect } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 import {
   getEffectiveBodyMode,
   isValidJsonBody,
@@ -291,8 +292,18 @@ export function SendWebhookPanel({
         if (!result.ok) {
           issues.push(t(`panels.sendWebhook.body.validation.${result.error}`));
         }
-      } else if (formData.bodyType === 'json' && !isValidJsonBody(formData.body || '')) {
-        issues.push(t('panels.sendWebhook.invalidJson'));
+        // EVO-1872: an unbalanced {{ }} expression in any structured value blocks Save.
+        if ((formData.bodyStructured || []).some(field => !isExpressionFieldValid(field.value))) {
+          issues.push(t('environmentManager.invalidExpression'));
+        }
+      } else {
+        if (formData.bodyType === 'json' && !isValidJsonBody(formData.body || '')) {
+          issues.push(t('panels.sendWebhook.invalidJson'));
+        }
+        // EVO-1872: an unbalanced {{ }} expression in the raw body blocks Save.
+        if (!isExpressionFieldValid(formData.body || '')) {
+          issues.push(t('environmentManager.invalidExpression'));
+        }
       }
     }
 

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
@@ -73,6 +73,7 @@ export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: We
                     placeholder={t('panels.sendWebhook.body.builder.valuePlaceholder')}
                     className="bg-sidebar border-sidebar-border text-sidebar-foreground"
                     journeyId={journeyId}
+                    validateExpression
                   />
                 </div>
 

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
@@ -286,6 +286,7 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
                 className="w-full h-32 p-3 text-sm bg-sidebar border-sidebar-border text-sidebar-foreground rounded-md font-mono resize-y"
                 style={{ minHeight: '120px' }}
                 journeyId={journeyId}
+                validateExpression
               />
             </div>
             <div className="text-xs text-gray-500 dark:text-gray-400">

--- a/src/components/journey/nodes/actions/set-variable/SetVariablePanel.tsx
+++ b/src/components/journey/nodes/actions/set-variable/SetVariablePanel.tsx
@@ -13,6 +13,7 @@ import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { VariableInput, VariableSelect } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 
 interface SetVariablePanelProps {
   nodeId: string;
@@ -140,11 +141,14 @@ export function SetVariablePanel({
   };
 
   const selectedOperation = OPERATIONS.find(op => op.value === formData.operation);
-  const isValid = Boolean(
-    formData.variableName &&
-      (!selectedOperation?.needsValue || formData.value) &&
-      (!selectedOperation?.needsCategory || formData.category),
-  );
+  const isValid =
+    Boolean(
+      formData.variableName &&
+        (!selectedOperation?.needsValue || formData.value) &&
+        (!selectedOperation?.needsCategory || formData.category),
+    ) &&
+    // EVO-1872: an unbalanced {{ }} expression in the value blocks Save.
+    isExpressionFieldValid(formData.value);
   const dirty = useMemo(
     () => JSON.stringify(formData) !== JSON.stringify(originalData),
     [formData, originalData],
@@ -165,9 +169,7 @@ export function SetVariablePanel({
             placeholder={t('panels.setVariable.placeholders.numericAmount')}
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
             journeyId={journeyId}
-            onVariableInsert={variable => {
-              console.log('Variable inserted in numeric operation:', variable);
-            }}
+            validateExpression
           />
         );
 
@@ -179,9 +181,7 @@ export function SetVariablePanel({
             placeholder={t('panels.setVariable.placeholders.customValue')}
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
             journeyId={journeyId}
-            onVariableInsert={variable => {
-              console.log('Variable inserted in custom value:', variable);
-            }}
+            validateExpression
           />
         );
     }

--- a/src/components/journey/nodes/actions/update-contact/UpdateContactPanel.tsx
+++ b/src/components/journey/nodes/actions/update-contact/UpdateContactPanel.tsx
@@ -13,6 +13,7 @@ import { UpdateContactNodeData } from './UpdateContactNode';
 import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 
 interface UpdateContactPanelProps {
   nodeId: string;
@@ -85,9 +86,10 @@ export function UpdateContactPanel({
     }));
   };
 
-  const isValid = Boolean(
-    formData.fieldToUpdate && formData.newValue && formData.newValue.trim() !== '',
-  );
+  const isValid =
+    Boolean(formData.fieldToUpdate && formData.newValue && formData.newValue.trim() !== '') &&
+    // EVO-1872: block Save on an unbalanced {{ }} expression in the new value.
+    isExpressionFieldValid(formData.newValue);
   const dirty = useMemo(
     () => JSON.stringify(formData) !== JSON.stringify(originalData),
     [formData, originalData],
@@ -159,6 +161,7 @@ export function UpdateContactPanel({
               onChange={e => handleValueChange(e.target.value)}
               className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
               journeyId={journeyId}
+              validateExpression
             />
           </div>
         )}

--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.spec.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateCustomAttributePanel } from './UpdateCustomAttributePanel';
@@ -114,5 +114,45 @@ describe('UpdateCustomAttributePanel — persists attribute_key (EVO-1850)', () 
     // The display name is shown; the raw slug must never surface in the UI.
     await waitFor(() => expect(screen.getAllByText('Plan Interest').length).toBeGreaterThan(0));
     expect(screen.queryByText('plan_interest')).toBeNull();
+  });
+});
+
+describe('UpdateCustomAttributePanel — expression validation (EVO-1872)', () => {
+  const SAVE_NAME = /save|salvar|guardar|enregistrer|salva/i;
+
+  it('disables Save on an unbalanced {{ }} value and re-enables it once balanced', async () => {
+    mockGetCustomAttributes.mockResolvedValue({ data: [PLAN_INTEREST_ATTR] });
+    const user = userEvent.setup();
+
+    render(
+      <UpdateCustomAttributePanel
+        nodeId="n1"
+        data={emptyData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    await waitFor(() => expect(mockGetCustomAttributes).toHaveBeenCalled());
+    await user.click(getAttributeTrigger());
+    const listbox = await screen.findByRole('listbox');
+    await user.click(within(listbox).getByText('Plan Interest'));
+
+    // fireEvent.change (not user.type) so the literal braces reach the field
+    // without userEvent's `{` keyboard escaping.
+    const valueInput = await screen.findByRole('textbox');
+    fireEvent.change(valueInput, { target: { value: '{{contact.name' } });
+
+    // The shared picker surfaces the error and blocks Save (dirty but invalid).
+    expect(valueInput).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('button', { name: SAVE_NAME })).toBeDisabled();
+
+    // Completing the expression clears the guard and re-enables Save.
+    fireEvent.change(valueInput, { target: { value: '{{contact.name}}' } });
+    expect(valueInput).toHaveAttribute('aria-invalid', 'false');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: SAVE_NAME })).not.toBeDisabled(),
+    );
   });
 });

--- a/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.tsx
+++ b/src/components/journey/nodes/actions/update-custom-attribute/UpdateCustomAttributePanel.tsx
@@ -16,6 +16,7 @@ import { customAttributesService } from '@/services/customAttributes/customAttri
 import type { CustomAttributeDefinition } from '@/types/settings';
 import { VariableInput } from '@/components/journey/environment-manager';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 
 interface UpdateCustomAttributePanelProps {
   nodeId: string;
@@ -115,9 +116,10 @@ export function UpdateCustomAttributePanel({
   };
 
   const selectedAttribute = attributes.find(attr => attr.id === formData.attributeId);
-  const isValid = Boolean(
-    formData.attributeId && formData.newValue !== undefined && formData.newValue !== '',
-  );
+  const isValid =
+    Boolean(formData.attributeId && formData.newValue !== undefined && formData.newValue !== '') &&
+    // EVO-1872: block Save on an unbalanced {{ }} expression in the new value.
+    isExpressionFieldValid(formData.newValue);
   const dirty = useMemo(
     () => JSON.stringify(formData) !== JSON.stringify(originalData),
     [formData, originalData],
@@ -208,6 +210,7 @@ export function UpdateCustomAttributePanel({
             onChange={e => handleValueChange(e.target.value)}
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
             journeyId={journeyId}
+            validateExpression
           />
         );
 
@@ -220,6 +223,7 @@ export function UpdateCustomAttributePanel({
             onChange={e => handleValueChange(e.target.value)}
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
             journeyId={journeyId}
+            validateExpression
           />
         );
 
@@ -232,6 +236,7 @@ export function UpdateCustomAttributePanel({
             onChange={e => handleValueChange(e.target.value)}
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
             journeyId={journeyId}
+            validateExpression
           />
         );
     }

--- a/src/components/journey/nodes/actions/wait/components/WaitHybridConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitHybridConfig.tsx
@@ -120,9 +120,6 @@ export function WaitHybridConfig({ data, onChange, journeyId }: WaitHybridConfig
               placeholder={t('panels.waitComponents.hybrid.timePlaceholder')}
               className="bg-sidebar border-sidebar-border text-sidebar-foreground"
               journeyId={journeyId}
-              onVariableInsert={variable => {
-                console.log('Variable inserted in hybrid max wait time:', variable);
-              }}
             />
           </div>
           <div className="space-y-2">

--- a/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.tsx
@@ -74,9 +74,6 @@ export function WaitTimeConfig({ data, onChange, journeyId }: WaitTimeConfigProp
           placeholder={t('panels.waitComponents.time.durationPlaceholder')}
           className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
           journeyId={journeyId}
-          onVariableInsert={variable => {
-            console.log('Variable inserted in wait duration:', variable);
-          }}
         />
         <p className="text-xs text-gray-500 dark:text-gray-400">
           {t('panels.waitComponents.time.variableHint')}

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { JourneyTriggerPanel } from './JourneyTriggerPanel';
@@ -253,5 +253,30 @@ describe('JourneyTriggerPanel — label/segment action round-trip (EVO-1754)', (
 
     const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
     expect(saved.segmentAction).toBe('entered');
+  });
+});
+
+describe('JourneyTriggerPanel — expression validation (EVO-1872)', () => {
+  it('blocks Save on an unbalanced {{ }} contact-field value and re-enables it once balanced', () => {
+    // Contact trigger renders the simple modal whose Save is now gated on the
+    // shared expression guard; seed a value-taking condition so the picker shows.
+    renderPanel({
+      triggerType: 'contactUpdated',
+      contactFields: [{ field: 'name', operator: 'equals', value: '' }],
+    });
+
+    // fireEvent.change (not user.type) so the literal braces bypass userEvent's
+    // `{` keyboard escaping.
+    const valueInput = screen.getByPlaceholderText(
+      /enter the value|digite o valor|introduce el valor|inserisci il valore|entrez la valeur/i,
+    );
+    fireEvent.change(valueInput, { target: { value: '{{contact.name' } });
+
+    expect(valueInput).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    fireEvent.change(valueInput, { target: { value: '{{contact.name}}' } });
+    expect(valueInput).toHaveAttribute('aria-invalid', 'false');
+    expect(screen.getByRole('button', { name: 'Save' })).not.toBeDisabled();
   });
 });

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -5,6 +5,7 @@ import { NodeConfigModal } from '@/components/journey/shared/NodeConfigModal';
 import { JourneyVariable } from '@/components/journey/environment-manager';
 import { FlowFeedbackBanner } from '@/components/journey/_ui';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isExpressionFieldValid } from '@/utils/templateVariables';
 import {
   TriggerTypeSelector,
   TriggerDescription,
@@ -208,6 +209,14 @@ export function JourneyTriggerPanel({
     m => m.sourcePath && m.variableName,
   ).length;
 
+  // EVO-1872: the contact / custom-attribute comparison values accept inserted
+  // {{ }} expressions; an unbalanced one must block Save. Only the currently
+  // shown config contributes (event/webhook/etc. carry no free-text expression).
+  const hasInvalidTriggerExpression =
+    (showCustomAttributeConfig && !isExpressionFieldValid(formData.customAttributeValue)) ||
+    (showContactConfig &&
+      contactFields.some(field => !isExpressionFieldValid(field.value)));
+
   // Shared chrome props for both the tabs (event) and simple (other types) modals.
   const commonModalProps = {
     open: true as const,
@@ -216,6 +225,7 @@ export function JourneyTriggerPanel({
     onCancel: onClose,
     onSave: handleSave,
     dirty,
+    saveDisabled: hasInvalidTriggerExpression,
     saveLabel: t('panels.actions.save'),
     cancelLabel: t('panels.actions.cancel'),
     savingAriaLabel: t('modal.actions.saving'),

--- a/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
@@ -232,9 +232,7 @@ export function ContactConfiguration({
                         placeholder={t('triggerComponents.contact.enterValue')}
                         className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
                         journeyId={journeyId}
-                        onVariableInsert={variable => {
-                          console.log('Variable inserted in contact field value:', variable);
-                        }}
+                        validateExpression
                       />
                       <p className="text-xs text-gray-500 dark:text-gray-400">
                         {t('triggerComponents.contact.useVariablesHint')}

--- a/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
@@ -250,9 +250,7 @@ export function CustomAttributeConfiguration({
                   : 'text'
               }
               journeyId={journeyId}
-              onVariableInsert={variable => {
-                console.log('Variable inserted in custom attribute value:', variable);
-              }}
+              validateExpression
             />
             <p className="text-xs text-gray-500 dark:text-gray-400">
               {t('triggerComponents.customAttribute.useVariablesHint')}

--- a/src/components/shared/PhoneInput.tsx
+++ b/src/components/shared/PhoneInput.tsx
@@ -11,6 +11,9 @@ interface PhoneInputProps {
   error?: boolean;
   placeholder?: string;
   className?: string;
+  // EVO-1872 (CR4): let callers wire the expression-error aria to the inner input.
+  'aria-invalid'?: React.AriaAttributes['aria-invalid'];
+  'aria-describedby'?: React.AriaAttributes['aria-describedby'];
 }
 
 /**
@@ -38,6 +41,8 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
   error = false,
   placeholder,
   className,
+  'aria-invalid': ariaInvalid,
+  'aria-describedby': ariaDescribedBy,
 }) => {
   return (
     <PhoneInputLib
@@ -57,6 +62,8 @@ export const PhoneInput: React.FC<PhoneInputProps> = ({
         disabled,
       }}
       numberInputProps={{
+        'aria-invalid': ariaInvalid,
+        'aria-describedby': ariaDescribedBy,
         className: cn(
           'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors',
           'file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground',

--- a/src/utils/templateVariables.ts
+++ b/src/utils/templateVariables.ts
@@ -139,3 +139,10 @@ export const isBalancedExpression = (expression: string): boolean => {
 
   return parens === 0 && braces === 0;
 };
+
+// EVO-1872: single predicate reused by the shared pickers (to render the inline
+// error) and by every panel's Save gate (to block Save). A non-string or blank
+// value counts as valid so numeric/empty fields never trip the guard; only a
+// non-empty string with unbalanced braces/parentheses is invalid.
+export const isExpressionFieldValid = (value: unknown): boolean =>
+  typeof value !== 'string' || value.trim() === '' || isBalancedExpression(value);


### PR DESCRIPTION
## Summary

Follow-up da EVO-1855 (finding CR5). Move a validação de expressão `{{ }}` balanceada para **dentro** dos pickers compartilhados `VariableInput`/`VariableTextarea`, de modo que todos os campos de expressão dos painéis de jornada ganhem o guard sem copy-paste — antes só `SendMessagePanel` e `ConditionalPanel` validavam, com o bloco (helper + `<p>` de erro + atributos aria) duplicado à mão em cada um.

**Decisões (alinhadas com o card):** bloqueio **hard** (Save desabilitado, como na 1855); ativação **opt-in** por prop `validateExpression` (default OFF, para campos literais como URL/header não gerarem falso-positivo); abrangência = **todos os campos de expressão**, pulando literais.

## Mudanças

- **Helper compartilhado** `isExpressionFieldValid` em `utils/templateVariables.ts` (reusa `isBalancedExpression`; não-string/branco = válido). Fonte única: o picker usa para renderizar o erro, o painel usa para gatear o Save — sem `onValidityChange` stateful, o gate segue derivado no pai.
- **`VariableInput`/`VariableTextarea`**: prop `validateExpression`, `useId` para id único do erro, erro inline + `aria-invalid`/`aria-describedby` mesclados sobre `{...props}`.
- **`PhoneInput` (CR4)**: passa a aceitar e encaminhar `aria-invalid`/`aria-describedby` para o input interno (`numberInputProps`) — antes o branch PhoneInput do `VariableInput` não encaminhava aria.
- **Migração sem regressão**: `ConditionalPanel` e `SendMessagePanel` trocam o bloco inline por `validateExpression` + helper (banner de topo do SendMessage mantido).
- **Guard ligado** (com fold no gate de Save do painel): `SetVariable`, `UpdateContact`, `UpdateCustomAttribute` (text/link/number), `SendWebhook` (body raw + `WebhookBodyBuilder` value → `getValidationStatus`), triggers `ContactConfiguration` e `CustomAttributeConfiguration` (novo `saveDisabled` no `JourneyTriggerPanel` modal simple; path event/`eventPropsValid` intacto).
- Removidos `console.log` no-op de `onVariableInsert` em vários painéis.

## Fora de escopo (nota)

**Wait**: `WaitTimeConfig`/`WaitHybridConfig` fazem `parseInt(value) || 1`, coagindo `duration`/`maxWaitTime` para número — o campo não consegue armazenar `{{ }}` (a inserção via picker é descartada). Validar ali seria dead code, então não foi incluído. O picker de variável no Wait é hoje decorativo/quebrado — vale um card de follow-up (remover o picker ou preservar a expressão no handler, o que muda o contrato `duration: number`).

Também fora de escopo por design: `VariableSelect` (dropdown id-based), campos literais (URL/headers/auth do webhook, nome de evento custom, date/datetime de custom-attr).

## Test plan

- **Componente**: `VariableInput.spec.tsx` (novo — invalid/valid/opt-in-off/PhoneInput CR4) e `VariableTextarea.spec.tsx` (+ validação).
- **Gate (integração)**: `UpdateCustomAttributePanel.spec.tsx` e `JourneyTriggerPanel.spec.tsx` (Save desabilita com expressão desbalanceada e reabilita ao balancear).
- **Regressão**: specs da 1855 (`ConditionalPanel`, `SendMessagePanel`) + `NodeConfigModal` seguem verdes.
- **79 testes verdes** na suíte afetada; `tsc -b` limpo. Suíte `journey` inteira: 255 pass (1 arquivo falha pré-existente e não-relacionado: `tokens.contrast.spec.ts`, dep `colorjs.io` ausente no ambiente). Lint: só erros `no-explicit-any` pré-existentes; nenhum novo.

## Summary by Sourcery

Introduce shared expression validation for journey expression fields and apply it across relevant panels and triggers to block saving on invalid expressions.

New Features:
- Add opt-in expression validation to VariableInput and VariableTextarea components, exposing validation state via aria attributes and inline error messaging.

Bug Fixes:
- Ensure PhoneInput forwards aria-invalid and aria-describedby attributes to its internal input for accessibility.

Enhancements:
- Introduce a shared isExpressionFieldValid helper to centralize expression-field validation logic based on balanced template expressions.
- Refactor ConditionalPanel, SendMessagePanel, SetVariablePanel, UpdateContactPanel, UpdateCustomAttributePanel, JourneyTriggerPanel, contact and custom-attribute trigger configs, and webhook body builders to rely on shared picker validation and to gate Save when expressions are invalid.
- Remove leftover console.log stubs from various journey panels.

Tests:
- Add unit tests for VariableInput and VariableTextarea expression validation behavior, including PhoneInput handling and opt-in semantics.
- Extend UpdateCustomAttributePanel and JourneyTriggerPanel tests to cover Save gating when expressions are unbalanced.