### PR TITLE
feat(rbac): persist coarse write group from role editor (EVO-2127)

### DIFF
--- a/src/config/permissionDomains.spec.ts
+++ b/src/config/permissionDomains.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { expandCoarseKeys } from './permissionDomains';
+
+// EVO-2127: expandCoarseKeys turns the granular keys the editor is about to save
+// into the additive, guarded coarse read/write/delete keys the screen shows.
+describe('expandCoarseKeys', () => {
+  // Backend carries every coarse action (post Task 2).
+  const catalogHasAll = () => true;
+
+  it('adds the coarse write and keeps the granular key (AC1/AC2)', () => {
+    const out = expandCoarseKeys(['ai_agents.create'], catalogHasAll);
+    expect(out).toContain('ai_agents.write'); // coarse emitted
+    expect(out).toContain('ai_agents.create'); // granular preserved (additive)
+  });
+
+  it('emits a coarse key for each distinct write group, deduped', () => {
+    const out = expandCoarseKeys(['ai_agents.create', 'ai_agents.update'], catalogHasAll);
+    expect(out.filter(k => k === 'ai_agents.write')).toHaveLength(1);
+    expect(out).toEqual(expect.arrayContaining(['ai_agents.create', 'ai_agents.update', 'ai_agents.write']));
+  });
+
+  it('does not emit write for a read-only selection (AC5)', () => {
+    const out = expandCoarseKeys(['ai_agents.read'], catalogHasAll);
+    expect(out).not.toContain('ai_agents.write');
+  });
+
+  it('guards on the catalog: omits write when the backend lacks it, no throw (AC7)', () => {
+    // Backend without the coarse write (Task 2 not yet deployed).
+    const catalogHasNoWrite = (_resource: string, action: string) => action !== 'write';
+    const out = expandCoarseKeys(['ai_agents.create'], catalogHasNoWrite);
+    expect(out).not.toContain('ai_agents.write');
+    expect(out).toContain('ai_agents.create');
+  });
+
+  it('does not synthesize a coarse delete (delete has no separate coarse key)', () => {
+    const out = expandCoarseKeys(['ai_agents.delete'], catalogHasAll);
+    expect(out).toEqual(['ai_agents.delete']); // granular preserved, nothing added
+  });
+
+  it('does not synthesize coarse read from a sibling read action like search (L1)', () => {
+    // groupOfAction('contacts','search') === 'read', but coarse read == the
+    // granular `contacts.read` — synthesizing it would grant a read the user
+    // never selected. Only write is synthesized.
+    const out = expandCoarseKeys(['contacts.search'], catalogHasAll);
+    expect(out).toEqual(['contacts.search']);
+  });
+
+  it('ignores standalone actions that belong to no group (e.g. conversations.read_all)', () => {
+    const out = expandCoarseKeys(['conversations.read_all'], catalogHasAll);
+    // read_all is standalone → groupOfAction returns null → nothing coarse added.
+    expect(out).toEqual(['conversations.read_all']);
+  });
+
+  it('returns the granular keys unchanged when nothing groups', () => {
+    const out = expandCoarseKeys([], catalogHasAll);
+    expect(out).toEqual([]);
+  });
+
+  it('drives correctly off a real ResourceActionsData-shaped catalog (handleSave guard lambda, L2)', () => {
+    // Mirrors the closure RoleDetail#handleSave passes:
+    //   (resource, action) => resourceActions.resources[resource]?.actions?.[action] !== undefined
+    const catalog = {
+      resources: {
+        ai_agents: { actions: { create: {}, read: {}, write: {} } },
+        // legacy: backend without the coarse write yet (Task 2 not deployed there)
+        legacy: { actions: { create: {} } },
+      },
+    } as unknown as { resources: Record<string, { actions: Record<string, unknown> }> };
+    const catalogHas = (resource: string, action: string) =>
+      catalog.resources[resource]?.actions?.[action] !== undefined;
+
+    const out = expandCoarseKeys(['ai_agents.create', 'legacy.create'], catalogHas);
+    expect(out).toContain('ai_agents.write'); // catalog declares it
+    expect(out).not.toContain('legacy.write'); // guard: catalog lacks it → no 422
+    expect(out).toEqual(expect.arrayContaining(['ai_agents.create', 'legacy.create']));
+  });
+});

--- a/src/config/permissionDomains.ts
+++ b/src/config/permissionDomains.ts
@@ -156,6 +156,9 @@ export interface ActionGroup {
 }
 
 // Reads. Everything else that is not a delete or a standalone is a write.
+// NOTE: mirrored on the backend as ResourceActionsConfig::NON_WRITE_ACTIONS —
+// keep the two in sync (a read added here must be added there, or the two
+// disagree on what a "write" is and a save 403s).
 const READ_ACTIONS = new Set([
   'read',
   'meta',
@@ -174,6 +177,13 @@ const READ_ACTIONS = new Set([
   'permissions',
   'check_permission',
   'export',
+  // View-only actions on AI/config resources (would otherwise mis-group as write).
+  'available',
+  'categories',
+  'config',
+  'access_shared',
+  'usage',
+  'metrics',
 ]);
 
 // Keys that are not CRUD at all and keep their own row.
@@ -194,6 +204,31 @@ export function groupOfAction(resourceKey: string, actionKey: string): ActionGro
   if (isStandaloneAction(resourceKey, actionKey)) return null;
   if (actionKey === 'delete') return 'delete';
   return READ_ACTIONS.has(actionKey) ? 'read' : 'write';
+}
+
+/**
+ * EVO-2127: given the granular keys about to be saved, also emit the coarse
+ * `<resource>.write` key the role editor's Write group displays — additively
+ * (the granular keys stay) and guarded (only when the catalog declares it, so a
+ * backend without `<resource>.write` never triggers a 422).
+ *
+ * Only WRITE is synthesized. Coarse `read`/`delete` are identical to their
+ * granular homonyms (`x.read` / `x.delete`), which are already in `knownKeys`
+ * whenever selected — synthesizing them would add nothing and could grant e.g.
+ * `x.read` off a sibling read action like `x.search`.
+ */
+export function expandCoarseKeys(
+  knownKeys: string[],
+  catalogHas: (resource: string, action: string) => boolean,
+): string[] {
+  const coarse = new Set<string>();
+  for (const key of knownKeys) {
+    const [resource, action] = key.split('.');
+    if (groupOfAction(resource, action) === 'write' && catalogHas(resource, 'write')) {
+      coarse.add(`${resource}.write`);
+    }
+  }
+  return Array.from(new Set([...knownKeys, ...coarse]));
 }
 
 const GROUP_ORDER: ActionGroup['key'][] = ['read', 'write', 'delete'];

--- a/src/pages/Admin/Roles/RoleDetail.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.tsx
@@ -22,6 +22,7 @@ import {
   groupsFor,
   isHiddenAction,
   isStandaloneAction,
+  expandCoarseKeys,
   type ActionGroup,
   RESOURCE_NESTING,
 } from '@/config/permissionDomains';
@@ -198,7 +199,14 @@ export default function RoleDetail() {
         // is only ever there because the role already had it.
         return cfg !== undefined && !isKeyLocked(key, selected);
       });
-      const updated = await rolesService.bulkUpdatePermissions(role.id, knownKeys);
+      // EVO-2127: also persist the coarse read/write/delete groups the editor
+      // shows — additively (granular stays) and guarded against the live catalog
+      // so a backend without `<resource>.write` never triggers a 422.
+      const payload = expandCoarseKeys(
+        knownKeys,
+        (resource, action) => resourceActions.resources[resource]?.actions?.[action] !== undefined,
+      );
+      const updated = await rolesService.bulkUpdatePermissions(role.id, payload);
       setRole(updated);
       permissionsService.clearPermissionsCache();
       toast.success(t('messages.permissionsSuccess'));


### PR DESCRIPTION
## Summary
- On save, emit the coarse `<resource>.write` key the Write group displays — additively (granular keys stay) and guarded against the live catalog, so a backend without `<resource>.write` never triggers a 422.
- Only `write` is synthesized: coarse `read`/`delete` equal their granular homonyms and are already sent when selected.
- Extend `READ_ACTIONS` with view-only AI/config actions (`available`, `categories`, `config`, `access_shared`, `usage`, `metrics`) so they no longer mis-group as writes — kept in sync with the auth backend.

## Test plan
- `npm run test` (vitest) → `permissionDomains.spec.ts` green (9 tests).
- `tsc --noEmit` clean.

## Notes
- Pairs with the auth PR (`evo-auth-service-community`). Deploy backend before/with this; the catalog guard makes FE-first non-breaking.
