### PR TITLE
fix(chat-header): remove órfãos que quebram o build do frontend (pós a47ac6a)

### DIFF
--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -18,8 +18,6 @@ import {
   Trash2,
   Mail,
   MailOpen,
-  Pin,
-  Archive,
   GitBranch,
   Check,
 } from 'lucide-react';
@@ -84,29 +82,18 @@ const ChatHeader = ({
   onBackClick,
   onCloseConversation,
   onContactSidebarOpen,
-  onMarkAsRead,
-  onMarkAsUnread,
   onMarkAsOpen,
   onMarkAsResolved,
   onPostpone,
   onMarkAsSnoozed,
   onSetPriority,
-  onPinConversation,
-  onUnpinConversation,
-  onArchiveConversation,
-  onUnarchiveConversation,
   onAssignAgent,
   onAssignTeam,
   onAssignTag,
-  onDeleteConversation,
-  unreadCount,
 }: ChatHeaderProps) => {
   const { t } = useLanguage('chat');
   const chatContext = useChatContext();
   const currentStatus = conversation.status;
-  const hasUnreadMessages = unreadCount > 0;
-  const isPinned = Boolean(conversation.custom_attributes?.pinned);
-  const isArchived = Boolean(conversation.custom_attributes?.archived);
 
   const inboxName = conversation.inbox?.name || '';
   const phoneDisplay = isPhoneBearingChannel(conversation.inbox?.channel_type)


### PR DESCRIPTION
## Contexto

O build do frontend está **quebrado no develop desde 02/07** (`npm run build` → `tsc` falha), o que reprova toda PR de frontend.

**Causa:** o commit `a47ac6a` (`feat(i18n): update translations for chat interface`, Davidson) foi, na real, um refactor grande que **moveu o menu de ações da conversa** (marcar lido/não-lido, fixar, arquivar, deletar) do `ChatHeader` para o componente dedicado **`ConversationActionsDropdown`** — mas deixou em `ChatHeader` os **props/imports/estado órfãos** que aquele menu usava:

- imports: `Pin`, `Archive`
- props destructurados sem uso: `onMarkAsRead`, `onMarkAsUnread`, `onPinConversation`, `onUnpinConversation`, `onArchiveConversation`, `onUnarchiveConversation`, `onDeleteConversation`
- locais sem uso: `hasUnreadMessages`, `isPinned`, `isArchived` (+ `unreadCount`, que só alimentava o `hasUnreadMessages`)

→ TypeScript estrito (**TS6133** "declared but never read") reprova o `tsc`.

## Fix

Remove os órfãos do `ChatHeader.tsx`. **A interface `ChatHeaderProps` é mantida** (o `Chat.tsx` ainda passa esses props e eles são consumidos pelo `ConversationActionsDropdown`), então **não cascateia** em `Chat.tsx` nem nos specs. As ações continuam funcionando — só saíram do header.

## Validação

- Confirmado por grep: `Pin`/`Archive`/`hasUnreadMessages`/`isPinned`/`isArchived` = 0 ocorrências (sem referência pendente); os props removidos ficaram só na interface; os props usados (`onMarkAsOpen`, `onSetPriority`, `onAssignTag`…) intactos e ainda consumidos no JSX.
- O CI (build) é a prova definitiva.

Ref: EVO-1998 (desbloqueia o build por PR do frontend).

## Summary by Sourcery

Bug Fixes:
- Fix TypeScript build failure by removing unused imports, props, and local state related to conversation actions from ChatHeader.