### PR TITLE
fix(integrations): normalize callback response envelope (Google Calendar/Sheets connect)

### DIFF
--- a/src/components/integrations/CallbackPage.tsx
+++ b/src/components/integrations/CallbackPage.tsx
@@ -80,9 +80,6 @@ export default function CallbackPage({ integrationName, onCallback, onSuccess, r
       // Pass empty strings if not found - callback can decode state itself if needed
       const response = await onCallback(code, state, agentIdFromState || '');
 
-      // TEMP debug: capture the runtime shape of the callback response.
-      console.log('[CB-DEBUG]', integrationName, 'success=', response?.success, 'keys=', response && Object.keys(response), 'raw=', JSON.stringify(response)?.slice(0, 160));
-
       if (response.success) {
         setStatus('success');
         const usernameText = response.username ? t('callback.success.username', { username: response.username }) : '';

--- a/src/components/integrations/CallbackPage.tsx
+++ b/src/components/integrations/CallbackPage.tsx
@@ -80,6 +80,9 @@ export default function CallbackPage({ integrationName, onCallback, onSuccess, r
       // Pass empty strings if not found - callback can decode state itself if needed
       const response = await onCallback(code, state, agentIdFromState || '');
 
+      // TEMP debug: capture the runtime shape of the callback response.
+      console.log('[CB-DEBUG]', integrationName, 'success=', response?.success, 'keys=', response && Object.keys(response), 'raw=', JSON.stringify(response)?.slice(0, 160));
+
       if (response.success) {
         setStatus('success');
         const usernameText = response.username ? t('callback.success.username', { username: response.username }) : '';

--- a/src/services/integrations/googleCalendarService.ts
+++ b/src/services/integrations/googleCalendarService.ts
@@ -40,9 +40,10 @@ const GoogleCalendarService = {
           state,
         }
       );
-      // Flatten the { success, data: {...} } envelope so callers read
-      // `.success` (CallbackPage) and `.email`/`.calendars` (onSuccess) directly.
-      return data?.data ? { success: data.success ?? true, ...data.data } : data;
+      // The callback may arrive wrapped ({ success, data: {...} }) or already
+      // flattened ({ email, calendars }). Normalize so callers always read
+      // `.success` (CallbackPage) and `.email`/`.calendars` (onSuccess).
+      return { success: data?.success ?? true, ...(data?.data ?? data ?? {}) };
     } catch (error) {
       console.error('GoogleCalendarService.completeAuthorization error:', error);
       throw error;

--- a/src/services/integrations/googleCalendarService.ts
+++ b/src/services/integrations/googleCalendarService.ts
@@ -40,7 +40,9 @@ const GoogleCalendarService = {
           state,
         }
       );
-      return data;
+      // Flatten the { success, data: {...} } envelope so callers read
+      // `.success` (CallbackPage) and `.email`/`.calendars` (onSuccess) directly.
+      return data?.data ? { success: data.success ?? true, ...data.data } : data;
     } catch (error) {
       console.error('GoogleCalendarService.completeAuthorization error:', error);
       throw error;

--- a/src/services/integrations/googleSheetsService.ts
+++ b/src/services/integrations/googleSheetsService.ts
@@ -40,7 +40,9 @@ const GoogleSheetsService = {
           state,
         }
       );
-      return data;
+      // Flatten the { success, data: {...} } envelope so callers read
+      // `.success` (CallbackPage) and `.email`/`.spreadsheets` (onSuccess) directly.
+      return data?.data ? { success: data.success ?? true, ...data.data } : data;
     } catch (error) {
       console.error('GoogleSheetsService.completeAuthorization error:', error);
       throw error;

--- a/src/services/integrations/googleSheetsService.ts
+++ b/src/services/integrations/googleSheetsService.ts
@@ -40,9 +40,10 @@ const GoogleSheetsService = {
           state,
         }
       );
-      // Flatten the { success, data: {...} } envelope so callers read
-      // `.success` (CallbackPage) and `.email`/`.spreadsheets` (onSuccess) directly.
-      return data?.data ? { success: data.success ?? true, ...data.data } : data;
+      // The callback may arrive wrapped ({ success, data: {...} }) or already
+      // flattened ({ email, spreadsheets }). Normalize so callers always read
+      // `.success` (CallbackPage) and `.email`/`.spreadsheets` (onSuccess).
+      return { success: data?.success ?? true, ...(data?.data ?? data ?? {}) };
     } catch (error) {
       console.error('GoogleSheetsService.completeAuthorization error:', error);
       throw error;


### PR DESCRIPTION
Flattens the completeAuthorization { success, data:{...} } envelope so CallbackPage reads .success and onSuccess reads email/spreadsheets|calendars directly. Fixes Google Sheets connect showing 'Erro ao conectar' despite a 200 success callback. Includes a TEMP [CB-DEBUG] console.log to capture the runtime response shape on staging — will be removed before merge.

## Summary by Sourcery

Flatten Google Sheets and Google Calendar authorization callback responses so callback handlers can read success and payload fields directly, and temporarily log the runtime callback response shape from CallbackPage for debugging.

Bug Fixes:
- Fix Google Sheets authorization flow incorrectly showing an error message despite a successful callback by aligning the response shape with CallbackPage expectations.

Enhancements:
- Align Google Calendar authorization callback response shape with the flattened structure expected by callback consumers.

Chores:
- Add a temporary debug log in CallbackPage to inspect the callback response structure at runtime.