### PR TITLE
feat(setup): etapa "Sua marca" no wizard de instalação (EVO-1980)

### DIFF
--- a/src/i18n/locales/en/setup.json
+++ b/src/i18n/locales/en/setup.json
@@ -45,8 +45,39 @@
     },
     "submit": {
       "idle": "Create account and continue",
-      "loading": "Setting up..."
+      "loading": "Setting up...",
+      "continue": "Continue"
     }
+  },
+  "brand": {
+    "title": "Your brand",
+    "subtitle": "Customize how this box looks — you can change it later",
+    "appTitle": {
+      "label": "App name",
+      "placeholder": "Evolution"
+    },
+    "primaryColor": {
+      "label": "Primary color"
+    },
+    "secondaryColor": {
+      "label": "Secondary color",
+      "placeholder": "Optional"
+    },
+    "color": {
+      "invalid": "Use a hex color like #22C55E"
+    },
+    "logo": {
+      "label": "Logo & favicon",
+      "hint": "PNG or WebP. You can add these later in settings.",
+      "light": "Light logo",
+      "dark": "Dark logo",
+      "favicon": "Favicon"
+    },
+    "skip": "Set up later",
+    "finish": "Finish",
+    "finishLoading": "Finishing...",
+    "back": "Back",
+    "logoUploadFailed": "Branding saved, but the logo upload didn't complete. You can upload it later in settings."
   },
   "success": {
     "title": "Setup complete!",

--- a/src/i18n/locales/es/setup.json
+++ b/src/i18n/locales/es/setup.json
@@ -45,8 +45,39 @@
     },
     "submit": {
       "idle": "Crear cuenta y continuar",
-      "loading": "Configurando..."
+      "loading": "Configurando...",
+      "continue": "Continuar"
     }
+  },
+  "brand": {
+    "title": "Tu marca",
+    "subtitle": "Personaliza la apariencia de este box — puedes cambiarlo después",
+    "appTitle": {
+      "label": "Nombre de la app",
+      "placeholder": "Evolution"
+    },
+    "primaryColor": {
+      "label": "Color primario"
+    },
+    "secondaryColor": {
+      "label": "Color secundario",
+      "placeholder": "Opcional"
+    },
+    "color": {
+      "invalid": "Usa un color hex como #22C55E"
+    },
+    "logo": {
+      "label": "Logo y favicon",
+      "hint": "PNG o WebP. Puedes añadirlos después en los ajustes.",
+      "light": "Logo claro",
+      "dark": "Logo oscuro",
+      "favicon": "Favicon"
+    },
+    "skip": "Configurar más tarde",
+    "finish": "Finalizar",
+    "finishLoading": "Finalizando...",
+    "back": "Atrás",
+    "logoUploadFailed": "Marca guardada, pero la subida del logo no se completó. Puedes subirlo más tarde en los ajustes."
   },
   "success": {
     "title": "¡Configuración completa!",

--- a/src/i18n/locales/fr/setup.json
+++ b/src/i18n/locales/fr/setup.json
@@ -45,8 +45,39 @@
     },
     "submit": {
       "idle": "Créer un compte et continuer",
-      "loading": "Configuration en cours..."
+      "loading": "Configuration en cours...",
+      "continue": "Continuer"
     }
+  },
+  "brand": {
+    "title": "Votre marque",
+    "subtitle": "Personnalisez l'apparence de ce box — modifiable plus tard",
+    "appTitle": {
+      "label": "Nom de l'app",
+      "placeholder": "Evolution"
+    },
+    "primaryColor": {
+      "label": "Couleur primaire"
+    },
+    "secondaryColor": {
+      "label": "Couleur secondaire",
+      "placeholder": "Facultatif"
+    },
+    "color": {
+      "invalid": "Utilisez une couleur hex comme #22C55E"
+    },
+    "logo": {
+      "label": "Logo et favicon",
+      "hint": "PNG ou WebP. Vous pourrez les ajouter plus tard dans les paramètres.",
+      "light": "Logo clair",
+      "dark": "Logo sombre",
+      "favicon": "Favicon"
+    },
+    "skip": "Configurer plus tard",
+    "finish": "Terminer",
+    "finishLoading": "Finalisation...",
+    "back": "Retour",
+    "logoUploadFailed": "Marque enregistrée, mais l'envoi du logo n'a pas abouti. Vous pourrez l'ajouter plus tard dans les paramètres."
   },
   "success": {
     "title": "Configuration terminée !",

--- a/src/i18n/locales/it/setup.json
+++ b/src/i18n/locales/it/setup.json
@@ -45,8 +45,39 @@
     },
     "submit": {
       "idle": "Crea account e continua",
-      "loading": "Configurazione in corso..."
+      "loading": "Configurazione in corso...",
+      "continue": "Continua"
     }
+  },
+  "brand": {
+    "title": "Il tuo brand",
+    "subtitle": "Personalizza l'aspetto di questo box — puoi cambiarlo in seguito",
+    "appTitle": {
+      "label": "Nome dell'app",
+      "placeholder": "Evolution"
+    },
+    "primaryColor": {
+      "label": "Colore primario"
+    },
+    "secondaryColor": {
+      "label": "Colore secondario",
+      "placeholder": "Facoltativo"
+    },
+    "color": {
+      "invalid": "Usa un colore hex come #22C55E"
+    },
+    "logo": {
+      "label": "Logo e favicon",
+      "hint": "PNG o WebP. Puoi aggiungerli in seguito nelle impostazioni.",
+      "light": "Logo chiaro",
+      "dark": "Logo scuro",
+      "favicon": "Favicon"
+    },
+    "skip": "Configura più tardi",
+    "finish": "Completa",
+    "finishLoading": "Completamento...",
+    "back": "Indietro",
+    "logoUploadFailed": "Brand salvato, ma il caricamento del logo non è andato a buon fine. Puoi caricarlo in seguito nelle impostazioni."
   },
   "success": {
     "title": "Configurazione completata!",

--- a/src/i18n/locales/pt-BR/setup.json
+++ b/src/i18n/locales/pt-BR/setup.json
@@ -45,8 +45,39 @@
     },
     "submit": {
       "idle": "Criar conta e continuar",
-      "loading": "Configurando..."
+      "loading": "Configurando...",
+      "continue": "Continuar"
     }
+  },
+  "brand": {
+    "title": "Sua marca",
+    "subtitle": "Personalize a aparência deste box — você pode alterar depois",
+    "appTitle": {
+      "label": "Nome do app",
+      "placeholder": "Evolution"
+    },
+    "primaryColor": {
+      "label": "Cor primária"
+    },
+    "secondaryColor": {
+      "label": "Cor secundária",
+      "placeholder": "Opcional"
+    },
+    "color": {
+      "invalid": "Use uma cor hex como #22C55E"
+    },
+    "logo": {
+      "label": "Logo e favicon",
+      "hint": "PNG ou WebP. Você pode adicioná-los depois nas configurações.",
+      "light": "Logo claro",
+      "dark": "Logo escuro",
+      "favicon": "Favicon"
+    },
+    "skip": "Configurar depois",
+    "finish": "Concluir",
+    "finishLoading": "Concluindo...",
+    "back": "Voltar",
+    "logoUploadFailed": "Marca salva, mas o envio do logo não foi concluído. Você pode enviá-lo depois nas configurações."
   },
   "success": {
     "title": "Configuração concluída!",

--- a/src/i18n/locales/pt/setup.json
+++ b/src/i18n/locales/pt/setup.json
@@ -45,8 +45,39 @@
     },
     "submit": {
       "idle": "Criar conta e continuar",
-      "loading": "A configurar..."
+      "loading": "A configurar...",
+      "continue": "Continuar"
     }
+  },
+  "brand": {
+    "title": "A sua marca",
+    "subtitle": "Personalize o aspeto deste box — pode alterar mais tarde",
+    "appTitle": {
+      "label": "Nome da app",
+      "placeholder": "Evolution"
+    },
+    "primaryColor": {
+      "label": "Cor primária"
+    },
+    "secondaryColor": {
+      "label": "Cor secundária",
+      "placeholder": "Opcional"
+    },
+    "color": {
+      "invalid": "Use uma cor hex como #22C55E"
+    },
+    "logo": {
+      "label": "Logótipo e favicon",
+      "hint": "PNG ou WebP. Pode adicioná-los mais tarde nas definições.",
+      "light": "Logótipo claro",
+      "dark": "Logótipo escuro",
+      "favicon": "Favicon"
+    },
+    "skip": "Configurar mais tarde",
+    "finish": "Concluir",
+    "finishLoading": "A concluir...",
+    "back": "Voltar",
+    "logoUploadFailed": "Marca guardada, mas o envio do logótipo não foi concluído. Pode enviá-lo mais tarde nas definições."
   },
   "success": {
     "title": "Configuração concluída!",

--- a/src/pages/Setup/Setup.spec.tsx
+++ b/src/pages/Setup/Setup.spec.tsx
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Setup from './Setup';
+import { setupService } from '@/services/setup/setupService';
+
+// t returns the key verbatim so tests can query by i18n key.
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    currentLanguage: 'pt-BR',
+    changeLanguage: vi.fn(),
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/services/setup/setupService', () => ({
+  setupService: {
+    getStatus: vi.fn(),
+    bootstrap: vi.fn(),
+    uploadBrandingLogos: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/GlobalConfigContext', () => ({
+  clearSetupCache: vi.fn(),
+}));
+
+vi.mock('@/components/AppLogo', () => ({
+  AppLogo: () => <div data-testid="app-logo">Logo</div>,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), info: vi.fn() },
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const renderSetup = () =>
+  render(
+    <MemoryRouter>
+      <Setup />
+    </MemoryRouter>,
+  );
+
+const fillAccount = () => {
+  fireEvent.change(screen.getByLabelText('form.firstName.label'), { target: { value: 'Ada' } });
+  fireEvent.change(screen.getByLabelText('form.lastName.label'), { target: { value: 'Lovelace' } });
+  fireEvent.change(screen.getByLabelText('form.email.label'), { target: { value: 'ada@box.dev' } });
+  fireEvent.change(screen.getByLabelText('form.password.label'), { target: { value: 'Abcd1234!' } });
+  fireEvent.change(screen.getByLabelText('form.confirmPassword.label'), { target: { value: 'Abcd1234!' } });
+};
+
+const ACCOUNT = {
+  first_name: 'Ada',
+  last_name: 'Lovelace',
+  email: 'ada@box.dev',
+  password: 'Abcd1234!',
+  password_confirmation: 'Abcd1234!',
+};
+
+describe('Setup wizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(setupService.bootstrap).mockResolvedValue({
+      status: 'ok',
+      message: 'ok',
+      survey_token: null,
+    });
+    vi.mocked(setupService.uploadBrandingLogos).mockResolvedValue(true);
+  });
+
+  it('on a community box (whitelabel false) bootstraps directly without a branding step', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: false });
+
+    renderSetup();
+    await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+
+    fillAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.idle' }));
+
+    await waitFor(() => expect(setupService.bootstrap).toHaveBeenCalledWith(ACCOUNT));
+    expect(screen.queryByText('brand.title')).not.toBeInTheDocument();
+    expect(setupService.uploadBrandingLogos).not.toHaveBeenCalled();
+  });
+
+  it('on a whitelabel box advances to the branding step instead of bootstrapping', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+
+    renderSetup();
+    await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+
+    fillAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
+
+    await screen.findByLabelText('brand.appTitle.label');
+    expect(setupService.bootstrap).not.toHaveBeenCalled();
+  });
+
+  it('skipping the branding step bootstraps with no brand fields', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+
+    renderSetup();
+    await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+
+    fillAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
+    await screen.findByLabelText('brand.appTitle.label');
+
+    fireEvent.click(screen.getByRole('button', { name: 'brand.skip' }));
+
+    await waitFor(() => expect(setupService.bootstrap).toHaveBeenCalledWith(ACCOUNT));
+    expect(setupService.uploadBrandingLogos).not.toHaveBeenCalled();
+  });
+
+  it('finishing sends the captured title and colors and defaults the primary color', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+
+    renderSetup();
+    await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+
+    fillAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
+    await screen.findByLabelText('brand.appTitle.label');
+
+    fireEvent.change(screen.getByLabelText('brand.appTitle.label'), { target: { value: 'Acme CRM' } });
+    fireEvent.click(screen.getByRole('button', { name: 'brand.finish' }));
+
+    await waitFor(() =>
+      expect(setupService.bootstrap).toHaveBeenCalledWith({
+        ...ACCOUNT,
+        app_title: 'Acme CRM',
+        primary_color: '#22C55E',
+      }),
+    );
+    // No logos were selected → the best-effort upload is skipped.
+    expect(setupService.uploadBrandingLogos).not.toHaveBeenCalled();
+  });
+
+  it('blocks finishing when the primary color is not a valid hex', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+
+    renderSetup();
+    await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+
+    fillAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
+    await screen.findByLabelText('brand.appTitle.label');
+
+    // The swatch and the hex field share the accessible name — target the text field.
+    fireEvent.change(
+      screen.getByLabelText('brand.primaryColor.label', { selector: 'input[type="text"]' }),
+      { target: { value: 'not-a-color' } },
+    );
+
+    expect(screen.getByRole('button', { name: 'brand.finish' })).toBeDisabled();
+    expect(screen.getByText('brand.color.invalid')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Setup/Setup.tsx
+++ b/src/pages/Setup/Setup.tsx
@@ -1,10 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { AlertCircle, Globe } from 'lucide-react';
+import { AlertCircle, Globe, ArrowLeft } from 'lucide-react';
 
 import {
   Button,
@@ -21,7 +21,11 @@ import {
 
 import { useLanguage } from '@/hooks/useLanguage';
 import { type Locale } from '@/i18n/config';
-import { setupService } from '@/services/setup/setupService';
+import {
+  setupService,
+  type BootstrapPayload,
+  type BrandingLogos,
+} from '@/services/setup/setupService';
 import { clearSetupCache } from '@/contexts/GlobalConfigContext';
 
 import { AppLogo } from '@/components/AppLogo';
@@ -34,11 +38,49 @@ type SetupFormData = {
   password_confirmation: string;
 };
 
+const DEFAULT_PRIMARY = '#22C55E';
+const HEX_COLOR = /^#[0-9A-Fa-f]{6}$/;
+const isValidHex = (value: string) => HEX_COLOR.test(value);
+
+type Step = 'account' | 'brand';
+
 const Setup: React.FC = () => {
   const navigate = useNavigate();
   const { t, currentLanguage, changeLanguage } = useLanguage('setup');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
+
+  // Whether the box supports box branding (enterprise whitelabel present). When
+  // true the wizard inserts a "Sua marca" step before finishing; a community
+  // install skips straight to bootstrap.
+  const [whitelabel, setWhitelabel] = useState(false);
+  const [step, setStep] = useState<Step>('account');
+  const [account, setAccount] = useState<SetupFormData | null>(null);
+
+  // Branding step state.
+  const [appTitle, setAppTitle] = useState('');
+  const [primaryColor, setPrimaryColor] = useState(DEFAULT_PRIMARY);
+  const [secondaryColor, setSecondaryColor] = useState('');
+  const [logoLight, setLogoLight] = useState<File | null>(null);
+  const [logoDark, setLogoDark] = useState<File | null>(null);
+  const [favicon, setFavicon] = useState<File | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    setupService
+      .getStatus()
+      .then(status => {
+        if (mounted) setWhitelabel(status.whitelabel === true);
+      })
+      .catch(() => {
+        // Fail soft: if the status probe fails, hide the branding step rather
+        // than showing an install-config field that would silently no-op.
+        if (mounted) setWhitelabel(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const setupSchema = useMemo(() => z
     .object({
@@ -85,14 +127,29 @@ const Setup: React.FC = () => {
     },
   });
 
-  const onSubmit = async (data: SetupFormData) => {
+  // Runs the actual install. Branding fields and logos are only supplied on a
+  // whitelabel box; the community path passes neither.
+  const runBootstrap = async (
+    data: SetupFormData,
+    brand: Partial<BootstrapPayload>,
+    logos?: BrandingLogos,
+  ) => {
     setIsLoading(true);
     setError('');
 
     try {
-      const result = await setupService.bootstrap(data);
+      const result = await setupService.bootstrap({ ...data, ...brand });
 
       clearSetupCache();
+
+      // Best-effort logo upload — never blocks finishing the install.
+      const hasLogos = !!(logos && (logos.light || logos.dark || logos.favicon));
+      if (hasLogos) {
+        const ok = await setupService.uploadBrandingLogos(data.email, data.password, logos!);
+        if (!ok) {
+          toast.info(t('brand.logoUploadFailed'));
+        }
+      }
 
       toast.success(t('success.title'), {
         description: t('success.description'),
@@ -113,39 +170,91 @@ const Setup: React.FC = () => {
       } else {
         setError(message);
       }
+      // Surface the error on the account step so it is always visible.
+      setStep('account');
     } finally {
       setIsLoading(false);
     }
+  };
+
+  // Step 1 submit: advance to the branding step on a whitelabel box, otherwise
+  // bootstrap immediately (community behavior).
+  const onAccountSubmit = (data: SetupFormData) => {
+    if (whitelabel) {
+      setAccount(data);
+      setError('');
+      setStep('brand');
+    } else {
+      runBootstrap(data, {});
+    }
+  };
+
+  const brandPayload = (): Partial<BootstrapPayload> => {
+    const payload: Partial<BootstrapPayload> = {};
+    if (appTitle.trim()) payload.app_title = appTitle.trim();
+    if (isValidHex(primaryColor)) payload.primary_color = primaryColor;
+    if (secondaryColor.trim() && isValidHex(secondaryColor)) {
+      payload.secondary_color = secondaryColor;
+    }
+    return payload;
+  };
+
+  // "Configurar depois" — finish without applying any branding.
+  const onSkipBrand = () => {
+    if (account) runBootstrap(account, {});
+  };
+
+  // "Concluir" — apply the captured branding (text persists via bootstrap,
+  // logos upload best-effort).
+  const onFinishBrand = () => {
+    if (!account) return;
+    runBootstrap(account, brandPayload(), {
+      light: logoLight ?? undefined,
+      dark: logoDark ?? undefined,
+      favicon: favicon ?? undefined,
+    });
   };
 
   const handleLanguageChange = (lng: string) => {
     changeLanguage(lng as Locale);
   };
 
+  const primaryInvalid = !isValidHex(primaryColor);
+  const secondaryInvalid = secondaryColor.trim().length > 0 && !isValidHex(secondaryColor);
+  const brandInvalid = primaryInvalid || secondaryInvalid;
+
+  const languageSelector = (
+    <div className="absolute top-4 right-4">
+      <Select value={currentLanguage} onValueChange={handleLanguageChange}>
+        <SelectTrigger>
+          <Globe className="h-4 w-4 text-primary" />
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="pt-BR">{t('language.portuguese')}</SelectItem>
+          <SelectItem value="en">{t('language.english')}</SelectItem>
+          <SelectItem value="es">{t('language.spanish')}</SelectItem>
+          <SelectItem value="fr">{t('language.french')}</SelectItem>
+          <SelectItem value="it">{t('language.italian')}</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-gradient-to-t from-primary/20 via-background/95 to-background">
-      <div className="absolute top-4 right-4">
-        <Select value={currentLanguage} onValueChange={handleLanguageChange}>
-          <SelectTrigger>
-            <Globe className="h-4 w-4 text-primary" />
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="pt-BR">{t('language.portuguese')}</SelectItem>
-            <SelectItem value="en">{t('language.english')}</SelectItem>
-            <SelectItem value="es">{t('language.spanish')}</SelectItem>
-            <SelectItem value="fr">{t('language.french')}</SelectItem>
-            <SelectItem value="it">{t('language.italian')}</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+      {languageSelector}
 
       <div className="w-full max-w-md space-y-6">
         <div className="flex flex-col items-center space-y-4">
           <AppLogo className="h-10" />
           <div className="text-center space-y-2">
-            <h1 className="text-3xl font-bold">{t('title')}</h1>
-            <p className="text-muted-foreground">{t('subtitle')}</p>
+            <h1 className="text-3xl font-bold">
+              {step === 'brand' ? t('brand.title') : t('title')}
+            </h1>
+            <p className="text-muted-foreground">
+              {step === 'brand' ? t('brand.subtitle') : t('subtitle')}
+            </p>
           </div>
         </div>
 
@@ -157,83 +266,217 @@ const Setup: React.FC = () => {
             </Alert>
           )}
 
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
+          {step === 'account' ? (
+            <form onSubmit={handleSubmit(onAccountSubmit)} className="space-y-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="first_name">{t('form.firstName.label')}</Label>
+                  <Input
+                    id="first_name"
+                    type="text"
+                    placeholder={t('form.firstName.placeholder')}
+                    disabled={isLoading}
+                    {...register('first_name')}
+                  />
+                  {errors.first_name && (
+                    <p className="text-destructive text-sm">{errors.first_name.message}</p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="last_name">{t('form.lastName.label')}</Label>
+                  <Input
+                    id="last_name"
+                    type="text"
+                    placeholder={t('form.lastName.placeholder')}
+                    disabled={isLoading}
+                    {...register('last_name')}
+                  />
+                  {errors.last_name && (
+                    <p className="text-destructive text-sm">{errors.last_name.message}</p>
+                  )}
+                </div>
+              </div>
+
               <div className="space-y-2">
-                <Label htmlFor="first_name">{t('form.firstName.label')}</Label>
+                <Label htmlFor="email">{t('form.email.label')}</Label>
                 <Input
-                  id="first_name"
-                  type="text"
-                  placeholder={t('form.firstName.placeholder')}
+                  id="email"
+                  type="email"
+                  placeholder={t('form.email.placeholder')}
                   disabled={isLoading}
-                  {...register('first_name')}
+                  {...register('email')}
                 />
-                {errors.first_name && (
-                  <p className="text-destructive text-sm">{errors.first_name.message}</p>
+                {errors.email && (
+                  <p className="text-destructive text-sm">{errors.email.message}</p>
                 )}
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="last_name">{t('form.lastName.label')}</Label>
+                <Label htmlFor="password">{t('form.password.label')}</Label>
                 <Input
-                  id="last_name"
-                  type="text"
-                  placeholder={t('form.lastName.placeholder')}
+                  id="password"
+                  type="password"
+                  placeholder={t('form.password.placeholder')}
                   disabled={isLoading}
-                  {...register('last_name')}
+                  {...register('password')}
                 />
-                {errors.last_name && (
-                  <p className="text-destructive text-sm">{errors.last_name.message}</p>
+                {errors.password && (
+                  <p className="text-destructive text-sm">{errors.password.message}</p>
                 )}
               </div>
-            </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">{t('form.email.label')}</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder={t('form.email.placeholder')}
-                disabled={isLoading}
-                {...register('email')}
-              />
-              {errors.email && (
-                <p className="text-destructive text-sm">{errors.email.message}</p>
-              )}
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="password_confirmation">{t('form.confirmPassword.label')}</Label>
+                <Input
+                  id="password_confirmation"
+                  type="password"
+                  placeholder={t('form.confirmPassword.placeholder')}
+                  disabled={isLoading}
+                  {...register('password_confirmation')}
+                />
+                {errors.password_confirmation && (
+                  <p className="text-destructive text-sm">{errors.password_confirmation.message}</p>
+                )}
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="password">{t('form.password.label')}</Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder={t('form.password.placeholder')}
-                disabled={isLoading}
-                {...register('password')}
-              />
-              {errors.password && (
-                <p className="text-destructive text-sm">{errors.password.message}</p>
-              )}
-            </div>
+              <Button type="submit" disabled={isLoading} className="w-full">
+                {isLoading
+                  ? t('form.submit.loading')
+                  : whitelabel
+                    ? t('form.submit.continue')
+                    : t('form.submit.idle')}
+              </Button>
+            </form>
+          ) : (
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="app_title">{t('brand.appTitle.label')}</Label>
+                <Input
+                  id="app_title"
+                  type="text"
+                  placeholder={t('brand.appTitle.placeholder')}
+                  disabled={isLoading}
+                  value={appTitle}
+                  maxLength={120}
+                  onChange={e => setAppTitle(e.target.value)}
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="password_confirmation">{t('form.confirmPassword.label')}</Label>
-              <Input
-                id="password_confirmation"
-                type="password"
-                placeholder={t('form.confirmPassword.placeholder')}
-                disabled={isLoading}
-                {...register('password_confirmation')}
-              />
-              {errors.password_confirmation && (
-                <p className="text-destructive text-sm">{errors.password_confirmation.message}</p>
-              )}
-            </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="primary_color">{t('brand.primaryColor.label')}</Label>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="color"
+                      aria-label={t('brand.primaryColor.label')}
+                      className="h-9 w-9 shrink-0 cursor-pointer rounded border bg-transparent p-0.5"
+                      value={isValidHex(primaryColor) ? primaryColor : DEFAULT_PRIMARY}
+                      disabled={isLoading}
+                      onChange={e => setPrimaryColor(e.target.value.toUpperCase())}
+                    />
+                    <Input
+                      id="primary_color"
+                      type="text"
+                      placeholder={DEFAULT_PRIMARY}
+                      disabled={isLoading}
+                      value={primaryColor}
+                      onChange={e => setPrimaryColor(e.target.value)}
+                    />
+                  </div>
+                  {primaryInvalid && (
+                    <p className="text-destructive text-sm">{t('brand.color.invalid')}</p>
+                  )}
+                </div>
 
-            <Button type="submit" disabled={isLoading} className="w-full">
-              {isLoading ? t('form.submit.loading') : t('form.submit.idle')}
-            </Button>
-          </form>
+                <div className="space-y-2">
+                  <Label htmlFor="secondary_color">{t('brand.secondaryColor.label')}</Label>
+                  <div className="flex items-center gap-2">
+                    <input
+                      type="color"
+                      aria-label={t('brand.secondaryColor.label')}
+                      className="h-9 w-9 shrink-0 cursor-pointer rounded border bg-transparent p-0.5"
+                      value={isValidHex(secondaryColor) ? secondaryColor : '#000000'}
+                      disabled={isLoading}
+                      onChange={e => setSecondaryColor(e.target.value.toUpperCase())}
+                    />
+                    <Input
+                      id="secondary_color"
+                      type="text"
+                      placeholder={t('brand.secondaryColor.placeholder')}
+                      disabled={isLoading}
+                      value={secondaryColor}
+                      onChange={e => setSecondaryColor(e.target.value)}
+                    />
+                  </div>
+                  {secondaryInvalid && (
+                    <p className="text-destructive text-sm">{t('brand.color.invalid')}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label>{t('brand.logo.label')}</Label>
+                <p className="text-muted-foreground text-xs">{t('brand.logo.hint')}</p>
+                <div className="grid grid-cols-3 gap-3">
+                  <LogoInput
+                    id="logo_light"
+                    label={t('brand.logo.light')}
+                    file={logoLight}
+                    disabled={isLoading}
+                    onSelect={setLogoLight}
+                  />
+                  <LogoInput
+                    id="logo_dark"
+                    label={t('brand.logo.dark')}
+                    file={logoDark}
+                    disabled={isLoading}
+                    onSelect={setLogoDark}
+                  />
+                  <LogoInput
+                    id="favicon"
+                    label={t('brand.logo.favicon')}
+                    file={favicon}
+                    disabled={isLoading}
+                    onSelect={setFavicon}
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 pt-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  disabled={isLoading}
+                  aria-label={t('brand.back')}
+                  onClick={() => {
+                    setError('');
+                    setStep('account');
+                  }}
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="flex-1"
+                  disabled={isLoading}
+                  onClick={onSkipBrand}
+                >
+                  {t('brand.skip')}
+                </Button>
+                <Button
+                  type="button"
+                  className="flex-1"
+                  disabled={isLoading || brandInvalid}
+                  onClick={onFinishBrand}
+                >
+                  {isLoading ? t('brand.finishLoading') : t('brand.finish')}
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="text-center text-xs text-muted-foreground">
@@ -243,5 +486,32 @@ const Setup: React.FC = () => {
     </div>
   );
 };
+
+interface LogoInputProps {
+  id: string;
+  label: string;
+  file: File | null;
+  disabled?: boolean;
+  onSelect: (file: File | null) => void;
+}
+
+const LogoInput: React.FC<LogoInputProps> = ({ id, label, file, disabled, onSelect }) => (
+  <div className="space-y-1">
+    <label
+      htmlFor={id}
+      className="flex h-16 cursor-pointer flex-col items-center justify-center gap-1 rounded-md border border-dashed text-center text-[11px] text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
+    >
+      <span className="px-1 truncate max-w-full">{file ? file.name : label}</span>
+    </label>
+    <input
+      id={id}
+      type="file"
+      accept="image/png,image/webp"
+      className="hidden"
+      disabled={disabled}
+      onChange={e => onSelect(e.target.files?.[0] ?? null)}
+    />
+  </div>
+);
 
 export default Setup;

--- a/src/services/setup/setupService.ts
+++ b/src/services/setup/setupService.ts
@@ -6,6 +6,10 @@ const authBaseURL =
   import.meta.env.VITE_API_URL ||
   'http://localhost:3001';
 
+// CRM (enterprise) origin — where the whitelabel logo endpoint lives. Empty in
+// the shell build so the request is same-origin and rides the reverse proxy.
+const crmBaseURL = import.meta.env.VITE_API_URL || '';
+
 const setupApi = axios.create({
   baseURL: authBaseURL,
   headers: { 'Content-Type': 'application/json' },
@@ -15,6 +19,9 @@ export interface SetupStatus {
   status: 'active' | 'inactive';
   instance_id: string | null;
   api_key?: string;
+  licensed?: boolean;
+  /** True when the box supports box branding (enterprise whitelabel present). */
+  whitelabel?: boolean;
 }
 
 export interface BootstrapPayload {
@@ -23,6 +30,19 @@ export interface BootstrapPayload {
   email: string;
   password: string;
   password_confirmation: string;
+  // Optional box branding captured at /setup on a whitelabel-capable box. The
+  // backend persists only the provided, non-blank fields onto the single
+  // agency's whitelabel row (no-op on a community-only install).
+  app_title?: string;
+  primary_color?: string;
+  secondary_color?: string;
+}
+
+/** Logo/favicon images captured in the branding step (all optional). */
+export interface BrandingLogos {
+  light?: File;
+  dark?: File;
+  favicon?: File;
 }
 
 export interface BootstrapResponse {
@@ -40,6 +60,60 @@ export const setupService = {
   async bootstrap(payload: BootstrapPayload): Promise<BootstrapResponse> {
     const { data } = await setupApi.post<BootstrapResponse>('/setup/bootstrap', payload);
     return data;
+  },
+
+  /**
+   * Best-effort upload of the box logo/favicon captured at /setup.
+   *
+   * The binary upload lives behind the authenticated enterprise endpoint
+   * (POST /enterprise/v1/admin/whitelabel/logo), so we sign in with the
+   * just-created admin to obtain a token — a standalone request that does NOT
+   * touch the global auth store (the operator still logs in fresh afterwards).
+   *
+   * This NEVER throws: a failure (endpoint unreachable, missing grant, etc.)
+   * must not block finishing the install — the text branding is already
+   * persisted by /setup/bootstrap, and logos can be re-uploaded later from the
+   * whitelabel settings. Returns true only when every provided image uploaded.
+   */
+  async uploadBrandingLogos(
+    email: string,
+    password: string,
+    logos: BrandingLogos,
+  ): Promise<boolean> {
+    const variants = (['light', 'dark', 'favicon'] as const).filter(v => logos[v]);
+    if (variants.length === 0) return true;
+
+    let token: string | null = null;
+    try {
+      const { data } = await axios.post(
+        `${authBaseURL}/api/v1/auth/login`,
+        { email, password },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+      token =
+        data?.data?.token?.access_token ||
+        data?.data?.access_token ||
+        data?.access_token ||
+        null;
+    } catch {
+      token = null;
+    }
+    if (!token) return false;
+
+    let allOk = true;
+    for (const variant of variants) {
+      try {
+        const formData = new FormData();
+        formData.append('file', logos[variant] as File);
+        formData.append('variant', variant);
+        await axios.post(`${crmBaseURL}/enterprise/v1/admin/whitelabel/logo`, formData, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+      } catch {
+        allOk = false;
+      }
+    }
+    return allOk;
   },
 
   /** POST /setup/survey — pre-login, authenticated via one-time survey_token */


### PR DESCRIPTION
## Summary
Frontend do Épico 7: etapa opcional **"Sua marca"** no wizard `/setup` do CRM.
- Wizard 2 etapas (conta → marca): título, cor primária/secundária, logo claro/escuro e favicon.
- Gate por `/setup/status.whitelabel` — só aparece num box whitelabel; community puro segue direto pro bootstrap, sem mudança de comportamento.
- Título/cores entram no `/setup/bootstrap`; logo/favicon sobem best-effort (auto-login + multipart pro endpoint enterprise; falha não trava, toast).
- Validação de cor hex no cliente espelhando o backend; i18n nos 6 locales.

## Test plan
- `vitest run src/pages/Setup/` → 10 verdes (gate, skip, concluir, cor inválida).
- `tsc -b`: arquivos tocados limpos.
- Validado no box self-hosted: etapa aparece, marca persiste e reflete no app (cor + logo).