### PR TITLE
fix(EVO-2191): route journeys through the CRM proxy (api), not evo-flow direct

### DIFF
--- a/src/components/journey/shared/JourneyEditorHeader/JourneyEditorHeader.tsx
+++ b/src/components/journey/shared/JourneyEditorHeader/JourneyEditorHeader.tsx
@@ -9,7 +9,10 @@ export type JourneyEditorHeaderProps = {
   title: string;
   subtitle?: string;
 
-  onViewSessions: () => void;
+  // Optional so the caller can withhold it when RBAC denies the action: sessions
+  // live behind journeys.manage_sessions on the CRM proxy (EVO-2191), and the
+  // zone renders nothing when there is no handler.
+  onViewSessions?: () => void;
   viewSessionsLabel?: string;
 
   environmentSlot?: ReactNode;
@@ -87,26 +90,28 @@ export function JourneyEditorHeader({
       </div>
 
       <div data-zone="actions" className="flex items-center gap-2">
-        <div className="flex items-center border-l border-flow-panel-divider pl-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onViewSessions}
-            className="gap-2 hidden md:inline-flex"
-          >
-            <Activity className="h-4 w-4" aria-hidden="true" />
-            {viewSessionsLabel}
-          </Button>
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={onViewSessions}
-            aria-label={viewSessionsLabel}
-            className="md:hidden h-9 w-9"
-          >
-            <Activity className="h-4 w-4" aria-hidden="true" />
-          </Button>
-        </div>
+        {onViewSessions ? (
+          <div className="flex items-center border-l border-flow-panel-divider pl-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onViewSessions}
+              className="gap-2 hidden md:inline-flex"
+            >
+              <Activity className="h-4 w-4" aria-hidden="true" />
+              {viewSessionsLabel}
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onViewSessions}
+              aria-label={viewSessionsLabel}
+              className="md:hidden h-9 w-9"
+            >
+              <Activity className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+        ) : null}
 
         {environmentSlot ? (
           <div className="flex items-center border-l border-flow-panel-divider pl-2">

--- a/src/pages/Customer/Journey/Journey.tsx
+++ b/src/pages/Customer/Journey/Journey.tsx
@@ -222,7 +222,14 @@ export default function JourneyPage() {
       label: t('table.columns.status'),
       render: journey => (
         <div className="flex items-center gap-2">
-          <Switch checked={journey.isActive} onCheckedChange={() => handleToggleJourney(journey)} />
+          {/* EVO-2191: the CRM proxy derives the permission from the subpath, so the
+              flip needs journeys.toggle_active — not journeys.update. Without this
+              the switch stayed clickable and the call came back 403. */}
+          <Switch
+            checked={journey.isActive}
+            disabled={!permissionsReady || !can('journeys', 'toggle_active')}
+            onCheckedChange={() => handleToggleJourney(journey)}
+          />
           <span className="text-sm text-sidebar-foreground/70">
             {journey.isActive ? t('table.status.active') : t('table.status.inactive')}
           </span>
@@ -264,7 +271,9 @@ export default function JourneyPage() {
       label: t('actions.duplicate'),
       icon: <Copy className="h-4 w-4" />,
       onClick: handleDuplicateJourney,
-      show: () => permissionsReady && can('journeys', 'create'),
+      // EVO-2191: POST /journeys/:id/duplicate resolves to journeys.duplicate on
+      // the CRM proxy, so gating on journeys.create showed an action that 403s.
+      show: () => permissionsReady && can('journeys', 'duplicate'),
     },
     {
       label: t('actions.delete'),

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 import { journeyService } from '@/services';
 import type { Journey } from '@/types/automation';
 import { useLanguage } from '@/hooks/useLanguage';
+import { usePermissions } from '@/contexts/PermissionsContext';
 import { validateJourney } from '@/utils/journeyFlowValidation';
 import { JourneyValidationProvider } from '@/contexts/JourneyValidationContext';
 import { buildFlowTriggers } from './journeyFlowTriggers';
@@ -174,6 +175,10 @@ function JourneyFlowEditor() {
   const hasUnsavedChanges = status !== 'idle';
   const relativeNow = useRelativeTime(lastSavedAt);
   const [showSessionsViewer, setShowSessionsViewer] = useState(false);
+  // EVO-2191: /journeys/:id/sessions* is gated by journeys.manage_sessions on the
+  // CRM proxy, so the entry point is withheld instead of opening a viewer that 403s.
+  const { can, isReady: permissionsReady } = usePermissions();
+  const canManageSessions = permissionsReady && can('journeys', 'manage_sessions');
 
   // Node types mapping para Journey
   const nodeTypes = useMemo(
@@ -856,7 +861,7 @@ function JourneyFlowEditor() {
         backLabel={t('flowEditor.back')}
         title={t('flowEditor.title', { name: journey.name })}
         subtitle={journey.description || undefined}
-        onViewSessions={() => setShowSessionsViewer(true)}
+        onViewSessions={canManageSessions ? () => setShowSessionsViewer(true) : undefined}
         viewSessionsLabel={t('flowEditor.viewSessions')}
         environmentSlot={<EnvironmentManager journeyId={id} />}
         onSave={saveChanges}

--- a/src/services/core/apiEvoFlow.ts
+++ b/src/services/core/apiEvoFlow.ts
@@ -2,9 +2,12 @@ import axios from 'axios';
 import { useAuthStore } from '@/store/authStore';
 import { applySetupInterceptor } from '@/services/core/setupInterceptor';
 
-// Dedicated axios instance for evo-flow (journeys, campaigns; segments
-// migrated to the CRM proxy).
-// Backend is single-account: no `account-id` header and no `/journeys` 401 bypass.
+// Dedicated axios instance for evo-flow. Only campaigns still uses it —
+// segments and journeys (EVO-2191) go through the CRM proxy (`api`), which
+// carries auth and the RBAC gate. Campaigns cannot follow yet: the CRM has no
+// /api/v1/campaigns proxy, so campaignsService still needs this instance and
+// VITE_EVOFLOW_API_URL must stay set in every deployment until it does.
+// Backend is single-account: no `account-id` header.
 const evoFlowApi = axios.create({
   baseURL: `${import.meta.env.VITE_EVOFLOW_API_URL}/api/v1`,
   headers: {

--- a/src/services/journeys/journeyService.spec.ts
+++ b/src/services/journeys/journeyService.spec.ts
@@ -140,48 +140,18 @@ describe('journeyService variable methods — envelope unwrap (EVO-1836)', () =>
   });
 });
 
-// EVO-2191/EVO-2188: the CRM proxy gates each operation by permission derived from
-// the HTTP method + subpath (Guilherme's review). These lock the exact URLs so a
-// future rename (e.g. /toggle-active -> /toggle, or breaking a /sessions path) can't
-// silently drift the operation onto the wrong journeys.* permission and 403.
-describe('CRM proxy path contract (permission mapping)', () => {
+// Migration smoke: journeys must go through the CRM proxy (`api`), not the
+// evo-flow-direct `apiEvoFlow` — that swap is the whole fix (EVO-2191). One
+// assertion that `create` hits the CRM base path is enough; the subpath ->
+// permission contract is owned and tested on the backend
+// (evo-ai-crm-community spec/requests/api/v1/journeys_proxy_rbac_spec.rb, EVO-2188),
+// which is where that heuristic actually runs — a frontend unit test can't verify it.
+describe('CRM proxy migration (EVO-2191)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  const ok = { data: { id: 'j1' } } as never;
-
-  it('createJourney POSTs /journeys (maps to journeys.create)', async () => {
-    vi.mocked(api.post).mockResolvedValue(ok);
+  it('createJourney goes through the CRM proxy (api) on /journeys', async () => {
+    vi.mocked(api.post).mockResolvedValue({ data: { id: 'j1' } } as never);
     await journeyService.createJourney({ name: 'x', flowData: {} as never, flowTriggers: [] as never });
     expect(api.post).toHaveBeenCalledWith('/journeys', expect.objectContaining({ name: 'x' }));
-  });
-
-  it('updateJourney PATCHes /journeys/:id (maps to journeys.update)', async () => {
-    vi.mocked(api.patch).mockResolvedValue(ok);
-    await journeyService.updateJourney('j1', { name: 'y' } as never);
-    expect(api.patch).toHaveBeenCalledWith('/journeys/j1', expect.objectContaining({ name: 'y' }));
-  });
-
-  it('deleteJourney DELETEs /journeys/:id (maps to journeys.delete)', async () => {
-    vi.mocked(api.delete).mockResolvedValue(ok);
-    await journeyService.deleteJourney('j1');
-    expect(api.delete).toHaveBeenCalledWith('/journeys/j1');
-  });
-
-  it('toggleJourney POSTs /journeys/:id/toggle-active (maps to journeys.toggle_active)', async () => {
-    vi.mocked(api.post).mockResolvedValue(ok);
-    await journeyService.toggleJourney('j1');
-    expect(api.post).toHaveBeenCalledWith('/journeys/j1/toggle-active', {});
-  });
-
-  it('duplicateJourney POSTs /journeys/:id/duplicate (maps to journeys.duplicate)', async () => {
-    vi.mocked(api.post).mockResolvedValue(ok);
-    await journeyService.duplicateJourney('j1');
-    expect(api.post).toHaveBeenCalledWith('/journeys/j1/duplicate', {});
-  });
-
-  it('deleteJourneySession DELETEs a /sessions/ path (maps to journeys.manage_sessions, not journeys.delete)', async () => {
-    vi.mocked(api.delete).mockResolvedValue(ok);
-    await journeyService.deleteJourneySession('j1', 's1');
-    expect(api.delete).toHaveBeenCalledWith('/journeys/j1/sessions/s1');
   });
 });

--- a/src/services/journeys/journeyService.spec.ts
+++ b/src/services/journeys/journeyService.spec.ts
@@ -139,3 +139,49 @@ describe('journeyService variable methods — envelope unwrap (EVO-1836)', () =>
     expect(result.data).toEqual(vars);
   });
 });
+
+// EVO-2191/EVO-2188: the CRM proxy gates each operation by permission derived from
+// the HTTP method + subpath (Guilherme's review). These lock the exact URLs so a
+// future rename (e.g. /toggle-active -> /toggle, or breaking a /sessions path) can't
+// silently drift the operation onto the wrong journeys.* permission and 403.
+describe('CRM proxy path contract (permission mapping)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const ok = { data: { id: 'j1' } } as never;
+
+  it('createJourney POSTs /journeys (maps to journeys.create)', async () => {
+    vi.mocked(api.post).mockResolvedValue(ok);
+    await journeyService.createJourney({ name: 'x', flowData: {} as never, flowTriggers: [] as never });
+    expect(api.post).toHaveBeenCalledWith('/journeys', expect.objectContaining({ name: 'x' }));
+  });
+
+  it('updateJourney PATCHes /journeys/:id (maps to journeys.update)', async () => {
+    vi.mocked(api.patch).mockResolvedValue(ok);
+    await journeyService.updateJourney('j1', { name: 'y' } as never);
+    expect(api.patch).toHaveBeenCalledWith('/journeys/j1', expect.objectContaining({ name: 'y' }));
+  });
+
+  it('deleteJourney DELETEs /journeys/:id (maps to journeys.delete)', async () => {
+    vi.mocked(api.delete).mockResolvedValue(ok);
+    await journeyService.deleteJourney('j1');
+    expect(api.delete).toHaveBeenCalledWith('/journeys/j1');
+  });
+
+  it('toggleJourney POSTs /journeys/:id/toggle-active (maps to journeys.toggle_active)', async () => {
+    vi.mocked(api.post).mockResolvedValue(ok);
+    await journeyService.toggleJourney('j1');
+    expect(api.post).toHaveBeenCalledWith('/journeys/j1/toggle-active', {});
+  });
+
+  it('duplicateJourney POSTs /journeys/:id/duplicate (maps to journeys.duplicate)', async () => {
+    vi.mocked(api.post).mockResolvedValue(ok);
+    await journeyService.duplicateJourney('j1');
+    expect(api.post).toHaveBeenCalledWith('/journeys/j1/duplicate', {});
+  });
+
+  it('deleteJourneySession DELETEs a /sessions/ path (maps to journeys.manage_sessions, not journeys.delete)', async () => {
+    vi.mocked(api.delete).mockResolvedValue(ok);
+    await journeyService.deleteJourneySession('j1', 's1');
+    expect(api.delete).toHaveBeenCalledWith('/journeys/j1/sessions/s1');
+  });
+});

--- a/src/services/journeys/journeyService.spec.ts
+++ b/src/services/journeys/journeyService.spec.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { journeyService } from './journeyService';
-import apiEvoFlow from '@/services/core/apiEvoFlow';
+import api from '@/services/core/api';
 
-vi.mock('@/services/core/apiEvoFlow', () => ({
+// EVO-2191: journeys now go through the CRM proxy (`api`), like segments — not the
+// evo-flow-direct `apiEvoFlow`. Mock `api` accordingly.
+vi.mock('@/services/core/api', () => ({
   default: {
     get: vi.fn(),
     post: vi.fn(),
+    patch: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -20,13 +23,13 @@ describe('journeyService session methods — envelope unwrap', () => {
       total: 3,
       byStatus: { active: 1, waiting: 0, paused: 0, completed: 2, failed: 0, cancelled: 0 },
     };
-    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+    vi.mocked(api.get).mockResolvedValue({
       data: { success: true, data: innerPayload },
     } as never);
 
     const result = await journeyService.getJourneySessionStats('journey-1');
 
-    expect(apiEvoFlow.get).toHaveBeenCalledWith('/journeys/journey-1/sessions/stats');
+    expect(api.get).toHaveBeenCalledWith('/journeys/journey-1/sessions/stats');
     expect(result.data).toEqual(innerPayload);
     expect(result.data.byStatus.active).toBe(1);
   });
@@ -36,7 +39,7 @@ describe('journeyService session methods — envelope unwrap', () => {
       total: 0,
       byStatus: { active: 0, waiting: 0, paused: 0, completed: 0, failed: 0, cancelled: 0 },
     };
-    vi.mocked(apiEvoFlow.get).mockResolvedValue({ data: rawPayload } as never);
+    vi.mocked(api.get).mockResolvedValue({ data: rawPayload } as never);
 
     const result = await journeyService.getJourneySessionStats('journey-1');
 
@@ -45,13 +48,13 @@ describe('journeyService session methods — envelope unwrap', () => {
 
   it('getJourneySessions unwraps the envelope and surfaces the sessions array', async () => {
     const inner = { sessions: [{ id: 's-1', status: 'active' }], total: 1, page: 1, pageSize: 20 };
-    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+    vi.mocked(api.get).mockResolvedValue({
       data: { success: true, data: inner },
     } as never);
 
     const result = await journeyService.getJourneySessions('journey-1', { page: 1, pageSize: 20 });
 
-    expect(apiEvoFlow.get).toHaveBeenCalledWith('/journeys/journey-1/sessions', {
+    expect(api.get).toHaveBeenCalledWith('/journeys/journey-1/sessions', {
       params: { page: 1, pageSize: 20 },
     });
     expect(result.data.sessions).toHaveLength(1);
@@ -60,7 +63,7 @@ describe('journeyService session methods — envelope unwrap', () => {
 
   it('getJourneySession unwraps the envelope for a single session lookup', async () => {
     const inner = { id: 's-1', status: 'active', journeyId: 'journey-1' };
-    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+    vi.mocked(api.get).mockResolvedValue({
       data: { success: true, data: inner },
     } as never);
 
@@ -71,13 +74,13 @@ describe('journeyService session methods — envelope unwrap', () => {
 
   it('cancelJourneySession unwraps the envelope on the post response', async () => {
     const inner = { id: 's-1', status: 'cancelled' };
-    vi.mocked(apiEvoFlow.post).mockResolvedValue({
+    vi.mocked(api.post).mockResolvedValue({
       data: { success: true, data: inner },
     } as never);
 
     const result = await journeyService.cancelJourneySession('journey-1', 's-1');
 
-    expect(apiEvoFlow.post).toHaveBeenCalledWith(
+    expect(api.post).toHaveBeenCalledWith(
       '/journeys/journey-1/sessions/s-1/cancel',
       {},
     );
@@ -85,7 +88,7 @@ describe('journeyService session methods — envelope unwrap', () => {
   });
 
   it('bulkDeleteJourneySessions unwraps the envelope on the bulk delete response', async () => {
-    vi.mocked(apiEvoFlow.delete).mockResolvedValue({
+    vi.mocked(api.delete).mockResolvedValue({
       data: { success: true, data: { deleted: 5 } },
     } as never);
 
@@ -102,19 +105,19 @@ describe('journeyService variable methods — envelope unwrap (EVO-1836)', () =>
 
   it('getJourneyVariables unwraps the { success, data } envelope into the variables array', async () => {
     const vars = [{ id: 'var_1', name: 'lead_score', type: 'number', defaultValue: '0' }];
-    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+    vi.mocked(api.get).mockResolvedValue({
       data: { success: true, data: vars },
     } as never);
 
     const result = await journeyService.getJourneyVariables('journey-1');
 
-    expect(apiEvoFlow.get).toHaveBeenCalledWith('/journeys/journey-1/variables');
+    expect(api.get).toHaveBeenCalledWith('/journeys/journey-1/variables');
     expect(Array.isArray(result.data)).toBe(true);
     expect(result.data).toEqual(vars);
   });
 
   it('getJourneyVariables returns [] when the unwrapped payload is not an array', async () => {
-    vi.mocked(apiEvoFlow.get).mockResolvedValue({
+    vi.mocked(api.get).mockResolvedValue({
       data: { success: true, data: null },
     } as never);
 
@@ -125,13 +128,13 @@ describe('journeyService variable methods — envelope unwrap (EVO-1836)', () =>
 
   it('updateJourneyVariables returns the variables array, not the envelope object (the crash regression)', async () => {
     const vars = [{ id: 'var_1', name: 'lead_score', type: 'number', defaultValue: '0' }];
-    vi.mocked(apiEvoFlow.post).mockResolvedValue({
+    vi.mocked(api.post).mockResolvedValue({
       data: { success: true, data: vars, meta: { timestamp: 'x' } },
     } as never);
 
     const result = await journeyService.updateJourneyVariables('journey-1', vars);
 
-    expect(apiEvoFlow.post).toHaveBeenCalledWith('/journeys/journey-1/variables', vars);
+    expect(api.post).toHaveBeenCalledWith('/journeys/journey-1/variables', vars);
     expect(Array.isArray(result.data)).toBe(true);
     expect(result.data).toEqual(vars);
   });

--- a/src/services/journeys/journeyService.spec.ts
+++ b/src/services/journeys/journeyService.spec.ts
@@ -154,4 +154,77 @@ describe('CRM proxy migration (EVO-2191)', () => {
     await journeyService.createJourney({ name: 'x', flowData: {} as never, flowTriggers: [] as never });
     expect(api.post).toHaveBeenCalledWith('/journeys', expect.objectContaining({ name: 'x' }));
   });
+
+  // The envelope tests above only reach 8 of the 16 calls; a leftover `apiEvoFlow`
+  // in any of the others would still ship green. Drive each remaining verb and
+  // assert the mocked proxy client took the call — the migration invariant, with
+  // no path string pinned (the subpath -> permission mapping is the backend's).
+  it.each([
+    ['getJourneys', () => journeyService.getJourneys(), 'get'],
+    ['getJourney', () => journeyService.getJourney('j1'), 'get'],
+    ['getJourneysByTriggerType', () => journeyService.getJourneysByTriggerType('message_received'), 'get'],
+    ['updateJourney', () => journeyService.updateJourney('j1', { name: 'y' }), 'patch'],
+    ['deleteJourney', () => journeyService.deleteJourney('j1'), 'delete'],
+    ['deleteJourneySession', () => journeyService.deleteJourneySession('j1', 's1'), 'delete'],
+    ['toggleJourney', () => journeyService.toggleJourney('j1'), 'post'],
+    ['duplicateJourney', () => journeyService.duplicateJourney('j1'), 'post'],
+  ] as const)('%s goes through the CRM proxy (api.%s)', async (_name, call, verb) => {
+    vi.mocked(api[verb]).mockResolvedValue({ data: { success: true, data: {} } } as never);
+
+    await call();
+
+    expect(api[verb]).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The proxy re-wraps evo-flow's error body and answers its own guards with shapes
+// of its own, so reading `data.message` alone — what the pre-proxy service did —
+// dropped every backend reason on the floor and showed the generic fallback.
+describe('error surfacing through the CRM proxy (EVO-2191)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const rejectWith = (verb: 'get' | 'post' | 'patch' | 'delete', data: unknown) =>
+    vi.mocked(api[verb]).mockRejectedValue({ response: { data } } as never);
+
+  it('surfaces the evo-flow message the proxy wrapped in `errors`', async () => {
+    rejectWith('post', { errors: { success: false, message: 'Journey name is required' } });
+
+    await expect(
+      journeyService.createJourney({ name: '', flowData: {} as never, flowTriggers: [] as never }),
+    ).rejects.toThrow('Journey name is required');
+  });
+
+  it('surfaces the proxy guard message (413 oversized payload)', async () => {
+    rejectWith('patch', { errors: { message: 'Journey payload is too large or too deeply nested' } });
+
+    await expect(journeyService.updateJourney('j1', { name: 'y' })).rejects.toThrow(
+      'Journey payload is too large or too deeply nested',
+    );
+  });
+
+  it('surfaces the 503 raised when evo-flow is not configured on the deployment', async () => {
+    rejectWith('get', {
+      success: false,
+      error: { code: 'SERVICE_UNAVAILABLE', message: 'Journeys are unavailable: the evo-flow integration is not configured on this deployment' },
+    });
+
+    await expect(journeyService.getJourneys()).rejects.toThrow(/evo-flow integration is not configured/);
+  });
+
+  it('surfaces the RBAC 403, which the CRM renders at the top level', async () => {
+    rejectWith('post', {
+      error: 'Forbidden - Insufficient permissions',
+      message: 'You do not have the required permissions to access this resource',
+    });
+
+    await expect(journeyService.toggleJourney('j1')).rejects.toThrow(
+      'You do not have the required permissions to access this resource',
+    );
+  });
+
+  it('falls back to the local message when the response carries none', async () => {
+    rejectWith('delete', {});
+
+    await expect(journeyService.deleteJourney('j1')).rejects.toThrow('Erro ao excluir jornada');
+  });
 });

--- a/src/services/journeys/journeyService.ts
+++ b/src/services/journeys/journeyService.ts
@@ -9,6 +9,37 @@ import type {
   JourneyDeleteResponse
 } from '@/types/automation';
 
+// EVO-2191: the CRM proxy does not relay evo-flow's error body verbatim — it wraps
+// it (`{ errors: <evo-flow body> }`) and answers its own guards with shapes of its
+// own: invalid subpath (400) and oversized payload (413) as `{ errors: { message } }`,
+// evo-flow not configured (503) as `{ error: { code, message } }`, permission denied
+// (403) as a top-level `{ message }`. Reading only `data.message`, as the pre-proxy
+// code did, collapsed every one of those into the generic fallback and the user lost
+// the reason. Walk the shapes before falling back.
+type ProxyErrorBody = {
+  message?: string;
+  // The CRM renders a permission denial as `{ error: '<string>', message }` and a
+  // coded failure as `{ error: { code, message } }` — both shapes reach here.
+  error?: string | { message?: string };
+  errors?: string | { message?: string; error?: { message?: string } };
+};
+
+function apiErrorMessage(error: unknown, fallback: string): string {
+  const data = (error as { response?: { data?: ProxyErrorBody } })?.response?.data;
+  const wrapped = data?.errors;
+
+  if (typeof wrapped === 'string' && wrapped) return wrapped;
+
+  const wrappedMessage =
+    wrapped && typeof wrapped === 'object'
+      ? wrapped.message || wrapped.error?.message
+      : undefined;
+  const codedMessage =
+    data?.error && typeof data.error === 'object' ? data.error.message : undefined;
+
+  return wrappedMessage || codedMessage || data?.message || fallback;
+}
+
 class JourneyService {
   private getBaseUrl() {
     return '/journeys';
@@ -29,7 +60,7 @@ class JourneyService {
       return extractResponse<Journey>(response) as JourneysResponse;
     } catch (error: any) {
       console.error('Erro ao buscar jornadas:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao buscar jornadas');
+      throw new Error(apiErrorMessage(error, 'Erro ao buscar jornadas'));
     }
   }
 
@@ -39,12 +70,7 @@ class JourneyService {
       return extractData<Journey>(response);
     } catch (error: any) {
       console.error('Erro ao buscar jornada:', error);
-      // Usar formato padrão de erro: { success: false, error: { code, message, details }, meta }
-      const errorMessage =
-        error?.response?.data?.error?.message ||
-        error?.response?.data?.message ||
-        'Erro ao buscar jornada';
-      throw new Error(errorMessage);
+      throw new Error(apiErrorMessage(error, 'Erro ao buscar jornada'));
     }
   }
 
@@ -66,13 +92,7 @@ class JourneyService {
       return extractData<Journey>(response);
     } catch (error: any) {
       console.error('Erro ao criar jornada:', error);
-
-      // Usar formato padrão de erro: { success: false, error: { code, message, details }, meta }
-      const errorMessage =
-        error?.response?.data?.error?.message ||
-        error?.response?.data?.message ||
-        'Erro ao criar jornada';
-      throw new Error(errorMessage);
+      throw new Error(apiErrorMessage(error, 'Erro ao criar jornada'));
     }
   }
 
@@ -93,13 +113,7 @@ class JourneyService {
       return extractData<Journey>(response);
     } catch (error: any) {
       console.error('Erro ao atualizar jornada:', error);
-
-      // Usar formato padrão de erro: { success: false, error: { code, message, details }, meta }
-      const errorMessage =
-        error?.response?.data?.error?.message ||
-        error?.response?.data?.message ||
-        'Erro ao atualizar jornada';
-      throw new Error(errorMessage);
+      throw new Error(apiErrorMessage(error, 'Erro ao atualizar jornada'));
     }
   }
 
@@ -109,7 +123,7 @@ class JourneyService {
       return extractData<JourneyDeleteResponse>(response);
     } catch (error: any) {
       console.error('Erro ao excluir jornada:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao excluir jornada');
+      throw new Error(apiErrorMessage(error, 'Erro ao excluir jornada'));
     }
   }
 
@@ -122,7 +136,7 @@ class JourneyService {
       return extractData<JourneyResponse>(response);
     } catch (error: any) {
       console.error('Erro ao alterar status da jornada:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao alterar status da jornada');
+      throw new Error(apiErrorMessage(error, 'Erro ao alterar status da jornada'));
     }
   }
 
@@ -137,7 +151,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao duplicar jornada:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao duplicar jornada');
+      throw new Error(apiErrorMessage(error, 'Erro ao duplicar jornada'));
     }
   }
 
@@ -145,7 +159,9 @@ class JourneyService {
     triggerType: string,
   ): Promise<{ data: Journey[] }> {
     try {
-      const response = await api.get(`${this.getBaseUrl()}/trigger-type/${triggerType}`);
+      const response = await api.get(
+        `${this.getBaseUrl()}/trigger-type/${encodeURIComponent(triggerType)}`,
+      );
       const data = extractData<Journey[]>(response);
       return {
         data: Array.isArray(data) ? data : [],
@@ -153,7 +169,7 @@ class JourneyService {
     } catch (error: any) {
       console.error('Erro ao buscar jornadas por tipo de trigger:', error);
       throw new Error(
-        error?.response?.data?.message || 'Erro ao buscar jornadas por tipo de trigger',
+        apiErrorMessage(error, 'Erro ao buscar jornadas por tipo de trigger'),
       );
     }
   }
@@ -169,7 +185,7 @@ class JourneyService {
     } catch (error: any) {
       console.error('❌ Erro ao buscar variáveis da jornada:', error);
       console.error('❌ Error details:', error?.response?.data);
-      throw new Error(error?.response?.data?.message || 'Erro ao buscar variáveis da jornada');
+      throw new Error(apiErrorMessage(error, 'Erro ao buscar variáveis da jornada'));
     }
   }
 
@@ -185,7 +201,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao atualizar variáveis da jornada:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao atualizar variáveis da jornada');
+      throw new Error(apiErrorMessage(error, 'Erro ao atualizar variáveis da jornada'));
     }
   }
 
@@ -211,7 +227,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao buscar sessões da jornada:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao buscar sessões da jornada');
+      throw new Error(apiErrorMessage(error, 'Erro ao buscar sessões da jornada'));
     }
   }
 
@@ -228,7 +244,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao buscar estatísticas de sessões:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao buscar estatísticas de sessões');
+      throw new Error(apiErrorMessage(error, 'Erro ao buscar estatísticas de sessões'));
     }
   }
 
@@ -245,7 +261,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao buscar sessão:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao buscar sessão');
+      throw new Error(apiErrorMessage(error, 'Erro ao buscar sessão'));
     }
   }
 
@@ -257,7 +273,7 @@ class JourneyService {
       await api.delete(`${this.getBaseUrl()}/${journeyId}/sessions/${sessionId}`);
     } catch (error: any) {
       console.error('Erro ao deletar sessão:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao deletar sessão');
+      throw new Error(apiErrorMessage(error, 'Erro ao deletar sessão'));
     }
   }
 
@@ -275,7 +291,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao cancelar sessão:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao cancelar sessão');
+      throw new Error(apiErrorMessage(error, 'Erro ao cancelar sessão'));
     }
   }
 
@@ -292,7 +308,7 @@ class JourneyService {
       };
     } catch (error: any) {
       console.error('Erro ao deletar sessões em lote:', error);
-      throw new Error(error?.response?.data?.message || 'Erro ao deletar sessões em lote');
+      throw new Error(apiErrorMessage(error, 'Erro ao deletar sessões em lote'));
     }
   }
 }

--- a/src/services/journeys/journeyService.ts
+++ b/src/services/journeys/journeyService.ts
@@ -1,4 +1,4 @@
-import apiEvoFlow from '../core/apiEvoFlow';
+import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
 import type {
   Journey,
@@ -23,7 +23,7 @@ class JourneyService {
     },
   ): Promise<JourneysResponse> {
     try {
-      const response = await apiEvoFlow.get(this.getBaseUrl(), {
+      const response = await api.get(this.getBaseUrl(), {
         params,
       });
       return extractResponse<Journey>(response) as JourneysResponse;
@@ -35,7 +35,7 @@ class JourneyService {
 
   async getJourney(id: string): Promise<Journey> {
     try {
-      const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${id}`);
+      const response = await api.get(`${this.getBaseUrl()}/${id}`);
       return extractData<Journey>(response);
     } catch (error: any) {
       console.error('Erro ao buscar jornada:', error);
@@ -52,7 +52,7 @@ class JourneyService {
     payload: CreateJourneyPayload,
   ): Promise<Journey> {
     try {
-      const response = await apiEvoFlow.post(
+      const response = await api.post(
         this.getBaseUrl(),
         {
           name: payload.name,
@@ -88,7 +88,7 @@ class JourneyService {
         delete updateData.id;
       }
 
-      const response = await apiEvoFlow.patch(`${this.getBaseUrl()}/${id}`, updateData);
+      const response = await api.patch(`${this.getBaseUrl()}/${id}`, updateData);
 
       return extractData<Journey>(response);
     } catch (error: any) {
@@ -105,7 +105,7 @@ class JourneyService {
 
   async deleteJourney(id: string): Promise<JourneyDeleteResponse> {
     try {
-      const response = await apiEvoFlow.delete(`${this.getBaseUrl()}/${id}`);
+      const response = await api.delete(`${this.getBaseUrl()}/${id}`);
       return extractData<JourneyDeleteResponse>(response);
     } catch (error: any) {
       console.error('Erro ao excluir jornada:', error);
@@ -115,7 +115,7 @@ class JourneyService {
 
   async toggleJourney(id: string): Promise<JourneyResponse> {
     try {
-      const response = await apiEvoFlow.post(
+      const response = await api.post(
         `${this.getBaseUrl()}/${id}/toggle-active`,
         {},
       );
@@ -128,7 +128,7 @@ class JourneyService {
 
   async duplicateJourney(id: string): Promise<{ data: Journey }> {
     try {
-      const response = await apiEvoFlow.post(
+      const response = await api.post(
         `${this.getBaseUrl()}/${id}/duplicate`,
         {},
       );
@@ -145,7 +145,7 @@ class JourneyService {
     triggerType: string,
   ): Promise<{ data: Journey[] }> {
     try {
-      const response = await apiEvoFlow.get(`${this.getBaseUrl()}/trigger-type/${triggerType}`);
+      const response = await api.get(`${this.getBaseUrl()}/trigger-type/${triggerType}`);
       const data = extractData<Journey[]>(response);
       return {
         data: Array.isArray(data) ? data : [],
@@ -160,7 +160,7 @@ class JourneyService {
 
   async getJourneyVariables(id: string): Promise<{ data: any[] }> {
     try {
-      const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${id}/variables`);
+      const response = await api.get(`${this.getBaseUrl()}/${id}/variables`);
 
       const data = extractData<unknown[]>(response);
       return {
@@ -178,7 +178,7 @@ class JourneyService {
     variables: any[],
   ): Promise<{ data: any[] }> {
     try {
-      const response = await apiEvoFlow.post(`${this.getBaseUrl()}/${id}/variables`, variables);
+      const response = await api.post(`${this.getBaseUrl()}/${id}/variables`, variables);
       const data = extractData<unknown[]>(response);
       return {
         data: Array.isArray(data) ? data : [],
@@ -203,7 +203,7 @@ class JourneyService {
     },
   ): Promise<{ data: any }> {
     try {
-      const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${journeyId}/sessions`, {
+      const response = await api.get(`${this.getBaseUrl()}/${journeyId}/sessions`, {
         params,
       });
       return {
@@ -222,7 +222,7 @@ class JourneyService {
     };
   }> {
     try {
-      const response = await apiEvoFlow.get(`${this.getBaseUrl()}/${journeyId}/sessions/stats`);
+      const response = await api.get(`${this.getBaseUrl()}/${journeyId}/sessions/stats`);
       return {
         data: extractData(response),
       };
@@ -237,7 +237,7 @@ class JourneyService {
     sessionId: string,
   ): Promise<{ data: any }> {
     try {
-      const response = await apiEvoFlow.get(
+      const response = await api.get(
         `${this.getBaseUrl()}/${journeyId}/sessions/${sessionId}`,
       );
       return {
@@ -254,7 +254,7 @@ class JourneyService {
     sessionId: string,
   ): Promise<void> {
     try {
-      await apiEvoFlow.delete(`${this.getBaseUrl()}/${journeyId}/sessions/${sessionId}`);
+      await api.delete(`${this.getBaseUrl()}/${journeyId}/sessions/${sessionId}`);
     } catch (error: any) {
       console.error('Erro ao deletar sessão:', error);
       throw new Error(error?.response?.data?.message || 'Erro ao deletar sessão');
@@ -266,7 +266,7 @@ class JourneyService {
     sessionId: string,
   ): Promise<{ data: any }> {
     try {
-      const response = await apiEvoFlow.post(
+      const response = await api.post(
         `${this.getBaseUrl()}/${journeyId}/sessions/${sessionId}/cancel`,
         {},
       );
@@ -284,7 +284,7 @@ class JourneyService {
     status: string,
   ): Promise<{ data: { deleted: number } }> {
     try {
-      const response = await apiEvoFlow.delete(
+      const response = await api.delete(
         `${this.getBaseUrl()}/${journeyId}/sessions/bulk/${status}`,
       );
       return {


### PR DESCRIPTION
## EVO-2191 — Journeys: usar o proxy do CRM (`api`), não o evo-flow direto

> **Metade frontend do EVO-2188.** Complementar ao backend: https://github.com/evolution-foundation/evo-ai-crm-community/pull/240 (proxy `/api/v1/journeys` no CRM). **As duas juntas** resolvem o 405 do cliente.

### Root cause do 405 que o cliente ainda via
Depois do proxy no CRM (EVO-2188), o cliente **ainda** recebeu 405:
```
POST https://chat.gestordeleads.com/VITE_EVOFLOW_API_URL_PLACEHOLDER/api/v1/journeys -> 405
```
`journeyService.ts` importava `apiEvoFlow` → `apiEvoFlow.ts:9` `baseURL = ${VITE_EVOFLOW_API_URL}/api/v1` → batia **direto no evo-flow**. Com `VITE_EVOFLOW_API_URL` não setada no deploy do cliente, o placeholder ficava literal → 405. O comentário em `apiEvoFlow.ts:5-6` já dizia: *"journeys, campaigns; **segments migrated to the CRM proxy**"* — o segments migrou, o journeys não.

### Correção
`apiEvoFlow` → `api` (`@/services/core/api`, same-origin `${VITE_API_URL}/api/v1`), **igual o `segmentsService.ts`**. Agora `/journeys*` resolve para `${VITE_API_URL}/api/v1/journeys*` → **proxy do CRM (EVO-2188)** → evo-flow, com auth + gate de permissão, **sem depender de `VITE_EVOFLOW_API_URL`**.

- `journeyService.ts`: import trocado; **16** chamadas `apiEvoFlow.*` → `api.*`; paths inalterados (`/journeys*`).
- `journeyService.spec.ts`: mock de `api` (incl. `patch`).

### Testes
- `vitest run journeyService.spec.ts` → **9 passed**.
- `tsc --noEmit` → **0 erros**.
- `grep apiEvoFlow` no service → **0** (só sobra a palavra num comentário do spec).

### Relacionado
- Backend: **EVO-2188** / evo-ai-crm-community#240 (proxy + `client.patch` + rota + gate de permissão).
- **Deploy conjunto:** o 405 só some com **as duas** (esta + #240). Isoladamente nenhuma resolve.

## Summary by Sourcery

Route all journey-related frontend requests through the CRM proxy API instead of the direct evo-flow client to avoid 405s and align with segments.

Bug Fixes:
- Fix journey endpoints failing with 405 when VITE_EVOFLOW_API_URL is unset by using the same-origin CRM proxy API client.

Enhancements:
- Align journeyService with segments by standardizing on the core api client for journeys, variables, and session operations.

Tests:
- Update journeyService unit tests to mock the core api client (including patch) and verify calls against the CRM-proxy-backed endpoints.