### PR TITLE
fix(chat): remove imports/props órfãos restantes (completa #230) — destrava o build do develop

### DIFF
--- a/src/components/chat/chat-area/ChatArea.tsx
+++ b/src/components/chat/chat-area/ChatArea.tsx
@@ -85,7 +85,6 @@ const ChatArea = ({
   onLoadMore,
   onRetryMessage,
   isPendingConversation = false,
-  onOpenConversation,
 }: ChatAreaProps) => {
   const { t } = useLanguage('chat');
   const { messages, websocket } = useChatContext();

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -3,10 +3,6 @@ import { Button } from '@evoapi/design-system/button';
 import {
   ArrowLeft,
   X,
-  MessageCircle,
-  CheckCircle,
-  Clock,
-  Pause,
   MoreVertical,
   ArrowUp,
   ArrowDown,
@@ -15,9 +11,6 @@ import {
   User as UserIcon,
   Users,
   Tag,
-  Trash2,
-  Mail,
-  MailOpen,
   GitBranch,
   Check,
 } from 'lucide-react';


### PR DESCRIPTION
Completa o #230 (que foi parcial — eu tinha lido o log de erro truncado). Remove os imports órfãos que sobraram no `ChatHeader` (`MessageCircle`, `CheckCircle`, `Clock`, `Pause`, `Trash2`, `Mail`, `MailOpen`) e o prop `onOpenConversation` destructurado sem uso no `ChatArea` — todos confirmados sem uso (TS6133). Sobras do refactor do commit a47ac6a.

**CI-provado:** este commit idêntico passou o `build-pr` (npm run build) na PR #228 do serviço. Desbloqueia o build do develop do frontend (vermelho desde 02/07). Ref EVO-1998.

## Summary by Sourcery

Clean up unused chat component imports and props to fix TypeScript build errors.

Bug Fixes:
- Remove unused icon imports from ChatHeader to resolve TS unused symbol errors and unblock the build.
- Drop an unused onOpenConversation prop from ChatArea to eliminate TypeScript unused variable warnings.