### PR TITLE
fix(composer): keep empty editor doc schema-valid so placeholder and focus survive send

### DIFF
--- a/src/components/chat/rich-text-editor/RichTextEditor.css
+++ b/src/components/chat/rich-text-editor/RichTextEditor.css
@@ -24,15 +24,21 @@
   margin: 0;
 }
 
-/* Placeholder */
-.prosemirror-editor:empty:before {
+/* Placeholder — the empty state is a single empty paragraph (the schema
+   requires `block+`, see emptyParagraphDoc in RichTextEditor.tsx), so the
+   editor is never literally :empty; ProseMirror renders it as
+   <p><br class="ProseMirror-trailingBreak"></p>. The :empty variant is kept
+   as a safety net. */
+.prosemirror-editor:empty:before,
+.prosemirror-editor:has(> p:only-child > br.ProseMirror-trailingBreak:only-child):before {
   content: attr(data-placeholder);
   color: hsl(var(--muted-foreground));
   position: absolute;
   pointer-events: none;
 }
 
-.prosemirror-editor:focus:empty:before {
+.prosemirror-editor:focus:empty:before,
+.prosemirror-editor:focus:has(> p:only-child > br.ProseMirror-trailingBreak:only-child):before {
   opacity: 0.5;
 }
 

--- a/src/components/chat/rich-text-editor/RichTextEditor.spec.tsx
+++ b/src/components/chat/rich-text-editor/RichTextEditor.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { createRef } from 'react';
+import { render, act } from '@testing-library/react';
+import { RichTextEditor, RichTextEditorRef } from './RichTextEditor';
+
+/**
+ * Regression guard for PR #233 (fix(composer): keep empty editor doc
+ * schema-valid). The empty state is a single empty paragraph (schema requires
+ * `doc: block+`), which serializes to a truthy `'<p></p>'`. getContent() must
+ * still report the cleared editor as '' so callers' empty-checks keep working
+ * (handleSend early return, canSend). If a future refactor lets the empty doc
+ * leak through as `'<p></p>'`, these tests fail before it reaches the composer.
+ */
+describe('RichTextEditor empty-state contract (PR #233)', () => {
+  const mount = () => {
+    const ref = createRef<RichTextEditorRef>();
+    render(<RichTextEditor ref={ref} />);
+    return ref;
+  };
+
+  it('reports a freshly mounted (empty) editor as ""', () => {
+    const ref = mount();
+    expect(ref.current?.getContent()).toBe('');
+  });
+
+  it('reports the editor as "" after clear()', () => {
+    const ref = mount();
+    act(() => ref.current?.setContent('hello'));
+    expect(ref.current?.getContent()).toBe('<p>hello</p>');
+
+    act(() => ref.current?.clear());
+    expect(ref.current?.getContent()).toBe('');
+  });
+
+  it('reports the editor as "" after setContent("")', () => {
+    const ref = mount();
+    act(() => ref.current?.setContent('hello'));
+    act(() => ref.current?.setContent(''));
+    expect(ref.current?.getContent()).toBe('');
+  });
+
+  it('serializes real content instead of collapsing it to ""', () => {
+    const ref = mount();
+    act(() => ref.current?.setContent('não colapsar'));
+    expect(ref.current?.getContent()).toBe('<p>não colapsar</p>');
+  });
+});

--- a/src/components/chat/rich-text-editor/RichTextEditor.tsx
+++ b/src/components/chat/rich-text-editor/RichTextEditor.tsx
@@ -250,8 +250,19 @@ export const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>
 
     return (
       // Clicks on the wrapper's padding (e.g. the composer pill around the text
-      // line) would otherwise blur the editor — forward them to focus.
-      <div className={className} onClick={() => !disabled && viewRef.current?.focus()}>
+      // line) would otherwise blur the editor — forward them to focus. Scope to
+      // clicks that land on the wrapper itself (target === currentTarget), so
+      // clicks on the editor content or on nested children (e.g. the formatting
+      // bubble menu) are left untouched. onMouseDown + preventDefault runs
+      // before the browser moves focus, avoiding a blur/refocus flicker.
+      <div
+        className={className}
+        onMouseDown={event => {
+          if (disabled || event.target !== event.currentTarget) return;
+          event.preventDefault();
+          viewRef.current?.focus();
+        }}
+      >
         <div ref={editorRef} className={`relative w-full ${disabled ? 'opacity-50' : ''}`} />
         {bubbleRect && viewRef.current && (
           <FormattingBubbleMenu

--- a/src/components/chat/rich-text-editor/RichTextEditor.tsx
+++ b/src/components/chat/rich-text-editor/RichTextEditor.tsx
@@ -24,6 +24,18 @@ const insertHardBreak = chainCommands(exitCode, (state, dispatch) => {
   return true;
 });
 
+/**
+ * The empty state must still satisfy the schema (`doc: { content: 'block+' }`):
+ * one empty paragraph, never a zero-block doc. A zero-block doc renders a
+ * 0px-high contenteditable, so after send the visible placeholder detaches from
+ * the editor (absolute ::before anchored to a collapsed box) and clicks on it
+ * land on the wrapper instead of the editor — blurring it with no way to focus
+ * back. The placeholder CSS targets this empty-paragraph state (see
+ * RichTextEditor.css).
+ */
+const emptyParagraphDoc = () =>
+  messageSchema.nodeFromJSON({ type: 'doc', content: [{ type: 'paragraph' }] });
+
 export interface RichTextEditorRef {
   focus: () => void;
   getContent: () => string;
@@ -72,6 +84,10 @@ export const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>
       getContent: () => {
         if (!viewRef.current) return '';
         const doc = viewRef.current.state.doc;
+        // A single empty paragraph is the cleared state — report it as ''
+        // so callers' empty-checks keep working (serializing it would yield
+        // '<p></p>', which is truthy).
+        if (!doc.textContent.trim() && doc.content.size <= 2) return '';
         const serializer = DOMSerializer.fromSchema(messageSchema);
         const fragment = serializer.serializeFragment(doc.content);
         const div = document.createElement('div');
@@ -87,12 +103,12 @@ export const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>
           wrapper.innerHTML = content;
           doc = ProseDOMParser.fromSchema(messageSchema).parse(wrapper);
         } else {
-          doc = messageSchema.nodeFromJSON({
-            type: 'doc',
-            content: content
-              ? [{ type: 'paragraph', content: [{ type: 'text', text: content }] }]
-              : [],
-          });
+          doc = content
+            ? messageSchema.nodeFromJSON({
+                type: 'doc',
+                content: [{ type: 'paragraph', content: [{ type: 'text', text: content }] }],
+              })
+            : emptyParagraphDoc();
         }
         const newState = EditorState.create({
           doc,
@@ -110,12 +126,8 @@ export const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>
       },
       clear: () => {
         if (!viewRef.current) return;
-        const emptyDoc = messageSchema.nodeFromJSON({
-          type: 'doc',
-          content: [],
-        });
         const newState = EditorState.create({
-          doc: emptyDoc,
+          doc: emptyParagraphDoc(),
           plugins: viewRef.current.state.plugins,
         });
         viewRef.current.updateState(newState);
@@ -132,10 +144,7 @@ export const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>
             type: 'doc',
             content: [{ type: 'paragraph', content: [{ type: 'text', text: value }] }],
           })
-        : messageSchema.nodeFromJSON({
-            type: 'doc',
-            content: [],
-          });
+        : emptyParagraphDoc();
 
       const state = EditorState.create({
         doc: initialDoc,
@@ -222,16 +231,27 @@ export const RichTextEditor = forwardRef<RichTextEditorRef, RichTextEditorProps>
       };
     }, []);
 
+    // Restore focus when re-enabling if the editor had it when it was disabled.
+    // Sending disables the editor (contenteditable=false drops focus) and the
+    // caller's async re-focus can fire while it is still disabled, becoming a
+    // no-op — this makes the round-trip deterministic.
+    const hadFocusRef = useRef(false);
     useEffect(() => {
-      if (viewRef.current) {
-        viewRef.current.setProps({
-          editable: () => !disabled,
-        });
+      if (!viewRef.current) return;
+      if (disabled) hadFocusRef.current = viewRef.current.hasFocus();
+      viewRef.current.setProps({
+        editable: () => !disabled,
+      });
+      if (!disabled && hadFocusRef.current) {
+        hadFocusRef.current = false;
+        viewRef.current.focus();
       }
     }, [disabled]);
 
     return (
-      <div className={className}>
+      // Clicks on the wrapper's padding (e.g. the composer pill around the text
+      // line) would otherwise blur the editor — forward them to focus.
+      <div className={className} onClick={() => !disabled && viewRef.current?.focus()}>
         <div ref={editorRef} className={`relative w-full ${disabled ? 'opacity-50' : ''}`} />
         {bubbleRect && viewRef.current && (
           <FormattingBubbleMenu


### PR DESCRIPTION
## Summary

After sending a message, the chat composer went dead: the "Type your message..." placeholder rendered out of place (below the pill's centerline), clicking it blurred the editor instead of focusing it, and no second message could be typed until the conversation was reopened.

Root cause: the message schema requires `doc: { content: 'block+' }`, but the editor's mount, `clear()` and `setContent('')` paths built a **zero-block doc**. ProseMirror renders that as a 0px-high contenteditable, so:

- the absolutely-positioned placeholder (`::before`) detached from the text line — anchored to a collapsed box that flex-centering puts at the pill midline, painting the text below center ("out of place");
- clicks at the placeholder's visual position landed on the pill wrapper, not the editor — blurring it with no way to focus back;
- the post-send programmatic re-focus raced `disabled={isSending}`: `setTimeout(focus, 0)` could fire while the editor was still `contenteditable=false`, becoming a no-op.

The first message of a freshly opened conversation always worked because focus is set programmatically on `conversationId` change — the user never needs to click until after the first send.

## Changes

- `RichTextEditor.tsx`
  - Empty state is now a single empty paragraph (schema-valid) in all three paths: mount, `clear()`, `setContent('')`.
  - `getContent()` reports the empty-paragraph doc as `''` — otherwise it would serialize to `'<p></p>'` (truthy) and break callers' empty-checks (e.g. `handleSend` early return).
  - The `[disabled]` effect restores focus when re-enabling if the editor had it when disabled, making the send round-trip deterministic regardless of effect/timeout ordering.
  - Clicks on the wrapper padding (the composer pill is this component's outer div) forward to `view.focus()`.
- `RichTextEditor.css`
  - Placeholder targets the empty-paragraph state (`:has(> p:only-child > br.ProseMirror-trailingBreak:only-child)`); the old `:empty` selector is kept as a safety net.

## Validation

- Headless ProseMirror harness reproducing the exact send flow (same schema, CSS and disable/clear/focus sequencing), measured before/after:
  - **broken**: editor collapses to 0px after send; `document.elementFromPoint` at the placeholder position returns the pill wrapper; clicking blurs; typed keys never reach the doc — in both outcomes of the focus race.
  - **fixed**: editor keeps line height (22.8px), placeholder visible and anchored, focus returns deterministically after send, click lands on the paragraph and the next message types normally.
- Manual test on the local review stack (vite dev against the stack gateway): sent consecutive WhatsApp messages through a live Evolution instance; composer keeps focus and placeholder position across sends.
- `tsc --noEmit` clean; eslint: no new findings (only the pre-existing `exhaustive-deps` warning on the mount effect).

## Notes

- No Linear card for this one; found while testing EVO-1911's review environment.

## Summary by Sourcery

Ensure the chat rich-text composer remains schema-valid and keeps placeholder and focus behavior consistent across message sends.

Bug Fixes:
- Prevent the composer from collapsing to a zero-height editable area after sending, so the placeholder stays correctly positioned and subsequent messages can be typed.
- Fix focus loss and click behavior by restoring focus when the editor is re-enabled and forwarding wrapper clicks to the editor.

Enhancements:
- Normalize the editor’s empty state to a single empty paragraph across mount, clear, and empty-content paths while keeping getContent() reporting it as empty.
- Update placeholder styling to target the ProseMirror empty-paragraph representation in addition to the literal empty state.