### PR TITLE
feat(setup): drive optional extra setup steps via plugin-host slot

### DIFF
--- a/src/i18n/locales/en/setup.json
+++ b/src/i18n/locales/en/setup.json
@@ -49,35 +49,9 @@
       "continue": "Continue"
     }
   },
-  "brand": {
-    "title": "Your brand",
-    "subtitle": "Customize how this box looks — you can change it later",
-    "appTitle": {
-      "label": "App name",
-      "placeholder": "Evolution"
-    },
-    "primaryColor": {
-      "label": "Primary color"
-    },
-    "secondaryColor": {
-      "label": "Secondary color",
-      "placeholder": "Optional"
-    },
-    "color": {
-      "invalid": "Use a hex color like #22C55E"
-    },
-    "logo": {
-      "label": "Logo & favicon",
-      "hint": "PNG or WebP. You can add these later in settings.",
-      "light": "Light logo",
-      "dark": "Dark logo",
-      "favicon": "Favicon"
-    },
-    "skip": "Set up later",
-    "finish": "Finish",
-    "finishLoading": "Finishing...",
-    "back": "Back",
-    "logoUploadFailed": "Branding saved, but the logo upload didn't complete. You can upload it later in settings."
+  "extension": {
+    "unavailable": "This setup step isn't available. Go back to finish setup.",
+    "back": "Back"
   },
   "success": {
     "title": "Setup complete!",

--- a/src/i18n/locales/es/setup.json
+++ b/src/i18n/locales/es/setup.json
@@ -49,35 +49,9 @@
       "continue": "Continuar"
     }
   },
-  "brand": {
-    "title": "Tu marca",
-    "subtitle": "Personaliza la apariencia de este box — puedes cambiarlo después",
-    "appTitle": {
-      "label": "Nombre de la app",
-      "placeholder": "Evolution"
-    },
-    "primaryColor": {
-      "label": "Color primario"
-    },
-    "secondaryColor": {
-      "label": "Color secundario",
-      "placeholder": "Opcional"
-    },
-    "color": {
-      "invalid": "Usa un color hex como #22C55E"
-    },
-    "logo": {
-      "label": "Logo y favicon",
-      "hint": "PNG o WebP. Puedes añadirlos después en los ajustes.",
-      "light": "Logo claro",
-      "dark": "Logo oscuro",
-      "favicon": "Favicon"
-    },
-    "skip": "Configurar más tarde",
-    "finish": "Finalizar",
-    "finishLoading": "Finalizando...",
-    "back": "Atrás",
-    "logoUploadFailed": "Marca guardada, pero la subida del logo no se completó. Puedes subirlo más tarde en los ajustes."
+  "extension": {
+    "unavailable": "Este paso de configuración no está disponible. Vuelve para completar la configuración.",
+    "back": "Volver"
   },
   "success": {
     "title": "¡Configuración completa!",

--- a/src/i18n/locales/fr/setup.json
+++ b/src/i18n/locales/fr/setup.json
@@ -49,35 +49,9 @@
       "continue": "Continuer"
     }
   },
-  "brand": {
-    "title": "Votre marque",
-    "subtitle": "Personnalisez l'apparence de ce box — modifiable plus tard",
-    "appTitle": {
-      "label": "Nom de l'app",
-      "placeholder": "Evolution"
-    },
-    "primaryColor": {
-      "label": "Couleur primaire"
-    },
-    "secondaryColor": {
-      "label": "Couleur secondaire",
-      "placeholder": "Facultatif"
-    },
-    "color": {
-      "invalid": "Utilisez une couleur hex comme #22C55E"
-    },
-    "logo": {
-      "label": "Logo et favicon",
-      "hint": "PNG ou WebP. Vous pourrez les ajouter plus tard dans les paramètres.",
-      "light": "Logo clair",
-      "dark": "Logo sombre",
-      "favicon": "Favicon"
-    },
-    "skip": "Configurer plus tard",
-    "finish": "Terminer",
-    "finishLoading": "Finalisation...",
-    "back": "Retour",
-    "logoUploadFailed": "Marque enregistrée, mais l'envoi du logo n'a pas abouti. Vous pourrez l'ajouter plus tard dans les paramètres."
+  "extension": {
+    "unavailable": "Cette étape de configuration n'est pas disponible. Revenez en arrière pour terminer.",
+    "back": "Retour"
   },
   "success": {
     "title": "Configuration terminée !",

--- a/src/i18n/locales/it/setup.json
+++ b/src/i18n/locales/it/setup.json
@@ -49,35 +49,9 @@
       "continue": "Continua"
     }
   },
-  "brand": {
-    "title": "Il tuo brand",
-    "subtitle": "Personalizza l'aspetto di questo box — puoi cambiarlo in seguito",
-    "appTitle": {
-      "label": "Nome dell'app",
-      "placeholder": "Evolution"
-    },
-    "primaryColor": {
-      "label": "Colore primario"
-    },
-    "secondaryColor": {
-      "label": "Colore secondario",
-      "placeholder": "Facoltativo"
-    },
-    "color": {
-      "invalid": "Usa un colore hex come #22C55E"
-    },
-    "logo": {
-      "label": "Logo e favicon",
-      "hint": "PNG o WebP. Puoi aggiungerli in seguito nelle impostazioni.",
-      "light": "Logo chiaro",
-      "dark": "Logo scuro",
-      "favicon": "Favicon"
-    },
-    "skip": "Configura più tardi",
-    "finish": "Completa",
-    "finishLoading": "Completamento...",
-    "back": "Indietro",
-    "logoUploadFailed": "Brand salvato, ma il caricamento del logo non è andato a buon fine. Puoi caricarlo in seguito nelle impostazioni."
+  "extension": {
+    "unavailable": "Questo passaggio di configurazione non è disponibile. Torna indietro per completare.",
+    "back": "Indietro"
   },
   "success": {
     "title": "Configurazione completata!",

--- a/src/i18n/locales/pt-BR/setup.json
+++ b/src/i18n/locales/pt-BR/setup.json
@@ -49,35 +49,9 @@
       "continue": "Continuar"
     }
   },
-  "brand": {
-    "title": "Sua marca",
-    "subtitle": "Personalize a aparência deste box — você pode alterar depois",
-    "appTitle": {
-      "label": "Nome do app",
-      "placeholder": "Evolution"
-    },
-    "primaryColor": {
-      "label": "Cor primária"
-    },
-    "secondaryColor": {
-      "label": "Cor secundária",
-      "placeholder": "Opcional"
-    },
-    "color": {
-      "invalid": "Use uma cor hex como #22C55E"
-    },
-    "logo": {
-      "label": "Logo e favicon",
-      "hint": "PNG ou WebP. Você pode adicioná-los depois nas configurações.",
-      "light": "Logo claro",
-      "dark": "Logo escuro",
-      "favicon": "Favicon"
-    },
-    "skip": "Configurar depois",
-    "finish": "Concluir",
-    "finishLoading": "Concluindo...",
-    "back": "Voltar",
-    "logoUploadFailed": "Marca salva, mas o envio do logo não foi concluído. Você pode enviá-lo depois nas configurações."
+  "extension": {
+    "unavailable": "Esta etapa de configuração não está disponível. Volte para concluir a configuração.",
+    "back": "Voltar"
   },
   "success": {
     "title": "Configuração concluída!",

--- a/src/i18n/locales/pt/setup.json
+++ b/src/i18n/locales/pt/setup.json
@@ -49,35 +49,9 @@
       "continue": "Continuar"
     }
   },
-  "brand": {
-    "title": "A sua marca",
-    "subtitle": "Personalize o aspeto deste box — pode alterar mais tarde",
-    "appTitle": {
-      "label": "Nome da app",
-      "placeholder": "Evolution"
-    },
-    "primaryColor": {
-      "label": "Cor primária"
-    },
-    "secondaryColor": {
-      "label": "Cor secundária",
-      "placeholder": "Opcional"
-    },
-    "color": {
-      "invalid": "Use uma cor hex como #22C55E"
-    },
-    "logo": {
-      "label": "Logótipo e favicon",
-      "hint": "PNG ou WebP. Pode adicioná-los mais tarde nas definições.",
-      "light": "Logótipo claro",
-      "dark": "Logótipo escuro",
-      "favicon": "Favicon"
-    },
-    "skip": "Configurar mais tarde",
-    "finish": "Concluir",
-    "finishLoading": "A concluir...",
-    "back": "Voltar",
-    "logoUploadFailed": "Marca guardada, mas o envio do logótipo não foi concluído. Pode enviá-lo mais tarde nas definições."
+  "extension": {
+    "unavailable": "Esta etapa de configuração não está disponível. Volte para concluir a configuração.",
+    "back": "Voltar"
   },
   "success": {
     "title": "Configuração concluída!",

--- a/src/pages/Setup/Setup.spec.tsx
+++ b/src/pages/Setup/Setup.spec.tsx
@@ -1,8 +1,10 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import Setup from './Setup';
 import { setupService } from '@/services/setup/setupService';
+import { registerPlugin, useSetupHost } from '@/plugin-host';
+import { __resetPluginHostForTests } from '@/plugin-host/test-utils';
 
 // t returns the key verbatim so tests can query by i18n key.
 vi.mock('@/hooks/useLanguage', () => ({
@@ -17,7 +19,6 @@ vi.mock('@/services/setup/setupService', () => ({
   setupService: {
     getStatus: vi.fn(),
     bootstrap: vi.fn(),
-    uploadBrandingLogos: vi.fn(),
   },
 }));
 
@@ -70,11 +71,19 @@ describe('Setup wizard', () => {
       message: 'ok',
       survey_token: null,
     });
-    vi.mocked(setupService.uploadBrandingLogos).mockResolvedValue(true);
   });
 
-  it('on a community box (whitelabel false) bootstraps directly without a branding step', async () => {
-    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: false });
+  afterEach(() => {
+    // The registry is process-global; wipe it so contributed steps don't leak.
+    __resetPluginHostForTests();
+  });
+
+  it('on a community-pure box bootstraps directly with no extension_payload and no extra step', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({
+      status: 'inactive',
+      instance_id: null,
+      extra_setup_steps: false,
+    });
 
     renderSetup();
     await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
@@ -83,12 +92,30 @@ describe('Setup wizard', () => {
     fireEvent.click(screen.getByRole('button', { name: 'form.submit.idle' }));
 
     await waitFor(() => expect(setupService.bootstrap).toHaveBeenCalledWith(ACCOUNT));
-    expect(screen.queryByText('brand.title')).not.toBeInTheDocument();
-    expect(setupService.uploadBrandingLogos).not.toHaveBeenCalled();
+    // No extension_payload rode along on the community path.
+    expect(setupService.bootstrap).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(setupService.bootstrap).mock.calls[0][0]).not.toHaveProperty('extension_payload');
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
   });
 
-  it('on a whitelabel box advances to the branding step instead of bootstrapping', async () => {
-    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+  it('advances to the contributed setup.steps slot when extra_setup_steps is true', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({
+      status: 'inactive',
+      instance_id: null,
+      extra_setup_steps: true,
+    });
+
+    registerPlugin({
+      id: 'fake-setup-step',
+      slots: {
+        'setup.steps': [
+          {
+            id: 'fake-step',
+            component: () => <div data-testid="fake-setup-step">extra step</div>,
+          },
+        ],
+      },
+    });
 
     renderSetup();
     await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
@@ -96,67 +123,106 @@ describe('Setup wizard', () => {
     fillAccount();
     fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
 
-    await screen.findByLabelText('brand.appTitle.label');
+    await screen.findByTestId('fake-setup-step');
+    // Advancing does not bootstrap — the contributed step finishes the install.
     expect(setupService.bootstrap).not.toHaveBeenCalled();
   });
 
-  it('skipping the branding step bootstraps with no brand fields', async () => {
-    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+  it('shows a recovery fallback with a back button when the flag is true but no plugin is registered', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({
+      status: 'inactive',
+      instance_id: null,
+      extra_setup_steps: true,
+    });
 
     renderSetup();
     await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
 
     fillAccount();
     fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
-    await screen.findByLabelText('brand.appTitle.label');
 
-    fireEvent.click(screen.getByRole('button', { name: 'brand.skip' }));
+    // No contribution → the host fallback keeps the operator unstranded.
+    await screen.findByText('extension.unavailable');
+    expect(setupService.bootstrap).not.toHaveBeenCalled();
 
-    await waitFor(() => expect(setupService.bootstrap).toHaveBeenCalledWith(ACCOUNT));
-    expect(setupService.uploadBrandingLogos).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'extension.back' }));
+    // Back returns to the account step.
+    expect(screen.getByLabelText('form.email.label')).toBeInTheDocument();
   });
 
-  it('finishing sends the captured title and colors and defaults the primary color', async () => {
-    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+  it('forwards the opaque extension_payload and runs the post-bootstrap callback', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({
+      status: 'inactive',
+      instance_id: null,
+      extra_setup_steps: true,
+    });
+
+    const afterBootstrap = vi.fn().mockResolvedValue(undefined);
+
+    const FakeStep = () => {
+      const host = useSetupHost();
+      return (
+        <button type="button" onClick={() => host.submit({ probe: 1 }, afterBootstrap)}>
+          finish
+        </button>
+      );
+    };
+
+    registerPlugin({
+      id: 'fake-setup-step',
+      slots: {
+        'setup.steps': [{ id: 'fake-step', component: FakeStep }],
+      },
+    });
 
     renderSetup();
     await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
 
     fillAccount();
     fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
-    await screen.findByLabelText('brand.appTitle.label');
 
-    fireEvent.change(screen.getByLabelText('brand.appTitle.label'), { target: { value: 'Acme CRM' } });
-    fireEvent.click(screen.getByRole('button', { name: 'brand.finish' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'finish' }));
 
     await waitFor(() =>
       expect(setupService.bootstrap).toHaveBeenCalledWith({
         ...ACCOUNT,
-        app_title: 'Acme CRM',
-        primary_color: '#22C55E',
+        extension_payload: { probe: 1 },
       }),
     );
-    // No logos were selected → the best-effort upload is skipped.
-    expect(setupService.uploadBrandingLogos).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(afterBootstrap).toHaveBeenCalledWith({
+        email: ACCOUNT.email,
+        password: ACCOUNT.password,
+      }),
+    );
   });
 
-  it('blocks finishing when the primary color is not a valid hex', async () => {
-    vi.mocked(setupService.getStatus).mockResolvedValue({ status: 'inactive', instance_id: null, whitelabel: true });
+  it('bootstraps immediately and never renders the slot when extra_setup_steps is false', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({
+      status: 'inactive',
+      instance_id: null,
+      extra_setup_steps: false,
+    });
+
+    registerPlugin({
+      id: 'fake-setup-step',
+      slots: {
+        'setup.steps': [
+          {
+            id: 'fake-step',
+            component: () => <div data-testid="fake-setup-step">extra step</div>,
+          },
+        ],
+      },
+    });
 
     renderSetup();
     await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
 
     fillAccount();
-    fireEvent.click(screen.getByRole('button', { name: 'form.submit.continue' }));
-    await screen.findByLabelText('brand.appTitle.label');
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.idle' }));
 
-    // The swatch and the hex field share the accessible name — target the text field.
-    fireEvent.change(
-      screen.getByLabelText('brand.primaryColor.label', { selector: 'input[type="text"]' }),
-      { target: { value: 'not-a-color' } },
-    );
-
-    expect(screen.getByRole('button', { name: 'brand.finish' })).toBeDisabled();
-    expect(screen.getByText('brand.color.invalid')).toBeInTheDocument();
+    await waitFor(() => expect(setupService.bootstrap).toHaveBeenCalledWith(ACCOUNT));
+    expect(screen.queryByTestId('fake-setup-step')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Setup/Setup.tsx
+++ b/src/pages/Setup/Setup.tsx
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { AlertCircle, Globe, ArrowLeft } from 'lucide-react';
+import { AlertCircle, Globe } from 'lucide-react';
 
 import {
   Button,
@@ -24,9 +24,14 @@ import { type Locale } from '@/i18n/config';
 import {
   setupService,
   type BootstrapPayload,
-  type BrandingLogos,
 } from '@/services/setup/setupService';
 import { clearSetupCache } from '@/contexts/GlobalConfigContext';
+import {
+  PluginSlot,
+  SetupHostProvider,
+  type SetupHostContextValue,
+  type SetupCredentials,
+} from '@/plugin-host';
 
 import { AppLogo } from '@/components/AppLogo';
 
@@ -38,11 +43,10 @@ type SetupFormData = {
   password_confirmation: string;
 };
 
-const DEFAULT_PRIMARY = '#22C55E';
-const HEX_COLOR = /^#[0-9A-Fa-f]{6}$/;
-const isValidHex = (value: string) => HEX_COLOR.test(value);
-
-type Step = 'account' | 'brand';
+// The wizard shell is community-owned. Phase 2 is plugin-provided (a
+// `setup.steps` slot contribution) — the community knows nothing about its
+// content; it only advances to it when the server reports extra setup steps.
+type Step = 'account' | 'extension';
 
 const Setup: React.FC = () => {
   const navigate = useNavigate();
@@ -50,32 +54,24 @@ const Setup: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 
-  // Whether the box supports box branding (enterprise whitelabel present). When
-  // true the wizard inserts a "Sua marca" step before finishing; a community
+  // Whether a consumer contributes extra setup steps. When true the wizard
+  // advances to the plugin-provided step before finishing; a community-pure
   // install skips straight to bootstrap.
-  const [whitelabel, setWhitelabel] = useState(false);
+  const [hasExtraSteps, setHasExtraSteps] = useState(false);
   const [step, setStep] = useState<Step>('account');
   const [account, setAccount] = useState<SetupFormData | null>(null);
-
-  // Branding step state.
-  const [appTitle, setAppTitle] = useState('');
-  const [primaryColor, setPrimaryColor] = useState(DEFAULT_PRIMARY);
-  const [secondaryColor, setSecondaryColor] = useState('');
-  const [logoLight, setLogoLight] = useState<File | null>(null);
-  const [logoDark, setLogoDark] = useState<File | null>(null);
-  const [favicon, setFavicon] = useState<File | null>(null);
 
   useEffect(() => {
     let mounted = true;
     setupService
       .getStatus()
       .then(status => {
-        if (mounted) setWhitelabel(status.whitelabel === true);
+        if (mounted) setHasExtraSteps(status.extra_setup_steps === true);
       })
       .catch(() => {
-        // Fail soft: if the status probe fails, hide the branding step rather
-        // than showing an install-config field that would silently no-op.
-        if (mounted) setWhitelabel(false);
+        // Fail soft: if the status probe fails, hide the extra step rather
+        // than advancing to a slot that would never render.
+        if (mounted) setHasExtraSteps(false);
       });
     return () => {
       mounted = false;
@@ -127,27 +123,33 @@ const Setup: React.FC = () => {
     },
   });
 
-  // Runs the actual install. Branding fields and logos are only supplied on a
-  // whitelabel box; the community path passes neither.
+  // Runs the actual install. The host owns the single /setup/bootstrap call. A
+  // contributed step may supply an opaque `extensionPayload` (merged under
+  // `extension_payload`) and a post-bootstrap callback; the community assigns
+  // no meaning to either.
   const runBootstrap = async (
     data: SetupFormData,
-    brand: Partial<BootstrapPayload>,
-    logos?: BrandingLogos,
+    extensionPayload?: Record<string, unknown>,
+    afterBootstrap?: (c: SetupCredentials) => Promise<void>,
   ) => {
     setIsLoading(true);
     setError('');
 
     try {
-      const result = await setupService.bootstrap({ ...data, ...brand });
+      const payload: BootstrapPayload = { ...data };
+      if (extensionPayload && Object.keys(extensionPayload).length > 0) {
+        payload.extension_payload = extensionPayload;
+      }
+
+      const result = await setupService.bootstrap(payload);
 
       clearSetupCache();
 
-      // Best-effort logo upload — never blocks finishing the install.
-      const hasLogos = !!(logos && (logos.light || logos.dark || logos.favicon));
-      if (hasLogos) {
-        const ok = await setupService.uploadBrandingLogos(data.email, data.password, logos!);
-        if (!ok) {
-          toast.info(t('brand.logoUploadFailed'));
+      if (afterBootstrap) {
+        try {
+          await afterBootstrap({ email: data.email, password: data.password });
+        } catch {
+          // Post-bootstrap side effects never block finishing the install.
         }
       }
 
@@ -177,51 +179,36 @@ const Setup: React.FC = () => {
     }
   };
 
-  // Step 1 submit: advance to the branding step on a whitelabel box, otherwise
-  // bootstrap immediately (community behavior).
+  // Step 1 submit: advance to the plugin-provided step when the box contributes
+  // extra setup steps, otherwise bootstrap immediately (community behavior).
   const onAccountSubmit = (data: SetupFormData) => {
-    if (whitelabel) {
+    if (hasExtraSteps) {
       setAccount(data);
       setError('');
-      setStep('brand');
+      setStep('extension');
     } else {
-      runBootstrap(data, {});
+      runBootstrap(data);
     }
-  };
-
-  const brandPayload = (): Partial<BootstrapPayload> => {
-    const payload: Partial<BootstrapPayload> = {};
-    if (appTitle.trim()) payload.app_title = appTitle.trim();
-    if (isValidHex(primaryColor)) payload.primary_color = primaryColor;
-    if (secondaryColor.trim() && isValidHex(secondaryColor)) {
-      payload.secondary_color = secondaryColor;
-    }
-    return payload;
-  };
-
-  // "Configurar depois" — finish without applying any branding.
-  const onSkipBrand = () => {
-    if (account) runBootstrap(account, {});
-  };
-
-  // "Concluir" — apply the captured branding (text persists via bootstrap,
-  // logos upload best-effort).
-  const onFinishBrand = () => {
-    if (!account) return;
-    runBootstrap(account, brandPayload(), {
-      light: logoLight ?? undefined,
-      dark: logoDark ?? undefined,
-      favicon: favicon ?? undefined,
-    });
   };
 
   const handleLanguageChange = (lng: string) => {
     changeLanguage(lng as Locale);
   };
 
-  const primaryInvalid = !isValidHex(primaryColor);
-  const secondaryInvalid = secondaryColor.trim().length > 0 && !isValidHex(secondaryColor);
-  const brandInvalid = primaryInvalid || secondaryInvalid;
+  // Generic wizard controls handed to the contributed step. The host exposes no
+  // brand-specific knowledge — just loading/error state and the finish/back
+  // actions.
+  const hostValue: SetupHostContextValue = {
+    isLoading,
+    error,
+    goBack: () => {
+      setError('');
+      setStep('account');
+    },
+    submit: (extensionPayload, afterBootstrap) => {
+      if (account) runBootstrap(account, extensionPayload, afterBootstrap);
+    },
+  };
 
   const languageSelector = (
     <div className="absolute top-4 right-4">
@@ -249,12 +236,8 @@ const Setup: React.FC = () => {
         <div className="flex flex-col items-center space-y-4">
           <AppLogo className="h-10" />
           <div className="text-center space-y-2">
-            <h1 className="text-3xl font-bold">
-              {step === 'brand' ? t('brand.title') : t('title')}
-            </h1>
-            <p className="text-muted-foreground">
-              {step === 'brand' ? t('brand.subtitle') : t('subtitle')}
-            </p>
+            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <p className="text-muted-foreground">{t('subtitle')}</p>
           </div>
         </div>
 
@@ -343,139 +326,37 @@ const Setup: React.FC = () => {
               <Button type="submit" disabled={isLoading} className="w-full">
                 {isLoading
                   ? t('form.submit.loading')
-                  : whitelabel
+                  : hasExtraSteps
                     ? t('form.submit.continue')
                     : t('form.submit.idle')}
               </Button>
             </form>
           ) : (
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="app_title">{t('brand.appTitle.label')}</Label>
-                <Input
-                  id="app_title"
-                  type="text"
-                  placeholder={t('brand.appTitle.placeholder')}
-                  disabled={isLoading}
-                  value={appTitle}
-                  maxLength={120}
-                  onChange={e => setAppTitle(e.target.value)}
-                />
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="primary_color">{t('brand.primaryColor.label')}</Label>
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="color"
-                      aria-label={t('brand.primaryColor.label')}
-                      className="h-9 w-9 shrink-0 cursor-pointer rounded border bg-transparent p-0.5"
-                      value={isValidHex(primaryColor) ? primaryColor : DEFAULT_PRIMARY}
-                      disabled={isLoading}
-                      onChange={e => setPrimaryColor(e.target.value.toUpperCase())}
-                    />
-                    <Input
-                      id="primary_color"
-                      type="text"
-                      placeholder={DEFAULT_PRIMARY}
-                      disabled={isLoading}
-                      value={primaryColor}
-                      onChange={e => setPrimaryColor(e.target.value)}
-                    />
+            <SetupHostProvider value={hostValue}>
+              <PluginSlot
+                id="setup.steps"
+                // Recovery for the flag/plugin mismatch (server reports extra
+                // steps but no contribution is registered — e.g. version skew).
+                // Without this the operator lands on a blank card with no way
+                // back; the contributed step renders its own controls instead.
+                fallback={
+                  <div className="space-y-4">
+                    <Alert>
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription>{t('extension.unavailable')}</AlertDescription>
+                    </Alert>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="w-full"
+                      onClick={hostValue.goBack}
+                    >
+                      {t('extension.back')}
+                    </Button>
                   </div>
-                  {primaryInvalid && (
-                    <p className="text-destructive text-sm">{t('brand.color.invalid')}</p>
-                  )}
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="secondary_color">{t('brand.secondaryColor.label')}</Label>
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="color"
-                      aria-label={t('brand.secondaryColor.label')}
-                      className="h-9 w-9 shrink-0 cursor-pointer rounded border bg-transparent p-0.5"
-                      value={isValidHex(secondaryColor) ? secondaryColor : '#000000'}
-                      disabled={isLoading}
-                      onChange={e => setSecondaryColor(e.target.value.toUpperCase())}
-                    />
-                    <Input
-                      id="secondary_color"
-                      type="text"
-                      placeholder={t('brand.secondaryColor.placeholder')}
-                      disabled={isLoading}
-                      value={secondaryColor}
-                      onChange={e => setSecondaryColor(e.target.value)}
-                    />
-                  </div>
-                  {secondaryInvalid && (
-                    <p className="text-destructive text-sm">{t('brand.color.invalid')}</p>
-                  )}
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <Label>{t('brand.logo.label')}</Label>
-                <p className="text-muted-foreground text-xs">{t('brand.logo.hint')}</p>
-                <div className="grid grid-cols-3 gap-3">
-                  <LogoInput
-                    id="logo_light"
-                    label={t('brand.logo.light')}
-                    file={logoLight}
-                    disabled={isLoading}
-                    onSelect={setLogoLight}
-                  />
-                  <LogoInput
-                    id="logo_dark"
-                    label={t('brand.logo.dark')}
-                    file={logoDark}
-                    disabled={isLoading}
-                    onSelect={setLogoDark}
-                  />
-                  <LogoInput
-                    id="favicon"
-                    label={t('brand.logo.favicon')}
-                    file={favicon}
-                    disabled={isLoading}
-                    onSelect={setFavicon}
-                  />
-                </div>
-              </div>
-
-              <div className="flex items-center gap-2 pt-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  disabled={isLoading}
-                  aria-label={t('brand.back')}
-                  onClick={() => {
-                    setError('');
-                    setStep('account');
-                  }}
-                >
-                  <ArrowLeft className="h-4 w-4" />
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="flex-1"
-                  disabled={isLoading}
-                  onClick={onSkipBrand}
-                >
-                  {t('brand.skip')}
-                </Button>
-                <Button
-                  type="button"
-                  className="flex-1"
-                  disabled={isLoading || brandInvalid}
-                  onClick={onFinishBrand}
-                >
-                  {isLoading ? t('brand.finishLoading') : t('brand.finish')}
-                </Button>
-              </div>
-            </div>
+                }
+              />
+            </SetupHostProvider>
           )}
         </div>
 
@@ -486,32 +367,5 @@ const Setup: React.FC = () => {
     </div>
   );
 };
-
-interface LogoInputProps {
-  id: string;
-  label: string;
-  file: File | null;
-  disabled?: boolean;
-  onSelect: (file: File | null) => void;
-}
-
-const LogoInput: React.FC<LogoInputProps> = ({ id, label, file, disabled, onSelect }) => (
-  <div className="space-y-1">
-    <label
-      htmlFor={id}
-      className="flex h-16 cursor-pointer flex-col items-center justify-center gap-1 rounded-md border border-dashed text-center text-[11px] text-muted-foreground transition-colors hover:border-primary hover:text-foreground"
-    >
-      <span className="px-1 truncate max-w-full">{file ? file.name : label}</span>
-    </label>
-    <input
-      id={id}
-      type="file"
-      accept="image/png,image/webp"
-      className="hidden"
-      disabled={disabled}
-      onChange={e => onSelect(e.target.files?.[0] ?? null)}
-    />
-  </div>
-);
 
 export default Setup;

--- a/src/plugin-host/index.ts
+++ b/src/plugin-host/index.ts
@@ -44,3 +44,6 @@ export {
 } from './runtimeContext';
 
 export { evaluateRouteAccess } from './guards';
+
+export { SetupHostProvider, useSetupHost } from './setupHost';
+export type { SetupHostContextValue, SetupCredentials } from './setupHost';

--- a/src/plugin-host/setupHost.tsx
+++ b/src/plugin-host/setupHost.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+/** Generic credentials the host hands a post-bootstrap step (e.g. to upload
+ *  assets behind an authenticated endpoint). Not brand-specific. */
+export interface SetupCredentials {
+  email: string;
+  password: string;
+}
+
+export interface SetupHostContextValue {
+  /** True while the host's bootstrap call is in flight. */
+  isLoading: boolean;
+  /** Host-level error string ('' when none). */
+  error: string;
+  /** Return to the account step. */
+  goBack: () => void;
+  /**
+   * Finish the install. The host merges `extensionPayload` into the single
+   * /setup/bootstrap request under the opaque `extension_payload` key, and on
+   * success invokes `afterBootstrap` with generic credentials. The host assigns
+   * NO meaning to `extensionPayload`.
+   */
+  submit: (
+    extensionPayload?: Record<string, unknown>,
+    afterBootstrap?: (credentials: SetupCredentials) => Promise<void>,
+  ) => void;
+}
+
+const SetupHostContext = createContext<SetupHostContextValue | null>(null);
+
+export function SetupHostProvider({
+  value,
+  children,
+}: {
+  value: SetupHostContextValue;
+  children: ReactNode;
+}) {
+  return <SetupHostContext.Provider value={value}>{children}</SetupHostContext.Provider>;
+}
+
+/** Read by a `setup.steps` slot contribution. Throws if used outside the host. */
+export function useSetupHost(): SetupHostContextValue {
+  const ctx = useContext(SetupHostContext);
+  if (!ctx) {
+    throw new Error('[plugin-host] useSetupHost must be used within <SetupHostProvider>');
+  }
+  return ctx;
+}

--- a/src/plugin-host/types.ts
+++ b/src/plugin-host/types.ts
@@ -9,7 +9,8 @@ export type SlotId =
   | 'admin.routes'
   | 'settings.sections'
   | 'dashboard.widgets'
-  | 'notifications.banner';
+  | 'notifications.banner'
+  | 'setup.steps';
 
 export type RouteNamespace = 'admin' | 'customer' | 'public';
 

--- a/src/services/setup/setupService.ts
+++ b/src/services/setup/setupService.ts
@@ -6,10 +6,6 @@ const authBaseURL =
   import.meta.env.VITE_API_URL ||
   'http://localhost:3001';
 
-// CRM (enterprise) origin — where the whitelabel logo endpoint lives. Empty in
-// the shell build so the request is same-origin and rides the reverse proxy.
-const crmBaseURL = import.meta.env.VITE_API_URL || '';
-
 const setupApi = axios.create({
   baseURL: authBaseURL,
   headers: { 'Content-Type': 'application/json' },
@@ -20,8 +16,8 @@ export interface SetupStatus {
   instance_id: string | null;
   api_key?: string;
   licensed?: boolean;
-  /** True when the box supports box branding (enterprise whitelabel present). */
-  whitelabel?: boolean;
+  /** True when a consumer contributes extra setup steps. */
+  extra_setup_steps?: boolean;
 }
 
 export interface BootstrapPayload {
@@ -30,19 +26,9 @@ export interface BootstrapPayload {
   email: string;
   password: string;
   password_confirmation: string;
-  // Optional box branding captured at /setup on a whitelabel-capable box. The
-  // backend persists only the provided, non-blank fields onto the single
-  // agency's whitelabel row (no-op on a community-only install).
-  app_title?: string;
-  primary_color?: string;
-  secondary_color?: string;
-}
-
-/** Logo/favicon images captured in the branding step (all optional). */
-export interface BrandingLogos {
-  light?: File;
-  dark?: File;
-  favicon?: File;
+  /** Opaque bag forwarded to the server's after_bootstrap hook; populated
+   *  only by a contributed step. */
+  extension_payload?: Record<string, unknown>;
 }
 
 export interface BootstrapResponse {
@@ -60,60 +46,6 @@ export const setupService = {
   async bootstrap(payload: BootstrapPayload): Promise<BootstrapResponse> {
     const { data } = await setupApi.post<BootstrapResponse>('/setup/bootstrap', payload);
     return data;
-  },
-
-  /**
-   * Best-effort upload of the box logo/favicon captured at /setup.
-   *
-   * The binary upload lives behind the authenticated enterprise endpoint
-   * (POST /enterprise/v1/admin/whitelabel/logo), so we sign in with the
-   * just-created admin to obtain a token — a standalone request that does NOT
-   * touch the global auth store (the operator still logs in fresh afterwards).
-   *
-   * This NEVER throws: a failure (endpoint unreachable, missing grant, etc.)
-   * must not block finishing the install — the text branding is already
-   * persisted by /setup/bootstrap, and logos can be re-uploaded later from the
-   * whitelabel settings. Returns true only when every provided image uploaded.
-   */
-  async uploadBrandingLogos(
-    email: string,
-    password: string,
-    logos: BrandingLogos,
-  ): Promise<boolean> {
-    const variants = (['light', 'dark', 'favicon'] as const).filter(v => logos[v]);
-    if (variants.length === 0) return true;
-
-    let token: string | null = null;
-    try {
-      const { data } = await axios.post(
-        `${authBaseURL}/api/v1/auth/login`,
-        { email, password },
-        { headers: { 'Content-Type': 'application/json' } },
-      );
-      token =
-        data?.data?.token?.access_token ||
-        data?.data?.access_token ||
-        data?.access_token ||
-        null;
-    } catch {
-      token = null;
-    }
-    if (!token) return false;
-
-    let allOk = true;
-    for (const variant of variants) {
-      try {
-        const formData = new FormData();
-        formData.append('file', logos[variant] as File);
-        formData.append('variant', variant);
-        await axios.post(`${crmBaseURL}/enterprise/v1/admin/whitelabel/logo`, formData, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-      } catch {
-        allOk = false;
-      }
-    }
-    return allOk;
   },
 
   /** POST /setup/survey — pre-login, authenticated via one-time survey_token */


### PR DESCRIPTION
## Setup wizard: optional extra steps via plugin-host slot

Refactors the first-run `/setup` wizard so any optional post-account steps are contributed through the existing plugin-host `setup.steps` slot instead of being hardcoded into the page. The wizard is single-step by default; a host-owned React context (`SetupHostProvider` / `useSetupHost`) lets a contributed step finish the install.

### What changed
- **`types.ts`** — add `'setup.steps'` to `SlotId`.
- **`setupHost.tsx`** (new) — `SetupHostProvider` + `useSetupHost()` + `SetupCredentials`; generic wizard controls (`isLoading`, `error`, `goBack`, `submit(extensionPayload?, afterBootstrap?)`).
- **`index.ts`** — export the host-context symbols.
- **`Setup.tsx`** — single-step account wizard; advances to `<PluginSlot id="setup.steps" />` when `status.extra_setup_steps === true`. The host owns the single `/setup/bootstrap` call and, on success, invokes the step-provided `afterBootstrap({ email, password })`.
- **`setupService.ts`** — `BootstrapPayload` gains opaque `extension_payload?`; `SetupStatus` gains `extra_setup_steps?`.
- **`Setup.spec.tsx`** — rewritten for the single-step wizard + slot gating.
- **6× `setup.json`** — locale keys aligned with the slot-driven wizard.

### Contract (matches the auth-service PR)
`extension_payload` (opaque envelope) · `after_bootstrap` hook with `payload:` · `GET /setup/status → extra_setup_steps: bool`.

### Verification
- `tsc -b`: pass · `Setup.spec`: 5/5 · plugin-host suite: 12/12.
- `i18n-parity`: 3 pre-existing failures in unrelated files (`channels` / `customTools` / `products.json`); baseline `develop` was 4 — this branch fixed one.
- Lint: 1 pre-existing `any` (untouched `catch`), no new issues.

### Review note
Host→step data flows via a React context (`useSetupHost`) rather than the `runtimeContext` prop, since the wizard needs a submit callback the slot API doesn't carry. Includes a host-owned fallback (message + back button) when the slot is enabled but no contribution is registered — a new spec case covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
