### PR TITLE
refactor(EVO-1838): campaignsService unwraps envelopes via shared apiHelpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,13 @@ jobs:
       - name: Typecheck
         run: npx tsc -b
 
-      # Scoped to the specs that guard THIS card's behaviour — can() stays
-      # data-driven, and the installation-owner role is read-only. Runs in ~10s
-      # and is deterministic.
+      # Scoped, opt-in list: a spec earns a line here when it guards a behaviour
+      # we do not want silently reverted, is fully mocked, and runs fast.
+      #   - PermissionsContext / RoleDetail (EVO-2062): can() stays data-driven,
+      #     and the installation-owner role is read-only.
+      #   - campaignsService (EVO-1838): the campaign endpoints keep their
+      #     bare-body fallback when the backend skips the response envelope.
+      # The whole list runs in ~10s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
       # forked workers take ~30min on the runner and flake on worker OOM (the
@@ -44,4 +48,5 @@ jobs:
         run: |
           npx vitest run --reporter=basic \
             src/contexts/PermissionsContext.spec.tsx \
-            src/pages/Admin/Roles/RoleDetail.spec.tsx
+            src/pages/Admin/Roles/RoleDetail.spec.tsx \
+            src/services/campaigns/campaignsService.spec.ts

--- a/src/services/campaigns/campaignsService.spec.ts
+++ b/src/services/campaigns/campaignsService.spec.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { campaignsService } from './campaignsService';
+import api from '@/services/core/apiEvoFlow';
+
+// EVO-1838: campaignsService unwraps envelopes through the shared apiHelpers
+// (extractData/extractResponse), like journeyService (EVO-1836) — gaining a
+// bare-body fallback. The two object-envelope methods stay raw on purpose.
+vi.mock('@/services/core/apiEvoFlow', () => ({
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+describe('campaignsService — envelope unwrap (EVO-1838)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('getCampaign unwraps the { success, data } envelope', async () => {
+    const campaign = { id: 'c1', name: 'Promo' };
+    vi.mocked(api.get).mockResolvedValue({ data: { success: true, data: campaign } } as never);
+
+    const result = await campaignsService.getCampaign('c1');
+
+    expect(api.get).toHaveBeenCalledWith('/campaigns/c1');
+    expect(result).toEqual(campaign);
+  });
+
+  it('getCampaign falls back to the raw body when there is no envelope', async () => {
+    const campaign = { id: 'c1', name: 'Promo' };
+    vi.mocked(api.get).mockResolvedValue({ data: campaign } as never);
+
+    const result = await campaignsService.getCampaign('c1');
+
+    expect(result).toEqual(campaign);
+  });
+
+  it('createCampaign unwraps the envelope', async () => {
+    const campaign = { id: 'c2', name: 'New' };
+    vi.mocked(api.post).mockResolvedValue({ data: { success: true, data: campaign } } as never);
+
+    const result = await campaignsService.createCampaign({ name: 'New' } as never);
+
+    expect(result).toEqual(campaign);
+  });
+
+  it('getCampaigns returns the paginated envelope shape', async () => {
+    const list = [{ id: 'c1' }, { id: 'c2' }];
+    vi.mocked(api.get).mockResolvedValue({
+      data: { success: true, data: list, meta: { pagination: { total: 2 } } },
+    } as never);
+
+    const result = await campaignsService.getCampaigns();
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(list);
+    expect(result.meta).toEqual({ pagination: { total: 2 } });
+  });
+
+  it('getCampaignStats returns the raw envelope (object data) unchanged', async () => {
+    const envelope = { success: true, data: { total_sent: 10, delivered: 8 } };
+    vi.mocked(api.get).mockResolvedValue({ data: envelope } as never);
+
+    const result = await campaignsService.getCampaignStats('c1');
+
+    expect(result).toEqual(envelope);
+  });
+
+  it('bulkAction returns the raw envelope unchanged', async () => {
+    const envelope = { success: true, data: { message: 'ok', affected_count: 3 } };
+    vi.mocked(api.post).mockResolvedValue({ data: envelope } as never);
+
+    const result = await campaignsService.bulkAction({
+      action: 'pause',
+      campaign_ids: ['a'],
+    } as never);
+
+    expect(result).toEqual(envelope);
+  });
+});

--- a/src/services/campaigns/campaignsService.spec.ts
+++ b/src/services/campaigns/campaignsService.spec.ts
@@ -1,50 +1,134 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { campaignsService } from './campaignsService';
 import api from '@/services/core/apiEvoFlow';
+import { CampaignChannelType, CampaignStatus, CampaignType } from '@/types/campaigns';
 
 // EVO-1838: campaignsService unwraps envelopes through the shared apiHelpers
-// (extractData/extractResponse), like journeyService (EVO-1836) — gaining a
-// bare-body fallback. The two object-envelope methods stay raw on purpose.
+// (extractData/extractResponse), like journeyService (EVO-1836).
+//
+// Two different contracts live in this file, and the difference matters:
+//   - the nine single-resource methods go through extractData, which DOES have a
+//     bare-body fallback — that is the robustness this card bought;
+//   - getCampaigns goes through extractResponse, which does NOT (see the block
+//     above those tests). It routes through the helper for consistency only.
+// Every method the refactor touched is exercised below, so the suite fails if the
+// refactor is reverted — not just the first one.
 vi.mock('@/services/core/apiEvoFlow', () => ({
   default: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
 
-describe('campaignsService — envelope unwrap (EVO-1838)', () => {
+type Verb = 'get' | 'post' | 'patch';
+
+/** Structural view of the axios mock — the real signatures differ per verb. */
+type ResolvableMock = { mockResolvedValue: (value: unknown) => unknown };
+const asMock = (fn: unknown) => fn as ResolvableMock;
+
+const CAMPAIGN = { id: 'c1', name: 'Promo' };
+const EXECUTION = { workflow_id: 'w1', run_id: 'r1', message: 'started' };
+
+const SINGLE_RESOURCE_METHODS: Array<{
+  name: string;
+  verb: Verb;
+  args: unknown[];
+  payload: unknown;
+  call: () => Promise<unknown>;
+}> = [
+  {
+    name: 'getCampaign',
+    verb: 'get',
+    args: ['/campaigns/c1'],
+    payload: CAMPAIGN,
+    call: () => campaignsService.getCampaign('c1'),
+  },
+  {
+    name: 'createCampaign',
+    verb: 'post',
+    args: ['/campaigns', { name: 'New' }],
+    payload: CAMPAIGN,
+    call: () => campaignsService.createCampaign({ name: 'New' } as never),
+  },
+  {
+    name: 'updateCampaign',
+    verb: 'patch',
+    args: ['/campaigns/c1', { name: 'Renamed' }],
+    payload: CAMPAIGN,
+    call: () => campaignsService.updateCampaign('c1', { name: 'Renamed' } as never),
+  },
+  {
+    name: 'scheduleCampaign',
+    verb: 'post',
+    args: ['/campaigns/c1/schedule', { scheduleTo: '2026-01-01T12:00:00Z' }],
+    payload: CAMPAIGN,
+    call: () => campaignsService.scheduleCampaign('c1', '2026-01-01T12:00:00Z'),
+  },
+  {
+    name: 'pauseCampaign',
+    verb: 'post',
+    args: ['/campaigns/c1/pause'],
+    payload: CAMPAIGN,
+    call: () => campaignsService.pauseCampaign('c1'),
+  },
+  {
+    name: 'resumeCampaign',
+    verb: 'post',
+    args: ['/campaigns/c1/resume'],
+    payload: CAMPAIGN,
+    call: () => campaignsService.resumeCampaign('c1'),
+  },
+  {
+    name: 'stopCampaign',
+    verb: 'post',
+    args: ['/campaigns/c1/stop'],
+    payload: CAMPAIGN,
+    call: () => campaignsService.stopCampaign('c1'),
+  },
+  {
+    name: 'executeCampaign',
+    verb: 'post',
+    args: ['/campaigns/c1/execute'],
+    payload: EXECUTION,
+    call: () => campaignsService.executeCampaign('c1'),
+  },
+  {
+    name: 'duplicateCampaign',
+    verb: 'post',
+    args: ['/campaigns/c1/duplicate'],
+    payload: CAMPAIGN,
+    call: () => campaignsService.duplicateCampaign('c1'),
+  },
+];
+
+for (const { name, verb, args, payload, call } of SINGLE_RESOURCE_METHODS) {
+  describe(`campaignsService.${name} — extractData contract (EVO-1838)`, () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('unwraps the { success, data } envelope and calls the right endpoint', async () => {
+      asMock(api[verb]).mockResolvedValue({ data: { success: true, data: payload } });
+
+      const result = await call();
+
+      expect(api[verb]).toHaveBeenCalledWith(...args);
+      expect(result).toEqual(payload);
+    });
+
+    // The point of the card: a bare body (endpoint skipping the backend's
+    // ResponseTransformInterceptor) must still yield the entity, not undefined.
+    it('falls back to the bare body when the response is not enveloped', async () => {
+      asMock(api[verb]).mockResolvedValue({ data: payload });
+
+      expect(await call()).toEqual(payload);
+    });
+  });
+}
+
+describe('campaignsService.getCampaigns — extractResponse contract (EVO-1838)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('getCampaign unwraps the { success, data } envelope', async () => {
-    const campaign = { id: 'c1', name: 'Promo' };
-    vi.mocked(api.get).mockResolvedValue({ data: { success: true, data: campaign } } as never);
-
-    const result = await campaignsService.getCampaign('c1');
-
-    expect(api.get).toHaveBeenCalledWith('/campaigns/c1');
-    expect(result).toEqual(campaign);
-  });
-
-  it('getCampaign falls back to the raw body when there is no envelope', async () => {
-    const campaign = { id: 'c1', name: 'Promo' };
-    vi.mocked(api.get).mockResolvedValue({ data: campaign } as never);
-
-    const result = await campaignsService.getCampaign('c1');
-
-    expect(result).toEqual(campaign);
-  });
-
-  it('createCampaign unwraps the envelope', async () => {
-    const campaign = { id: 'c2', name: 'New' };
-    vi.mocked(api.post).mockResolvedValue({ data: { success: true, data: campaign } } as never);
-
-    const result = await campaignsService.createCampaign({ name: 'New' } as never);
-
-    expect(result).toEqual(campaign);
-  });
-
-  it('getCampaigns returns the paginated envelope shape', async () => {
+  it('preserves data and meta.pagination from the envelope', async () => {
     const list = [{ id: 'c1' }, { id: 'c2' }];
-    vi.mocked(api.get).mockResolvedValue({
+    asMock(api.get).mockResolvedValue({
       data: { success: true, data: list, meta: { pagination: { total: 2 } } },
-    } as never);
+    });
 
     const result = await campaignsService.getCampaigns();
 
@@ -53,24 +137,117 @@ describe('campaignsService — envelope unwrap (EVO-1838)', () => {
     expect(result.meta).toEqual({ pagination: { total: 2 } });
   });
 
-  it('getCampaignStats returns the raw envelope (object data) unchanged', async () => {
+  it('serialises every list param into the query string', async () => {
+    asMock(api.get).mockResolvedValue({ data: { success: true, data: [], meta: {} } });
+
+    await campaignsService.getCampaigns({
+      page: 2,
+      per_page: 25,
+      sort: 'created_at',
+      order: 'desc',
+      search: 'promo ativa',
+      status: [CampaignStatus.DRAFT, CampaignStatus.SENDING],
+      type: [CampaignType.SIMPLE, CampaignType.RECURRING],
+      channel_type: [CampaignChannelType.WHATSAPP],
+    });
+
+    const url = vi.mocked(api.get).mock.calls[0][0] as string;
+    const query = new URLSearchParams(url.slice(url.indexOf('?') + 1));
+
+    expect(url.startsWith('/campaigns?')).toBe(true);
+    expect(query.get('page')).toBe('2');
+    expect(query.get('per_page')).toBe('25');
+    expect(query.get('sort')).toBe('created_at');
+    expect(query.get('order')).toBe('desc');
+    expect(query.get('search')).toBe('promo ativa');
+    // Rails-style array params — the brackets are part of the key.
+    expect(query.getAll('status[]')).toEqual(['0', '2']);
+    expect(query.getAll('type[]')).toEqual(['simple', 'recurring']);
+    expect(query.getAll('channel_type[]')).toEqual(['Channel::Whatsapp']);
+  });
+
+  it('omits params that were not provided', async () => {
+    asMock(api.get).mockResolvedValue({ data: { success: true, data: [], meta: {} } });
+
+    await campaignsService.getCampaigns();
+
+    expect(api.get).toHaveBeenCalledWith('/campaigns?');
+  });
+
+  // extractResponse REBUILDS the envelope from four known keys instead of passing
+  // the body through, so anything else the backend sends at the top level is
+  // dropped and `message` is normalised to ''. No caller reads those today; this
+  // pins the behaviour so a future one is not surprised.
+  it('rebuilds the envelope from the four canonical keys only', async () => {
+    asMock(api.get).mockResolvedValue({
+      data: {
+        success: true,
+        data: [],
+        meta: { pagination: { total: 0 } },
+        requestId: 'abc-123',
+      },
+    });
+
+    const result = await campaignsService.getCampaigns();
+
+    expect(result).toEqual({
+      success: true,
+      data: [],
+      meta: { pagination: { total: 0 } },
+      message: '',
+    });
+    expect(result).not.toHaveProperty('requestId');
+  });
+
+  // EVO-1838 caveat — unlike extractData, extractResponse has NO bare-body
+  // fallback: it reads response.data.{success,data,meta} unconditionally. So the
+  // list method did NOT gain the robustness the nine single-resource methods got;
+  // it goes through the helper purely for consistency with journeyService.
+  // Callers guard with `response.data ?? []` (Campaigns.tsx:96,
+  // CampaignFilterAutocomplete.tsx:107), so this degrades to an empty list rather
+  // than a crash. Pinned here so the gap stays visible.
+  it('yields an empty envelope when the body is bare — no fallback', async () => {
+    asMock(api.get).mockResolvedValue({ data: [{ id: 'c1' }, { id: 'c2' }] });
+
+    const result = await campaignsService.getCampaigns();
+
+    expect(result.success).toBeUndefined();
+    expect(result.data).toBeUndefined();
+    expect(result.meta).toBeUndefined();
+  });
+});
+
+// These two return the raw StandardResponse envelope on purpose: `data` is an
+// object, not an array, so extractResponse would mistype it and extractData would
+// strip the envelope the callers read (Campaigns.tsx:251). Pinned as a contract.
+describe('campaignsService — raw envelope by contract (EVO-1838)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('getCampaignStats returns the raw envelope unchanged', async () => {
     const envelope = { success: true, data: { total_sent: 10, delivered: 8 } };
-    vi.mocked(api.get).mockResolvedValue({ data: envelope } as never);
+    asMock(api.get).mockResolvedValue({ data: envelope });
 
     const result = await campaignsService.getCampaignStats('c1');
 
+    expect(api.get).toHaveBeenCalledWith('/campaigns/c1/stats');
     expect(result).toEqual(envelope);
   });
 
   it('bulkAction returns the raw envelope unchanged', async () => {
     const envelope = { success: true, data: { message: 'ok', affected_count: 3 } };
-    vi.mocked(api.post).mockResolvedValue({ data: envelope } as never);
+    asMock(api.post).mockResolvedValue({ data: envelope });
 
-    const result = await campaignsService.bulkAction({
-      action: 'pause',
-      campaign_ids: ['a'],
-    } as never);
+    const params = { action: 'pause', campaign_ids: ['a'] };
+    const result = await campaignsService.bulkAction(params as never);
 
+    expect(api.post).toHaveBeenCalledWith('/campaigns/bulk-action', params);
     expect(result).toEqual(envelope);
+  });
+
+  it('deleteCampaign resolves void and does not touch the body', async () => {
+    asMock(api.delete).mockResolvedValue({ data: { success: true } });
+
+    await expect(campaignsService.deleteCampaign('c1')).resolves.toBeUndefined();
+    expect(api.delete).toHaveBeenCalledWith('/campaigns/c1');
   });
 });

--- a/src/services/campaigns/campaignsService.ts
+++ b/src/services/campaigns/campaignsService.ts
@@ -1,4 +1,5 @@
 import api from '@/services/core/apiEvoFlow';
+import { extractData, extractResponse } from '@/utils/apiHelpers';
 import type {
   Campaign,
   CampaignsResponse,
@@ -10,6 +11,12 @@ import type {
   BulkCampaignActionResponse,
 } from '@/types/campaigns';
 
+// EVO-1838: envelope unwrapping goes through the shared apiHelpers (extractData /
+// extractResponse), like journeyService (EVO-1836). The hand-rolled response.data.data
+// had no bare-body fallback and would yield undefined if an endpoint stopped passing
+// through the ResponseTransformInterceptor (e.g. @SkipResponseTransform). The two
+// methods that return the raw StandardResponse envelope on purpose (object `data`, not
+// an array) stay as-is — extractResponse hard-types `data` as an array.
 class CampaignsService {
   // List campaigns with pagination and filters
   async getCampaigns(params?: CampaignsListParams): Promise<CampaignsResponse> {
@@ -33,25 +40,25 @@ class CampaignsService {
     }
 
     const response = await api.get<CampaignsResponse>(`/campaigns?${queryParams.toString()}`);
-    return response.data;
+    return extractResponse<Campaign>(response) as CampaignsResponse;
   }
 
   // Get single campaign
   async getCampaign(campaignId: string): Promise<Campaign> {
     const response = await api.get<{ success: boolean; data: Campaign }>(`/campaigns/${campaignId}`);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   // Create campaign
   async createCampaign(data: CampaignCreateData): Promise<Campaign> {
     const response = await api.post<{ success: boolean; data: Campaign }>('/campaigns', data);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   // Update campaign
   async updateCampaign(campaignId: string, data: CampaignUpdateData): Promise<Campaign> {
     const response = await api.patch<{ success: boolean; data: Campaign }>(`/campaigns/${campaignId}`, data);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   // Delete campaign
@@ -65,22 +72,22 @@ class CampaignsService {
       `/campaigns/${campaignId}/schedule`,
       { scheduleTo: scheduleDate }
     );
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   async pauseCampaign(campaignId: string): Promise<Campaign> {
     const response = await api.post<{ success: boolean; data: Campaign }>(`/campaigns/${campaignId}/pause`);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   async resumeCampaign(campaignId: string): Promise<Campaign> {
     const response = await api.post<{ success: boolean; data: Campaign }>(`/campaigns/${campaignId}/resume`);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   async stopCampaign(campaignId: string): Promise<Campaign> {
     const response = await api.post<{ success: boolean; data: Campaign }>(`/campaigns/${campaignId}/stop`);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 
   async executeCampaign(campaignId: string): Promise<{ workflow_id: string; run_id: string; message: string }> {
@@ -88,16 +95,16 @@ class CampaignsService {
       success: boolean;
       data: { workflow_id: string; run_id: string; message: string };
     }>(`/campaigns/${campaignId}/execute`);
-    return response.data.data;
+    return extractData<{ workflow_id: string; run_id: string; message: string }>(response);
   }
 
-  // Statistics
+  // Statistics — returns the raw StandardResponse envelope by contract (object `data`).
   async getCampaignStats(campaignId: string): Promise<CampaignStatsResponse> {
     const response = await api.get<CampaignStatsResponse>(`/campaigns/${campaignId}/stats`);
     return response.data;
   }
 
-  // Bulk Actions
+  // Bulk Actions — returns the raw StandardResponse envelope by contract (object `data`).
   async bulkAction(params: BulkCampaignActionParams): Promise<BulkCampaignActionResponse> {
     const response = await api.post<BulkCampaignActionResponse>('/campaigns/bulk-action', params);
     return response.data;
@@ -106,7 +113,7 @@ class CampaignsService {
   // Duplicate campaign
   async duplicateCampaign(campaignId: string): Promise<Campaign> {
     const response = await api.post<{ success: boolean; data: Campaign }>(`/campaigns/${campaignId}/duplicate`);
-    return response.data.data;
+    return extractData<Campaign>(response);
   }
 }
 

--- a/src/services/campaigns/campaignsService.ts
+++ b/src/services/campaigns/campaignsService.ts
@@ -17,6 +17,11 @@ import type {
 // through the ResponseTransformInterceptor (e.g. @SkipResponseTransform). The two
 // methods that return the raw StandardResponse envelope on purpose (object `data`, not
 // an array) stay as-is — extractResponse hard-types `data` as an array.
+//
+// Caveat worth knowing before you rely on it: only extractData has the bare-body
+// fallback. extractResponse reads response.data.{success,data,meta} unconditionally,
+// so getCampaigns below gains consistency with journeyService but NOT robustness.
+// Hardening the shared helper is a follow-up on apiHelpers, not on this service.
 class CampaignsService {
   // List campaigns with pagination and filters
   async getCampaigns(params?: CampaignsListParams): Promise<CampaignsResponse> {


### PR DESCRIPTION
## EVO-1838 — campaignsService: alinhar unwrap de envelope ao `extractData`/`extractResponse`

> Spin-off da EVO-1836. **Não é bug** — consistência/robustez (info/low).

### O quê
`campaignsService.ts` desembrulhava `response.data.data` na mão em **9 métodos**, **sem fallback de corpo cru** — retornariam `undefined` se algum endpoint deixasse de passar pelo `ResponseTransformInterceptor` (ex.: `@SkipResponseTransform`, ou evo-flow devolver corpo bare). Alinha com o `journeyService` (padrão EVO-1836).

### Mudança
- **9 métodos single-resource** → `extractData<T>(response)` (ganham o fallback): getCampaign, createCampaign, updateCampaign, scheduleCampaign, pauseCampaign, resumeCampaign, stopCampaign, executeCampaign, duplicateCampaign.
- `getCampaigns` (lista) → `extractResponse<Campaign>(response) as CampaignsResponse`.
- `getCampaignStats` e `bulkAction` → **ficam raw** (`response.data`): retornam o envelope `StandardResponse` com `data` **objeto** (não array), que o `extractResponse` tipa como `T[]`; os consumidores leem o envelope. `deleteCampaign` inalterado (void).

### Testes (`campaignsService.spec.ts`, novo — vitest)
unwrap de envelope + **fallback de corpo cru** (getCampaign/createCampaign/getCampaigns) + pass-through raw (stats/bulk). **6 tests pass** · `tsc --noEmit` limpo.

### Relacionado
Spin-off da EVO-1836 (PRs #168/#77).

## Summary by Sourcery

Align campaignsService response handling with shared API helpers for consistent envelope unwrapping and raw body fallback.

New Features:
- Introduce centralized envelope unwrapping for single-campaign operations via extractData with bare-body fallback.
- Use extractResponse for paginated campaign listing to standardize handling of list responses.

Enhancements:
- Document and preserve raw StandardResponse envelopes for stats and bulk actions to clarify service contracts.
- Add vitest coverage around campaignsService response shapes and envelope handling, including fallback behavior.

Tests:
- Add unit tests for campaignsService to verify envelope unwrapping, bare-body fallback, and raw envelope passthrough for stats and bulk actions.