### PR TITLE
fix(agents,integrations): tabela lista-only + desaninha envelope do processor

### DIFF
--- a/src/components/agents/AgentsTable.tsx
+++ b/src/components/agents/AgentsTable.tsx
@@ -34,8 +34,12 @@ export default function AgentsTable({
   const getAgentTypeInfo = (type: string) => {
     const types: Record<string, { label: string; color: string }> = {
       llm: {
-        label: 'Agente LLM',
+        label: 'Nativo',
         color: 'bg-green-100 text-green-800 border-green-200 dark:bg-green-950 dark:text-green-500 dark:border-green-900',
+      },
+      external: {
+        label: 'Externo',
+        color: 'bg-blue-100 text-blue-800 border-blue-200 dark:bg-blue-900 dark:text-blue-200 dark:border-blue-700',
       },
       a2a: {
         label: 'A2A',
@@ -89,7 +93,10 @@ export default function AgentsTable({
       label: t('fields.name'),
       sortable: true,
       render: agent => (
-        <div className="flex items-center gap-3">
+        <div
+          className="flex items-center gap-3 cursor-pointer hover:opacity-80 py-2"
+          onClick={() => onEditAgent(agent)}
+        >
           <div className="flex-shrink-0">{getAgentTypeIcon(agent.type)}</div>
           <span className="font-medium">{agent.name}</span>
         </div>

--- a/src/services/core/agentProcessorApi.ts
+++ b/src/services/core/agentProcessorApi.ts
@@ -23,7 +23,25 @@ agentProcessorApi.interceptors.request.use(config => {
 
 // Interceptador para tratar respostas e erros
 agentProcessorApi.interceptors.response.use(
-  response => response,
+  response => {
+    // O processor envelopa TODA resposta como { success, data, meta } (success_response).
+    // Os services consomem `response.data` esperando o payload direto (ex.: { url },
+    // { config }), então o envelope faz `response.data.url` virar undefined ("não
+    // acontece nada" ao conectar OAuth). Desembrulhamos aqui, no limite de transporte.
+    // Defensivo: só desembrulha quando o shape é claramente o envelope (tem `success`
+    // e `data`); respostas não-envelopadas (arrays, downloads) passam intactas.
+    const body = response.data;
+    if (
+      body &&
+      typeof body === 'object' &&
+      !Array.isArray(body) &&
+      'success' in body &&
+      'data' in body
+    ) {
+      response.data = body.data;
+    }
+    return response;
+  },
   error => {
     const detail =
       error?.response?.data?.error?.message ||


### PR DESCRIPTION
## Mudanças

### AgentsTable (padrão lista)
- **Clique no nome abre o agente** (`onClick={() => onEditAgent(agent)}` + `cursor-pointer hover:opacity-80`), mesmo padrão do `ContactsTable`.
- Rótulo do tipo **`Agente LLM` → `Nativo`** e adicionado **`Externo`** (tipo `external`), batendo com o rename do wizard.

### agentProcessorApi (envelope)
- Interceptor de resposta que **desaninha o envelope** `{success, data, meta}` do processor. Os services fazem `return data` esperando o payload direto (ex.: `{ url }` no connect OAuth); com o envelope, `response.url` vinha `undefined` e o botão "Conectar" **não redirecionava** (sem erro). É o espelho, no front, do desaninhamento feito no processor.
- **Defensivo**: só desaninha quando o body tem `success` + `data` (respostas não-envelopadas passam intactas). Audit: 0 consumers de `agentProcessorApi` eram envelope-aware.

Par do PR do processor: evolution-foundation/evo-ai-processor-community#28