### PR TITLE
fix(docker): normalize .sh line endings to fix Windows-build entrypoint crash (EVO-2020)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Normalize shell scripts to LF so a Windows checkout (core.autocrlf=true) does not
+# embed CRLF in shebangs — CRLF breaks the Docker entrypoint at runtime
+# ("exec /docker-entrypoint.sh: no such file or directory"). See EVO-2020.
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,11 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy runtime entrypoint
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+# Normalize CRLF->LF (defense in depth alongside .gitattributes): a Windows
+# checkout leaves \r in the shebang (#!/bin/sh\r), making the kernel look for
+# "/bin/sh\r" -> "exec: no such file or directory". See EVO-2020.
+RUN sed -i 's/\r$//' /docker-entrypoint.sh \
+    && chmod +x /docker-entrypoint.sh
 
 # Expose port
 EXPOSE 80


### PR DESCRIPTION
## Problema
Buildar a imagem do frontend a partir de um **checkout Windows** (`git core.autocrlf=true`) gera container em **crash-loop**: `exec /docker-entrypoint.sh: no such file or directory` (exit 255) — o kernel procura `/bin/sh\r` porque o shebang carrega um `\r`.

## Causa-raiz (verificável)
- `git cat-file blob HEAD:docker-entrypoint.sh` → `#!/bin/sh\n` (o blob é **LF**).
- Sem `.gitattributes` (`git check-attr eol` → `unspecified`) + `core.autocrlf=true` → checkout reescreve para CRLF.
- `Dockerfile`: `COPY` + `chmod` **sem normalizar** → shebang CRLF embarcado na imagem.

## Escopo (verificado, não inferido)
`.github/workflows/docker-publish.yml` builda em `runs-on: ubuntu-latest` / `platforms: linux/amd64,linux/arm64` → **CI/produção não afetado** (checkout Linux mantém LF). O bug é **exclusivo de builds locais Windows**. Mesma classe do EVO-2011 (crm/auth).

## Cobertura
`git ls-files '*.sh'` → **apenas** `docker-entrypoint.sh`. É o único shell script versionado; `.gitattributes *.sh` + `sed` cobrem 100% da superfície.

## Correção (defesa em profundidade)
- **`.gitattributes`** `*.sh text eol=lf` — correção de origem. Vale para checkouts futuros/renormalização (`git add --renormalize` para working trees já em CRLF).
- **`Dockerfile`** `sed -i 's/\r$//'` antes do `chmod` — garante o build imediato mesmo com working tree em CRLF (cobre a lacuna do item acima). Alinhado ao EVO-2011.

## Testes
- [x] `git check-attr eol -- docker-entrypoint.sh` → `eol: lf`.
- [x] Rebuild local Windows (`autocrlf=true`) → container **healthy** (antes `Restarting (255)`); `GET :5173 → 200`.
- [x] CI roda em runner Linux (`ubuntu-latest`) — comportamento inalterado (blob já era LF).

Closes EVO-2020
