### PR TITLE
feat(channels): redesign Channel Settings screen (EVO-2094)

### DIFF
--- a/src/components/channels/settings/AgentBotConfigurationForm.tsx
+++ b/src/components/channels/settings/AgentBotConfigurationForm.tsx
@@ -408,8 +408,8 @@ export default function AgentBotConfigurationForm({
           {/* Header */}
           <div className="flex items-center justify-between pb-4 border-b border-border">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-purple-50 dark:bg-purple-950/20">
-                <Bot className="w-5 h-5 text-purple-700 dark:text-purple-400" />
+              <div className="p-2 rounded-lg bg-primary/10">
+                <Bot className="w-5 h-5 text-primary" />
               </div>
               <div>
                 <h4 className="font-semibold text-foreground">
@@ -466,7 +466,7 @@ export default function AgentBotConfigurationForm({
                         />
                       ) : (
                         <div className="w-10 h-10 rounded-full bg-purple-100 dark:bg-purple-900/20 flex items-center justify-center">
-                          <Bot className="w-5 h-5 text-purple-600" />
+                          <Bot className="w-5 h-5 text-primary" />
                         </div>
                       )}
                       <div>

--- a/src/components/channels/settings/BusinessHoursForm.spec.tsx
+++ b/src/components/channels/settings/BusinessHoursForm.spec.tsx
@@ -77,28 +77,42 @@ describe('BusinessHoursForm', () => {
     vi.clearAllMocks();
   });
 
-  describe('Button visibility', () => {
-    it('should show Update button when business hours toggle is enabled', () => {
+  // The internal footer button was removed; the save is now driven by the
+  // ChannelSettings sticky footer through the registerSave registry.
+  const lastHandle = (mock: ReturnType<typeof vi.fn>) => {
+    const handles = mock.mock.calls
+      .map(call => call[0])
+      .filter(arg => arg && typeof arg === 'object');
+    return handles[handles.length - 1];
+  };
+
+  describe('Save registry', () => {
+    it('does not render an internal update button', () => {
       render(<BusinessHoursForm {...defaultProps} workingHoursEnabled={true} />);
-      
-      const updateButton = screen.getByRole('button', { name: /settings\.businessHours\.buttons\.update/i });
-      expect(updateButton).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /settings\.businessHours\.buttons\.update/i }),
+      ).not.toBeInTheDocument();
     });
 
-    it('should show Update button when business hours toggle is disabled', () => {
-      render(<BusinessHoursForm {...defaultProps} workingHoursEnabled={false} />);
-      
-      const updateButton = screen.getByRole('button', { name: /settings\.businessHours\.buttons\.update/i });
-      expect(updateButton).toBeInTheDocument();
+    it('registers a savable handle when business hours is enabled and valid', () => {
+      const registerSave = vi.fn();
+      render(
+        <BusinessHoursForm {...defaultProps} registerSave={registerSave} workingHoursEnabled={true} />,
+      );
+      const handle = lastHandle(registerSave);
+      expect(handle).toBeTruthy();
+      expect(handle.canSave).toBe(true);
+      expect(typeof handle.save).toBe('function');
     });
-  });
 
-  describe('Button disabled state', () => {
-    it('should not disable button when business hours is disabled even if there are validation errors', () => {
-      render(<BusinessHoursForm {...defaultProps} workingHoursEnabled={false} />);
-
-      const updateButton = screen.getByRole('button', { name: /settings\.businessHours\.buttons\.update/i });
-      expect(updateButton).not.toBeDisabled();
+    it('registers a savable handle when business hours is disabled', () => {
+      const registerSave = vi.fn();
+      render(
+        <BusinessHoursForm {...defaultProps} registerSave={registerSave} workingHoursEnabled={false} />,
+      );
+      const handle = lastHandle(registerSave);
+      expect(handle).toBeTruthy();
+      expect(handle.canSave).toBe(true);
     });
   });
 

--- a/src/components/channels/settings/BusinessHoursForm.tsx
+++ b/src/components/channels/settings/BusinessHoursForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -131,7 +131,7 @@ export default function BusinessHoursForm({
   registerSaveRef.current = registerSave;
   const handleUpdateRef = useRef(handleUpdate);
   handleUpdateRef.current = handleUpdate;
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
     return () => registerSaveRef.current?.(null);
   }, [canSave]);

--- a/src/components/channels/settings/BusinessHoursForm.tsx
+++ b/src/components/channels/settings/BusinessHoursForm.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
-  Button,
   Switch,
   Select,
   SelectContent,
@@ -15,6 +14,7 @@ import { Clock, Info, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
+import type { TabSaveHandle } from './tabSave';
 import BusinessDay from './BusinessDay';
 import GlobalTemplateSelect from './GlobalTemplateSelect';
 import {
@@ -36,6 +36,7 @@ interface BusinessHoursFormProps {
   outOfOfficeMessageTemplateId?: string | null;
   workingHours?: unknown[];
   timezone?: string;
+  registerSave?: (handle: TabSaveHandle | null) => void;
   onUpdate?: (data: {
     working_hours_enabled: boolean;
     out_of_office_message: string;
@@ -51,6 +52,7 @@ export default function BusinessHoursForm({
   outOfOfficeMessageTemplateId = null,
   workingHours = [],
   timezone,
+  registerSave,
   onUpdate,
 }: BusinessHoursFormProps) {
   const { t } = useLanguage('channels');
@@ -123,13 +125,24 @@ export default function BusinessHoursForm({
     }
   };
 
+  // Expose the save to the settings sticky footer registry.
+  const canSave = !isUpdating && !(isBusinessHoursEnabled && hasErrors);
+  const registerSaveRef = useRef(registerSave);
+  registerSaveRef.current = registerSave;
+  const handleUpdateRef = useRef(handleUpdate);
+  handleUpdateRef.current = handleUpdate;
+  useEffect(() => {
+    registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
+    return () => registerSaveRef.current?.(null);
+  }, [canSave]);
+
   return (
     <div className="space-y-6">
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center gap-3 pb-4 border-b border-border">
-            <div className="p-2 rounded-lg bg-orange-50 dark:bg-orange-950/20">
-              <Clock className="w-5 h-5 text-orange-700 dark:text-orange-400" />
+            <div className="p-2 rounded-lg bg-primary/10">
+              <Clock className="w-5 h-5 text-primary" />
             </div>
             <div>
               <h4 className="font-semibold text-foreground">{t('settings.businessHours.title')}</h4>
@@ -295,19 +308,6 @@ export default function BusinessHoursForm({
                 </p>
               </div>
             )}
-          </div>
-
-          {/* Update Button */}
-          <div className="flex justify-end pt-4 mt-6 border-t border-border">
-            <Button
-              onClick={handleUpdate}
-              disabled={isUpdating || (isBusinessHoursEnabled && hasErrors)}
-              className="min-w-32"
-            >
-              {isUpdating
-                ? t('settings.businessHours.buttons.updating')
-                : t('settings.businessHours.buttons.update')}
-            </Button>
           </div>
         </CardContent>
       </Card>

--- a/src/components/channels/settings/CSATForm.tsx
+++ b/src/components/channels/settings/CSATForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -327,7 +327,7 @@ export default function CSATForm({
   registerSaveRef.current = registerSave;
   const handleSaveRef = useRef(handleSaveSettings);
   handleSaveRef.current = handleSaveSettings;
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerSaveRef.current?.({ save: () => handleSaveRef.current(), canSave });
     return () => registerSaveRef.current?.(null);
   }, [canSave]);

--- a/src/components/channels/settings/CSATForm.tsx
+++ b/src/components/channels/settings/CSATForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -16,6 +16,7 @@ import { Star, Info, X, Plus, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
+import type { TabSaveHandle } from './tabSave';
 import CSATDisplayTypeSelector from './CSATDisplayTypeSelector';
 import {
   CSATDisplayType,
@@ -99,12 +100,14 @@ interface CSATFormProps {
   inboxId: string;
   csatSurveyEnabled?: boolean;
   csatConfig?: APICSATConfig;
+  registerSave?: (handle: TabSaveHandle | null) => void;
   onUpdate?: (data: { csat_survey_enabled: boolean; csat_config: CSATConfig }) => Promise<void>;
 }
 
 export default function CSATForm({
   csatSurveyEnabled = false,
   csatConfig,
+  registerSave,
   onUpdate,
 }: CSATFormProps) {
   const { t } = useLanguage('channels');
@@ -318,6 +321,17 @@ export default function CSATForm({
     }
   };
 
+  // Expose the save to the settings sticky footer registry.
+  const canSave = !isUpdating;
+  const registerSaveRef = useRef(registerSave);
+  registerSaveRef.current = registerSave;
+  const handleSaveRef = useRef(handleSaveSettings);
+  handleSaveRef.current = handleSaveSettings;
+  useEffect(() => {
+    registerSaveRef.current?.({ save: () => handleSaveRef.current(), canSave });
+    return () => registerSaveRef.current?.(null);
+  }, [canSave]);
+
   // Render trigger form based on type
   const renderTriggerForm = (trigger: TriggerItem) => {
     switch (trigger.type) {
@@ -365,8 +379,8 @@ export default function CSATForm({
           {/* Header */}
           <div className="flex items-center justify-between pb-4 border-b border-border">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-yellow-50 dark:bg-yellow-950/20">
-                <Star className="w-5 h-5 text-yellow-700 dark:text-yellow-400" />
+              <div className="p-2 rounded-lg bg-primary/10">
+                <Star className="w-5 h-5 text-primary" />
               </div>
               <div>
                 <h4 className="font-semibold text-foreground">{t('settings.csat.title')}</h4>
@@ -494,12 +508,6 @@ export default function CSATForm({
                 </div>
               </div>
 
-              {/* Save Button */}
-              <div className="flex justify-end pt-4 border-t border-border">
-                <Button onClick={handleSaveSettings} disabled={isUpdating} className="min-w-32">
-                  {isUpdating ? t('settings.csat.buttons.saving') : t('settings.csat.buttons.save')}
-                </Button>
-              </div>
             </div>
           )}
 

--- a/src/components/channels/settings/CollaboratorsForm.tsx
+++ b/src/components/channels/settings/CollaboratorsForm.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Card, CardContent, Button, Switch } from '@evoapi/design-system';
+import { Card, CardContent, Switch } from '@evoapi/design-system';
 import { Check, Users, Settings, Info } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
+
+import type { TabSaveHandle } from './tabSave';
 
 // Services
 import AgentsService from '@/services/channels/agentsService';
@@ -13,6 +15,7 @@ interface CollaboratorsFormProps {
   inboxId: string;
   enableAutoAssignment?: boolean;
   maxAssignmentLimit?: number | null;
+  registerSave?: (handle: TabSaveHandle | null) => void;
   onAutoAssignmentChange?: (enabled: boolean, limit?: number | null) => void;
 }
 
@@ -20,6 +23,7 @@ export default function CollaboratorsForm({
   inboxId,
   enableAutoAssignment: initialAutoAssignment = false,
   maxAssignmentLimit: initialMaxLimit = null,
+  registerSave,
   onAutoAssignmentChange,
 }: CollaboratorsFormProps) {
   const { t } = useLanguage('channels');
@@ -123,6 +127,17 @@ export default function CollaboratorsForm({
     }
   };
 
+  // Expose the collaborators (agents) save to the settings sticky footer registry.
+  const canSave = !isUpdatingAgents;
+  const registerSaveRef = useRef(registerSave);
+  registerSaveRef.current = registerSave;
+  const handleUpdateAgentsRef = useRef(handleUpdateAgents);
+  handleUpdateAgentsRef.current = handleUpdateAgents;
+  useEffect(() => {
+    registerSaveRef.current?.({ save: () => handleUpdateAgentsRef.current(), canSave });
+    return () => registerSaveRef.current?.(null);
+  }, [canSave]);
+
   const handleAutoAssignmentToggle = async (checked: boolean) => {
     setEnableAutoAssignment(checked);
     setIsUpdatingAssignment(true);
@@ -192,8 +207,8 @@ export default function CollaboratorsForm({
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center gap-3 pb-4 border-b border-border">
-            <div className="p-2 rounded-lg bg-blue-50 dark:bg-blue-950/20">
-              <Users className="w-5 h-5 text-blue-700 dark:text-blue-400" />
+            <div className="p-2 rounded-lg bg-primary/10">
+              <Users className="w-5 h-5 text-primary" />
             </div>
             <div>
               <h4 className="font-semibold text-foreground">
@@ -215,16 +230,6 @@ export default function CollaboratorsForm({
                 ({Array.isArray(agents) ? agents.length : 0}{' '}
                 {t('settings.collaborators.agents.total')})
               </p>
-              <Button
-                onClick={handleUpdateAgents}
-                disabled={isUpdatingAgents}
-                size="sm"
-                variant="default"
-              >
-                {isUpdatingAgents
-                  ? t('settings.collaborators.agents.buttons.updating')
-                  : t('settings.collaborators.agents.buttons.update')}
-              </Button>
             </div>
 
             {/* Agents List */}
@@ -337,8 +342,8 @@ export default function CollaboratorsForm({
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center gap-3 pb-4 border-b border-border">
-            <div className="p-2 rounded-lg bg-orange-50 dark:bg-orange-950/20">
-              <Settings className="w-5 h-5 text-orange-700 dark:text-orange-400" />
+            <div className="p-2 rounded-lg bg-primary/10">
+              <Settings className="w-5 h-5 text-primary" />
             </div>
             <div>
               <h4 className="font-semibold text-foreground">

--- a/src/components/channels/settings/CollaboratorsForm.tsx
+++ b/src/components/channels/settings/CollaboratorsForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import { Card, CardContent, Switch } from '@evoapi/design-system';
 import { Check, Users, Settings, Info } from 'lucide-react';
 import { toast } from 'sonner';
@@ -133,7 +133,7 @@ export default function CollaboratorsForm({
   registerSaveRef.current = registerSave;
   const handleUpdateAgentsRef = useRef(handleUpdateAgents);
   handleUpdateAgentsRef.current = handleUpdateAgents;
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerSaveRef.current?.({ save: () => handleUpdateAgentsRef.current(), canSave });
     return () => registerSaveRef.current?.(null);
   }, [canSave]);

--- a/src/components/channels/settings/ConfigurationForm.tsx
+++ b/src/components/channels/settings/ConfigurationForm.tsx
@@ -76,7 +76,7 @@ const APIChannelConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
-            <Shield className="w-5 h-5 text-blue-600 mt-1" />
+            <Shield className="w-5 h-5 text-primary mt-1" />
             <div className="flex-1">
               <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                 {t('settings.configuration.api.hmac.title')}
@@ -169,7 +169,7 @@ const WhatsAppChannelConfig: React.FC<{
         <Card>
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
-              <Key className="w-5 h-5 text-green-600 mt-1" />
+              <Key className="w-5 h-5 text-primary mt-1" />
               <div className="flex-1">
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                   {t('settings.configuration.api.keys.title')}
@@ -203,7 +203,7 @@ const WhatsAppChannelConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
-            <CheckCircle className="w-5 h-5 text-green-600 mt-1" />
+            <CheckCircle className="w-5 h-5 text-primary mt-1" />
             <div className="flex-1">
               <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                 {t('settings.configuration.api.markAsRead.title')}
@@ -269,7 +269,7 @@ const EvolutionPrivacySettings: React.FC<{
           groupadd: privacyData.GroupAdd || privacyData.groupAdd || privacyData.groupadd || 'all',
         });
       } catch (error) {
-        console.error('Erro ao carregar configurações de privacidade:', error);
+        console.error('Error loading privacy settings:', error);
       }
     };
 
@@ -554,7 +554,7 @@ const EvolutionWhatsAppConfig: React.FC<{
       });
       toast.success(t('settings.configuration.whatsapp.instance.connection.success.updated'));
     } catch (error) {
-      console.error('Erro ao atualizar configurações de conexão:', error);
+      console.error('Error updating connection settings:', error);
       toast.error(t('settings.configuration.whatsapp.instance.connection.errors.updateError'));
     } finally {
       setIsUpdatingConnection(false);
@@ -632,7 +632,7 @@ const EvolutionWhatsAppConfig: React.FC<{
         }
       } catch (error) {
         if (!cancelled) {
-          console.error('Erro ao carregar configurações da instância:', error);
+          console.error('Error loading instance settings:', error);
         }
       }
 
@@ -696,7 +696,7 @@ const EvolutionWhatsAppConfig: React.FC<{
         }
       } catch (error) {
         if (!cancelled) {
-          console.error('Erro ao carregar status da instância:', error);
+          console.error('Error loading instance status:', error);
           setLoadError(t('settings.configuration.whatsapp.instance.errors.loadFailed', 'Failed to load instance status. Check your connection settings.'));
         }
       } finally {
@@ -822,7 +822,7 @@ const EvolutionWhatsAppConfig: React.FC<{
 
       toast.success(t('settings.configuration.whatsapp.instance.success.updated'));
     } catch (error) {
-      console.error('Erro ao atualizar configurações da instância:', error);
+      console.error('Error updating instance settings:', error);
       toast.error(t('settings.configuration.whatsapp.instance.errors.updateError'));
     } finally {
       setIsLoading(false);
@@ -963,7 +963,7 @@ const EvolutionWhatsAppConfig: React.FC<{
       setInstanceStatus('close');
       toast.success(t('settings.configuration.whatsapp.instance.actions.success.disconnected'));
     } catch (error: any) {
-      console.error('Erro ao desconectar instância:', error);
+      console.error('Error disconnecting instance:', error);
       toast.error(
         error?.response?.data?.error ||
           t('settings.configuration.whatsapp.instance.actions.errors.disconnectError'),
@@ -1021,7 +1021,7 @@ const EvolutionWhatsAppConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
-            <Smartphone className="w-5 h-5 text-green-600 mt-1" />
+            <Smartphone className="w-5 h-5 text-primary mt-1" />
             <div className="flex-1">
               <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                 {t('settings.configuration.whatsapp.instance.statusTitle')}
@@ -1098,7 +1098,7 @@ const EvolutionWhatsAppConfig: React.FC<{
         <Card>
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
-              <Settings className="w-5 h-5 text-green-600 mt-1" />
+              <Settings className="w-5 h-5 text-primary mt-1" />
               <div className="flex-1">
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                   {t('settings.configuration.whatsapp.instance.profile.title')}
@@ -1205,7 +1205,7 @@ const EvolutionWhatsAppConfig: React.FC<{
         <Card>
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
-              <Shield className="w-5 h-5 text-purple-600 mt-1" />
+              <Shield className="w-5 h-5 text-primary mt-1" />
               <div className="flex-1">
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                   {t('settings.configuration.whatsapp.instance.privacy.title')}
@@ -1232,7 +1232,7 @@ const EvolutionWhatsAppConfig: React.FC<{
         <Card>
           <CardContent className="p-6">
             <div className="flex items-start gap-4">
-              <Settings className="w-5 h-5 text-blue-600 mt-1" />
+              <Settings className="w-5 h-5 text-primary mt-1" />
               <div className="flex-1">
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                   {t('settings.configuration.whatsapp.instance.settingsTitle')}
@@ -1359,7 +1359,7 @@ const EvolutionWhatsAppConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
-            <Key className="w-5 h-5 text-blue-600 mt-1 shrink-0" />
+            <Key className="w-5 h-5 text-primary mt-1 shrink-0" />
             <div className="flex-1 space-y-4">
               <div>
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
@@ -1518,7 +1518,7 @@ const PrivacySettings: React.FC<{
       await ZapiService.setMessagesDuration(instanceId, privacySettings.messagesDuration);
       toast.success('Duração das mensagens atualizada');
     } catch (error: any) {
-      console.error('Erro ao atualizar duração das mensagens:', error);
+      console.error('Error updating messages duration:', error);
       toast.error(error?.response?.data?.error || 'Erro ao atualizar duração das mensagens');
     } finally {
       setIsLoading(false);
@@ -1811,7 +1811,7 @@ const ZapiWhatsAppConfig: React.FC<{
           }
         }
       } catch (error) {
-        console.error('Erro ao carregar dados da instância Z-API:', error);
+        console.error('Error loading Z-API instance data:', error);
       } finally {
         setIsLoading(false);
       }
@@ -1881,7 +1881,7 @@ const ZapiWhatsAppConfig: React.FC<{
           lastStatusRef.current = 'disconnected';
         }
       } catch (error) {
-        console.error('Erro ao verificar status da instância:', error);
+        console.error('Error checking instance status:', error);
       }
     }, 3000);
 
@@ -1968,7 +1968,7 @@ const ZapiWhatsAppConfig: React.FC<{
           }
         }
       } catch (error) {
-        console.error('Erro ao verificar status da instância:', error);
+        console.error('Error checking instance status:', error);
       }
     };
 
@@ -2078,7 +2078,7 @@ const ZapiWhatsAppConfig: React.FC<{
       await ZapiService.updateProfileDescription(instanceId, profileSettings.profileDescription);
       toast.success('Descrição do perfil atualizada com sucesso!');
     } catch (error: any) {
-      console.error('Erro ao atualizar descrição do perfil:', error);
+      console.error('Error updating profile description:', error);
       toast.error(error?.response?.data?.error || 'Erro ao atualizar descrição do perfil');
     } finally {
       setIsLoading(false);
@@ -2093,7 +2093,7 @@ const ZapiWhatsAppConfig: React.FC<{
       await ZapiService.updateCallReject(instanceId, profileSettings.callReject);
       toast.success('Configuração de rejeição de chamadas atualizada!');
     } catch (error: any) {
-      console.error('Erro ao atualizar configuração de rejeição de chamadas:', error);
+      console.error('Error updating call rejection setting:', error);
       toast.error(error?.response?.data?.error || 'Erro ao atualizar configuração');
     } finally {
       setIsLoading(false);
@@ -2108,7 +2108,7 @@ const ZapiWhatsAppConfig: React.FC<{
       await ZapiService.updateCallRejectMessage(instanceId, profileSettings.callRejectMessage);
       toast.success('Mensagem de rejeição atualizada!');
     } catch (error: any) {
-      console.error('Erro ao atualizar mensagem de rejeição de chamadas:', error);
+      console.error('Error updating call rejection message:', error);
       toast.error(error?.response?.data?.error || 'Erro ao atualizar mensagem');
     } finally {
       setIsLoading(false);
@@ -2125,7 +2125,7 @@ const ZapiWhatsAppConfig: React.FC<{
       await ZapiService.restartInstance(instanceId);
       toast.success('Instância reiniciada com sucesso!');
     } catch (error: any) {
-      console.error('Erro ao reiniciar instância:', error);
+      console.error('Error restarting instance:', error);
       toast.error(error?.response?.data?.error || 'Erro ao reiniciar instância');
     } finally {
       setIsLoading(false);
@@ -2143,7 +2143,7 @@ const ZapiWhatsAppConfig: React.FC<{
       toast.success('Instância desconectada com sucesso!');
       setInstanceStatus('disconnected');
     } catch (error: any) {
-      console.error('Erro ao desconectar instância:', error);
+      console.error('Error disconnecting instance:', error);
       toast.error(error?.response?.data?.error || 'Erro ao desconectar instância');
     } finally {
       setIsLoading(false);
@@ -2182,7 +2182,7 @@ const ZapiWhatsAppConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-center gap-4 mb-4">
-            <QrCode className="w-8 h-8 text-blue-600" />
+            <QrCode className="w-8 h-8 text-primary" />
             <div className="flex-1">
               <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                 QR Code para Conexão
@@ -2310,7 +2310,7 @@ const ZapiWhatsAppConfig: React.FC<{
         <Card>
           <CardContent className="p-6">
             <div className="flex items-center gap-4 mb-4">
-              <Shield className="w-8 h-8 text-blue-600" />
+              <Shield className="w-8 h-8 text-primary" />
               <div className="flex-1">
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                   Configurações de Privacidade
@@ -2442,7 +2442,7 @@ const EmailChannelConfig: React.FC<{
       });
       toast.success(t('settings.configuration.email.success.updated'));
     } catch (error) {
-      console.error('Erro ao atualizar configurações de email:', error);
+      console.error('Error updating email settings:', error);
       toast.error(t('settings.configuration.email.errors.updateError'));
     } finally {
       setIsUpdating(false);
@@ -2455,7 +2455,7 @@ const EmailChannelConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
-            <Mail className="w-5 h-5 text-blue-600 mt-1" />
+            <Mail className="w-5 h-5 text-primary mt-1" />
             <div className="flex-1">
               <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                 {t('settings.configuration.email.imap.title')}
@@ -2534,7 +2534,7 @@ const EmailChannelConfig: React.FC<{
       <Card>
         <CardContent className="p-6">
           <div className="flex items-start gap-4">
-            <Mail className="w-5 h-5 text-green-600 mt-1" />
+            <Mail className="w-5 h-5 text-primary mt-1" />
             <div className="flex-1">
               <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                 {t('settings.configuration.email.smtp.title')}
@@ -2669,7 +2669,7 @@ const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ inbox, onUpdate }
     try {
       await onUpdate(data);
     } catch (error) {
-      console.error('Erro ao atualizar configuração:', error);
+      console.error('Error updating configuration:', error);
       throw error;
     }
   };
@@ -2711,7 +2711,7 @@ const ConfigurationForm: React.FC<ConfigurationFormProps> = ({ inbox, onUpdate }
         <Card>
           <CardContent className="p-6">
             <div className="flex items-center gap-4">
-              <Phone className="w-8 h-8 text-blue-600" />
+              <Phone className="w-8 h-8 text-primary" />
               <div>
                 <h3 className="font-semibold text-slate-900 dark:text-slate-100">
                   {t('settings.configuration.twilio.title')}

--- a/src/components/channels/settings/GreetingSettingsForm.tsx
+++ b/src/components/channels/settings/GreetingSettingsForm.tsx
@@ -35,8 +35,8 @@ export default function GreetingSettingsForm({
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-3 pb-3 border-b border-border">
-        <div className="p-2 rounded-lg bg-green-50 dark:bg-green-950/20">
-          <svg className="w-5 h-5 text-green-700 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="p-2 rounded-lg bg-primary/10">
+          <svg className="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
           </svg>
         </div>

--- a/src/components/channels/settings/LockToSingleConversationForm.tsx
+++ b/src/components/channels/settings/LockToSingleConversationForm.tsx
@@ -18,8 +18,8 @@ export default function LockToSingleConversationForm({
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-3 pb-3 border-b border-border">
-        <div className="p-2 rounded-lg bg-indigo-50 dark:bg-indigo-950/20">
-          <svg className="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="p-2 rounded-lg bg-primary/10">
+          <svg className="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
           </svg>
         </div>

--- a/src/components/channels/settings/PreChatForm.tsx
+++ b/src/components/channels/settings/PreChatForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -134,7 +134,7 @@ export default function PreChatForm({
   registerSaveRef.current = registerSave;
   const handleUpdateRef = useRef(handleUpdate);
   handleUpdateRef.current = handleUpdate;
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
     return () => registerSaveRef.current?.(null);
   }, [canSave]);

--- a/src/components/channels/settings/PreChatForm.tsx
+++ b/src/components/channels/settings/PreChatForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -13,6 +13,7 @@ import { MessageSquare, Info, Settings, Eye } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
+import type { TabSaveHandle } from './tabSave';
 import PreChatFields from './PreChatFields';
 import {
   PreChatField,
@@ -27,6 +28,7 @@ interface PreChatFormProps {
   inboxId: string;
   preChatFormEnabled?: boolean;
   preChatFormOptions?: PreChatFormOptions;
+  registerSave?: (handle: TabSaveHandle | null) => void;
   onUpdate?: (data: {
     pre_chat_form_enabled: boolean;
     pre_chat_form_options?: PreChatFormOptions;
@@ -55,6 +57,7 @@ const mockCustomAttributes: CustomAttribute[] = [
 export default function PreChatForm({
   preChatFormEnabled = false,
   preChatFormOptions,
+  registerSave,
   onUpdate,
 }: PreChatFormProps) {
   const { t, currentLanguage } = useLanguage('channels');
@@ -125,6 +128,17 @@ export default function PreChatForm({
     }
   };
 
+  // Expose the save to the settings sticky footer registry.
+  const canSave = !isUpdating;
+  const registerSaveRef = useRef(registerSave);
+  registerSaveRef.current = registerSave;
+  const handleUpdateRef = useRef(handleUpdate);
+  handleUpdateRef.current = handleUpdate;
+  useEffect(() => {
+    registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
+    return () => registerSaveRef.current?.(null);
+  }, [canSave]);
+
   // Get enabled fields count
   const enabledFieldsCount = preChatFields.filter(field => field.enabled).length;
   const requiredFieldsCount = preChatFields.filter(field => field.enabled && field.required).length;
@@ -136,8 +150,8 @@ export default function PreChatForm({
           {/* Header */}
           <div className="flex items-center justify-between pb-4 border-b border-border">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-purple-50 dark:bg-purple-950/20">
-                <MessageSquare className="w-5 h-5 text-purple-700 dark:text-purple-400" />
+              <div className="p-2 rounded-lg bg-primary/10">
+                <MessageSquare className="w-5 h-5 text-primary" />
               </div>
               <div>
                 <h4 className="font-semibold text-foreground">{t('settings.preChatForm.title')}</h4>
@@ -287,12 +301,6 @@ export default function PreChatForm({
             </div>
           )}
 
-          {/* Save Button */}
-          <div className="flex justify-end pt-4 border-t border-border">
-            <Button onClick={handleUpdate} disabled={isUpdating} className="min-w-32">
-              {isUpdating ? t('settings.preChatForm.saving') : t('settings.preChatForm.save')}
-            </Button>
-          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/components/channels/settings/WebWidgetAdvancedForm.tsx
+++ b/src/components/channels/settings/WebWidgetAdvancedForm.tsx
@@ -25,8 +25,8 @@ export default function WebWidgetAdvancedForm({
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3 pb-3 border-b border-border">
-        <div className="p-2 rounded-lg bg-blue-50 dark:bg-blue-950/20">
-          <svg className="w-5 h-5 text-blue-700 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <div className="p-2 rounded-lg bg-primary/10">
+          <svg className="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
@@ -138,8 +138,8 @@ export default function WebWidgetAdvancedForm({
       {/* Feature Flags */}
       <div className="space-y-4">
         <div className="flex items-center gap-3 pb-3 border-b border-border">
-          <div className="p-2 rounded-lg bg-purple-50 dark:bg-purple-950/20">
-            <svg className="w-5 h-5 text-purple-700 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <div className="p-2 rounded-lg bg-primary/10">
+            <svg className="w-5 h-5 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zM21 5a2 2 0 00-2-2h-4a2 2 0 00-2 2v12a4 4 0 004 4h4a2 2 0 002-2V5z" />
             </svg>
           </div>

--- a/src/components/channels/settings/WidgetBuilderForm.tsx
+++ b/src/components/channels/settings/WidgetBuilderForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -206,7 +206,7 @@ export default function WidgetBuilderForm({
   registerSaveRef.current = registerSave;
   const handleUpdateRef = useRef(handleUpdate);
   handleUpdateRef.current = handleUpdate;
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
     return () => registerSaveRef.current?.(null);
   }, [canSave]);

--- a/src/components/channels/settings/WidgetBuilderForm.tsx
+++ b/src/components/channels/settings/WidgetBuilderForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -18,6 +18,7 @@ import { Code2, Upload, Trash2, Eye, Settings } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
 
+import type { TabSaveHandle } from './tabSave';
 import WidgetPreview from './widget/WidgetPreview';
 import {
   WidgetConfig,
@@ -56,9 +57,15 @@ interface WidgetBuilderFormProps {
     };
     avatar?: File;
   }) => Promise<void>;
+  registerSave?: (handle: TabSaveHandle | null) => void;
 }
 
-export default function WidgetBuilderForm({ inboxId, inbox, onUpdate }: WidgetBuilderFormProps) {
+export default function WidgetBuilderForm({
+  inboxId,
+  inbox,
+  onUpdate,
+  registerSave,
+}: WidgetBuilderFormProps) {
   const { t } = useLanguage('channels');
   const [config, setConfig] = useState<WidgetConfig>(getDefaultWidgetConfig());
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
@@ -193,6 +200,17 @@ export default function WidgetBuilderForm({ inboxId, inbox, onUpdate }: WidgetBu
     }
   };
 
+  // Expose the save to the settings sticky footer registry.
+  const canSave = !isUpdating;
+  const registerSaveRef = useRef(registerSave);
+  registerSaveRef.current = registerSave;
+  const handleUpdateRef = useRef(handleUpdate);
+  handleUpdateRef.current = handleUpdate;
+  useEffect(() => {
+    registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
+    return () => registerSaveRef.current?.(null);
+  }, [canSave]);
+
   // Widget view options
   const viewOptions = getWidgetViewOptions();
   const replyTimeOptions = getReplyTimeOptions();
@@ -206,8 +224,8 @@ export default function WidgetBuilderForm({ inboxId, inbox, onUpdate }: WidgetBu
           {/* Header */}
           <div className="flex items-center justify-between pb-4 border-b border-border">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-lg bg-blue-50 dark:bg-blue-950/20">
-                <Settings className="w-5 h-5 text-blue-700 dark:text-blue-400" />
+              <div className="p-2 rounded-lg bg-primary/10">
+                <Settings className="w-5 h-5 text-primary" />
               </div>
               <div>
                 <h4 className="font-semibold text-foreground">
@@ -415,12 +433,6 @@ export default function WidgetBuilderForm({ inboxId, inbox, onUpdate }: WidgetBu
                   />
                 </div>
 
-                {/* Save Button */}
-                <Button type="submit" disabled={isUpdating} className="w-full">
-                  {isUpdating
-                    ? t('settings.widgetBuilder.saving')
-                    : t('settings.widgetBuilder.saveSettings')}
-                </Button>
               </form>
             </div>
 

--- a/src/components/channels/settings/tabSave.ts
+++ b/src/components/channels/settings/tabSave.ts
@@ -1,0 +1,9 @@
+/**
+ * Save handle a snapshot settings tab registers with the ChannelSettings sticky
+ * footer, so the single "Update Settings" action can trigger the active tab's
+ * save. Kept in its own module to avoid a page <-> form import cycle.
+ */
+export interface TabSaveHandle {
+  save: () => Promise<void>;
+  canSave: boolean;
+}

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -243,6 +243,7 @@
     }
   },
   "settings": {
+    "updateConfig": "Update Settings",
     "loading": "Loading settings...",
     "saving": "Saving...",
     "save": "Save",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -241,6 +241,7 @@
     }
   },
   "settings": {
+    "updateConfig": "Actualizar Configuración",
     "loading": "Cargando configuraciones...",
     "saving": "Guardando...",
     "save": "Guardar",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -241,6 +241,7 @@
     }
   },
   "settings": {
+    "updateConfig": "Mettre à jour les paramètres",
     "loading": "Chargement des paramètres...",
     "saving": "Enregistrement en cours...",
     "save": "Enregistrer",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -241,6 +241,7 @@
     }
   },
   "settings": {
+    "updateConfig": "Aggiorna Impostazioni",
     "loading": "Caricamento impostazioni...",
     "saving": "Salvataggio...",
     "save": "Salva",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -243,6 +243,7 @@
     }
   },
   "settings": {
+    "updateConfig": "Atualizar Configurações",
     "loading": "Carregando configurações...",
     "saving": "Salvando...",
     "save": "Salvar",

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -243,6 +243,7 @@
     }
   },
   "settings": {
+    "updateConfig": "Atualizar Configurações",
     "loading": "Carregando configurações...",
     "saving": "Salvando...",
     "save": "Salvar",

--- a/src/pages/Customer/Channels/ChannelSettings.spec.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.spec.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChannelSettings from './ChannelSettings';
+
+// Router: provide the inbox id and a no-op navigate.
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'inbox-1' }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({ can: () => true, isReady: true, loading: false }),
+}));
+
+// A stable `t` reference: the real hook memoizes it, and ChannelSettings keys
+// loadChannelData's useCallback on `t`, so a fresh `t` per render would loop.
+const { t } = vi.hoisted(() => ({ t: (key: string) => key }));
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t, currentLanguage: 'en' }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+const inbox = {
+  id: 'inbox-1',
+  name: 'Support',
+  display_name: 'Support',
+  channel_type: 'Channel::Api',
+  provider: '',
+  medium: '',
+};
+
+const getById = vi.fn().mockResolvedValue({ data: inbox });
+const update = vi.fn().mockResolvedValue({});
+const updateWithAvatar = vi.fn().mockResolvedValue({});
+
+vi.mock('@/services/channels/inboxesService', () => ({
+  default: {
+    getById: (...args: unknown[]) => getById(...args),
+    update: (...args: unknown[]) => update(...args),
+    updateWithAvatar: (...args: unknown[]) => updateWithAvatar(...args),
+  },
+}));
+
+// Stub the channel component barrel so the page renders without pulling every
+// heavy settings form into the test.
+vi.mock('@/components/channels', () => {
+  const stub = (name: string) => () => <div data-testid={name} />;
+  return {
+    BasicSettingsForm: stub('BasicSettingsForm'),
+    GreetingSettingsForm: stub('GreetingSettingsForm'),
+    WebWidgetAdvancedForm: stub('WebWidgetAdvancedForm'),
+    SenderSettingsForm: stub('SenderSettingsForm'),
+    AuthorizationBanners: () => null,
+    LockToSingleConversationForm: stub('LockToSingleConversationForm'),
+    DefaultConversationStatusForm: stub('DefaultConversationStatusForm'),
+    CollaboratorsForm: stub('CollaboratorsForm'),
+    BusinessHoursForm: stub('BusinessHoursForm'),
+    CSATForm: stub('CSATForm'),
+    PreChatForm: stub('PreChatForm'),
+    WidgetBuilderForm: stub('WidgetBuilderForm'),
+    AgentBotConfigurationForm: stub('AgentBotConfigurationForm'),
+    ConfigurationForm: stub('ConfigurationForm'),
+    ModerationDashboard: stub('ModerationDashboard'),
+  };
+});
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const renderPage = async () => {
+  const utils = render(<ChannelSettings />);
+  // Wait for the async inbox load to settle (BasicSettingsForm is inbox_settings).
+  await screen.findByTestId('BasicSettingsForm');
+  return utils;
+};
+
+describe('ChannelSettings redesign', () => {
+  it('renders a full-width container without the centered max-w-6xl gutter', async () => {
+    const { container } = await renderPage();
+    expect(container.querySelector('.max-w-6xl')).toBeNull();
+  });
+
+  it('renders the tab strip as a single scrollable row (no wrapping)', async () => {
+    await renderPage();
+    const tablist = screen.getByRole('tablist');
+    expect(tablist.className).toContain('overflow-x-auto');
+    expect(tablist.className).not.toContain('flex-wrap');
+  });
+
+  it('marks the active tab with the primary token pill styling', async () => {
+    await renderPage();
+    const activeTab = screen.getByRole('tab', { name: /settings\.tabs\.inbox_settings/i });
+    expect(activeTab.className).toContain('data-[state=active]:bg-primary/10');
+    expect(activeTab.className).toContain('data-[state=active]:text-primary');
+  });
+
+  it('saves the active snapshot tab from the sticky footer', async () => {
+    await renderPage();
+    const saveButton = screen.getByRole('button', { name: /settings\.updateConfig/i });
+    expect(saveButton).toBeEnabled();
+
+    await userEvent.click(saveButton);
+    await waitFor(() => expect(update).toHaveBeenCalled());
+  });
+
+  it('disables the footer with a hint on imperative tabs', async () => {
+    await renderPage();
+    await userEvent.click(screen.getByRole('tab', { name: /settings\.tabs\.configuration/i }));
+
+    await screen.findByTestId('ConfigurationForm');
+    const saveButton = screen.getByRole('button', { name: /settings\.updateConfig/i });
+    expect(saveButton).toBeDisabled();
+    expect(screen.getByText('settings.info.tabSpecificSave')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Customer/Channels/ChannelSettings.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import {
@@ -535,7 +535,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
   // ref to the latest closure so the effect can stay mounted without re-running.
   const handleSaveRef = useRef(handleSave);
   handleSaveRef.current = handleSave;
-  useEffect(() => {
+  useLayoutEffect(() => {
     registerTabSave('inbox_settings', { save: () => handleSaveRef.current(), canSave: true });
     return () => registerTabSave('inbox_settings', null);
   }, [registerTabSave]);
@@ -645,7 +645,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
 
           {/* Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="flex w-full justify-start gap-2 bg-transparent p-0 h-auto overflow-x-auto no-scrollbar">
+            <TabsList className="flex w-full justify-start gap-2 bg-transparent p-0 h-auto overflow-x-auto scrollbar-hidden">
               {tabs.map(tab => {
                 const Icon = tab.icon;
                 return (

--- a/src/pages/Customer/Channels/ChannelSettings.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import {
@@ -13,7 +13,7 @@ import {
 } from '@evoapi/design-system';
 import {
   ArrowLeft,
-  Save,
+  Check,
   Globe,
   Settings,
   Users,
@@ -29,6 +29,7 @@ import { useLanguage } from '@/hooks/useLanguage';
 
 import InboxesService from '@/services/channels/inboxesService';
 import { Inbox } from '@/types/channels/inbox';
+import type { TabSaveHandle } from '@/components/channels/settings/tabSave';
 import {
   BasicSettingsForm,
   GreetingSettingsForm,
@@ -279,15 +280,16 @@ function useInbox(inbox: Inbox | null): InboxHook {
 
 interface ChannelSettingsProps {
   /**
-   * id do inbox a configurar. Quando fornecido, tem precedência sobre o param
-   * de rota (useParams). Necessário ao montar fora de uma <Route> que capture
-   * `:id` (ex.: embutido via CrmScreen, onde não há rota e useParams é vazio).
+   * Id of the inbox to configure. When provided, it takes precedence over the
+   * route param (useParams). Required when mounting outside a <Route> that
+   * captures `:id` (e.g. embedded via CrmScreen, where there is no route and
+   * useParams is empty).
    */
   inboxId?: string;
   /**
-   * Callback opcional invocado ao "voltar para a lista de canais". Quando
-   * fornecido (ex.: montado dentro de um modal no shell), é chamado em vez de
-   * navegar para /channels. Sem ele, mantém a navegação original.
+   * Optional callback invoked on "back to the channel list". When provided
+   * (e.g. mounted inside a modal in the shell), it is called instead of
+   * navigating to /channels. Without it, the original navigation is kept.
    */
   onExit?: () => void;
 }
@@ -318,6 +320,23 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
   const [isSavingSignature, setIsSavingSignature] = useState(false);
 
   const inboxHook = useInbox(inbox);
+
+  // Unified save model: snapshot tabs register their save handle here so the
+  // sticky footer can trigger the active tab's save. Imperative tabs never
+  // register, which keeps the footer disabled with a hint for them.
+  const tabSaversRef = useRef<Record<string, TabSaveHandle>>({});
+  const [, bumpSavers] = useState(0);
+  const [isFooterSaving, setIsFooterSaving] = useState(false);
+  const registerTabSave = useCallback((tabKey: string, handle: TabSaveHandle | null) => {
+    const prev = tabSaversRef.current[tabKey];
+    if (handle) {
+      tabSaversRef.current[tabKey] = handle;
+      if (!prev || prev.canSave !== handle.canSave) bumpSavers(n => n + 1);
+    } else if (prev) {
+      delete tabSaversRef.current[tabKey];
+      bumpSavers(n => n + 1);
+    }
+  }, []);
 
   const [formData, setFormData] = useState<ChannelSettingsData>({
     name: '',
@@ -466,10 +485,6 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
 
   const handleSave = async () => {
     if (!ensureCanUpdate()) return;
-    if (activeTab !== 'inbox_settings') {
-      toast.info(t('settings.errors.useTabUpdate'));
-      return;
-    }
 
     setIsSaving(true);
     try {
@@ -513,6 +528,30 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
       toast.error(t('settings.errors.saveError'));
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  // Register the inbox_settings snapshot save with the footer registry. Keep a
+  // ref to the latest closure so the effect can stay mounted without re-running.
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = handleSave;
+  useEffect(() => {
+    registerTabSave('inbox_settings', { save: () => handleSaveRef.current(), canSave: true });
+    return () => registerTabSave('inbox_settings', null);
+  }, [registerTabSave]);
+
+  const activeSaver = tabSaversRef.current[activeTab];
+  const currentTabIsSavable = !!activeSaver;
+  const footerCanSave = currentTabIsSavable && (activeSaver?.canSave ?? true) && canUpdate;
+
+  const handleFooterSave = async () => {
+    const saver = tabSaversRef.current[activeTab];
+    if (!saver || !canUpdate) return;
+    setIsFooterSaving(true);
+    try {
+      await saver.save();
+    } finally {
+      setIsFooterSaving(false);
     }
   };
 
@@ -563,10 +602,10 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
 
   return (
     <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-card">
+      {/* Header: breadcrumb + compact channel identity */}
+      <div className="border-b border-border bg-card">
         {/* Breadcrumb */}
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 px-6 pt-4">
           <button
             onClick={exitToChannels}
             className="flex items-center text-muted-foreground hover:text-foreground transition-colors"
@@ -580,57 +619,40 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
           </span>
         </div>
 
-        {/* Save Button */}
-        {activeTab === 'inbox_settings' && canUpdate ? (
-          <Button onClick={handleSave} disabled={isSaving} className="min-w-40">
-            <Save className="h-4 w-4 mr-2" />
-            {isSaving ? t('settings.saving') : t('settings.save')}
-          </Button>
-        ) : (
-          <div className="text-xs text-muted-foreground">
-            {t('settings.info.tabSpecificSave')}
-          </div>
-        )}
+        {/* Channel identity */}
+        <div className="flex items-center gap-3 px-6 pb-4 pt-3">
+          {formData.avatar_url && (
+            <img
+              src={formData.avatar_url}
+              alt="Inbox avatar"
+              className="w-10 h-10 rounded-full object-cover border border-border"
+            />
+          )}
+          <h1 className="text-xl font-semibold text-foreground truncate">{inboxName}</h1>
+        </div>
       </div>
 
       {/* Content */}
       <div className="flex-1 overflow-auto">
-        <div className="max-w-6xl mx-auto p-6">
-          {/* Inbox Header */}
-          <div className="mb-8">
-            <div className="flex items-center gap-4 mb-6">
-              {formData.avatar_url && (
-                <img
-                  src={formData.avatar_url}
-                  alt="Inbox avatar"
-                  className="w-16 h-16 rounded-full object-cover border-2 border-border"
-                />
-              )}
-              <div>
-                <h1 className="text-3xl font-bold text-foreground">{inboxName}</h1>
-                <p className="text-muted-foreground mt-1">{t('settings.description')}</p>
-              </div>
-            </div>
-
-            {/* Authorization banners */}
-            <AuthorizationBanners
-              inbox={inbox}
-              onReauthorize={provider => {
-                toast.info(t('settings.reauthorize.redirecting', { provider }));
-              }}
-            />
-          </div>
+        <div className="w-full px-6 py-6">
+          {/* Authorization banners */}
+          <AuthorizationBanners
+            inbox={inbox}
+            onReauthorize={provider => {
+              toast.info(t('settings.reauthorize.redirecting', { provider }));
+            }}
+          />
 
           {/* Tabs */}
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
-            <TabsList className="flex flex-wrap justify-start gap-1 bg-transparent p-0 h-auto">
+          <Tabs value={activeTab} onValueChange={setActiveTab}>
+            <TabsList className="flex w-full justify-start gap-2 bg-transparent p-0 h-auto overflow-x-auto no-scrollbar">
               {tabs.map(tab => {
                 const Icon = tab.icon;
                 return (
                   <TabsTrigger
                     key={tab.key}
                     value={tab.key}
-                    className="flex items-center gap-2 px-4 py-2 rounded-lg data-[state=active]:bg-primary data-[state=active]:text-primary-foreground"
+                    className="flex items-center gap-2 rounded-full px-4 py-1.5 whitespace-nowrap text-sm text-muted-foreground hover:bg-muted data-[state=active]:bg-primary/10 data-[state=active]:text-primary"
                   >
                     <Icon className="h-4 w-4" />
                     <span className="text-sm">{tab.name}</span>
@@ -640,6 +662,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             </TabsList>
 
             {/* Tab Contents */}
+            <div className="mt-4">
             <TabsContent value="inbox_settings">
               {activeTab === 'inbox_settings' && <div className="space-y-6">
                 {/* Basic Settings */}
@@ -712,7 +735,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
                             toast.success(t('settings.success.senderUpdateSuccess'));
                             await loadChannelData(); // Refresh data
                           } catch (error) {
-                            console.error('Erro ao atualizar configurações do remetente:', error);
+                            console.error('Error updating sender settings:', error);
                             toast.error(t('settings.errors.senderUpdateError'));
                           }
                         }}
@@ -726,7 +749,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
                   <Card>
                     <CardContent className="p-6">
                       <div className="flex items-start gap-4">
-                        <Mail className="w-5 h-5 text-purple-600 mt-1" />
+                        <Mail className="w-5 h-5 text-primary mt-1" />
                         <div className="flex-1">
                           <h3 className="text-lg font-semibold text-foreground">
                             {t('settings.configuration.email.signature.title')}
@@ -765,7 +788,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
                             loading={isSavingSignature}
                             className="mt-4"
                           >
-                            {t('settings.configuration.email.signature.save', { defaultValue: 'Salvar Assinatura' })}
+                            {t('settings.configuration.email.signature.save', { defaultValue: 'Save Signature' })}
                           </Button>
                         </div>
                       </div>
@@ -779,6 +802,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="collaborators">
               {activeTab === 'collaborators' && <CollaboratorsForm
                 inboxId={inboxId}
+                registerSave={handle => registerTabSave('collaborators', handle)}
                 enableAutoAssignment={inbox?.enable_auto_assignment === true}
                 maxAssignmentLimit={
                   inbox?.auto_assignment_config?.max_assignment_limit !== undefined
@@ -804,6 +828,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="businesshours">
               {activeTab === 'businesshours' && <BusinessHoursForm
                 inboxId={inboxId}
+                registerSave={handle => registerTabSave('businesshours', handle)}
                 workingHoursEnabled={inbox?.working_hours_enabled === true}
                 outOfOfficeMessage={inbox?.out_of_office_message || ''}
                 outOfOfficeMessageTemplateId={inbox?.out_of_office_message_template_id || null}
@@ -829,6 +854,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="csat">
               {activeTab === 'csat' && <CSATForm
                 inboxId={inboxId}
+                registerSave={handle => registerTabSave('csat', handle)}
                 csatSurveyEnabled={inbox?.csat_survey_enabled === true}
                 csatConfig={
                   inbox?.csat_config && Object.keys(inbox.csat_config).length > 0
@@ -852,6 +878,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="preChatForm">
               {activeTab === 'preChatForm' && <PreChatForm
                 inboxId={inboxId}
+                registerSave={handle => registerTabSave('preChatForm', handle)}
                 preChatFormEnabled={inbox?.pre_chat_form_enabled === true}
                 preChatFormOptions={inbox?.pre_chat_form_options || undefined}
                 onUpdate={async data => {
@@ -873,6 +900,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="widgetBuilder">
               {activeTab === 'widgetBuilder' && <WidgetBuilderForm
                 inboxId={inboxId}
+                registerSave={handle => registerTabSave('widgetBuilder', handle)}
                 inbox={{
                   name: inbox?.name,
                   welcome_title: inbox?.welcome_title,
@@ -919,7 +947,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
                     toast.success(t('settings.success.configUpdateSuccess'));
                     await loadChannelData(); // Refresh data
                   } catch (error) {
-                    console.error('Erro ao atualizar configuração:', error);
+                    console.error('Error updating configuration:', error);
                     toast.error(t('settings.errors.configUpdateError'));
                   }
                 }}
@@ -933,8 +961,27 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="moderation">
               {activeTab === 'moderation' && <ModerationDashboard />}
             </TabsContent>
+            </div>
           </Tabs>
         </div>
+      </div>
+
+      {/* Fixed footer: single unified save action, anchored to the content box */}
+      <div className="flex items-center justify-end gap-3 border-t border-border bg-card px-6 py-3">
+        {!currentTabIsSavable && (
+          <span className="text-xs text-muted-foreground">
+            {t('settings.info.tabSpecificSave')}
+          </span>
+        )}
+        <Button
+          onClick={handleFooterSave}
+          loading={isFooterSaving || isSaving || undefined}
+          disabled={!footerCanSave || isFooterSaving || isSaving}
+          className="min-w-48"
+        >
+          <Check className="h-4 w-4 mr-2" />
+          {t('settings.updateConfig')}
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## EVO-2094 — Redesign Canais · Settings (`/channels/:id/settings`)

Reskin/relayout **só de tela** (front) da tela de Configurações do Canal para o padrão do sistema. Sub-issue de EVO-2091.

### Mudanças
- **Container full-width** — removido `max-w-6xl mx-auto` (fim do gutter centralizado).
- **Header de identidade compacto** — avatar + nome (`text-xl`), sem `text-3xl` nem descrição redundante; `AuthorizationBanners` preservado.
- **Abas em pílula, linha única** com scroll horizontal (`overflow-x-auto no-scrollbar`), coladas à esquerda; ativa = `bg-primary/10 text-primary`.
- **Faixa fixa no rodapé** com **um** botão "Atualizar Configurações" (`Check`), ancorada no box de conteúdo (não vaza no modo embutido).
- **Save unificado (registry)** — abas-snapshot (`inbox_settings`, `collaborators`, `businesshours`, `csat`, `preChatForm`, `widgetBuilder`) registram seu save; a faixa dispara o save da aba ativa e os **botões internos dessas abas foram removidos**. Abas imperativas (`configuration`, `botConfiguration`, `moderation`) **não registram** → faixa desabilitada com hint, controles inline intocados. Lazy-mount preservado.
- **Chips de header → token primary** (`text-primary`/`bg-primary/10`); nenhum hex de protótipo hardcoded.
- **Limpeza PT** — JSDoc e `console.error` em PT dos arquivos tocados traduzidos pra inglês (toasts user-facing mantidos como estão — cópia de produto).
- **i18n** `settings.updateConfig` nos 6 locales; novo módulo de tipo `tabSave.ts` (evita ciclo página↔form).

### Fora de escopo (mantido)
Semântica imperativa das abas `configuration`/`botConfiguration`/`moderation`; Twilio/status ao vivo/backend. i18n dos toasts/labels PT hardcoded no ConfigurationForm (Z-API) fica pra acerto separado.

### Validação
- ✅ `tsc -b` limpo (projeto inteiro).
- ✅ Novo `ChannelSettings.spec.tsx` 5/5 (full-width, tab-strip single-row + token ativo, footer salva snapshot, footer desabilitado+hint em aba imperativa).
- ✅ `BusinessHoursForm.spec.tsx` adaptado ao contrato do registry.
- ✅ ESLint sem erros novos (os `no-explicit-any` já existem idênticos no develop).
