### PR TITLE
fix(agents): make Google Calendar & Sheets available in agent integrations

### DIFF
--- a/src/pages/Customer/Agents/Agent/sections/IntegrationsSection.tsx
+++ b/src/pages/Customer/Agents/Agent/sections/IntegrationsSection.tsx
@@ -104,7 +104,11 @@ const IntegrationsSection = ({
   // pelo administrador. Google Calendar / Sheets usam OAuth global e portanto
   // só ficam disponíveis quando o mapa `available` (endpoint de disponibilidade
   // do CRM) indica que o admin configurou as chaves correspondentes.
-  const ALWAYS_AVAILABLE_INTEGRATIONS = ['elevenlabs', 'knowledge-nexus'];
+  // Google Calendar / Sheets connect via per-agent OAuth (their own config
+  // dialogs), not a globally-configured client credential — so they are always
+  // available, like ElevenLabs (API key). Keeping them out of this list left them
+  // stuck on "NÃO DISPONÍVEL" despite the render logic already wiring their dialogs.
+  const ALWAYS_AVAILABLE_INTEGRATIONS = ['elevenlabs', 'knowledge-nexus', 'google-calendar', 'google-sheets'];
 
   const availableIntegrations: Integration[] = [
     {


### PR DESCRIPTION
## Google Calendar & Sheets ficavam "NÃO DISPONÍVEL" nas Integrações do Agente

**Bug:** na tela **Agente → Integrações**, Google Calendar e Google Sheets apareciam como "NÃO DISPONÍVEL".

`ALWAYS_AVAILABLE_INTEGRATIONS` só tinha `['elevenlabs', 'knowledge-nexus']`. Como Calendar/Sheets ficavam de fora, a disponibilidade caía em `credentialsConfigured[id]` — sempre `false` pra eles, porque conectam via **OAuth por-agente** (dialogs próprios), não por credencial global.

O render e os `onClick` já disparavam os dialogs certos (`GoogleCalendarConfigDialog`/`GoogleSheetsConfigDialog`), e o comentário inline já dizia que Calendar/Sheets *deveriam* ser sempre disponíveis — só a lista contradizia.

**Fix (1 linha):** adicionar `google-calendar` e `google-sheets` ao `ALWAYS_AVAILABLE_INTEGRATIONS`. Agora mostram **ATIVAR** (abre o dialog de OAuth por-agente), igual ao ElevenLabs.

**Verificação:** `tsc -b` limpo · ESLint limpo · validado na tela (preview vite do worktree, agente de teste).

## Summary by Sourcery

Bug Fixes:
- Fix Google Calendar and Google Sheets showing as unavailable in agent integrations by marking them as always available.