### PR TITLE
feat(admin): copy-callback-url button on channel & integration OAuth config

### DIFF
--- a/src/components/common/CopyCallbackUrl.tsx
+++ b/src/components/common/CopyCallbackUrl.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Input, Label, Button } from '@evoapi/design-system';
+import { Copy, Check } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface CopyCallbackUrlProps {
+  /** Fully-built callback URL to display and copy (e.g. `${window.location.origin}/google/callback`). */
+  url: string;
+  /** Field label (already translated). */
+  label: string;
+  /** Optional helper text under the field (already translated). */
+  hint?: string;
+  /** Toast shown after a successful copy (already translated). */
+  copiedMessage: string;
+  /** Accessible label / tooltip for the copy button (already translated). */
+  copyLabel: string;
+}
+
+/**
+ * Read-only callback URL with a copy-to-clipboard button.
+ *
+ * The URL is derived by the caller from `window.location.origin`, so it always
+ * matches the deployment host (localhost / staging / prod) — this is the exact
+ * value the operator must register as the OAuth redirect URI in the provider
+ * console. i18n-agnostic on purpose: all user-facing strings arrive as props.
+ */
+export default function CopyCallbackUrl({ url, label, hint, copiedMessage, copyLabel }: CopyCallbackUrlProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // Clipboard API unavailable (non-secure context); the value stays visible/selectable.
+    }
+    setCopied(true);
+    toast.success(copiedMessage);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="space-y-2">
+      <Label>{label}</Label>
+      <div className="flex items-center gap-2">
+        <Input
+          readOnly
+          value={url}
+          className="font-mono text-xs"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleCopy}
+          aria-label={copyLabel}
+          title={copyLabel}
+          className="shrink-0"
+        >
+          {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+        </Button>
+      </div>
+      {hint && <p className="text-xs text-sidebar-foreground/60">{hint}</p>}
+    </div>
+  );
+}

--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -117,6 +117,12 @@
     }
   },
   "socialLogin": {
+    "callbackUrl": {
+      "label": "OAuth redirect URI (register in the provider console)",
+      "hint": "Add this exact URL to your OAuth app's authorized redirect URIs — it must match exactly (https, no trailing slash).",
+      "copy": "Copy callback URL",
+      "copied": "Callback URL copied"
+    },
     "title": "Email provider credentials (OAuth)",
     "description": "OAuth app credentials (Google / Microsoft) used to connect Gmail and Outlook email channels.",
     "google": {
@@ -343,6 +349,12 @@
     "saving": "Saving..."
   },
   "integrations": {
+    "callbackUrl": {
+      "label": "OAuth redirect URI (register in the provider console)",
+      "hint": "Add this exact URL to your OAuth app's authorized redirect URIs — it must match exactly (https, no trailing slash).",
+      "copy": "Copy callback URL",
+      "copied": "Callback URL copied"
+    },
     "title": "Integrations Configuration",
     "description": "Configure OAuth credentials for third-party integrations such as Linear, GitHub, Notion, and others.",
     "secretConfigured": "Configured",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -5,7 +5,7 @@
     "storage": "Armazenamento",
     "channels": "Canais",
     "openai": "OpenAI",
-    "integrations": "Integracoes",
+    "integrations": "Integrações",
     "evolutionHub": "Evo Hub"
   },
   "email": {
@@ -117,6 +117,12 @@
     }
   },
   "socialLogin": {
+    "callbackUrl": {
+      "label": "URI de redirecionamento OAuth (cadastre no console do provedor)",
+      "hint": "Adicione esta URL exata nas URIs de redirecionamento autorizadas do seu app OAuth — precisa bater exatamente (https, sem barra no final).",
+      "copy": "Copiar URL de callback",
+      "copied": "URL de callback copiada"
+    },
     "title": "Credenciais de provedor de e-mail (OAuth)",
     "description": "Credenciais de app OAuth (Google / Microsoft) usadas para conectar canais de e-mail Gmail e Outlook.",
     "google": {
@@ -168,7 +174,7 @@
     "email": {
       "tabTitle": "E-mail"
     },
-    "title": "Integracoes de Canais",
+    "title": "Integrações de Canais",
     "description": "Configure as credenciais para os canais de mensagens e integracoes.",
     "secretConfigured": "Configurado",
     "secretNotConfigured": "Nao configurado",
@@ -343,7 +349,13 @@
     "saving": "Salvando..."
   },
   "integrations": {
-    "title": "Configuracao de Integracoes",
+    "callbackUrl": {
+      "label": "URI de redirecionamento OAuth (cadastre no console do provedor)",
+      "hint": "Adicione esta URL exata nas URIs de redirecionamento autorizadas do seu app OAuth — precisa bater exatamente (https, sem barra no final).",
+      "copy": "Copiar URL de callback",
+      "copied": "URL de callback copiada"
+    },
+    "title": "Configuração de Integrações",
     "description": "Configure credenciais OAuth para integracoes de terceiros como Linear, GitHub, Notion e outras.",
     "secretConfigured": "Configurado",
     "secretNotConfigured": "Nao configurado",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -5,7 +5,7 @@
     "storage": "Armazenamento",
     "channels": "Canais",
     "openai": "OpenAI",
-    "integrations": "Integracoes"
+    "integrations": "Integrações"
   },
   "email": {
     "title": "Configuracao de E-mail",
@@ -116,6 +116,12 @@
     }
   },
   "socialLogin": {
+    "callbackUrl": {
+      "label": "URI de redirecionamento OAuth (cadastre no console do provedor)",
+      "hint": "Adicione esta URL exata nas URIs de redirecionamento autorizadas do seu app OAuth — precisa bater exatamente (https, sem barra no final).",
+      "copy": "Copiar URL de callback",
+      "copied": "URL de callback copiada"
+    },
     "title": "Credenciais de provedor de e-mail (OAuth)",
     "description": "Credenciais de app OAuth (Google / Microsoft) usadas para ligar canais de e-mail Gmail e Outlook.",
     "google": {
@@ -167,7 +173,7 @@
     "email": {
       "tabTitle": "E-mail"
     },
-    "title": "Integracoes de Canais",
+    "title": "Integrações de Canais",
     "description": "Configure as credenciais para os canais de mensagens e integracoes.",
     "secretConfigured": "Configurado",
     "secretNotConfigured": "Nao configurado",
@@ -342,7 +348,13 @@
     "saving": "A guardar..."
   },
   "integrations": {
-    "title": "Configuracao de Integracoes",
+    "callbackUrl": {
+      "label": "URI de redirecionamento OAuth (cadastre no console do provedor)",
+      "hint": "Adicione esta URL exata nas URIs de redirecionamento autorizadas do seu app OAuth — precisa bater exatamente (https, sem barra no final).",
+      "copy": "Copiar URL de callback",
+      "copied": "URL de callback copiada"
+    },
+    "title": "Configuração de Integrações",
     "description": "Configure credenciais OAuth para integracoes de terceiros como Linear, GitHub, Notion e outras.",
     "secretConfigured": "Configurado",
     "secretNotConfigured": "Nao configurado",

--- a/src/pages/Admin/Settings/IntegrationsConfig.tsx
+++ b/src/pages/Admin/Settings/IntegrationsConfig.tsx
@@ -20,6 +20,7 @@ import { adminConfigService } from '@/services/admin/adminConfigService';
 import { extractError } from '@/utils/apiHelpers';
 import type { AdminConfigData } from '@/types/admin/adminConfig';
 import BrandIcon, { getBrandIcon } from '@/components/BrandIcon';
+import CopyCallbackUrl from '@/components/common/CopyCallbackUrl';
 import { INTEGRATIONS, type IntegrationDef } from './integrationsCatalog';
 import FrontendServicesSection from './FrontendServicesSection';
 
@@ -273,6 +274,16 @@ function IntegrationDialogContent({ def, initialData, onClose, onSaved, t }: Int
           sectionKey={def.key}
           t={t}
         />
+
+        {def.callbackPath && (
+          <CopyCallbackUrl
+            url={`${window.location.origin}${def.callbackPath}`}
+            label={t('integrations.callbackUrl.label')}
+            hint={t('integrations.callbackUrl.hint')}
+            copyLabel={t('integrations.callbackUrl.copy')}
+            copiedMessage={t('integrations.callbackUrl.copied')}
+          />
+        )}
 
         <DialogFooter className="gap-2 sm:justify-between">
           {configured ? (

--- a/src/pages/Admin/Settings/SocialLoginConfig.spec.tsx
+++ b/src/pages/Admin/Settings/SocialLoginConfig.spec.tsx
@@ -101,14 +101,26 @@ describe('SocialLoginConfig', () => {
     expect(screen.getByText('socialLogin.microsoft.cardTitle')).toBeInTheDocument();
   });
 
-  it('renders all 5 form fields (3 Google + 2 Microsoft)', async () => {
+  it('renders all 4 form fields (2 Google + 2 Microsoft)', async () => {
     await renderAndWait();
 
     expect(screen.getByLabelText('socialLogin.google.fields.clientId')).toBeInTheDocument();
     expect(screen.getByLabelText('socialLogin.google.fields.clientSecret')).toBeInTheDocument();
-    expect(screen.getByLabelText('socialLogin.google.fields.callbackUrl')).toBeInTheDocument();
     expect(screen.getByLabelText('socialLogin.microsoft.fields.appId')).toBeInTheDocument();
     expect(screen.getByLabelText('socialLogin.microsoft.fields.appSecret')).toBeInTheDocument();
+  });
+
+  it('shows a read-only callback URL with copy button on each provider card', async () => {
+    await renderAndWait();
+
+    // One callback URL box per card (Gmail channel + Outlook channel).
+    expect(screen.getAllByText('socialLogin.callbackUrl.label')).toHaveLength(2);
+    expect(
+      screen.getByDisplayValue(`${window.location.origin}/google/callback`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue(`${window.location.origin}/microsoft/callback`),
+    ).toBeInTheDocument();
   });
 
   it('shows secret configured status for masked secrets', async () => {

--- a/src/pages/Admin/Settings/SocialLoginConfig.tsx
+++ b/src/pages/Admin/Settings/SocialLoginConfig.tsx
@@ -17,6 +17,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 import { adminConfigService } from '@/services/admin/adminConfigService';
 import { extractError } from '@/utils/apiHelpers';
 import type { AdminConfigData } from '@/types/admin/adminConfig';
+import CopyCallbackUrl from '@/components/common/CopyCallbackUrl';
 
 // --- Schema factories with i18n ---
 
@@ -24,7 +25,6 @@ function createGoogleOauthSchema(t: (key: string) => string) {
   return z.object({
     GOOGLE_OAUTH_CLIENT_ID: z.string().min(1, t('socialLogin.validation.clientIdRequired')),
     GOOGLE_OAUTH_CLIENT_SECRET: z.string().optional().nullable(),
-    GOOGLE_OAUTH_CALLBACK_URL: z.string().url(t('socialLogin.validation.callbackUrlInvalid')).or(z.literal('')),
   });
 }
 
@@ -44,7 +44,6 @@ type MicrosoftFieldKey = keyof MicrosoftFormData;
 const GOOGLE_DEFAULTS: GoogleOauthFormData = {
   GOOGLE_OAUTH_CLIENT_ID: '',
   GOOGLE_OAUTH_CLIENT_SECRET: null,
-  GOOGLE_OAUTH_CALLBACK_URL: '',
 };
 
 const MICROSOFT_DEFAULTS: MicrosoftFormData = {
@@ -337,17 +336,13 @@ export default function SocialLoginConfig() {
               t={t}
             />
 
-            <div className="space-y-2">
-              <Label htmlFor="GOOGLE_OAUTH_CALLBACK_URL">{t('socialLogin.google.fields.callbackUrl')}</Label>
-              <Input
-                id="GOOGLE_OAUTH_CALLBACK_URL"
-                placeholder={t('socialLogin.google.placeholders.callbackUrl')}
-                {...googleForm.register('GOOGLE_OAUTH_CALLBACK_URL')}
-              />
-              {googleForm.formState.errors.GOOGLE_OAUTH_CALLBACK_URL && (
-                <p className="text-xs text-destructive">{googleForm.formState.errors.GOOGLE_OAUTH_CALLBACK_URL.message}</p>
-              )}
-            </div>
+            <CopyCallbackUrl
+              url={`${window.location.origin}/google/callback`}
+              label={t('socialLogin.callbackUrl.label')}
+              hint={t('socialLogin.callbackUrl.hint')}
+              copyLabel={t('socialLogin.callbackUrl.copy')}
+              copiedMessage={t('socialLogin.callbackUrl.copied')}
+            />
 
             <div className="pt-2">
               <Button type="submit" disabled={savingGoogle}>
@@ -389,6 +384,14 @@ export default function SocialLoginConfig() {
               onClear={() => handleClearMicrosoftSecret('AZURE_APP_SECRET')}
               sectionKey="microsoft"
               t={t}
+            />
+
+            <CopyCallbackUrl
+              url={`${window.location.origin}/microsoft/callback`}
+              label={t('socialLogin.callbackUrl.label')}
+              hint={t('socialLogin.callbackUrl.hint')}
+              copyLabel={t('socialLogin.callbackUrl.copy')}
+              copiedMessage={t('socialLogin.callbackUrl.copied')}
             />
 
             <div className="pt-2">

--- a/src/pages/Admin/Settings/integrationsCatalog.ts
+++ b/src/pages/Admin/Settings/integrationsCatalog.ts
@@ -13,6 +13,14 @@ export interface IntegrationDef {
   configType: string;
   clientIdKey: string;
   clientSecretKey: string;
+  /**
+   * Fixed OAuth redirect path (host-relative) the operator must register in the
+   * provider console. Built at render time as `${window.location.origin}${callbackPath}`
+   * so it tracks the deployment host. Only set for integrations that expose a
+   * fixed callback URL (mirrors the service `getOAuthCallbackUrl()`); omit for
+   * integrations whose redirect is dynamic/agent-scoped.
+   */
+  callbackPath?: string;
 }
 
 export const INTEGRATIONS: IntegrationDef[] = [
@@ -29,8 +37,8 @@ export const INTEGRATIONS: IntegrationDef[] = [
   { key: 'notion', configType: 'notion', clientIdKey: 'NOTION_OAUTH_CLIENT_ID', clientSecretKey: 'NOTION_OAUTH_CLIENT_SECRET' },
   { key: 'asana', configType: 'asana', clientIdKey: 'ASANA_OAUTH_CLIENT_ID', clientSecretKey: 'ASANA_OAUTH_CLIENT_SECRET' },
   { key: 'canva', configType: 'canva', clientIdKey: 'CANVA_OAUTH_CLIENT_ID', clientSecretKey: 'CANVA_OAUTH_CLIENT_SECRET' },
-  { key: 'google_calendar', configType: 'google_calendar', clientIdKey: 'GOOGLE_CALENDAR_CLIENT_ID', clientSecretKey: 'GOOGLE_CALENDAR_CLIENT_SECRET' },
-  { key: 'google_sheets', configType: 'google_sheets', clientIdKey: 'GOOGLE_SHEETS_CLIENT_ID', clientSecretKey: 'GOOGLE_SHEETS_CLIENT_SECRET' },
+  { key: 'google_calendar', configType: 'google_calendar', clientIdKey: 'GOOGLE_CALENDAR_CLIENT_ID', clientSecretKey: 'GOOGLE_CALENDAR_CLIENT_SECRET', callbackPath: '/oauth/google-calendar/callback' },
+  { key: 'google_sheets', configType: 'google_sheets', clientIdKey: 'GOOGLE_SHEETS_CLIENT_ID', clientSecretKey: 'GOOGLE_SHEETS_CLIENT_SECRET', callbackPath: '/oauth/google-sheets/callback' },
   { key: 'monday', configType: 'monday', clientIdKey: 'MONDAY_OAUTH_CLIENT_ID', clientSecretKey: 'MONDAY_OAUTH_CLIENT_SECRET' },
   { key: 'paypal', configType: 'paypal', clientIdKey: 'PAYPAL_OAUTH_CLIENT_ID', clientSecretKey: 'PAYPAL_OAUTH_CLIENT_SECRET' },
   { key: 'atlassian', configType: 'atlassian', clientIdKey: 'ATLASSIAN_OAUTH_CLIENT_ID', clientSecretKey: 'ATLASSIAN_OAUTH_CLIENT_SECRET' },


### PR DESCRIPTION
## Copy-callback-URL button on channel & integration OAuth config

**Problema:** ao configurar OAuth (Gmail/Outlook, Google Calendar/Sheets), o operador não tinha como ver a URL de redirect exata pra cadastrar no console do provedor → `redirect_uri_mismatch`. A URL nem estava na tela.

**Mudança:** campo read-only "URL de callback" com botão de copiar, derivado de `window.location.origin` (acompanha o host: localhost/staging/prod).

### Canais (Admin → Integrações de Canais / SocialLoginConfig)
- Card **Google** mostra `{origin}/google/callback`; card **Microsoft** mostra `{origin}/microsoft/callback`.
- **Removido** o campo `GOOGLE_OAUTH_CALLBACK_URL` — ele configurava o callback de um "login com Google" (OmniAuth) que **não tem UI** neste produto; o canal Gmail usa um redirect fixo `/google/callback` e nunca lia esse campo.

### Integrações (Admin → Integrações / IntegrationsConfig)
- `callbackPath` opcional no `IntegrationDef`; botão de copiar aparece no dialog das integrações com redirect fixo: **google_calendar** (`/oauth/google-calendar/callback`) e **google_sheets** (`/oauth/google-sheets/callback`) — espelha os `getOAuthCallbackUrl()` dos services. Demais integrações (redirect dinâmico por-agente) não mostram.

### Outros
- Typo do menu pt-BR/pt: `Integracoes` → **Integrações** (+ títulos "Integrações de Canais", "Configuração de Integrações").
- Novo componente reusável `CopyCallbackUrl` (i18n-agnóstico, clipboard + toast).
- Chaves i18n em en/pt-BR/pt (demais locales caem no fallback en).

### Fora de escopo (sinalizado)
- `components/integrations/forms/GoogleOAuthForm.tsx` tem o mesmo campo, mas é **código morto** (só exportado no barrel, nenhum render o usa — família do `useOAuthFlow` legado). Não tocado.

### Verificação
`tsc -b` limpo · ESLint limpo · SocialLoginConfig 19/19 · IntegrationsConfig 15/15 · validado na tela (preview vite do worktree).
