### PR TITLE
fix(chat-sidebar): stop status filter leak between popover e navegação por chip

### DIFF
--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -306,20 +306,22 @@ const ChatSidebar = ({
     onFilterApply([...segmentPreset, ...advanced]);
   };
 
-  // Apply do MODAL avançado: status/unread/is_group são navegação por chip e NÃO
-  // aparecem no modal. Preserva SÓ o `status` ao aplicar filtros avançados, pois é
-  // a única navegação por chip que TAMBÉM é atributo válido no POST /filter.
-  // unread/is_group são GET-only (CHIP_ONLY) — incluí-los no POST daria 400; são
-  // descartados ao aplicar um filtro avançado (comportamento original). Se o
-  // usuário adicionou o mesmo atributo no modal, o do modal vence.
+  // Apply do POPOVER avançado: unread/is_group são navegação SÓ de chip (não têm
+  // seção no popover) e precisam ser preservados, senão desaparecem a cada apply
+  // avançado. `status`, ao contrário, TEM seção própria no popover (checkboxes) —
+  // o popover é autoritativo pra ele, e `advancedFilters` já reflete exatamente o
+  // que o usuário deixou marcado (inclusive "nada marcado" = sem filtro de status).
+  // Tentar "preservar" status vindo de activeFilters aqui reintroduzia um status
+  // stale sempre que o usuário desmarcava tudo e aplicava (EVO-2037): activeFilters
+  // ainda carregava o status do apply ANTERIOR, e como advancedFilters não tinha
+  // mais nenhuma entrada 'status', ele voltava a ser re-mesclado.
   const handleApplyAdvancedFilters = async (advancedFilters: BaseFilter[]) => {
     setConversationFilters(advancedFilters);
     const advancedKeys = new Set(advancedFilters.map(f => f.attributeKey));
     const chipNav = filters.state.activeFilters
       .filter(
         (f: ConversationFilter) =>
-          CHIP_NAV_KEYS.includes(f.attribute_key) &&
-          !CHIP_ONLY_FILTER_KEYS.includes(f.attribute_key) &&
+          CHIP_ONLY_FILTER_KEYS.includes(f.attribute_key) &&
           !advancedKeys.has(f.attribute_key),
       )
       .map(conversationFilterToBaseFilter);

--- a/src/components/chat/filters/ConversationsFilterPopover.tsx
+++ b/src/components/chat/filters/ConversationsFilterPopover.tsx
@@ -47,13 +47,23 @@ const SECTIONS: FilterSection[] = [
 // os chips de busca (ConversationSegments), sem duplicar a arquitetura.
 const STATUS_OPTIONS: ConversationStatus[] = ['pending', 'open', 'resolved', 'snoozed'];
 
+// `status: ['all']` é o DEFAULT_FILTER global (FiltersContext.tsx) — sentinela de
+// "sem filtro de status", não uma seleção real. Chega até o draft deste popover via
+// o sync activeFilters->popover em ChatSidebar.tsx (que inclui `status` de propósito,
+// para refletir chips de status já ativos). Sem filtrar o sentinela aqui, ele: (1)
+// acende o badge/dot como se houvesse um filtro aplicado com nenhum checkbox marcado,
+// e (2) ao marcar um status real, é ACUMULADO junto (['all','pending']) em vez de
+// substituído, e o attribute_key final chega ao backend como 'all' sozinho de novo.
+const STATUS_SENTINEL = 'all';
+
 const filterToValues = (filter: BaseFilter | undefined): string[] => {
   if (!filter) return [];
-  return Array.isArray(filter.values)
+  const raw = Array.isArray(filter.values)
     ? filter.values.map(String)
     : String(filter.values || '')
         .split(',')
         .filter(Boolean);
+  return filter.attributeKey === 'status' ? raw.filter(v => v !== STATUS_SENTINEL) : raw;
 };
 
 const buildFilter = (attributeKey: string, values: string[]): BaseFilter => ({


### PR DESCRIPTION
## Problema

3 sintomas reportados na tela de Conversas, todos com a mesma raiz — o `status` sendo compartilhado entre o eixo de navegação por chip (`activeFilters` global) e o rascunho (draft) do popover de filtros avançados:

1. **Desmarcar todos os status e aplicar não trazia "todos" de volta** — o filtro antigo continuava sendo reaplicado silenciosamente.
2. **Só salvava se marcasse mais de um status** — na prática, o sentinela interno `status: ['all']` (usado como baseline de "sem filtro") vazava pro draft do popover e, como a seção Status usa toggle multi-select, marcar um status real *acumulava* em cima do sentinela (`['all', 'pending']`) em vez de substituí-lo — então o request de fato aplicado continuava saindo como `status=all`.
3. **Indicador verde ("Filtros") ficava aceso mesmo depois de "Limpar filtros"**, com nenhum checkbox marcado — mesma causa: o sentinela `'all'` era contado como "1 filtro aplicado" pelo popover.

## Causa raiz

- `filterToValues()` (`ConversationsFilterPopover.tsx`) não filtrava o sentinela `'all'` do atributo `status` — ele é o valor padrão global (`DEFAULT_FILTER` em `FiltersContext.tsx`), não uma seleção real do usuário.
- `handleApplyAdvancedFilters()` (`ChatSidebar.tsx`) tentava "preservar" o `status` vindo de `activeFilters` sempre que o `advancedFilters` recém-aplicado não trazia uma entrada de status — reintroduzindo silenciosamente um status obsoleto quando o usuário desmarcava tudo.

## Fix

- `filterToValues()` agora descarta o sentinela `'all'` especificamente para `status`, então ele nunca conta como valor real em nenhum consumidor (contagem do badge, indicador do botão, acumulação no toggle).
- `handleApplyAdvancedFilters()` não tenta mais preservar `status` de `activeFilters` — o popover tem seção própria pra Status e `advancedFilters` já é a fonte de verdade completa (inclusive "nada marcado" = sem filtro). Só `unread`/`is_group` (que não têm seção no popover) continuam precisando dessa preservação.

## Test plan

Verificado via Playwright autenticado (não só leitura de código), fluxo completo:
- [x] Marcar "Pending" no popover + Aplicar → request real vai como `status=pending` (antes: `status=all`, bug silencioso)
- [x] Reabrir popover → checkbox "Pending" continua marcado (sync-in já funcionava, `24e94ae`)
- [x] Desmarcar "Pending" + Aplicar → request volta a `GET /conversations` sem `status` (= todas) — antes reaplicava `status=pending` stale
- [x] Reabrir popover após desmarcar → nenhum checkbox marcado, sem badge "N filtros", sem indicador verde no botão "Filtros"
- [x] Clicar "Limpar filtros" (Clear all) explicitamente → mesmo resultado: sem dot, sem badge, lista completa
- [x] `npx tsc --noEmit` limpo nos arquivos tocados
- [x] `npx vitest run src/components/chat/chat-sidebar src/components/chat/filters` — mesmas 7 falhas pré-existentes (confirmado via `git stash`, não relacionadas a esta mudança), sem novas regressões

## Summary by Sourcery

Fix conversation status filtering so the advanced filters popover becomes the single source of truth for status and chip-only filters are preserved correctly.

Bug Fixes:
- Prevent the status 'all' sentinel from being treated as a real selection in the advanced filters popover, avoiding false active-filter indicators and incorrect status values being sent to the backend.
- Ensure clearing or unselecting all status checkboxes in the advanced filters popover actually removes the status filter instead of silently reapplying a stale status from previous navigation.
- Preserve only chip-only filters (such as unread/is_group) when applying advanced filters so they are not unintentionally dropped.

Enhancements:
- Align advanced filter application with chip navigation by making the popover authoritative for status filters while keeping chip-only filters in sync.