### PR TITLE
fix(csp): allow plain-http media origins in img-src/media-src (EVO-1961)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,13 +24,41 @@ for file in $(find "$HTML_DIR" -name '*.js' -type f); do
 done
 
 # Configure nginx CSP based on environment (default: development)
+# The CSP shipped in nginx.conf is the production default: img-src/media-src
+# allow 'https:' (external buckets) but no plain-http origin. Chat media served
+# by the backend (ActiveStorage local disk) comes from the API origin, which is
+# plain http in development and in self-hosted deploys without TLS — without
+# the adjustments below the browser blocks images/audio in the chat (EVO-1961).
+# All substitutions are anchored on the trailing ';' or guarded so a container
+# restart does not append the same source twice.
 APP_ENV="${VITE_APP_ENV:-development}"
+NGINX_CONF="/etc/nginx/conf.d/default.conf"
 
 if [ "$APP_ENV" = "development" ]; then
-  # Development: Allow localhost connections and permissive frame-ancestors for widget
-  sed -i "s|connect-src 'self' blob: https: wss: ws:|connect-src 'self' blob: https: wss: ws: http://localhost:*|g" /etc/nginx/conf.d/default.conf
-  sed -i "s|frame-ancestors 'self'|frame-ancestors *|g" /etc/nginx/conf.d/default.conf
+  # Development: allow localhost (any port) for API calls and for media served
+  # by the backend, and permissive frame-ancestors for the widget.
+  sed -i \
+    -e "s|connect-src 'self' blob: https: wss: ws:;|connect-src 'self' blob: https: wss: ws: http://localhost:*;|" \
+    -e "s|img-src 'self' data: blob: https:;|img-src 'self' data: blob: https: http://localhost:*;|" \
+    -e "s|media-src 'self' blob: https:;|media-src 'self' blob: https: http://localhost:*;|" \
+    -e "s|frame-ancestors 'self';|frame-ancestors *;|" \
+    "$NGINX_CONF"
 fi
+
+# Self-hosted over plain http (no TLS): media and API calls come from the API
+# origin and 'https:' does not cover http origins, so allow it explicitly.
+case "$VITE_API_URL" in
+  http://*)
+    API_ORIGIN="$(printf '%s' "$VITE_API_URL" | sed "s|^\(http://[^/]*\).*|\1|")"
+    if ! grep -q "img-src[^;]* $API_ORIGIN" "$NGINX_CONF"; then
+      sed -i \
+        -e "s|\(img-src [^;]*\);|\1 ${API_ORIGIN};|" \
+        -e "s|\(media-src [^;]*\);|\1 ${API_ORIGIN};|" \
+        -e "s|\(connect-src [^;]*\);|\1 ${API_ORIGIN};|" \
+        "$NGINX_CONF"
+    fi
+    ;;
+esac
 
 
 exec "$@"


### PR DESCRIPTION
## Problem

The CSP in `nginx.conf` allows `https:` in `img-src`/`media-src` (external buckets) but no plain-http origin. Chat media served by the backend (ActiveStorage local disk) comes from the API origin, which is plain http in development and in self-hosted deploys without TLS. The browser blocked images/audio in the chat while API calls kept working (`connect-src` already had `http://localhost:*` in development) — this is why media only rendered with S3 configured (EVO-1961).

## Fix (docker-entrypoint.sh, following the existing per-environment CSP convention)

- Extend the development CSP block to add `http://localhost:*` to `img-src` and `media-src` (mirroring `connect-src`)
- When `VITE_API_URL` is a plain-http origin (self-hosted without TLS), allow that origin in `img-src`/`media-src`/`connect-src` in any `APP_ENV`
- Anchor all substitutions on the trailing `;` and guard the origin injection: container restarts no longer duplicate sources (the previous `connect-src` sed re-appended `http://localhost:*` on every restart)

Production https deploys are untouched (`https:` already covers bucket and app origins; verified the sed logic leaves the conf byte-identical).

## Validation

- Sed logic exercised in busybox `sh` across 5 scenarios (dev, dev+restart, prod-http, prod-http+restart, prod-https): only the `add_header Content-Security-Policy` line changes; restarts are idempotent
- Clean image rebuilt from this branch and deployed against the local full stack with `ACTIVE_STORAGE_SERVICE=local` (no bucket) and a real Evolution API WhatsApp channel: inbound image, audio (PTT), small PDF and 27 MB PDF all render/play in the dashboard
- Companion CRM fix: evolution-foundation/evo-ai-crm-community#193

## Linked Issue

- EVO-1961

## Summary by Sourcery

Adjust nginx CSP configuration to support plain-http media and API origins in development and self-hosted deployments while keeping production HTTPS settings unchanged.

Bug Fixes:
- Allow localhost http media and API origins in img-src, media-src, and connect-src for development CSP.
- Permit plain-http API origins in CSP directives for self-hosted deployments without TLS so chat media loads correctly.
- Ensure CSP sed substitutions are idempotent to avoid duplicating sources across container restarts.