### PR TITLE
fix(custom-mcp): guard null tools + use test tools_count in toast (EVO-2139)

### DIFF
--- a/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
+++ b/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
@@ -307,7 +307,13 @@ export default function CustomMCPServers() {
     try {
       const result = await testCustomMcpServer(server.id);
       if (result.test_result.success) {
-        toast.success(t('success.testSuccess', { count: result.server.tools.length || 0 }));
+        // EVO-2139: prioriza `tools_count` do próprio test (número descoberto
+        // agora no handshake MCP) sobre `server.tools.length` (DB, que fica
+        // stale se o Create original não conseguiu popular). Optional-chaining
+        // no fallback evita o crash silencioso quando o server tem tools=null.
+        const count =
+          result.test_result.tools_count ?? result.server.tools?.length ?? 0;
+        toast.success(t('success.testSuccess', { count }));
         // Update server with latest tools
         setState(prev => ({
           ...prev,

--- a/src/types/ai/customMcpServer.ts
+++ b/src/types/ai/customMcpServer.ts
@@ -56,6 +56,9 @@ export interface CustomMcpServerTestResponse {
     status_code: number;
     success: boolean;
     url_tested: string;
+    // EVO-2139: quantidade de tools descobertas neste test (via handshake MCP).
+    // Refletir sempre este valor no toast, não `server.tools.length` (DB-stale).
+    tools_count?: number;
   };
 }
 


### PR DESCRIPTION
## Summary
- Optional-chaining em `server.tools?.length ?? 0` — evita TypeError que caía no catch e mostrava toast genérico de erro mesmo com backend retornando 200 (era o bug real do botão Test após companion PRs de backend).
- Prefere `test_result.tools_count` no toast — reflete o que o handshake acabou de descobrir, não o DB-stale.
- Type `test_result.tools_count?: number` optional pra backward compat com core-service antigo.

## Test plan
- [x] Local dev server + companion PRs de backend rodando → botão Test com `https://mcp.deepwiki.com/mcp` mostra toast verde "3 ferramentas descobertas".
- [ ] Reviewer: server com `tools: null` no DB (criado antes do fix) → sem crash, count correto do test_result.
- [ ] Reviewer: core-service antigo (sem tools_count) → fallback pra server.tools.length, sem crash.

Companion PRs:
- processor: https://github.com/evolution-foundation/evo-ai-processor-community/pull/36
- core-service: https://github.com/evolution-foundation/evo-ai-core-service-community/pull/new/marcelosoares/evo-2139-test-connection-delegate

Linear: https://linear.app/evoai/issue/EVO-2139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve Custom MCP server test feedback and robustness when reporting discovered tools.

Bug Fixes:
- Prevent crashes when testing MCP servers that have a null tools list in the database.

Enhancements:
- Use the tools_count from the MCP test result handshake as the primary source for the discovered tools count shown in the success toast, falling back to the stored tools list only when necessary.