### PR TITLE
fix(custom-tools): hint de anexar ao agente e chaves de i18n quebradas (EVO-2125)

### DIFF
--- a/src/components/customTools/wizard/Step6_Finish.tsx
+++ b/src/components/customTools/wizard/Step6_Finish.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Button, Input, Label } from '@evoapi/design-system';
-import { ArrowLeft, Plus, X, Check } from 'lucide-react';
+import { ArrowLeft, Plus, X, Check, Link2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 
 export interface Step6Data {
@@ -100,6 +100,11 @@ export default function Step6_Finish({
 
           <p className="text-xs text-muted-foreground bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded p-3">
             {t('wizard.step6.testHint')}
+          </p>
+
+          <p className="flex items-start gap-2 text-xs text-muted-foreground bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded p-3">
+            <Link2 className="h-4 w-4 flex-shrink-0 mt-px text-blue-600 dark:text-blue-400" />
+            <span>{t('wizard.step6.attachHint')}</span>
           </p>
         </div>
       </div>

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -273,7 +273,8 @@
       "title": "Final touches",
       "subtitle": "Add usage examples that help agents understand when to call this tool.",
       "helperText": "Examples are short text descriptions of how to use the tool.",
-      "testHint": "After creating, you'll be able to test the tool against the real endpoint."
+      "testHint": "After creating, you'll be able to test the tool against the real endpoint.",
+      "attachHint": "Creating the tool only adds it to the catalog. To have an agent use it, attach it to the agent in its Tools tab."
     },
     "actions": {
       "continue": "Continue",
@@ -339,6 +340,19 @@
     "deleteSuccess": "Custom tool deleted successfully",
     "deleteError": "Error deleting custom tool",
     "testSuccess": "Test executed successfully",
-    "testError": "Error testing custom tool"
+    "testError": "Error testing custom tool",
+    "applyFiltersError": "Error applying filters"
+  },
+  "deleteDialog": {
+    "title": "Delete Custom Tool",
+    "description": "Are you sure you want to delete the tool \"{{name}}\"? This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirm": "Delete"
+  },
+  "permissions": {
+    "viewDenied": "You don't have permission to view custom tools",
+    "createDenied": "You don't have permission to create custom tools",
+    "editDenied": "You don't have permission to edit custom tools",
+    "deleteDenied": "You don't have permission to delete custom tools"
   }
 }

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -273,7 +273,8 @@
       "title": "Toques finales",
       "subtitle": "Agrega ejemplos de uso que ayuden a los agentes a saber cuándo llamar esta herramienta.",
       "helperText": "Los ejemplos son descripciones cortas de cómo usar la herramienta.",
-      "testHint": "Después de crear, podrás probar la herramienta contra el endpoint real."
+      "testHint": "Después de crear, podrás probar la herramienta contra el endpoint real.",
+      "attachHint": "Crear la herramienta solo la agrega al catálogo. Para que un agente la use, adjúntala al agente en su pestaña Herramientas."
     },
     "actions": {
       "continue": "Continuar",
@@ -339,6 +340,19 @@
     "deleteSuccess": "Herramienta personalizada eliminada con éxito",
     "deleteError": "Error al eliminar herramienta personalizada",
     "testSuccess": "Prueba ejecutada con éxito",
-    "testError": "Error al probar herramienta personalizada"
+    "testError": "Error al probar herramienta personalizada",
+    "applyFiltersError": "Error al aplicar filtros"
+  },
+  "deleteDialog": {
+    "title": "Eliminar Herramienta Personalizada",
+    "description": "¿Seguro que deseas eliminar la herramienta \"{{name}}\"? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "permissions": {
+    "viewDenied": "No tienes permiso para ver herramientas personalizadas",
+    "createDenied": "No tienes permiso para crear herramientas personalizadas",
+    "editDenied": "No tienes permiso para editar herramientas personalizadas",
+    "deleteDenied": "No tienes permiso para eliminar herramientas personalizadas"
   }
 }

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -273,7 +273,8 @@
       "title": "Touches finales",
       "subtitle": "Ajoutez des exemples d'usage pour aider les agents à savoir quand appeler cet outil.",
       "helperText": "Les exemples sont de courtes descriptions d'utilisation de l'outil.",
-      "testHint": "Après création, vous pourrez tester l'outil contre l'endpoint réel."
+      "testHint": "Après création, vous pourrez tester l'outil contre l'endpoint réel.",
+      "attachHint": "Créer l'outil ne fait que l'ajouter au catalogue. Pour qu'un agent l'utilise, attachez-le à l'agent dans son onglet Outils."
     },
     "actions": {
       "continue": "Continuer",
@@ -339,6 +340,19 @@
     "deleteSuccess": "Outil personnalisé supprimé avec succès",
     "deleteError": "Erreur lors de la suppression de l'outil personnalisé",
     "testSuccess": "Test exécuté avec succès",
-    "testError": "Erreur lors du test de l'outil personnalisé"
+    "testError": "Erreur lors du test de l'outil personnalisé",
+    "applyFiltersError": "Erreur lors de l'application des filtres"
+  },
+  "deleteDialog": {
+    "title": "Supprimer l'outil personnalisé",
+    "description": "Voulez-vous vraiment supprimer l'outil \"{{name}}\" ? Cette action est irréversible.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer"
+  },
+  "permissions": {
+    "viewDenied": "Vous n'avez pas la permission de voir les outils personnalisés",
+    "createDenied": "Vous n'avez pas la permission de créer des outils personnalisés",
+    "editDenied": "Vous n'avez pas la permission de modifier les outils personnalisés",
+    "deleteDenied": "Vous n'avez pas la permission de supprimer les outils personnalisés"
   }
 }

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -273,7 +273,8 @@
       "title": "Tocchi finali",
       "subtitle": "Aggiungi esempi d'uso che aiutino gli agenti a sapere quando chiamare questo strumento.",
       "helperText": "Gli esempi sono brevi descrizioni di come usare lo strumento.",
-      "testHint": "Dopo la creazione, potrai testare lo strumento contro l'endpoint reale."
+      "testHint": "Dopo la creazione, potrai testare lo strumento contro l'endpoint reale.",
+      "attachHint": "Creare lo strumento lo aggiunge solo al catalogo. Perché un agente lo usi, collegalo all'agente nella sua scheda Strumenti."
     },
     "actions": {
       "continue": "Continua",
@@ -339,6 +340,19 @@
     "deleteSuccess": "Strumento personalizzato eliminato con successo",
     "deleteError": "Errore nell'eliminazione dello strumento personalizzato",
     "testSuccess": "Test eseguito con successo",
-    "testError": "Errore nel test dello strumento personalizzato"
+    "testError": "Errore nel test dello strumento personalizzato",
+    "applyFiltersError": "Errore durante l'applicazione dei filtri"
+  },
+  "deleteDialog": {
+    "title": "Elimina Strumento Personalizzato",
+    "description": "Vuoi davvero eliminare lo strumento \"{{name}}\"? Questa azione non può essere annullata.",
+    "cancel": "Annulla",
+    "confirm": "Elimina"
+  },
+  "permissions": {
+    "viewDenied": "Non hai il permesso di vedere gli strumenti personalizzati",
+    "createDenied": "Non hai il permesso di creare strumenti personalizzati",
+    "editDenied": "Non hai il permesso di modificare gli strumenti personalizzati",
+    "deleteDenied": "Non hai il permesso di eliminare strumenti personalizzati"
   }
 }

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -273,7 +273,8 @@
       "title": "Toques finais",
       "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
       "helperText": "Exemplos são descrições curtas de como usar a tool.",
-      "testHint": "Após criar, você poderá testar a tool contra o endpoint real."
+      "testHint": "Após criar, você poderá testar a tool contra o endpoint real.",
+      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele."
     },
     "actions": {
       "continue": "Continuar",
@@ -339,6 +340,19 @@
     "deleteSuccess": "Ferramenta personalizada deletada com sucesso",
     "deleteError": "Erro ao deletar ferramenta personalizada",
     "testSuccess": "Teste executado com sucesso",
-    "testError": "Erro ao testar ferramenta personalizada"
+    "testError": "Erro ao testar ferramenta personalizada",
+    "applyFiltersError": "Erro ao aplicar filtros"
+  },
+  "deleteDialog": {
+    "title": "Excluir Ferramenta Personalizada",
+    "description": "Tem certeza que deseja excluir a ferramenta \"{{name}}\"? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "permissions": {
+    "viewDenied": "Você não tem permissão para ver ferramentas personalizadas",
+    "createDenied": "Você não tem permissão para criar ferramentas personalizadas",
+    "editDenied": "Você não tem permissão para editar ferramentas personalizadas",
+    "deleteDenied": "Você não tem permissão para excluir ferramentas personalizadas"
   }
 }

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -273,7 +273,8 @@
       "title": "Toques finais",
       "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
       "helperText": "Exemplos são descrições curtas de como usar a tool.",
-      "testHint": "Após criar, você poderá testar a tool contra o endpoint real."
+      "testHint": "Após criar, você poderá testar a tool contra o endpoint real.",
+      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele."
     },
     "actions": {
       "continue": "Continuar",
@@ -339,6 +340,19 @@
     "deleteSuccess": "Ferramenta personalizada deletada com sucesso",
     "deleteError": "Erro ao deletar ferramenta personalizada",
     "testSuccess": "Teste executado com sucesso",
-    "testError": "Erro ao testar ferramenta personalizada"
+    "testError": "Erro ao testar ferramenta personalizada",
+    "applyFiltersError": "Erro ao aplicar filtros"
+  },
+  "deleteDialog": {
+    "title": "Excluir Ferramenta Personalizada",
+    "description": "Tem certeza que deseja excluir a ferramenta \"{{name}}\"? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "permissions": {
+    "viewDenied": "Você não tem permissão para ver ferramentas personalizadas",
+    "createDenied": "Você não tem permissão para criar ferramentas personalizadas",
+    "editDenied": "Você não tem permissão para editar ferramentas personalizadas",
+    "deleteDenied": "Você não tem permissão para excluir ferramentas personalizadas"
   }
 }

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -126,7 +126,7 @@ export default function CustomTools() {
         }));
       } catch (error) {
         console.error('Error loading custom tools:', error);
-        toast.error(getErrorMessage(error as Error, t('errors.loadError')));
+        toast.error(getErrorMessage(error as Error, t('messages.loadError')));
         setState(prev => ({ ...prev, loading: { ...prev.loading, list: false } }));
       }
     },
@@ -182,7 +182,7 @@ export default function CustomTools() {
       await loadTools({ skip: 0, search: state.searchQuery }, filters);
     } catch (error) {
       console.error('Error applying filters:', error);
-      toast.error(getErrorMessage(error as Error, t('errors.applyFiltersError')));
+      toast.error(getErrorMessage(error as Error, t('messages.applyFiltersError')));
     }
   };
 
@@ -259,7 +259,7 @@ export default function CustomTools() {
       })
       .catch(err => {
         console.error('Failed to load tool for edit:', err);
-        toast.error(t('errors.loadError'));
+        toast.error(t('messages.loadError'));
         navigate('/agents/custom-tools');
       });
     return () => {
@@ -287,7 +287,7 @@ export default function CustomTools() {
       setTestResultOpen(true);
     } catch (error) {
       console.error('Error testing custom tool:', error);
-      toast.error(getErrorMessage(error as Error, t('errors.testError')));
+      toast.error(getErrorMessage(error as Error, t('messages.testError')));
     } finally {
       setTestingTool(null);
       setState(prev => ({ ...prev, loading: { ...prev.loading, test: false } }));
@@ -304,7 +304,7 @@ export default function CustomTools() {
 
     try {
       await deleteCustomTool(toolToDelete.id);
-      toast.success(t('success.deleteSuccess'));
+      toast.success(t('messages.deleteSuccess'));
 
       // Refresh the list
       loadTools();
@@ -313,7 +313,7 @@ export default function CustomTools() {
       setToolToDelete(null);
     } catch (error) {
       console.error('Error deleting custom tool:', error);
-      toast.error(t('errors.deleteError'));
+      toast.error(t('messages.deleteError'));
     } finally {
       setState(prev => ({ ...prev, loading: { ...prev.loading, delete: false } }));
     }
@@ -332,7 +332,7 @@ export default function CustomTools() {
       if (editingTool) {
         // Update existing tool
         const response = await updateCustomTool(editingTool.id, data);
-        toast.success(t('success.updateSuccess'));
+        toast.success(t('messages.updateSuccess'));
 
         // Update the specific tool in the list with the latest data
         setState(prev => ({
@@ -346,7 +346,7 @@ export default function CustomTools() {
       } else {
         // Create new tool
         await createCustomTool(data);
-        toast.success(t('success.createSuccess'));
+        toast.success(t('messages.createSuccess'));
 
         // Refresh the entire list for new tools
         loadTools();
@@ -359,7 +359,7 @@ export default function CustomTools() {
       }
     } catch (error) {
       console.error('Error saving custom tool:', error);
-      toast.error(editingTool ? t('errors.updateError') : t('errors.createError'));
+      toast.error(editingTool ? t('messages.updateError') : t('messages.createError'));
     } finally {
       setState(prev => ({
         ...prev,


### PR DESCRIPTION
## 1. Hint de anexar ao agente (escopo do card)

Criar uma ferramenta só a coloca no catálogo — nada na tela dizia que ela precisa ser **anexada a um agente** (aba Ferramentas do agente) pra ter efeito. Adicionado hint no passo 6 do wizard, com a chave `wizard.step6.attachHint` nos 6 idiomas.

## 2. Chaves de i18n que não resolviam (bug pré-existente, achado testando)

A tela pedia `t('success.updateSuccess')`, `t('errors.loadError')` e companhia, mas essas strings moram em `messages.*` no namespace. Não há fallback que salve: o `common.json` tem `success` como **string** (`"Sucesso"`), não como objeto. Resultado: o i18next renderizava a **chave crua** na tela.

Eram **17 chaves**, em todos os 6 idiomas:

- todos os toasts (criar, editar, excluir, testar, carregar, aplicar filtros)
- os 4 avisos de permissão negada
- o diálogo de exclusão inteiro (título, descrição, Cancelar, Excluir)

A convenção do app é `messages.*` — é o que `accessTokens`, `apiKeys` e `labels` usam; nenhum namespace usa `success.*`/`errors.*`. Então a tela passou a usar as chaves convencionais (**que já estavam traduzidas nos 6 idiomas**) e criei os blocos que faltavam de verdade, espelhando o formato do `accessTokens`: `deleteDialog`, `permissions` e `messages.applyFiltersError`.

> Este segundo item **não está no EVO-2125** — apareceu ao validar a tela. Mesma tela, mesma branch. Se preferir separar em card próprio, é só falar.

## Testes

`tsc --noEmit` e eslint limpos; 193 testes passando (inclui os 172 de paridade de i18n).
Checagem extra: varredura de todo `t('…')` dos componentes de custom tools contra os 6 locales → **0 chaves cruas**.

Sem mudança de contrato com o backend.

Card: EVO-2125
