### PR TITLE
[codex] Fix local development CSP localhost access

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,7 +27,7 @@ APP_ENV="${VITE_APP_ENV:-development}"
 
 if [ "$APP_ENV" = "development" ]; then
   # Development: Allow localhost connections and permissive frame-ancestors for widget
-  sed -i "s|connect-src 'self' https: wss: ws:|connect-src 'self' https: wss: ws: http://localhost:*|g" /etc/nginx/conf.d/default.conf
+  sed -i "s|connect-src 'self' blob: https: wss: ws:|connect-src 'self' blob: https: wss: ws: http://localhost:*|g" /etc/nginx/conf.d/default.conf
   sed -i "s|frame-ancestors 'self'|frame-ancestors *|g" /etc/nginx/conf.d/default.conf
 fi
 


### PR DESCRIPTION
## Summary

Fix the local development CSP runtime patch so the frontend allows browser requests to localhost services such as the auth API on `http://localhost:3001`.

## Root cause

The entrypoint looks for:

```sh
connect-src 'self' https: wss: ws:
```

but the nginx config now contains:

```nginx
connect-src 'self' blob: https: wss: ws:
```

Because the string no longer matches, `http://localhost:*` is not appended in development. That can block setup/login API calls from the browser.

## Changes

- Update the development CSP `sed` pattern to include `blob:`.
- Preserve `blob:` while appending `http://localhost:*`.

## Validation

- Rebuilt the frontend image locally.
- Recreated the frontend container.
- Confirmed the served CSP includes `connect-src ... http://localhost:*`.

## Summary by Sourcery

Bug Fixes:
- Ensure local development CSP appends http://localhost:* to connect-src even when blob: is present in the nginx config.