### PR TITLE
feat(EVO-1739): advanced (raw JSON) mode + Test button in the Custom MCP wizard

### DIFF
--- a/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.spec.tsx
+++ b/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.spec.tsx
@@ -13,12 +13,14 @@ vi.mock('@/services/agents/customToolsService', () => ({
   createCustomTool: vi.fn(),
 }));
 
-vi.mock('@/components/customTools/CustomToolForm', () => ({
-  default: ({ onCancel }: { onCancel: () => void }) => (
-    <div data-testid="custom-tool-form">
-      <button onClick={onCancel}>cancel-form</button>
-    </div>
-  ),
+// EVO-1738: the agent-builder create path now renders the guided wizard.
+vi.mock('@/components/customTools/CustomToolWizardModal', () => ({
+  default: ({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) =>
+    open ? (
+      <div data-testid="custom-tool-wizard">
+        <button onClick={() => onOpenChange(false)}>close-wizard</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock('sonner', () => ({
@@ -50,7 +52,7 @@ describe('CustomToolsSelectionDialog', () => {
     });
   });
 
-  it('opens inline create sub-dialog without closing selection dialog when header button is clicked', async () => {
+  it('opens the create wizard without closing the selection dialog when header button is clicked', async () => {
     const onOpenChange = vi.fn();
     render(<CustomToolsSelectionDialog {...makeProps({ onOpenChange })} />);
 
@@ -62,12 +64,12 @@ describe('CustomToolsSelectionDialog', () => {
     const createButtons = screen.getAllByText('tools.customTools.create');
     fireEvent.click(createButtons[0].closest('button')!);
 
-    // Inline form should appear without closing the parent dialog
-    expect(screen.getByTestId('custom-tool-form')).toBeTruthy();
+    // The wizard should appear without closing the parent selection dialog
+    expect(screen.getByTestId('custom-tool-wizard')).toBeTruthy();
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it('closes the create sub-dialog when form is cancelled, keeping selection dialog open', async () => {
+  it('closes the create wizard when dismissed, keeping the selection dialog open', async () => {
     render(<CustomToolsSelectionDialog {...makeProps()} />);
 
     await waitFor(() => {
@@ -76,14 +78,14 @@ describe('CustomToolsSelectionDialog', () => {
 
     const createButtons = screen.getAllByText('tools.customTools.create');
     fireEvent.click(createButtons[0].closest('button')!);
-    expect(screen.getByTestId('custom-tool-form')).toBeTruthy();
+    expect(screen.getByTestId('custom-tool-wizard')).toBeTruthy();
 
-    // Cancel the form
-    fireEvent.click(screen.getByText('cancel-form'));
+    // Close the wizard
+    fireEvent.click(screen.getByText('close-wizard'));
 
-    // Form should be gone
+    // Wizard should be gone
     await waitFor(() => {
-      expect(screen.queryByTestId('custom-tool-form')).toBeNull();
+      expect(screen.queryByTestId('custom-tool-wizard')).toBeNull();
     });
   });
 });

--- a/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.tsx
+++ b/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.tsx
@@ -15,7 +15,7 @@ import { Search, Code, Tag, Plus, ExternalLink } from 'lucide-react';
 import { listCustomTools, createCustomTool } from '@/services/agents/customToolsService';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import { useLanguage } from '@/hooks/useLanguage';
-import CustomToolForm from '@/components/customTools/CustomToolForm';
+import CustomToolWizardModal from '@/components/customTools/CustomToolWizardModal';
 import { toast } from 'sonner';
 
 interface CustomToolsSelectionDialogProps {
@@ -308,23 +308,14 @@ const CustomToolsSelectionDialog = ({
         </DialogContent>
       </Dialog>
 
-      {/* Inline create tool sub-dialog — preserves wizard state */}
-      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-        <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Plus className="h-5 w-5 text-purple-500" />
-              {t('tools.customTools.create')}
-            </DialogTitle>
-          </DialogHeader>
-          <CustomToolForm
-            mode="create"
-            loading={isCreatingTool}
-            onSubmit={handleCreateTool}
-            onCancel={() => setShowCreateDialog(false)}
-          />
-        </DialogContent>
-      </Dialog>
+      {/* EVO-1738: the agent-builder create path now uses the guided wizard
+          (n8n-style) instead of the old sectioned form. */}
+      <CustomToolWizardModal
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        loading={isCreatingTool}
+        onSubmit={handleCreateTool}
+      />
     </>
   );
 };

--- a/src/components/ai_agents/shared/AdvancedJsonEditor.spec.tsx
+++ b/src/components/ai_agents/shared/AdvancedJsonEditor.spec.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AdvancedJsonEditor from './AdvancedJsonEditor';
+
+// EVO-1738/1739: the advanced (raw JSON) escape hatch must parse on every edit and
+// report validity so the wizard blocks submit on malformed JSON.
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (k: string) => k }),
+}));
+
+describe('AdvancedJsonEditor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the value as pretty JSON', () => {
+    render(<AdvancedJsonEditor value={{ name: 'srv', url: 'https://x' }} onChange={vi.fn()} />);
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement;
+    expect(ta.value).toContain('"name": "srv"');
+    expect(ta.value).toContain('"url": "https://x"');
+  });
+
+  it('emits the parsed object and valid=true on a valid edit', () => {
+    const onChange = vi.fn();
+    const onValidityChange = vi.fn();
+    render(<AdvancedJsonEditor value={{}} onChange={onChange} onValidityChange={onValidityChange} />);
+    const ta = screen.getByRole('textbox');
+    fireEvent.change(ta, { target: { value: '{"name":"api","timeout":30}' } });
+    expect(onChange).toHaveBeenLastCalledWith({ name: 'api', timeout: 30 });
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it('reports valid=false on malformed JSON and does not call onChange', () => {
+    const onChange = vi.fn();
+    const onValidityChange = vi.fn();
+    render(<AdvancedJsonEditor value={{}} onChange={onChange} onValidityChange={onValidityChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '{ not json' } });
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('rejects a top-level array/primitive as not an object', () => {
+    const onValidityChange = vi.fn();
+    render(<AdvancedJsonEditor value={{}} onChange={vi.fn()} onValidityChange={onValidityChange} />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '[1,2,3]' } });
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/src/components/ai_agents/shared/AdvancedJsonEditor.tsx
+++ b/src/components/ai_agents/shared/AdvancedJsonEditor.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Textarea } from '@evoapi/design-system';
+import { useLanguage } from '@/hooks/useLanguage';
+
+/**
+ * EVO-1738/EVO-1739: full-config raw-JSON escape hatch for the Custom Tools / Custom
+ * MCP wizards (n8n-style "advanced mode"). Renders the whole config object as editable
+ * JSON, parses on every keystroke, and reports validity so the wizard can block submit
+ * on malformed JSON. Shared primitive — the parent owns the object and the mode toggle.
+ */
+export interface AdvancedJsonEditorProps {
+  /** Current config object (rendered as pretty JSON on mount). */
+  value: Record<string, unknown>;
+  /** Called with the parsed object on every valid edit. */
+  onChange: (parsed: Record<string, unknown>) => void;
+  /** Called whenever the parse validity changes (false → wizard must block submit). */
+  onValidityChange?: (valid: boolean) => void;
+  rows?: number;
+  label?: string;
+  hint?: string;
+}
+
+export default function AdvancedJsonEditor({
+  value,
+  onChange,
+  onValidityChange,
+  rows = 18,
+  label,
+  hint,
+}: AdvancedJsonEditorProps) {
+  const { t } = useLanguage('customTools');
+  // Initialize once from the incoming object; the parent remounts this editor each time
+  // advanced mode is (re)entered, so we never clobber in-progress typing with prop syncs.
+  const [text, setText] = useState(() => JSON.stringify(value ?? {}, null, 2));
+  const [error, setError] = useState('');
+
+  const handleChange = (next: string) => {
+    setText(next);
+    try {
+      const parsed = JSON.parse(next);
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        setError(t('advancedJson.mustBeObject'));
+        onValidityChange?.(false);
+        return;
+      }
+      setError('');
+      onValidityChange?.(true);
+      onChange(parsed as Record<string, unknown>);
+    } catch {
+      setError(t('advancedJson.invalid'));
+      onValidityChange?.(false);
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      {label && <span className="text-sm font-semibold block">{label}</span>}
+      <Textarea
+        value={text}
+        onChange={e => handleChange(e.target.value)}
+        rows={rows}
+        spellCheck={false}
+        className={`font-mono text-xs ${error ? 'border-red-500' : ''}`}
+        aria-label={label || t('advancedJson.title')}
+      />
+      {error ? (
+        <p className="text-sm text-red-600">{error}</p>
+      ) : (
+        hint && <p className="text-xs text-muted-foreground">{hint}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ai_agents/shared/AdvancedJsonEditor.tsx
+++ b/src/components/ai_agents/shared/AdvancedJsonEditor.tsx
@@ -3,15 +3,9 @@ import { Textarea } from '@evoapi/design-system';
 import { useLanguage } from '@/hooks/useLanguage';
 
 /**
- * EVO-1738/EVO-1739: full-config raw-JSON escape hatch for the Custom Tools / Custom
- * MCP wizards (n8n-style "advanced mode"). Renders the whole config object as editable
- * JSON, parses on every keystroke, and reports validity so the wizard can block submit
- * on malformed JSON. Shared primitive — the parent owns the object and the mode toggle.
- *
- * Validity has two layers, and the parent owns the second one: this component only
- * decides whether the text is *syntactically* a JSON object. Whether that object is a
- * usable config (url parses, timeout in range, …) is domain knowledge, so the parent
- * validates it and passes the messages back down via `issues` for display.
+ * EVO-1738/EVO-1739: raw-JSON escape hatch for the Custom Tools / Custom MCP wizards.
+ * Reports only *syntactic* validity — whether the config is usable is domain knowledge
+ * the parent owns and feeds back through `issues`.
  */
 export interface AdvancedJsonEditorProps {
   /** Current config object (rendered as pretty JSON on mount). */
@@ -42,10 +36,8 @@ export default function AdvancedJsonEditor({
   const [text, setText] = useState(() => JSON.stringify(value ?? {}, null, 2));
   const [error, setError] = useState('');
 
-  // The initial text is always valid JSON — we just serialized it — but the parent has no
-  // way to know that unless we say so. Without this it keeps whatever validity it was left
-  // with (e.g. `false` from a previous visit to advanced mode) and the submit button stays
-  // dead while a perfectly valid config sits on screen.
+  // Announce the initial text as valid, otherwise the parent keeps whatever validity a
+  // previous visit left it with and gates submit on stale state.
   const onValidityChangeRef = useRef(onValidityChange);
   onValidityChangeRef.current = onValidityChange;
   useEffect(() => {

--- a/src/components/ai_agents/shared/AdvancedJsonEditor.tsx
+++ b/src/components/ai_agents/shared/AdvancedJsonEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Textarea } from '@evoapi/design-system';
 import { useLanguage } from '@/hooks/useLanguage';
 
@@ -7,6 +7,11 @@ import { useLanguage } from '@/hooks/useLanguage';
  * MCP wizards (n8n-style "advanced mode"). Renders the whole config object as editable
  * JSON, parses on every keystroke, and reports validity so the wizard can block submit
  * on malformed JSON. Shared primitive — the parent owns the object and the mode toggle.
+ *
+ * Validity has two layers, and the parent owns the second one: this component only
+ * decides whether the text is *syntactically* a JSON object. Whether that object is a
+ * usable config (url parses, timeout in range, …) is domain knowledge, so the parent
+ * validates it and passes the messages back down via `issues` for display.
  */
 export interface AdvancedJsonEditorProps {
   /** Current config object (rendered as pretty JSON on mount). */
@@ -15,6 +20,8 @@ export interface AdvancedJsonEditorProps {
   onChange: (parsed: Record<string, unknown>) => void;
   /** Called whenever the parse validity changes (false → wizard must block submit). */
   onValidityChange?: (valid: boolean) => void;
+  /** Semantic errors from the parent's own validation, listed under the editor. */
+  issues?: string[];
   rows?: number;
   label?: string;
   hint?: string;
@@ -24,6 +31,7 @@ export default function AdvancedJsonEditor({
   value,
   onChange,
   onValidityChange,
+  issues = [],
   rows = 18,
   label,
   hint,
@@ -33,6 +41,16 @@ export default function AdvancedJsonEditor({
   // advanced mode is (re)entered, so we never clobber in-progress typing with prop syncs.
   const [text, setText] = useState(() => JSON.stringify(value ?? {}, null, 2));
   const [error, setError] = useState('');
+
+  // The initial text is always valid JSON — we just serialized it — but the parent has no
+  // way to know that unless we say so. Without this it keeps whatever validity it was left
+  // with (e.g. `false` from a previous visit to advanced mode) and the submit button stays
+  // dead while a perfectly valid config sits on screen.
+  const onValidityChangeRef = useRef(onValidityChange);
+  onValidityChangeRef.current = onValidityChange;
+  useEffect(() => {
+    onValidityChangeRef.current?.(true);
+  }, []);
 
   const handleChange = (next: string) => {
     setText(next);
@@ -52,6 +70,8 @@ export default function AdvancedJsonEditor({
     }
   };
 
+  const hasProblem = !!error || issues.length > 0;
+
   return (
     <div className="space-y-1.5">
       {label && <span className="text-sm font-semibold block">{label}</span>}
@@ -60,14 +80,21 @@ export default function AdvancedJsonEditor({
         onChange={e => handleChange(e.target.value)}
         rows={rows}
         spellCheck={false}
-        className={`font-mono text-xs ${error ? 'border-red-500' : ''}`}
+        className={`font-mono text-xs ${hasProblem ? 'border-red-500' : ''}`}
         aria-label={label || t('advancedJson.title')}
+        aria-invalid={hasProblem}
       />
-      {error ? (
-        <p className="text-sm text-red-600">{error}</p>
-      ) : (
-        hint && <p className="text-xs text-muted-foreground">{hint}</p>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      {!error && issues.length > 0 && (
+        <ul className="space-y-0.5">
+          {issues.map(issue => (
+            <li key={issue} className="text-sm text-red-600">
+              {issue}
+            </li>
+          ))}
+        </ul>
       )}
+      {!hasProblem && hint && <p className="text-xs text-muted-foreground">{hint}</p>}
     </div>
   );
 }

--- a/src/components/ai_agents/shared/TestRequestButton.spec.tsx
+++ b/src/components/ai_agents/shared/TestRequestButton.spec.tsx
@@ -7,9 +7,19 @@ vi.mock('@/hooks/useLanguage', () => ({
 }));
 
 const mockTestCustomTool = vi.fn();
-vi.mock('@/services/agents/customToolsService', () => ({
-  testCustomTool: (...args: unknown[]) => mockTestCustomTool(...args),
-}));
+const mockTestCustomToolPayload = vi.fn();
+vi.mock('@/services/agents/customToolsService', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/agents/customToolsService')
+  >('@/services/agents/customToolsService');
+  return {
+    // getErrorMessage is exercised for real: asserting on the message the user
+    // actually reads is the point of the failure tests below.
+    getErrorMessage: actual.getErrorMessage,
+    testCustomTool: (...args: unknown[]) => mockTestCustomTool(...args),
+    testCustomToolPayload: (...args: unknown[]) => mockTestCustomToolPayload(...args),
+  };
+});
 
 describe('TestRequestButton', () => {
   beforeEach(() => {
@@ -57,6 +67,93 @@ describe('TestRequestButton', () => {
     fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
     await waitFor(() => {
       expect(screen.getByText('network down')).toBeTruthy();
+    });
+  });
+
+  // EVO-1738 test-before-save (R1 review).
+  describe('payload mode', () => {
+    const payload = {
+      method: 'GET',
+      endpoint: 'https://api.example.com/users/{id}',
+      headers: { 'X-Token': 'abc' },
+      path_params: { id: '42' },
+      query_params: { limit: 10 },
+      body_params: {},
+    };
+
+    it('is enabled in create mode and tests the draft payload, not a saved tool', async () => {
+      mockTestCustomToolPayload.mockResolvedValue({
+        test_result: {
+          error: '',
+          headers: { 'content-type': 'application/json' },
+          response_time: 0.25,
+          status_code: 201,
+          success: true,
+          body: '{"id":1}',
+        },
+      });
+
+      render(<TestRequestButton mode="create" getPayload={() => payload} />);
+      const btn = screen.getByRole('button', { name: 'testRequest.button' });
+      // The create-mode lockout only existed because an unsaved tool had no id.
+      expect((btn as HTMLButtonElement).disabled).toBe(false);
+
+      fireEvent.click(btn);
+      await waitFor(() => {
+        expect(screen.getByTestId('test-request-result')).toBeTruthy();
+      });
+
+      expect(mockTestCustomToolPayload).toHaveBeenCalledWith(payload);
+      expect(mockTestCustomTool).not.toHaveBeenCalled();
+      expect(screen.getByText('201')).toBeTruthy();
+      expect(screen.getByText('250ms')).toBeTruthy();
+      // The response body is the whole point of testing — it must be rendered.
+      expect(screen.getByText(/"id": 1/)).toBeTruthy();
+    });
+
+    it("surfaces the API's reason, not axios's generic status line", async () => {
+      // Core's envelope: { success:false, error:{ code, message, details } }.
+      mockTestCustomToolPayload.mockRejectedValue({
+        message: 'Request failed with status code 400',
+        response: {
+          data: {
+            success: false,
+            error: { code: 'INVALID_INPUT', message: 'unsupported method: TRACE' },
+          },
+        },
+      });
+
+      render(<TestRequestButton mode="create" getPayload={() => payload} />);
+      fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('unsupported method: TRACE')).toBeTruthy();
+      });
+      expect(screen.queryByText('Request failed with status code 400')).toBeNull();
+    });
+
+    it('appends validation field details so the user knows what to fix', async () => {
+      mockTestCustomToolPayload.mockRejectedValue({
+        message: 'Request failed with status code 400',
+        response: {
+          data: {
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Validation failed',
+              details: { fields: [{ field: 'Endpoint', message: 'is required' }] },
+            },
+          },
+        },
+      });
+
+      render(<TestRequestButton mode="create" getPayload={() => payload} />);
+      fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Validation failed (Endpoint: is required)'),
+        ).toBeTruthy();
+      });
     });
   });
 });

--- a/src/components/ai_agents/shared/TestRequestButton.tsx
+++ b/src/components/ai_agents/shared/TestRequestButton.tsx
@@ -11,7 +11,12 @@ import {
 } from '@evoapi/design-system';
 import { Play, ChevronDown, Loader2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { testCustomTool } from '@/services/agents/customToolsService';
+import {
+  testCustomTool,
+  testCustomToolPayload,
+  getErrorMessage,
+  type CustomToolTestPayload,
+} from '@/services/agents/customToolsService';
 import type { CustomToolTestResponse } from '@/types/ai';
 
 /** Shared between Custom Tools (EVO-1790) and Custom MCP (EVO-1791) UIs. */
@@ -20,6 +25,13 @@ export interface TestRequestButtonProps {
   toolId?: string;
   onResult?: (result: CustomToolTestResponse['test_result']) => void;
   disabled?: boolean;
+  /**
+   * EVO-1738 test-before-save: when provided, the button runs the DRAFT config
+   * through the stateless endpoint instead of replaying a saved tool. Takes
+   * precedence over toolId and lifts the create-mode lockout — that lockout only
+   * ever existed because an unsaved tool had no id to test.
+   */
+  getPayload?: () => CustomToolTestPayload;
 }
 
 type TestResult = CustomToolTestResponse['test_result'];
@@ -53,6 +65,7 @@ export default function TestRequestButton({
   toolId,
   onResult,
   disabled = false,
+  getPayload,
 }: TestRequestButtonProps) {
   const { t } = useLanguage('customTools');
   const [loading, setLoading] = useState(false);
@@ -61,25 +74,33 @@ export default function TestRequestButton({
   const [responseBody, setResponseBody] = useState<unknown>(null);
   const [headersOpen, setHeadersOpen] = useState(false);
 
-  const isCreateMode = mode === 'create';
-  const buttonDisabled = disabled || loading || isCreateMode || !toolId;
+  // With a draft payload there is nothing to be "not saved yet" about, so the
+  // create-mode tooltip/lockout does not apply.
+  const isCreateMode = !getPayload && mode === 'create';
+  const buttonDisabled = disabled || loading || (!getPayload && (isCreateMode || !toolId));
 
   const handleClick = async () => {
-    if (!toolId) return;
+    if (!getPayload && !toolId) return;
     setLoading(true);
     setError(null);
     setResult(null);
     setResponseBody(null);
     try {
-      const resp = await testCustomTool(toolId);
-      setResult(resp.test_result);
-      const body = (resp as unknown as Record<string, unknown>).body
-        ?? (resp.test_result as unknown as Record<string, unknown>).body;
-      setResponseBody(body ?? null);
-      onResult?.(resp.test_result);
+      if (getPayload) {
+        const { test_result } = await testCustomToolPayload(getPayload());
+        setResult(test_result);
+        setResponseBody(test_result?.body ?? null);
+        onResult?.(test_result);
+      } else {
+        const resp = await testCustomTool(toolId!);
+        const body = (resp as unknown as Record<string, unknown>).body
+          ?? (resp.test_result as unknown as Record<string, unknown>).body;
+        setResult(resp.test_result);
+        setResponseBody(body ?? null);
+        onResult?.(resp.test_result);
+      }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setError(msg || t('testRequest.error'));
+      setError(getErrorMessage(e, t('testRequest.error')));
     } finally {
       setLoading(false);
     }

--- a/src/components/ai_agents/shared/index.ts
+++ b/src/components/ai_agents/shared/index.ts
@@ -2,6 +2,8 @@ export { default as KeyValueEditor } from './KeyValueEditor';
 export type { KeyValueEditorProps } from './KeyValueEditor';
 export { default as AdvancedJsonCollapse } from './AdvancedJsonCollapse';
 export type { AdvancedJsonCollapseProps } from './AdvancedJsonCollapse';
+export { default as AdvancedJsonEditor } from './AdvancedJsonEditor';
+export type { AdvancedJsonEditorProps } from './AdvancedJsonEditor';
 export { default as TestRequestButton } from './TestRequestButton';
 export type { TestRequestButtonProps } from './TestRequestButton';
 export { default as TagInput } from './TagInput';

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.spec.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.spec.tsx
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CustomMCPServerWizardModal from './CustomMCPServerWizardModal';
+import { parseWizardConfig } from './wizardConfig';
+import type { CustomMcpServer } from '@/types/ai';
+
+// EVO-1739: the advanced (raw JSON) escape hatch must be lossless and must not be a way
+// around the validation the step form enforces. Every case below reproduced a real defect
+// in the first cut of the wizard.
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (k: string, o?: Record<string, unknown>) => (o ? `${k}:${JSON.stringify(o)}` : k),
+  }),
+}));
+vi.mock('@/services/agents/customMcpServerService', () => ({
+  testCustomMcpServerConnection: vi.fn(),
+}));
+
+const t = (k: string, o?: Record<string, unknown>) => (o ? `${k}:${JSON.stringify(o)}` : k);
+
+const server: CustomMcpServer = {
+  id: 'srv-1',
+  client_id: 'c1',
+  name: 'My MCP',
+  description: 'original description',
+  url: 'https://mcp.example/mcp',
+  headers: { Authorization: 'Bearer sk' },
+  timeout: 30,
+  retry_count: 3,
+  tags: ['search'],
+  tools: [],
+  created_at: '',
+  updated_at: '',
+};
+
+const validConfig = {
+  name: 'My MCP',
+  description: 'original description',
+  url: 'https://mcp.example/mcp',
+  headers: { Authorization: 'Bearer sk' },
+  timeout: 30,
+  retry_count: 3,
+  tags: ['search'],
+};
+
+const renderWizard = (onSubmit = vi.fn()) => {
+  render(
+    <CustomMCPServerWizardModal
+      open
+      embedded
+      onOpenChange={vi.fn()}
+      onSubmit={onSubmit}
+      server={server}
+    />,
+  );
+  return onSubmit;
+};
+
+const goJson = () => fireEvent.click(screen.getByText('wizard.mode.json'));
+const goForm = () => fireEvent.click(screen.getByText('wizard.mode.form'));
+const editor = () => screen.getByRole('textbox') as HTMLTextAreaElement;
+const saveButton = () => screen.getByText('wizard.actions.save').closest('button')!;
+const writeJson = (config: unknown) =>
+  fireEvent.change(editor(), { target: { value: JSON.stringify(config) } });
+
+describe('parseWizardConfig', () => {
+  it('accepts a well-formed config with no issues', () => {
+    const { data, issues } = parseWizardConfig(validConfig, t);
+    expect(issues).toEqual([]);
+    expect(data).toEqual(validConfig);
+  });
+
+  it('treats an absent key as cleared instead of keeping the old value', () => {
+    // Deleting `description` from the JSON must actually clear it. The first cut kept the
+    // previous value, so a field could never be emptied from advanced mode.
+    const { data, issues } = parseWizardConfig({ ...validConfig, description: undefined }, t);
+    expect(issues).toEqual([]);
+    expect(data.description).toBe('');
+  });
+
+  it('reports a wrong-typed number instead of silently reverting it', () => {
+    // `"timeout": "60"` used to be dropped and saved as the default 30, with no feedback.
+    const { issues } = parseWizardConfig({ ...validConfig, timeout: '60' }, t);
+    expect(issues).toContain(t('wizard.advanced.errors.timeoutRange', { min: 1, max: 300 }));
+  });
+
+  it.each([
+    ['timeout below the range', { timeout: 0 }, 'timeoutRange'],
+    ['timeout above the range', { timeout: 999999 }, 'timeoutRange'],
+    ['fractional timeout', { timeout: 1.5 }, 'timeoutRange'],
+    ['retry_count above the range', { retry_count: 500 }, 'retryRange'],
+    ['negative retry_count', { retry_count: -1 }, 'retryRange'],
+  ])('enforces the same bounds as the step form: %s', (_label, patch, key) => {
+    const { issues } = parseWizardConfig({ ...validConfig, ...patch }, t);
+    expect(issues.some(i => i.startsWith(`wizard.advanced.errors.${key}`))).toBe(true);
+  });
+
+  it('rejects an unparseable url that the step form would have caught', () => {
+    const { issues } = parseWizardConfig({ ...validConfig, url: 'not-a-url' }, t);
+    expect(issues).toContain(t('wizard.advanced.errors.urlInvalid'));
+  });
+
+  it.each([
+    ['empty name', { name: '   ' }, 'nameRequired'],
+    ['missing name', { name: undefined }, 'nameRequired'],
+    ['empty url', { url: '' }, 'urlRequired'],
+    ['missing url', { url: undefined }, 'urlRequired'],
+  ])('requires the mandatory fields: %s', (_label, patch, key) => {
+    const { issues } = parseWizardConfig({ ...validConfig, ...patch }, t);
+    expect(issues).toContain(t(`wizard.advanced.errors.${key}`));
+  });
+
+  it('names the header keys whose values are not text', () => {
+    // The API binds headers into a string map, so this would be a 400 at submit time.
+    const { issues } = parseWizardConfig(
+      { ...validConfig, headers: { 'X-Api-Key': 123, Ok: 'yes', 'X-Flag': true } },
+      t,
+    );
+    expect(issues).toContain(
+      t('wizard.advanced.errors.headerValueType', { keys: 'X-Api-Key, X-Flag' }),
+    );
+  });
+
+  it('rejects non-string tags rather than stringifying them', () => {
+    // `.map(String)` used to turn [1, {}] into ["1", "[object Object]"].
+    const { issues } = parseWizardConfig({ ...validConfig, tags: [1, {}] }, t);
+    expect(issues).toContain(t('wizard.advanced.errors.tagsType'));
+  });
+
+  it('collects every problem in one pass', () => {
+    const { issues } = parseWizardConfig({ name: '', url: 'nope', timeout: 0, tags: 'a,b' }, t);
+    expect(issues).toHaveLength(4);
+  });
+});
+
+describe('CustomMCPServerWizardModal — advanced JSON mode', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('re-enables submit when a valid config is back on screen', () => {
+    // Regression: validity was only ever reported from an edit, and never reset on a mode
+    // switch, so after typing malformed JSON the save button stayed dead even once the
+    // editor was showing a perfectly valid config again.
+    renderWizard();
+    goJson();
+    expect(saveButton()).not.toBeDisabled();
+
+    fireEvent.change(editor(), { target: { value: '{ broken' } });
+    expect(saveButton()).toBeDisabled();
+
+    goForm();
+    goJson();
+
+    expect(() => JSON.parse(editor().value)).not.toThrow();
+    expect(saveButton()).not.toBeDisabled();
+  });
+
+  it('blocks submit and lists the problem while the config is invalid', () => {
+    const onSubmit = renderWizard();
+    goJson();
+    writeJson({ ...validConfig, timeout: '60' });
+
+    expect(saveButton()).toBeDisabled();
+    expect(
+      screen.getByText(t('wizard.advanced.errors.timeoutRange', { min: 1, max: 300 })),
+    ).toBeTruthy();
+
+    fireEvent.click(saveButton());
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not commit a partially valid edit', () => {
+    // While issues stand, nothing is applied — otherwise `data` ends up half the user's
+    // edit and half stale values, which the form/JSON round-trip cannot untangle.
+    const onSubmit = renderWizard();
+    goJson();
+    writeJson({ ...validConfig, name: 'Renamed', timeout: 'nope' });
+    writeJson(validConfig);
+    fireEvent.click(saveButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ name: 'My MCP' }));
+  });
+
+  it('saves a config edited entirely through JSON', () => {
+    const onSubmit = renderWizard();
+    goJson();
+    writeJson({
+      name: 'Renamed',
+      description: '',
+      url: 'https://other.example/mcp',
+      headers: { 'X-Key': 'v' },
+      timeout: 120,
+      retry_count: 5,
+      tags: ['a', 'b'],
+    });
+    fireEvent.click(saveButton());
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      name: 'Renamed',
+      description: '',
+      url: 'https://other.example/mcp',
+      headers: { 'X-Key': 'v' },
+      timeout: 120,
+      retry_count: 5,
+      tags: ['a', 'b'],
+    });
+  });
+
+  it('clears a field when its key is removed from the JSON', () => {
+    const onSubmit = renderWizard();
+    goJson();
+    const withoutDescription: Record<string, unknown> = { ...validConfig };
+    delete withoutDescription.description;
+    writeJson(withoutDescription);
+    fireEvent.click(saveButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ description: '' }));
+  });
+
+  it('keeps JSON edits when switching back to the form', () => {
+    const onSubmit = renderWizard();
+    goJson();
+    writeJson({ ...validConfig, name: 'Renamed in JSON', timeout: 90 });
+    goForm();
+    goJson();
+
+    const roundTripped = JSON.parse(editor().value);
+    expect(roundTripped.name).toBe('Renamed in JSON');
+    expect(roundTripped.timeout).toBe(90);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.spec.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.spec.tsx
@@ -4,9 +4,8 @@ import CustomMCPServerWizardModal from './CustomMCPServerWizardModal';
 import { parseWizardConfig } from './wizardConfig';
 import type { CustomMcpServer } from '@/types/ai';
 
-// EVO-1739: the advanced (raw JSON) escape hatch must be lossless and must not be a way
-// around the validation the step form enforces. Every case below reproduced a real defect
-// in the first cut of the wizard.
+// EVO-1739: the advanced (raw JSON) mode must be lossless and must not bypass the
+// validation the step form enforces.
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({
     t: (k: string, o?: Record<string, unknown>) => (o ? `${k}:${JSON.stringify(o)}` : k),
@@ -71,15 +70,14 @@ describe('parseWizardConfig', () => {
   });
 
   it('treats an absent key as cleared instead of keeping the old value', () => {
-    // Deleting `description` from the JSON must actually clear it. The first cut kept the
-    // previous value, so a field could never be emptied from advanced mode.
+    // Deleting a key must clear the field, not fall back to the previous value.
     const { data, issues } = parseWizardConfig({ ...validConfig, description: undefined }, t);
     expect(issues).toEqual([]);
     expect(data.description).toBe('');
   });
 
   it('reports a wrong-typed number instead of silently reverting it', () => {
-    // `"timeout": "60"` used to be dropped and saved as the default 30, with no feedback.
+    // A wrong-typed number must surface, not revert to the default.
     const { issues } = parseWizardConfig({ ...validConfig, timeout: '60' }, t);
     expect(issues).toContain(t('wizard.advanced.errors.timeoutRange', { min: 1, max: 300 }));
   });
@@ -111,7 +109,7 @@ describe('parseWizardConfig', () => {
   });
 
   it('names the header keys whose values are not text', () => {
-    // The API binds headers into a string map, so this would be a 400 at submit time.
+    // The API binds headers into a string map, so this is a 400 on submit.
     const { issues } = parseWizardConfig(
       { ...validConfig, headers: { 'X-Api-Key': 123, Ok: 'yes', 'X-Flag': true } },
       t,
@@ -122,7 +120,7 @@ describe('parseWizardConfig', () => {
   });
 
   it('rejects non-string tags rather than stringifying them', () => {
-    // `.map(String)` used to turn [1, {}] into ["1", "[object Object]"].
+    // Coercing would smuggle in [object Object].
     const { issues } = parseWizardConfig({ ...validConfig, tags: [1, {}] }, t);
     expect(issues).toContain(t('wizard.advanced.errors.tagsType'));
   });
@@ -137,9 +135,7 @@ describe('CustomMCPServerWizardModal — advanced JSON mode', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('re-enables submit when a valid config is back on screen', () => {
-    // Regression: validity was only ever reported from an edit, and never reset on a mode
-    // switch, so after typing malformed JSON the save button stayed dead even once the
-    // editor was showing a perfectly valid config again.
+    // Regression: submit used to latch disabled once malformed JSON had been typed.
     renderWizard();
     goJson();
     expect(saveButton()).not.toBeDisabled();
@@ -169,8 +165,7 @@ describe('CustomMCPServerWizardModal — advanced JSON mode', () => {
   });
 
   it('does not commit a partially valid edit', () => {
-    // While issues stand, nothing is applied — otherwise `data` ends up half the user's
-    // edit and half stale values, which the form/JSON round-trip cannot untangle.
+    // Nothing applies while issues stand, so `data` never mixes fresh and stale values.
     const onSubmit = renderWizard();
     goJson();
     writeJson({ ...validConfig, name: 'Renamed', timeout: 'nope' });

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogContent, DialogTitle } from '@evoapi/design-system';
-import { X } from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle, Button } from '@evoapi/design-system';
+import { X, Code2, LayoutList } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CustomMcpServer, CustomMcpServerFormData } from '@/types/ai';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
+import { AdvancedJsonEditor } from '@/components/ai_agents/shared';
 import {
   Step1_Identity,
   Step2_Connection,
@@ -71,12 +72,17 @@ export default function CustomMCPServerWizardModal({
   const [data, setData] = useState<WizardData>(() =>
     server ? serverToWizardData(server) : initialWizardData,
   );
+  // EVO-1739: advanced (raw JSON) mode — the whole config as editable JSON.
+  const [mode, setMode] = useState<'form' | 'json'>('form');
+  const [jsonValid, setJsonValid] = useState(true);
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) {
       const timeout = setTimeout(() => {
         setCurrentStep(1);
+        setMode('form');
+        setJsonValid(true);
         setData(server ? serverToWizardData(server) : initialWizardData);
       }, 300);
       return () => clearTimeout(timeout);
@@ -124,6 +130,35 @@ export default function CustomMCPServerWizardModal({
     };
     onSubmit(payload);
   };
+
+  // EVO-1739: the config object shown/edited in advanced (raw JSON) mode.
+  const configObject = (): Record<string, unknown> => ({
+    name: data.name,
+    description: data.description,
+    url: data.url,
+    headers: data.headers,
+    timeout: data.timeout,
+    retry_count: data.retry_count,
+    tags: data.tags,
+  });
+
+  const applyJson = (parsed: Record<string, unknown>) => {
+    setData(prev => ({
+      ...prev,
+      name: typeof parsed.name === 'string' ? parsed.name : prev.name,
+      description: typeof parsed.description === 'string' ? parsed.description : prev.description,
+      url: typeof parsed.url === 'string' ? parsed.url : prev.url,
+      headers:
+        parsed.headers && typeof parsed.headers === 'object' && !Array.isArray(parsed.headers)
+          ? (parsed.headers as Record<string, unknown>)
+          : prev.headers,
+      timeout: typeof parsed.timeout === 'number' ? parsed.timeout : prev.timeout,
+      retry_count: typeof parsed.retry_count === 'number' ? parsed.retry_count : prev.retry_count,
+      tags: Array.isArray(parsed.tags) ? parsed.tags.map(String) : prev.tags,
+    }));
+  };
+
+  const canSubmitJson = jsonValid && !!data.name.trim() && !!data.url.trim();
 
   const renderStep = () => {
     switch (currentStep) {
@@ -190,7 +225,34 @@ export default function CustomMCPServerWizardModal({
 
   const wizardContent = (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex items-center justify-end px-3 pt-3 pb-0 flex-shrink-0">
+      <div className="flex items-center justify-between px-3 pt-3 pb-0 flex-shrink-0">
+        {/* EVO-1739: Form ↔ advanced (raw JSON) mode toggle. */}
+        <div className="inline-flex rounded-md border p-0.5" role="tablist" aria-label={t('wizard.mode.label')}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'form'}
+            onClick={() => setMode('form')}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'form' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <LayoutList className="h-3.5 w-3.5" />
+            {t('wizard.mode.form')}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'json'}
+            onClick={() => setMode('json')}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'json' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Code2 className="h-3.5 w-3.5" />
+            {t('wizard.mode.json')}
+          </button>
+        </div>
         <button
           type="button"
           onClick={() => onOpenChange(false)}
@@ -201,30 +263,56 @@ export default function CustomMCPServerWizardModal({
         </button>
       </div>
 
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
-          <div className="text-center">
-            <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
-            {header.subtitle && (
-              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
-                {header.subtitle}
-              </p>
-            )}
+      {mode === 'json' ? (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0 text-center">
+            <h2 className="text-2xl font-semibold leading-tight">{t('wizard.advanced.title')}</h2>
+            <p className="text-sm text-muted-foreground mt-1">{t('wizard.advanced.subtitle')}</p>
+          </div>
+          <div ref={contentRef} className="flex-1 overflow-y-auto px-4 py-3 min-h-0">
+            <AdvancedJsonEditor
+              value={configObject()}
+              onChange={applyJson}
+              onValidityChange={setJsonValid}
+              rows={20}
+              hint={t('wizard.advanced.hint')}
+            />
+          </div>
+          <div className="flex justify-end gap-2 flex-shrink-0 p-3 border-t">
+            <Button variant="outline" className="px-6" onClick={() => onOpenChange(false)}>
+              {t('wizard.actions.cancel')}
+            </Button>
+            <Button className="px-6" onClick={handleSubmit} disabled={loading || !canSubmitJson}>
+              {isEdit ? t('wizard.actions.save') : t('wizard.actions.create')}
+            </Button>
           </div>
         </div>
+      ) : (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
+            <div className="text-center">
+              <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
+              {header.subtitle && (
+                <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
+                  {header.subtitle}
+                </p>
+              )}
+            </div>
+          </div>
 
-        <div className="py-2 px-4 flex-shrink-0 bg-transparent">
-          <WizardProgress
-            currentStep={currentStep}
-            totalSteps={TOTAL_STEPS}
-            steps={steps}
-          />
-        </div>
+          <div className="py-2 px-4 flex-shrink-0 bg-transparent">
+            <WizardProgress
+              currentStep={currentStep}
+              totalSteps={TOTAL_STEPS}
+              steps={steps}
+            />
+          </div>
 
-        <div ref={contentRef} className="flex-1 overflow-y-auto px-3 min-h-0">
-          {renderStep()}
+          <div ref={contentRef} className="flex-1 overflow-y-auto px-3 min-h-0">
+            {renderStep()}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
@@ -3,6 +3,12 @@ import { Dialog, DialogContent, DialogTitle, Button } from '@evoapi/design-syste
 import { X, Code2, LayoutList } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CustomMcpServer, CustomMcpServerFormData } from '@/types/ai';
+import {
+  WizardData,
+  initialWizardData,
+  serverToWizardData,
+  parseWizardConfig,
+} from './wizardConfig';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
 import { AdvancedJsonEditor } from '@/components/ai_agents/shared';
 import {
@@ -23,39 +29,6 @@ interface CustomMCPServerWizardModalProps {
   server?: CustomMcpServer;
 }
 
-interface WizardData {
-  // Step 1 — Identity
-  name: string;
-  description: string;
-  tags: string[];
-  // Step 2 — Connection
-  url: string;
-  headers: Record<string, unknown>;
-  // Step 3 — Advanced
-  timeout: number;
-  retry_count: number;
-}
-
-const initialWizardData: WizardData = {
-  name: '',
-  description: '',
-  tags: [],
-  url: '',
-  headers: {},
-  timeout: 30,
-  retry_count: 3,
-};
-
-const serverToWizardData = (server: CustomMcpServer): WizardData => ({
-  name: server.name || '',
-  description: server.description || '',
-  tags: server.tags || [],
-  url: server.url || '',
-  headers: (server.headers as Record<string, unknown>) || {},
-  timeout: server.timeout ?? 30,
-  retry_count: server.retry_count ?? 3,
-});
-
 const TOTAL_STEPS = 4;
 
 export default function CustomMCPServerWizardModal({
@@ -74,7 +47,11 @@ export default function CustomMCPServerWizardModal({
   );
   // EVO-1739: advanced (raw JSON) mode — the whole config as editable JSON.
   const [mode, setMode] = useState<'form' | 'json'>('form');
+  // Syntax validity (is it a JSON object?) is reported by the editor; `jsonIssues` holds
+  // the semantic problems this component finds in that object. Both must be clear before
+  // the config can be saved.
   const [jsonValid, setJsonValid] = useState(true);
+  const [jsonIssues, setJsonIssues] = useState<string[]>([]);
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -83,6 +60,7 @@ export default function CustomMCPServerWizardModal({
         setCurrentStep(1);
         setMode('form');
         setJsonValid(true);
+        setJsonIssues([]);
         setData(server ? serverToWizardData(server) : initialWizardData);
       }, 300);
       return () => clearTimeout(timeout);
@@ -143,22 +121,23 @@ export default function CustomMCPServerWizardModal({
   });
 
   const applyJson = (parsed: Record<string, unknown>) => {
-    setData(prev => ({
-      ...prev,
-      name: typeof parsed.name === 'string' ? parsed.name : prev.name,
-      description: typeof parsed.description === 'string' ? parsed.description : prev.description,
-      url: typeof parsed.url === 'string' ? parsed.url : prev.url,
-      headers:
-        parsed.headers && typeof parsed.headers === 'object' && !Array.isArray(parsed.headers)
-          ? (parsed.headers as Record<string, unknown>)
-          : prev.headers,
-      timeout: typeof parsed.timeout === 'number' ? parsed.timeout : prev.timeout,
-      retry_count: typeof parsed.retry_count === 'number' ? parsed.retry_count : prev.retry_count,
-      tags: Array.isArray(parsed.tags) ? parsed.tags.map(String) : prev.tags,
-    }));
+    const { data: next, issues } = parseWizardConfig(parsed, t);
+    setJsonIssues(issues);
+    // Commit only a fully valid config. A partial commit would leave `data` holding some
+    // of the user's edits and some stale values, which is the ambiguity the form/JSON
+    // round-trip cannot recover from. While issues are listed, submit is blocked anyway.
+    if (issues.length === 0) setData(next);
   };
 
-  const canSubmitJson = jsonValid && !!data.name.trim() && !!data.url.trim();
+  // Entering advanced mode re-derives the issues from the config that is about to be
+  // serialized into the editor, so the listed problems always describe what is on screen.
+  const enterJsonMode = () => {
+    setJsonValid(true);
+    setJsonIssues(parseWizardConfig(configObject(), t).issues);
+    setMode('json');
+  };
+
+  const canSubmitJson = jsonValid && jsonIssues.length === 0;
 
   const renderStep = () => {
     switch (currentStep) {
@@ -244,7 +223,7 @@ export default function CustomMCPServerWizardModal({
             type="button"
             role="tab"
             aria-selected={mode === 'json'}
-            onClick={() => setMode('json')}
+            onClick={enterJsonMode}
             className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
               mode === 'json' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
             }`}
@@ -274,6 +253,7 @@ export default function CustomMCPServerWizardModal({
               value={configObject()}
               onChange={applyJson}
               onValidityChange={setJsonValid}
+              issues={jsonIssues}
               rows={20}
               hint={t('wizard.advanced.hint')}
             />

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
@@ -47,9 +47,7 @@ export default function CustomMCPServerWizardModal({
   );
   // EVO-1739: advanced (raw JSON) mode — the whole config as editable JSON.
   const [mode, setMode] = useState<'form' | 'json'>('form');
-  // Syntax validity (is it a JSON object?) is reported by the editor; `jsonIssues` holds
-  // the semantic problems this component finds in that object. Both must be clear before
-  // the config can be saved.
+  // Editor reports syntax; `jsonIssues` holds the semantic problems. Both must be clear.
   const [jsonValid, setJsonValid] = useState(true);
   const [jsonIssues, setJsonIssues] = useState<string[]>([]);
   const contentRef = useRef<HTMLDivElement | null>(null);
@@ -123,14 +121,12 @@ export default function CustomMCPServerWizardModal({
   const applyJson = (parsed: Record<string, unknown>) => {
     const { data: next, issues } = parseWizardConfig(parsed, t);
     setJsonIssues(issues);
-    // Commit only a fully valid config. A partial commit would leave `data` holding some
-    // of the user's edits and some stale values, which is the ambiguity the form/JSON
-    // round-trip cannot recover from. While issues are listed, submit is blocked anyway.
+    // All-or-nothing: a partial commit would mix fresh edits with stale values, which the
+    // form/JSON round-trip cannot untangle.
     if (issues.length === 0) setData(next);
   };
 
-  // Entering advanced mode re-derives the issues from the config that is about to be
-  // serialized into the editor, so the listed problems always describe what is on screen.
+  // Re-derive issues from the config about to be serialized, so they describe what shows.
   const enterJsonMode = () => {
     setJsonValid(true);
     setJsonIssues(parseWizardConfig(configObject(), t).issues);

--- a/src/components/customMcpServers/wizard/Step2_Connection.spec.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.spec.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Step2_Connection from './Step2_Connection';
+import { testCustomMcpServerConnection } from '@/services/agents/customMcpServerService';
+
+// EVO-1739: the test-before-save button is only worth having if its verdict is trustworthy
+// — a result must never outlive the url/headers it was produced for.
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (k: string, o?: Record<string, unknown>) => (o ? `${k}:${JSON.stringify(o)}` : k),
+  }),
+}));
+vi.mock('@/services/agents/customMcpServerService', () => ({
+  testCustomMcpServerConnection: vi.fn(),
+}));
+
+const okResult = {
+  test_result: {
+    success: true,
+    tools_count: 3,
+    error: '',
+    message: '',
+    response_time: 0.1,
+    status_code: 200,
+    url_tested: 'https://good.example/mcp',
+  },
+};
+
+const renderStep = (url: string, headers: Record<string, unknown> = {}) => {
+  const props = { onChange: vi.fn(), onNext: vi.fn(), onBack: vi.fn() };
+  const { rerender } = render(<Step2_Connection data={{ url, headers }} {...props} />);
+  return {
+    ...props,
+    setData: (nextUrl: string, nextHeaders: Record<string, unknown> = {}) =>
+      rerender(<Step2_Connection data={{ url: nextUrl, headers: nextHeaders }} {...props} />),
+  };
+};
+
+const clickTest = () => fireEvent.click(screen.getByText('wizard.test.button'));
+const successPanel = () => screen.queryByText(/^wizard\.test\.ok/);
+
+describe('Step2_Connection — test before save', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sends the typed url and headers to the stateless endpoint', async () => {
+    vi.mocked(testCustomMcpServerConnection).mockResolvedValue(okResult);
+    renderStep('  https://good.example/mcp  ', { Authorization: 'Bearer sk' });
+
+    clickTest();
+
+    await waitFor(() => expect(successPanel()).toBeTruthy());
+    expect(testCustomMcpServerConnection).toHaveBeenCalledWith('https://good.example/mcp', {
+      Authorization: 'Bearer sk',
+    });
+    // The count comes from the live handshake, not from a persisted tools array.
+    expect(successPanel()!.textContent).toContain('"count":3');
+  });
+
+  it('drops the result once the url changes', async () => {
+    vi.mocked(testCustomMcpServerConnection).mockResolvedValue(okResult);
+    const { setData } = renderStep('https://good.example/mcp');
+
+    clickTest();
+    await waitFor(() => expect(successPanel()).toBeTruthy());
+
+    setData('https://typo.invalid/nope');
+
+    expect(successPanel()).toBeNull();
+  });
+
+  it('drops the result once a header changes', async () => {
+    vi.mocked(testCustomMcpServerConnection).mockResolvedValue(okResult);
+    const { setData } = renderStep('https://good.example/mcp', { Authorization: 'Bearer old' });
+
+    clickTest();
+    await waitFor(() => expect(successPanel()).toBeTruthy());
+
+    setData('https://good.example/mcp', { Authorization: 'Bearer new' });
+
+    expect(successPanel()).toBeNull();
+  });
+
+  it('ignores a reply that lands after the user moved on', async () => {
+    let resolveTest: (v: typeof okResult) => void = () => {};
+    vi.mocked(testCustomMcpServerConnection).mockReturnValue(
+      new Promise(resolve => {
+        resolveTest = resolve;
+      }),
+    );
+    const { setData } = renderStep('https://good.example/mcp');
+
+    clickTest();
+    setData('https://changed.example/mcp');
+    resolveTest(okResult);
+
+    await waitFor(() =>
+      expect(screen.getByText('wizard.test.button')).toBeTruthy(),
+    );
+    expect(successPanel()).toBeNull();
+  });
+
+  it('shows the failure message when the handshake fails', async () => {
+    vi.mocked(testCustomMcpServerConnection).mockResolvedValue({
+      test_result: { ...okResult.test_result, success: false, message: 'connection refused' },
+    });
+    renderStep('https://bad.example/mcp');
+
+    clickTest();
+
+    await waitFor(() => expect(screen.getByText('connection refused')).toBeTruthy());
+  });
+
+  it('does not call the API for an unparseable url', () => {
+    renderStep('not-a-url');
+
+    clickTest();
+
+    expect(testCustomMcpServerConnection).not.toHaveBeenCalled();
+    expect(screen.getByText('form.validation.urlInvalid')).toBeTruthy();
+  });
+});

--- a/src/components/customMcpServers/wizard/Step2_Connection.spec.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.spec.tsx
@@ -3,8 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Step2_Connection from './Step2_Connection';
 import { testCustomMcpServerConnection } from '@/services/agents/customMcpServerService';
 
-// EVO-1739: the test-before-save button is only worth having if its verdict is trustworthy
-// — a result must never outlive the url/headers it was produced for.
+// EVO-1739: a test result must never outlive the url/headers it was produced for.
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({
     t: (k: string, o?: Record<string, unknown>) => (o ? `${k}:${JSON.stringify(o)}` : k),
@@ -52,7 +51,7 @@ describe('Step2_Connection — test before save', () => {
     expect(testCustomMcpServerConnection).toHaveBeenCalledWith('https://good.example/mcp', {
       Authorization: 'Bearer sk',
     });
-    // The count comes from the live handshake, not from a persisted tools array.
+    // The count comes from the live handshake, not a persisted tools array.
     expect(successPanel()!.textContent).toContain('"count":3');
   });
 

--- a/src/components/customMcpServers/wizard/Step2_Connection.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import { Input, Label, Button } from '@evoapi/design-system';
-import { ArrowRight, ArrowLeft } from 'lucide-react';
+import { ArrowRight, ArrowLeft, PlugZap, Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { KeyValueEditor } from '@/components/ai_agents/shared';
+import { testCustomMcpServerConnection } from '@/services/agents/customMcpServerService';
+import type { McpTestResult } from '@/types/ai';
 
 export interface Step2Data {
   url: string;
@@ -19,20 +21,45 @@ interface Step2Props {
 export default function Step2_Connection({ data, onChange, onNext, onBack }: Step2Props) {
   const { t } = useLanguage('customMcpServers');
   const [error, setError] = useState('');
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<McpTestResult | null>(null);
+  const [testError, setTestError] = useState('');
 
-  const handleNext = () => {
+  const validateUrl = (): boolean => {
     if (!data.url || !data.url.trim()) {
       setError(t('form.validation.urlRequired'));
-      return;
+      return false;
     }
     try {
       new URL(data.url);
     } catch {
       setError(t('form.validation.urlInvalid'));
-      return;
+      return false;
     }
     setError('');
-    onNext();
+    return true;
+  };
+
+  const handleNext = () => {
+    if (validateUrl()) onNext();
+  };
+
+  // EVO-1739: test-before-save — hit the stateless endpoint with the typed url/headers
+  // and surface the MCP handshake result (discovered tool count / error).
+  const handleTest = async () => {
+    if (!validateUrl()) return;
+    setTesting(true);
+    setTestResult(null);
+    setTestError('');
+    try {
+      const res = await testCustomMcpServerConnection(data.url.trim(), data.headers);
+      setTestResult(res.test_result);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } }; message?: string };
+      setTestError(err?.response?.data?.message || err?.message || t('wizard.test.fail'));
+    } finally {
+      setTesting(false);
+    }
   };
 
   return (
@@ -61,6 +88,48 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
               onChange={next => onChange({ ...data, headers: next })}
               hint={t('form.hints.headers')}
             />
+          </div>
+
+          {/* EVO-1739: test the connection before saving. */}
+          <div className="pt-2 space-y-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="gap-2"
+              onClick={handleTest}
+              disabled={testing || !data.url}
+            >
+              {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlugZap className="h-4 w-4" />}
+              {testing ? t('wizard.test.testing') : t('wizard.test.button')}
+            </Button>
+
+            {testResult && (
+              <div
+                className={`flex items-start gap-2 rounded-md border p-3 text-sm ${
+                  testResult.success
+                    ? 'border-green-500/40 bg-green-500/5 text-green-700'
+                    : 'border-red-500/40 bg-red-500/5 text-red-700'
+                }`}
+              >
+                {testResult.success ? (
+                  <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                ) : (
+                  <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                )}
+                <span>
+                  {testResult.success
+                    ? t('wizard.test.ok', { count: testResult.tools_count ?? 0 })
+                    : testResult.message || testResult.error || t('wizard.test.fail')}
+                </span>
+              </div>
+            )}
+
+            {testError && (
+              <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm text-red-700">
+                <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                <span>{testError}</span>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/customMcpServers/wizard/Step2_Connection.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.tsx
@@ -25,10 +25,8 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
   const [testResult, setTestResult] = useState<McpTestResult | null>(null);
   const [testError, setTestError] = useState('');
 
-  // EVO-1739: a result only describes the url/headers it was run against, so it is tagged
-  // with those and shown only while they still match. That covers editing after a test (a
-  // green "connected, 3 tools" panel must not keep vouching for a url the user has since
-  // replaced) as well as a reply that lands after the user already moved on.
+  // EVO-1739: tag the result with what it was run against and show it only while those
+  // still match — covers both editing after a test and a reply landing too late.
   const [testedKey, setTestedKey] = useState<string | null>(null);
   const connectionKey = `${data.url} ${JSON.stringify(data.headers ?? {})}`;
   const resultIsCurrent = testedKey === connectionKey;

--- a/src/components/customMcpServers/wizard/Step2_Connection.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.tsx
@@ -25,6 +25,14 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
   const [testResult, setTestResult] = useState<McpTestResult | null>(null);
   const [testError, setTestError] = useState('');
 
+  // EVO-1739: a result only describes the url/headers it was run against, so it is tagged
+  // with those and shown only while they still match. That covers editing after a test (a
+  // green "connected, 3 tools" panel must not keep vouching for a url the user has since
+  // replaced) as well as a reply that lands after the user already moved on.
+  const [testedKey, setTestedKey] = useState<string | null>(null);
+  const connectionKey = `${data.url} ${JSON.stringify(data.headers ?? {})}`;
+  const resultIsCurrent = testedKey === connectionKey;
+
   const validateUrl = (): boolean => {
     if (!data.url || !data.url.trim()) {
       setError(t('form.validation.urlRequired'));
@@ -48,6 +56,7 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
   // and surface the MCP handshake result (discovered tool count / error).
   const handleTest = async () => {
     if (!validateUrl()) return;
+    const key = connectionKey;
     setTesting(true);
     setTestResult(null);
     setTestError('');
@@ -58,6 +67,7 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
       const err = e as { response?: { data?: { message?: string } }; message?: string };
       setTestError(err?.response?.data?.message || err?.message || t('wizard.test.fail'));
     } finally {
+      setTestedKey(key);
       setTesting(false);
     }
   };
@@ -103,7 +113,7 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
               {testing ? t('wizard.test.testing') : t('wizard.test.button')}
             </Button>
 
-            {testResult && (
+            {resultIsCurrent && testResult && (
               <div
                 className={`flex items-start gap-2 rounded-md border p-3 text-sm ${
                   testResult.success
@@ -124,7 +134,7 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
               </div>
             )}
 
-            {testError && (
+            {resultIsCurrent && testError && (
               <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm text-red-700">
                 <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
                 <span>{testError}</span>

--- a/src/components/customMcpServers/wizardConfig.ts
+++ b/src/components/customMcpServers/wizardConfig.ts
@@ -1,0 +1,161 @@
+import type { CustomMcpServer } from '@/types/ai';
+
+/**
+ * EVO-1739: the shape the MCP wizard edits, and the rules that decide whether a given
+ * config is savable. Kept out of the modal so both the step form and the advanced
+ * (raw JSON) mode answer to the same definition of "valid".
+ */
+export interface WizardData {
+  // Step 1 — Identity
+  name: string;
+  description: string;
+  tags: string[];
+  // Step 2 — Connection
+  url: string;
+  headers: Record<string, unknown>;
+  // Step 3 — Advanced
+  timeout: number;
+  retry_count: number;
+}
+
+export const initialWizardData: WizardData = {
+  name: '',
+  description: '',
+  tags: [],
+  url: '',
+  headers: {},
+  timeout: 30,
+  retry_count: 3,
+};
+
+export const serverToWizardData = (server: CustomMcpServer): WizardData => ({
+  name: server.name || '',
+  description: server.description || '',
+  tags: server.tags || [],
+  url: server.url || '',
+  headers: (server.headers as Record<string, unknown>) || {},
+  timeout: server.timeout ?? 30,
+  retry_count: server.retry_count ?? 3,
+});
+
+/** Same bounds the Step 3 number inputs enforce — advanced mode must not be a way around them. */
+export const TIMEOUT_MIN = 1;
+export const TIMEOUT_MAX = 300;
+export const RETRY_MIN = 0;
+export const RETRY_MAX = 10;
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const isInteger = (v: unknown): v is number => typeof v === 'number' && Number.isInteger(v);
+
+/**
+ * Turn the raw JSON object from advanced mode into WizardData, reporting every problem
+ * instead of silently keeping the previous value.
+ *
+ * Two rules make advanced mode an actual escape hatch rather than a lossy one:
+ *  - a key that is ABSENT falls back to the empty/default value, so deleting `description`
+ *    from the JSON really clears it (the earlier `typeof x === 'string' ? x : prev.x` kept
+ *    the old value, which made a field impossible to empty);
+ *  - a key with the WRONG type or an out-of-range value is an error the user sees, never a
+ *    silent revert (`"timeout": "60"` used to save as 30 with no feedback at all).
+ *
+ * The checks mirror the per-step validation exactly, so the two modes cannot disagree
+ * about what a valid server is.
+ */
+export const parseWizardConfig = (
+  parsed: Record<string, unknown>,
+  t: Translate,
+): { data: WizardData; issues: string[] } => {
+  const issues: string[] = [];
+  const next: WizardData = { ...initialWizardData };
+
+  // name — required, same as Step 1.
+  if (parsed.name === undefined) {
+    issues.push(t('wizard.advanced.errors.nameRequired'));
+  } else if (typeof parsed.name !== 'string') {
+    issues.push(t('wizard.advanced.errors.nameType'));
+  } else if (!parsed.name.trim()) {
+    issues.push(t('wizard.advanced.errors.nameRequired'));
+  } else {
+    next.name = parsed.name;
+  }
+
+  // description — optional; absent means empty.
+  if (parsed.description === undefined) {
+    next.description = '';
+  } else if (typeof parsed.description !== 'string') {
+    issues.push(t('wizard.advanced.errors.descriptionType'));
+  } else {
+    next.description = parsed.description;
+  }
+
+  // url — required and parseable, same as Step 2.
+  if (parsed.url === undefined || (typeof parsed.url === 'string' && !parsed.url.trim())) {
+    issues.push(t('wizard.advanced.errors.urlRequired'));
+  } else if (typeof parsed.url !== 'string') {
+    issues.push(t('wizard.advanced.errors.urlType'));
+  } else {
+    try {
+      new URL(parsed.url);
+      next.url = parsed.url;
+    } catch {
+      issues.push(t('wizard.advanced.errors.urlInvalid'));
+    }
+  }
+
+  // headers — the API binds these into a string map, so a number here is a 400 at submit
+  // time rather than something the UI should wave through.
+  if (parsed.headers === undefined) {
+    next.headers = {};
+  } else if (!isPlainObject(parsed.headers)) {
+    issues.push(t('wizard.advanced.errors.headersType'));
+  } else {
+    const badKeys = Object.entries(parsed.headers)
+      .filter(([, v]) => typeof v !== 'string')
+      .map(([k]) => k);
+    if (badKeys.length > 0) {
+      issues.push(t('wizard.advanced.errors.headerValueType', { keys: badKeys.join(', ') }));
+    } else {
+      next.headers = parsed.headers;
+    }
+  }
+
+  // timeout / retry_count — same bounds as the Step 3 inputs.
+  if (parsed.timeout === undefined) {
+    next.timeout = initialWizardData.timeout;
+  } else if (
+    !isInteger(parsed.timeout) ||
+    parsed.timeout < TIMEOUT_MIN ||
+    parsed.timeout > TIMEOUT_MAX
+  ) {
+    issues.push(t('wizard.advanced.errors.timeoutRange', { min: TIMEOUT_MIN, max: TIMEOUT_MAX }));
+  } else {
+    next.timeout = parsed.timeout;
+  }
+
+  if (parsed.retry_count === undefined) {
+    next.retry_count = initialWizardData.retry_count;
+  } else if (
+    !isInteger(parsed.retry_count) ||
+    parsed.retry_count < RETRY_MIN ||
+    parsed.retry_count > RETRY_MAX
+  ) {
+    issues.push(t('wizard.advanced.errors.retryRange', { min: RETRY_MIN, max: RETRY_MAX }));
+  } else {
+    next.retry_count = parsed.retry_count;
+  }
+
+  // tags — a string array. `.map(String)` used to turn [1, {}] into ["1", "[object Object]"].
+  if (parsed.tags === undefined) {
+    next.tags = [];
+  } else if (!Array.isArray(parsed.tags) || parsed.tags.some(tag => typeof tag !== 'string')) {
+    issues.push(t('wizard.advanced.errors.tagsType'));
+  } else {
+    next.tags = parsed.tags as string[];
+  }
+
+  return { data: next, issues };
+};

--- a/src/components/customMcpServers/wizardConfig.ts
+++ b/src/components/customMcpServers/wizardConfig.ts
@@ -1,9 +1,8 @@
 import type { CustomMcpServer } from '@/types/ai';
 
 /**
- * EVO-1739: the shape the MCP wizard edits, and the rules that decide whether a given
- * config is savable. Kept out of the modal so both the step form and the advanced
- * (raw JSON) mode answer to the same definition of "valid".
+ * EVO-1739: the shape the MCP wizard edits and the rules that make it savable. Kept out
+ * of the modal so the step form and the advanced (raw JSON) mode share one definition.
  */
 export interface WizardData {
   // Step 1 — Identity
@@ -52,18 +51,9 @@ const isPlainObject = (v: unknown): v is Record<string, unknown> =>
 const isInteger = (v: unknown): v is number => typeof v === 'number' && Number.isInteger(v);
 
 /**
- * Turn the raw JSON object from advanced mode into WizardData, reporting every problem
- * instead of silently keeping the previous value.
- *
- * Two rules make advanced mode an actual escape hatch rather than a lossy one:
- *  - a key that is ABSENT falls back to the empty/default value, so deleting `description`
- *    from the JSON really clears it (the earlier `typeof x === 'string' ? x : prev.x` kept
- *    the old value, which made a field impossible to empty);
- *  - a key with the WRONG type or an out-of-range value is an error the user sees, never a
- *    silent revert (`"timeout": "60"` used to save as 30 with no feedback at all).
- *
- * The checks mirror the per-step validation exactly, so the two modes cannot disagree
- * about what a valid server is.
+ * Turn the raw JSON from advanced mode into WizardData. An absent key falls back to the
+ * default, so deleting one clears the field; a wrong-typed or out-of-range one is a
+ * reported issue, never a silent revert.
  */
 export const parseWizardConfig = (
   parsed: Record<string, unknown>,
@@ -83,7 +73,6 @@ export const parseWizardConfig = (
     next.name = parsed.name;
   }
 
-  // description — optional; absent means empty.
   if (parsed.description === undefined) {
     next.description = '';
   } else if (typeof parsed.description !== 'string') {
@@ -106,8 +95,7 @@ export const parseWizardConfig = (
     }
   }
 
-  // headers — the API binds these into a string map, so a number here is a 400 at submit
-  // time rather than something the UI should wave through.
+  // headers — the API binds these into a string map, so a non-string is a 400 on submit.
   if (parsed.headers === undefined) {
     next.headers = {};
   } else if (!isPlainObject(parsed.headers)) {
@@ -148,7 +136,7 @@ export const parseWizardConfig = (
     next.retry_count = parsed.retry_count;
   }
 
-  // tags — a string array. `.map(String)` used to turn [1, {}] into ["1", "[object Object]"].
+  // tags — a string array; coercing would smuggle in [object Object].
   if (parsed.tags === undefined) {
     next.tags = [];
   } else if (!Array.isArray(parsed.tags) || parsed.tags.some(tag => typeof tag !== 'string')) {

--- a/src/components/customTools/CustomToolWizardModal.spec.tsx
+++ b/src/components/customTools/CustomToolWizardModal.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import CustomToolWizardModal from './CustomToolWizardModal';
 
@@ -6,9 +6,17 @@ vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@/services/agents/customToolsService', () => ({
-  testCustomTool: vi.fn(),
-}));
+const mockTestCustomToolPayload = vi.fn();
+vi.mock('@/services/agents/customToolsService', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/agents/customToolsService')
+  >('@/services/agents/customToolsService');
+  return {
+    getErrorMessage: actual.getErrorMessage,
+    testCustomTool: vi.fn(),
+    testCustomToolPayload: (...args: unknown[]) => mockTestCustomToolPayload(...args),
+  };
+});
 
 const makeProps = (overrides: Record<string, unknown> = {}) => ({
   open: true,
@@ -330,5 +338,139 @@ describe('CustomToolWizardModal', () => {
     expect(values.beta).toBe('b');
     expect(values.__evo_modes_meta__).toBeUndefined();
     expect(values.__modes_meta__).toBeUndefined();
+  });
+
+  // ----- EVO-1738 advanced (raw JSON) mode. R1 review: none of this branch had
+  // coverage — the toggle, the submit source and the required-key gate were all
+  // untested, and the gate is what stands between the user and an opaque 400.
+
+  const editorTextarea = () =>
+    screen.getByLabelText('advancedJson.title') as HTMLTextAreaElement;
+
+  const enterJsonMode = () => {
+    fireEvent.click(screen.getByRole('tab', { name: 'wizard.mode.json' }));
+  };
+
+  const fillNameAndEndpoint = () => {
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'My Tool' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'https://api.example.com/x' },
+    });
+  };
+
+  it('seeds the JSON editor from the form and submits the raw JSON verbatim', () => {
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ onSubmit })} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    expect(seeded.name).toBe('My Tool');
+    expect(seeded.endpoint).toBe('https://api.example.com/x');
+
+    fireEvent.change(editorTextarea(), {
+      target: { value: JSON.stringify({ ...seeded, description: 'edited raw' }) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.create' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].description).toBe('edited raw');
+  });
+
+  it('blocks submit when the JSON drops a key the API requires', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    delete seeded.path_params;
+    fireEvent.change(editorTextarea(), { target: { value: JSON.stringify(seeded) } });
+
+    const createBtn = screen.getByRole('button', { name: 'wizard.actions.create' });
+    expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+    // And say which key, otherwise the user only sees a disabled button.
+    expect(screen.getByRole('alert').textContent).toContain('wizard.advanced.missingFields');
+  });
+
+  it('blocks submit on malformed JSON', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    fireEvent.change(editorTextarea(), { target: { value: '{ not json' } });
+    const createBtn = screen.getByRole('button', { name: 'wizard.actions.create' });
+    expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('keeps raw JSON edits across a round trip through the form tab', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    fireEvent.change(editorTextarea(), {
+      target: { value: JSON.stringify({ ...seeded, description: 'hand written' }) },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'wizard.mode.form' }));
+    enterJsonMode();
+
+    // The form did not move, so the user's raw edits must survive.
+    expect(JSON.parse(editorTextarea().value).description).toBe('hand written');
+  });
+
+  it('re-seeds from the form when the form actually changed', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    fireEvent.change(editorTextarea(), {
+      target: { value: JSON.stringify({ ...seeded, description: 'hand written' }) },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'wizard.mode.form' }));
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'https://api.example.com/changed' },
+    });
+    enterJsonMode();
+
+    const reseeded = JSON.parse(editorTextarea().value);
+    expect(reseeded.endpoint).toBe('https://api.example.com/changed');
+    expect(reseeded.description).toBe('');
+  });
+
+  it('tests the draft config from JSON mode, path and query params included', async () => {
+    mockTestCustomToolPayload.mockResolvedValue({
+      test_result: { error: '', headers: {}, response_time: 0.1, status_code: 200, success: true },
+    });
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    fireEvent.change(editorTextarea(), {
+      target: {
+        value: JSON.stringify({
+          ...seeded,
+          path_params: { id: '42' },
+          query_params: { limit: 10 },
+        }),
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+
+    await waitFor(() => {
+      expect(mockTestCustomToolPayload).toHaveBeenCalledTimes(1);
+    });
+    expect(mockTestCustomToolPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://api.example.com/x',
+        path_params: { id: '42' },
+        query_params: { limit: 10 },
+      }),
+    );
   });
 });

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogContent, DialogTitle } from '@evoapi/design-system';
-import { X } from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle, Button } from '@evoapi/design-system';
+import { X, Code2, LayoutList } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
+import { AdvancedJsonEditor, TestRequestButton } from '@/components/ai_agents/shared';
+import type { CustomToolTestPayload } from '@/services/agents/customToolsService';
 import {
   Step1_Identity,
   Step2_Endpoint,
@@ -185,6 +187,17 @@ const initialWizardData: WizardData = {
 
 const TOTAL_STEPS = 6;
 
+// Keys the API refuses to bind as nil (CustomToolBase `binding:"required"`).
+// buildPayload always emits them; raw JSON mode is the only way to lose one.
+const REQUIRED_PAYLOAD_KEYS = [
+  'headers',
+  'path_params',
+  'query_params',
+  'body_params',
+  'error_handling',
+  'values',
+] as const;
+
 const mergeErrorHandlingForSave = (
   eh: ErrorHandling,
   extras: Record<string, unknown>,
@@ -223,12 +236,26 @@ export default function CustomToolWizardModal({
   const [data, setData] = useState<WizardData>(() =>
     tool ? toolToWizardData(tool) : initialWizardData,
   );
+  // EVO-1738: advanced (raw JSON) mode — edit the whole save payload as JSON.
+  // jsonPayload holds edits while in JSON mode (source of truth for submit there);
+  // no back-map to the step form (the model's inverse mapping is lossy).
+  const [mode, setMode] = useState<'form' | 'json'>('form');
+  const [jsonValid, setJsonValid] = useState(true);
+  const [jsonPayload, setJsonPayload] = useState<CustomToolFormData | null>(null);
+  // Form payload as of the last hand-off to JSON mode — lets enterJsonMode tell
+  // "user came back untouched" (keep their raw edits) from "user edited the form"
+  // (form wins, re-snapshot).
+  const [jsonBaseline, setJsonBaseline] = useState<CustomToolFormData | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) {
       const timeout = setTimeout(() => {
         setCurrentStep(1);
+        setMode('form');
+        setJsonValid(true);
+        setJsonPayload(null);
+        setJsonBaseline(null);
         setData(tool ? toolToWizardData(tool) : initialWizardData);
       }, 300);
       return () => clearTimeout(timeout);
@@ -268,7 +295,9 @@ export default function CustomToolWizardModal({
   const handleNext = () => setCurrentStep(s => Math.min(s + 1, TOTAL_STEPS));
   const handleBack = () => setCurrentStep(s => Math.max(s - 1, 1));
 
-  const handleSubmit = () => {
+  // Build the save payload from the step form. Extracted so advanced (raw JSON)
+  // mode can snapshot it and submit can pick the right source. EVO-1738.
+  const buildPayload = (): CustomToolFormData => {
     // Mode descriptions live in `values` under our namespaced key. We
     // never overwrite an unrelated user-owned `__evo_modes_meta__` key
     // because cleanValues stripped it on read and the user can't recreate
@@ -282,7 +311,7 @@ export default function CustomToolWizardModal({
         ? { ...data.values, [MODES_META_KEY]: modesMeta }
         : data.values;
 
-    const payload: CustomToolFormData = {
+    return {
       name: data.name.trim(),
       description: data.description.trim(),
       method: data.method,
@@ -301,8 +330,62 @@ export default function CustomToolWizardModal({
       tags: data.tags,
       examples: data.examples,
     };
-    onSubmit(payload);
   };
+
+  // In JSON mode the edited raw payload is the source of truth; otherwise the form.
+  const handleSubmit = () => {
+    onSubmit(mode === 'json' && jsonPayload ? jsonPayload : buildPayload());
+  };
+
+  const enterJsonMode = () => {
+    const fromForm = buildPayload();
+    // Re-snapshot only when the form actually moved since we last handed it over.
+    // Toggling Form → JSON used to overwrite the raw edits unconditionally, so a
+    // round trip through the form tab silently threw the user's JSON away.
+    const formChanged =
+      !jsonBaseline || JSON.stringify(fromForm) !== JSON.stringify(jsonBaseline);
+    if (formChanged || !jsonPayload) {
+      setJsonPayload(fromForm);
+      setJsonBaseline(fromForm);
+      setJsonValid(true);
+    }
+    setMode('json');
+  };
+
+  // The API rejects a nil map on any of these (CustomToolBase binding:"required"),
+  // and the create/update error surfaces as a generic toast — so a payload missing
+  // one of them must never leave the editor.
+  const missingJsonKeys = jsonPayload
+    ? REQUIRED_PAYLOAD_KEYS.filter(
+        k => (jsonPayload as unknown as Record<string, unknown>)[k] == null,
+      )
+    : [];
+
+  const jsonCanSubmit =
+    jsonValid &&
+    !!jsonPayload?.name?.trim() &&
+    !!jsonPayload?.endpoint?.trim() &&
+    !!jsonPayload?.method?.trim() &&
+    missingJsonKeys.length === 0;
+
+  // EVO-1738 test-before-save: the request-shaping subset of whichever source is
+  // authoritative right now. path/query params included — without them the test
+  // would report OK for a request missing the user's configuration.
+  const getTestPayload = (): CustomToolTestPayload => {
+    const p = mode === 'json' && jsonPayload ? jsonPayload : buildPayload();
+    return {
+      method: p.method,
+      endpoint: p.endpoint,
+      headers: p.headers,
+      path_params: p.path_params,
+      query_params: p.query_params,
+      body_params: p.body_params,
+    };
+  };
+
+  // Remount the test button whenever the request definition changes, so a stale
+  // "HTTP 200" can never describe a config the user has since edited.
+  const testKey = JSON.stringify(getTestPayload());
 
   const renderStep = () => {
     switch (currentStep) {
@@ -387,6 +470,8 @@ export default function CustomToolWizardModal({
             onSubmit={handleSubmit}
             loading={loading}
             mode={isEdit ? 'edit' : 'create'}
+            getTestPayload={getTestPayload}
+            testKey={testKey}
           />
         );
       default:
@@ -398,7 +483,34 @@ export default function CustomToolWizardModal({
 
   const wizardContent = (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex items-center justify-end px-3 pt-3 pb-0 flex-shrink-0">
+      <div className="flex items-center justify-between px-3 pt-3 pb-0 flex-shrink-0">
+        {/* EVO-1738: Form ↔ advanced (raw JSON) mode toggle. */}
+        <div className="inline-flex rounded-md border p-0.5" role="tablist" aria-label={t('wizard.mode.label')}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'form'}
+            onClick={() => setMode('form')}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'form' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <LayoutList className="h-3.5 w-3.5" />
+            {t('wizard.mode.form')}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'json'}
+            onClick={enterJsonMode}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'json' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Code2 className="h-3.5 w-3.5" />
+            {t('wizard.mode.json')}
+          </button>
+        </div>
         <button
           type="button"
           onClick={() => onOpenChange(false)}
@@ -409,33 +521,68 @@ export default function CustomToolWizardModal({
         </button>
       </div>
 
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
-          <div className="text-center">
-            <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
-            {header.subtitle && (
-              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
-                {header.subtitle}
+      {mode === 'json' ? (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0 text-center">
+            <h2 className="text-2xl font-semibold leading-tight">{t('wizard.advanced.title')}</h2>
+            <p className="text-sm text-muted-foreground mt-1">{t('wizard.advanced.subtitle')}</p>
+          </div>
+          <div ref={contentRef} className="flex-1 overflow-y-auto px-4 py-3 min-h-0 space-y-3">
+            <AdvancedJsonEditor
+              value={(jsonPayload ?? buildPayload()) as unknown as Record<string, unknown>}
+              onChange={p => setJsonPayload(p as unknown as CustomToolFormData)}
+              onValidityChange={setJsonValid}
+              rows={22}
+              hint={t('wizard.advanced.hint')}
+            />
+
+            {jsonValid && missingJsonKeys.length > 0 && (
+              <p className="text-sm text-destructive" role="alert">
+                {t('wizard.advanced.missingFields', { fields: missingJsonKeys.join(', ') })}
               </p>
             )}
+
+            {/* Raw-JSON authors are exactly who needs test-before-save the most. */}
+            <TestRequestButton key={testKey} mode={isEdit ? 'edit' : 'create'} getPayload={getTestPayload} />
+          </div>
+          <div className="flex justify-end gap-2 flex-shrink-0 p-3 border-t">
+            <Button variant="outline" className="px-6" onClick={() => onOpenChange(false)}>
+              {t('wizard.actions.cancel')}
+            </Button>
+            <Button className="px-6" onClick={handleSubmit} disabled={loading || !jsonCanSubmit}>
+              {isEdit ? t('wizard.actions.save') : t('wizard.actions.create')}
+            </Button>
           </div>
         </div>
+      ) : (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
+            <div className="text-center">
+              <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
+              {header.subtitle && (
+                <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
+                  {header.subtitle}
+                </p>
+              )}
+            </div>
+          </div>
 
-        <div className="py-2 px-4 flex-shrink-0 bg-transparent">
-          <WizardProgress
-            currentStep={currentStep}
-            totalSteps={TOTAL_STEPS}
-            steps={steps}
-          />
-        </div>
+          <div className="py-2 px-4 flex-shrink-0 bg-transparent">
+            <WizardProgress
+              currentStep={currentStep}
+              totalSteps={TOTAL_STEPS}
+              steps={steps}
+            />
+          </div>
 
-        <div
-          ref={contentRef}
-          className="flex-1 overflow-y-auto px-3 min-h-0"
-        >
-          {renderStep()}
+          <div
+            ref={contentRef}
+            className="flex-1 overflow-y-auto px-3 min-h-0"
+          >
+            {renderStep()}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 

--- a/src/components/customTools/wizard/Step6_Finish.tsx
+++ b/src/components/customTools/wizard/Step6_Finish.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { Button, Input, Label } from '@evoapi/design-system';
 import { ArrowLeft, Plus, X, Check, Link2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { TestRequestButton } from '@/components/ai_agents/shared';
+import type { CustomToolTestPayload } from '@/services/agents/customToolsService';
 
 export interface Step6Data {
   examples: string[];
@@ -14,6 +16,18 @@ interface Step6Props {
   onSubmit: () => void;
   loading?: boolean;
   mode?: 'create' | 'edit';
+  /**
+   * EVO-1738 test-before-save. Rendering goes through the shared
+   * TestRequestButton so the wizard shows the same rich result the rest of the
+   * product does (status code, response time, headers, body) instead of a
+   * status-only banner.
+   */
+  getTestPayload?: () => CustomToolTestPayload;
+  /**
+   * Serialized request definition. Changing it remounts the test button, so a
+   * previous "HTTP 200" can never linger next to a config the user has edited.
+   */
+  testKey?: string;
 }
 
 export default function Step6_Finish({
@@ -23,6 +37,8 @@ export default function Step6_Finish({
   onSubmit,
   loading = false,
   mode = 'create',
+  getTestPayload,
+  testKey,
 }: Step6Props) {
   const { t } = useLanguage('customTools');
   const [newExample, setNewExample] = useState('');
@@ -98,8 +114,13 @@ export default function Step6_Finish({
             )}
           </div>
 
+          {/* EVO-1738: test the request before saving. */}
+          {getTestPayload && (
+            <TestRequestButton key={testKey} mode={mode} getPayload={getTestPayload} />
+          )}
+
           <p className="text-xs text-muted-foreground bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded p-3">
-            {t('wizard.step6.testHint')}
+            {getTestPayload ? t('wizard.step6.testHintDraft') : t('wizard.step6.testHint')}
           </p>
 
           <p className="flex items-start gap-2 text-xs text-muted-foreground bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded p-3">

--- a/src/i18n/locales/en/customMcpServers.json
+++ b/src/i18n/locales/en/customMcpServers.json
@@ -191,6 +191,12 @@
       "title": "Advanced config (JSON)",
       "subtitle": "Edit the whole server config as raw JSON.",
       "hint": "Fields: name, description, url, headers, timeout, retry_count, tags."
+    },
+    "test": {
+      "button": "Test connection",
+      "testing": "Testing…",
+      "ok": "Connected — {{count}} tools discovered",
+      "fail": "Connection failed"
     }
   },
   "modal": {

--- a/src/i18n/locales/en/customMcpServers.json
+++ b/src/i18n/locales/en/customMcpServers.json
@@ -208,7 +208,8 @@
     "test": {
       "button": "Test connection",
       "testing": "Testing…",
-      "ok": "Connected — {{count}} tools discovered",
+      "ok_one": "Connected — {{count}} tool discovered",
+      "ok_other": "Connected — {{count}} tools discovered",
       "fail": "Connection failed"
     }
   },

--- a/src/i18n/locales/en/customMcpServers.json
+++ b/src/i18n/locales/en/customMcpServers.json
@@ -179,7 +179,18 @@
       "continue": "Continue",
       "back": "Back",
       "create": "Create MCP server",
-      "save": "Save changes"
+      "save": "Save changes",
+      "cancel": "Cancel"
+    },
+    "mode": {
+      "label": "Edit mode",
+      "form": "Form",
+      "json": "Advanced JSON"
+    },
+    "advanced": {
+      "title": "Advanced config (JSON)",
+      "subtitle": "Edit the whole server config as raw JSON.",
+      "hint": "Fields: name, description, url, headers, timeout, retry_count, tags."
     }
   },
   "modal": {

--- a/src/i18n/locales/en/customMcpServers.json
+++ b/src/i18n/locales/en/customMcpServers.json
@@ -190,7 +190,20 @@
     "advanced": {
       "title": "Advanced config (JSON)",
       "subtitle": "Edit the whole server config as raw JSON.",
-      "hint": "Fields: name, description, url, headers, timeout, retry_count, tags."
+      "hint": "Fields: name, description, url, headers, timeout, retry_count, tags.",
+      "errors": {
+        "nameRequired": "\"name\" is required and cannot be empty.",
+        "nameType": "\"name\" must be text.",
+        "descriptionType": "\"description\" must be text.",
+        "urlRequired": "\"url\" is required and cannot be empty.",
+        "urlType": "\"url\" must be text.",
+        "urlInvalid": "\"url\" is not a valid URL (e.g. https://my-server.com/mcp).",
+        "headersType": "\"headers\" must be an object.",
+        "headerValueType": "Header values must be text: {{keys}}.",
+        "timeoutRange": "\"timeout\" must be a whole number between {{min}} and {{max}}.",
+        "retryRange": "\"retry_count\" must be a whole number between {{min}} and {{max}}.",
+        "tagsType": "\"tags\" must be a list of text values."
+      }
     },
     "test": {
       "button": "Test connection",

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -274,14 +274,27 @@
       "subtitle": "Add usage examples that help agents understand when to call this tool.",
       "helperText": "Examples are short text descriptions of how to use the tool.",
       "testHint": "After creating, you'll be able to test the tool against the real endpoint.",
-      "attachHint": "Creating the tool only adds it to the catalog. To have an agent use it, attach it to the agent in its Tools tab."
+      "attachHint": "Creating the tool only adds it to the catalog. To have an agent use it, attach it to the agent in its Tools tab.",
+      "testHintDraft": "Use “Test request” to try the endpoint before saving. The result reflects the config above, including path and query params."
     },
     "actions": {
       "continue": "Continue",
       "back": "Back",
       "skip": "Skip",
       "create": "Create tool",
-      "save": "Save changes"
+      "save": "Save changes",
+      "cancel": "Cancel"
+    },
+    "mode": {
+      "label": "Edit mode",
+      "form": "Form",
+      "json": "Advanced JSON"
+    },
+    "advanced": {
+      "title": "Advanced config (JSON)",
+      "subtitle": "Edit the whole tool config as raw JSON.",
+      "hint": "Fields: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Required: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (use {} when empty).",
+      "missingFields": "Required fields missing from the JSON: {{fields}}. Add them back before saving."
     }
   },
   "modal": {

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -354,5 +354,10 @@
     "createDenied": "You don't have permission to create custom tools",
     "editDenied": "You don't have permission to edit custom tools",
     "deleteDenied": "You don't have permission to delete custom tools"
+  },
+  "advancedJson": {
+    "title": "Advanced JSON",
+    "mustBeObject": "The JSON must be an object.",
+    "invalid": "Invalid JSON."
   }
 }

--- a/src/i18n/locales/es/customMcpServers.json
+++ b/src/i18n/locales/es/customMcpServers.json
@@ -208,7 +208,8 @@
     "test": {
       "button": "Probar conexión",
       "testing": "Probando…",
-      "ok": "Conectado — {{count}} herramientas descubiertas",
+      "ok_one": "Conectado — {{count}} herramienta descubierta",
+      "ok_other": "Conectado — {{count}} herramientas descubiertas",
       "fail": "Error de conexión"
     }
   },

--- a/src/i18n/locales/es/customMcpServers.json
+++ b/src/i18n/locales/es/customMcpServers.json
@@ -179,7 +179,18 @@
       "continue": "Continuar",
       "back": "Atrás",
       "create": "Crear servidor MCP",
-      "save": "Guardar cambios"
+      "save": "Guardar cambios",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edición",
+      "form": "Formulario",
+      "json": "JSON avanzado"
+    },
+    "advanced": {
+      "title": "Configuración avanzada (JSON)",
+      "subtitle": "Edita toda la configuración del servidor como JSON sin formato.",
+      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customMcpServers.json
+++ b/src/i18n/locales/es/customMcpServers.json
@@ -191,6 +191,12 @@
       "title": "Configuración avanzada (JSON)",
       "subtitle": "Edita toda la configuración del servidor como JSON sin formato.",
       "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
+    },
+    "test": {
+      "button": "Probar conexión",
+      "testing": "Probando…",
+      "ok": "Conectado — {{count}} herramientas descubiertas",
+      "fail": "Error de conexión"
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customMcpServers.json
+++ b/src/i18n/locales/es/customMcpServers.json
@@ -190,7 +190,20 @@
     "advanced": {
       "title": "Configuración avanzada (JSON)",
       "subtitle": "Edita toda la configuración del servidor como JSON sin formato.",
-      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
+      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags.",
+      "errors": {
+        "nameRequired": "El campo \"name\" es obligatorio y no puede estar vacío.",
+        "nameType": "El campo \"name\" debe ser texto.",
+        "descriptionType": "El campo \"description\" debe ser texto.",
+        "urlRequired": "El campo \"url\" es obligatorio y no puede estar vacío.",
+        "urlType": "El campo \"url\" debe ser texto.",
+        "urlInvalid": "El campo \"url\" no es una URL válida (ej.: https://mi-servidor.com/mcp).",
+        "headersType": "El campo \"headers\" debe ser un objeto.",
+        "headerValueType": "Los valores de las cabeceras deben ser texto: {{keys}}.",
+        "timeoutRange": "El campo \"timeout\" debe ser un número entero entre {{min}} y {{max}}.",
+        "retryRange": "El campo \"retry_count\" debe ser un número entero entre {{min}} y {{max}}.",
+        "tagsType": "El campo \"tags\" debe ser una lista de textos."
+      }
     },
     "test": {
       "button": "Probar conexión",

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -274,14 +274,27 @@
       "subtitle": "Agrega ejemplos de uso que ayuden a los agentes a saber cuándo llamar esta herramienta.",
       "helperText": "Los ejemplos son descripciones cortas de cómo usar la herramienta.",
       "testHint": "Después de crear, podrás probar la herramienta contra el endpoint real.",
-      "attachHint": "Crear la herramienta solo la agrega al catálogo. Para que un agente la use, adjúntala al agente en su pestaña Herramientas."
+      "attachHint": "Crear la herramienta solo la agrega al catálogo. Para que un agente la use, adjúntala al agente en su pestaña Herramientas.",
+      "testHintDraft": "Usa “Probar solicitud” para probar el endpoint antes de guardar. El resultado refleja la configuración de arriba, incluidos path y query params."
     },
     "actions": {
       "continue": "Continuar",
       "back": "Volver",
       "skip": "Saltar",
       "create": "Crear herramienta",
-      "save": "Guardar cambios"
+      "save": "Guardar cambios",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edición",
+      "form": "Formulario",
+      "json": "JSON avanzado"
+    },
+    "advanced": {
+      "title": "Configuración avanzada (JSON)",
+      "subtitle": "Edita toda la configuración de la herramienta como JSON sin formato.",
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obligatorios: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (usa {} si están vacíos).",
+      "missingFields": "Faltan campos obligatorios en el JSON: {{fields}}. Vuélvelos a agregar antes de guardar."
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -354,5 +354,10 @@
     "createDenied": "No tienes permiso para crear herramientas personalizadas",
     "editDenied": "No tienes permiso para editar herramientas personalizadas",
     "deleteDenied": "No tienes permiso para eliminar herramientas personalizadas"
+  },
+  "advancedJson": {
+    "title": "JSON avanzado",
+    "mustBeObject": "El JSON debe ser un objeto.",
+    "invalid": "JSON no válido."
   }
 }

--- a/src/i18n/locales/fr/customMcpServers.json
+++ b/src/i18n/locales/fr/customMcpServers.json
@@ -191,6 +191,12 @@
       "title": "Configuration avancée (JSON)",
       "subtitle": "Modifiez toute la configuration du serveur en JSON brut.",
       "hint": "Champs : name, description, url, headers, timeout, retry_count, tags."
+    },
+    "test": {
+      "button": "Tester la connexion",
+      "testing": "Test en cours…",
+      "ok": "Connecté — {{count}} outils découverts",
+      "fail": "Échec de la connexion"
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customMcpServers.json
+++ b/src/i18n/locales/fr/customMcpServers.json
@@ -179,7 +179,18 @@
       "continue": "Continuer",
       "back": "Retour",
       "create": "Créer le serveur MCP",
-      "save": "Enregistrer les modifications"
+      "save": "Enregistrer les modifications",
+      "cancel": "Annuler"
+    },
+    "mode": {
+      "label": "Mode d'édition",
+      "form": "Formulaire",
+      "json": "JSON avancé"
+    },
+    "advanced": {
+      "title": "Configuration avancée (JSON)",
+      "subtitle": "Modifiez toute la configuration du serveur en JSON brut.",
+      "hint": "Champs : name, description, url, headers, timeout, retry_count, tags."
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customMcpServers.json
+++ b/src/i18n/locales/fr/customMcpServers.json
@@ -190,7 +190,20 @@
     "advanced": {
       "title": "Configuration avancée (JSON)",
       "subtitle": "Modifiez toute la configuration du serveur en JSON brut.",
-      "hint": "Champs : name, description, url, headers, timeout, retry_count, tags."
+      "hint": "Champs : name, description, url, headers, timeout, retry_count, tags.",
+      "errors": {
+        "nameRequired": "Le champ « name » est obligatoire et ne peut pas être vide.",
+        "nameType": "Le champ « name » doit être du texte.",
+        "descriptionType": "Le champ « description » doit être du texte.",
+        "urlRequired": "Le champ « url » est obligatoire et ne peut pas être vide.",
+        "urlType": "Le champ « url » doit être du texte.",
+        "urlInvalid": "Le champ « url » n'est pas une URL valide (ex. : https://mon-serveur.com/mcp).",
+        "headersType": "Le champ « headers » doit être un objet.",
+        "headerValueType": "Les valeurs des en-têtes doivent être du texte : {{keys}}.",
+        "timeoutRange": "Le champ « timeout » doit être un nombre entier entre {{min}} et {{max}}.",
+        "retryRange": "Le champ « retry_count » doit être un nombre entier entre {{min}} et {{max}}.",
+        "tagsType": "Le champ « tags » doit être une liste de textes."
+      }
     },
     "test": {
       "button": "Tester la connexion",

--- a/src/i18n/locales/fr/customMcpServers.json
+++ b/src/i18n/locales/fr/customMcpServers.json
@@ -208,7 +208,8 @@
     "test": {
       "button": "Tester la connexion",
       "testing": "Test en cours…",
-      "ok": "Connecté — {{count}} outils découverts",
+      "ok_one": "Connecté — {{count}} outil découvert",
+      "ok_other": "Connecté — {{count}} outils découverts",
       "fail": "Échec de la connexion"
     }
   },

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -274,14 +274,27 @@
       "subtitle": "Ajoutez des exemples d'usage pour aider les agents à savoir quand appeler cet outil.",
       "helperText": "Les exemples sont de courtes descriptions d'utilisation de l'outil.",
       "testHint": "Après création, vous pourrez tester l'outil contre l'endpoint réel.",
-      "attachHint": "Créer l'outil ne fait que l'ajouter au catalogue. Pour qu'un agent l'utilise, attachez-le à l'agent dans son onglet Outils."
+      "attachHint": "Créer l'outil ne fait que l'ajouter au catalogue. Pour qu'un agent l'utilise, attachez-le à l'agent dans son onglet Outils.",
+      "testHintDraft": "Utilisez « Tester la requête » pour essayer l'endpoint avant d'enregistrer. Le résultat reflète la config ci-dessus, y compris les path et query params."
     },
     "actions": {
       "continue": "Continuer",
       "back": "Retour",
       "skip": "Passer",
       "create": "Créer l'outil",
-      "save": "Enregistrer les modifications"
+      "save": "Enregistrer les modifications",
+      "cancel": "Annuler"
+    },
+    "mode": {
+      "label": "Mode d'édition",
+      "form": "Formulaire",
+      "json": "JSON avancé"
+    },
+    "advanced": {
+      "title": "Configuration avancée (JSON)",
+      "subtitle": "Modifiez toute la configuration de l'outil en JSON brut.",
+      "hint": "Champs : name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obligatoires : name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (utilisez {} si vide).",
+      "missingFields": "Champs obligatoires absents du JSON : {{fields}}. Remettez-les avant d'enregistrer."
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -354,5 +354,10 @@
     "createDenied": "Vous n'avez pas la permission de créer des outils personnalisés",
     "editDenied": "Vous n'avez pas la permission de modifier les outils personnalisés",
     "deleteDenied": "Vous n'avez pas la permission de supprimer les outils personnalisés"
+  },
+  "advancedJson": {
+    "title": "JSON avancé",
+    "mustBeObject": "Le JSON doit être un objet.",
+    "invalid": "JSON invalide."
   }
 }

--- a/src/i18n/locales/it/customMcpServers.json
+++ b/src/i18n/locales/it/customMcpServers.json
@@ -179,7 +179,18 @@
       "continue": "Continua",
       "back": "Indietro",
       "create": "Crea server MCP",
-      "save": "Salva modifiche"
+      "save": "Salva modifiche",
+      "cancel": "Annulla"
+    },
+    "mode": {
+      "label": "Modalità di modifica",
+      "form": "Modulo",
+      "json": "JSON avanzato"
+    },
+    "advanced": {
+      "title": "Configurazione avanzata (JSON)",
+      "subtitle": "Modifica l'intera configurazione del server come JSON grezzo.",
+      "hint": "Campi: name, description, url, headers, timeout, retry_count, tags."
     }
   },
   "modal": {

--- a/src/i18n/locales/it/customMcpServers.json
+++ b/src/i18n/locales/it/customMcpServers.json
@@ -190,7 +190,20 @@
     "advanced": {
       "title": "Configurazione avanzata (JSON)",
       "subtitle": "Modifica l'intera configurazione del server come JSON grezzo.",
-      "hint": "Campi: name, description, url, headers, timeout, retry_count, tags."
+      "hint": "Campi: name, description, url, headers, timeout, retry_count, tags.",
+      "errors": {
+        "nameRequired": "Il campo \"name\" è obbligatorio e non può essere vuoto.",
+        "nameType": "Il campo \"name\" deve essere testo.",
+        "descriptionType": "Il campo \"description\" deve essere testo.",
+        "urlRequired": "Il campo \"url\" è obbligatorio e non può essere vuoto.",
+        "urlType": "Il campo \"url\" deve essere testo.",
+        "urlInvalid": "Il campo \"url\" non è un URL valido (es.: https://mio-server.com/mcp).",
+        "headersType": "Il campo \"headers\" deve essere un oggetto.",
+        "headerValueType": "I valori degli header devono essere testo: {{keys}}.",
+        "timeoutRange": "Il campo \"timeout\" deve essere un numero intero tra {{min}} e {{max}}.",
+        "retryRange": "Il campo \"retry_count\" deve essere un numero intero tra {{min}} e {{max}}.",
+        "tagsType": "Il campo \"tags\" deve essere un elenco di testi."
+      }
     },
     "test": {
       "button": "Prova connessione",

--- a/src/i18n/locales/it/customMcpServers.json
+++ b/src/i18n/locales/it/customMcpServers.json
@@ -208,7 +208,8 @@
     "test": {
       "button": "Prova connessione",
       "testing": "Prova in corso…",
-      "ok": "Connesso — {{count}} strumenti scoperti",
+      "ok_one": "Connesso — {{count}} strumento scoperto",
+      "ok_other": "Connesso — {{count}} strumenti scoperti",
       "fail": "Connessione fallita"
     }
   },

--- a/src/i18n/locales/it/customMcpServers.json
+++ b/src/i18n/locales/it/customMcpServers.json
@@ -191,6 +191,12 @@
       "title": "Configurazione avanzata (JSON)",
       "subtitle": "Modifica l'intera configurazione del server come JSON grezzo.",
       "hint": "Campi: name, description, url, headers, timeout, retry_count, tags."
+    },
+    "test": {
+      "button": "Prova connessione",
+      "testing": "Prova in corso…",
+      "ok": "Connesso — {{count}} strumenti scoperti",
+      "fail": "Connessione fallita"
     }
   },
   "modal": {

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -354,5 +354,10 @@
     "createDenied": "Non hai il permesso di creare strumenti personalizzati",
     "editDenied": "Non hai il permesso di modificare gli strumenti personalizzati",
     "deleteDenied": "Non hai il permesso di eliminare strumenti personalizzati"
+  },
+  "advancedJson": {
+    "title": "JSON avanzato",
+    "mustBeObject": "Il JSON deve essere un oggetto.",
+    "invalid": "JSON non valido."
   }
 }

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -274,14 +274,27 @@
       "subtitle": "Aggiungi esempi d'uso che aiutino gli agenti a sapere quando chiamare questo strumento.",
       "helperText": "Gli esempi sono brevi descrizioni di come usare lo strumento.",
       "testHint": "Dopo la creazione, potrai testare lo strumento contro l'endpoint reale.",
-      "attachHint": "Creare lo strumento lo aggiunge solo al catalogo. Perché un agente lo usi, collegalo all'agente nella sua scheda Strumenti."
+      "attachHint": "Creare lo strumento lo aggiunge solo al catalogo. Perché un agente lo usi, collegalo all'agente nella sua scheda Strumenti.",
+      "testHintDraft": "Usa “Prova richiesta” per provare l'endpoint prima di salvare. Il risultato riflette la config qui sopra, inclusi path e query params."
     },
     "actions": {
       "continue": "Continua",
       "back": "Indietro",
       "skip": "Salta",
       "create": "Crea strumento",
-      "save": "Salva modifiche"
+      "save": "Salva modifiche",
+      "cancel": "Annulla"
+    },
+    "mode": {
+      "label": "Modalità di modifica",
+      "form": "Modulo",
+      "json": "JSON avanzato"
+    },
+    "advanced": {
+      "title": "Configurazione avanzata (JSON)",
+      "subtitle": "Modifica l'intera configurazione dello strumento come JSON grezzo.",
+      "hint": "Campi: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obbligatori: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (usa {} se vuoti).",
+      "missingFields": "Campi obbligatori mancanti nel JSON: {{fields}}. Reinseriscili prima di salvare."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt-BR/customMcpServers.json
+++ b/src/i18n/locales/pt-BR/customMcpServers.json
@@ -179,7 +179,18 @@
       "continue": "Continuar",
       "back": "Voltar",
       "create": "Criar servidor MCP",
-      "save": "Salvar alterações"
+      "save": "Salvar alterações",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edição",
+      "form": "Formulário",
+      "json": "JSON avançado"
+    },
+    "advanced": {
+      "title": "Configuração avançada (JSON)",
+      "subtitle": "Edite a configuração inteira do servidor como JSON cru.",
+      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt-BR/customMcpServers.json
+++ b/src/i18n/locales/pt-BR/customMcpServers.json
@@ -191,6 +191,12 @@
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira do servidor como JSON cru.",
       "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
+    },
+    "test": {
+      "button": "Testar conexão",
+      "testing": "Testando…",
+      "ok": "Conectado — {{count}} ferramentas descobertas",
+      "fail": "Falha na conexão"
     }
   },
   "modal": {

--- a/src/i18n/locales/pt-BR/customMcpServers.json
+++ b/src/i18n/locales/pt-BR/customMcpServers.json
@@ -208,7 +208,8 @@
     "test": {
       "button": "Testar conexão",
       "testing": "Testando…",
-      "ok": "Conectado — {{count}} ferramentas descobertas",
+      "ok_one": "Conectado — {{count}} ferramenta descoberta",
+      "ok_other": "Conectado — {{count}} ferramentas descobertas",
       "fail": "Falha na conexão"
     }
   },

--- a/src/i18n/locales/pt-BR/customMcpServers.json
+++ b/src/i18n/locales/pt-BR/customMcpServers.json
@@ -190,7 +190,20 @@
     "advanced": {
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira do servidor como JSON cru.",
-      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
+      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags.",
+      "errors": {
+        "nameRequired": "O campo \"name\" é obrigatório e não pode ficar vazio.",
+        "nameType": "O campo \"name\" precisa ser texto.",
+        "descriptionType": "O campo \"description\" precisa ser texto.",
+        "urlRequired": "O campo \"url\" é obrigatório e não pode ficar vazio.",
+        "urlType": "O campo \"url\" precisa ser texto.",
+        "urlInvalid": "O campo \"url\" não é uma URL válida (ex.: https://meu-servidor.com/mcp).",
+        "headersType": "O campo \"headers\" precisa ser um objeto.",
+        "headerValueType": "Os valores dos headers precisam ser texto: {{keys}}.",
+        "timeoutRange": "O campo \"timeout\" precisa ser um número inteiro entre {{min}} e {{max}}.",
+        "retryRange": "O campo \"retry_count\" precisa ser um número inteiro entre {{min}} e {{max}}.",
+        "tagsType": "O campo \"tags\" precisa ser uma lista de textos."
+      }
     },
     "test": {
       "button": "Testar conexão",

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -354,5 +354,10 @@
     "createDenied": "Você não tem permissão para criar ferramentas personalizadas",
     "editDenied": "Você não tem permissão para editar ferramentas personalizadas",
     "deleteDenied": "Você não tem permissão para excluir ferramentas personalizadas"
+  },
+  "advancedJson": {
+    "title": "JSON avançado",
+    "mustBeObject": "O JSON deve ser um objeto.",
+    "invalid": "JSON inválido."
   }
 }

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -274,14 +274,27 @@
       "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
       "helperText": "Exemplos são descrições curtas de como usar a tool.",
       "testHint": "Após criar, você poderá testar a tool contra o endpoint real.",
-      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele."
+      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele.",
+      "testHintDraft": "Use “Testar requisição” para experimentar o endpoint antes de salvar. O resultado reflete a config acima, incluindo path e query params."
     },
     "actions": {
       "continue": "Continuar",
       "back": "Voltar",
       "skip": "Pular",
       "create": "Criar tool",
-      "save": "Salvar alterações"
+      "save": "Salvar alterações",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edição",
+      "form": "Formulário",
+      "json": "JSON avançado"
+    },
+    "advanced": {
+      "title": "Configuração avançada (JSON)",
+      "subtitle": "Edite a configuração inteira da tool como JSON cru.",
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obrigatórios: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (use {} quando vazio).",
+      "missingFields": "Campos obrigatórios ausentes no JSON: {{fields}}. Adicione de volta antes de salvar."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customMcpServers.json
+++ b/src/i18n/locales/pt/customMcpServers.json
@@ -208,7 +208,8 @@
     "test": {
       "button": "Testar conexão",
       "testing": "Testando…",
-      "ok": "Conectado — {{count}} ferramentas descobertas",
+      "ok_one": "Ligado — {{count}} ferramenta descoberta",
+      "ok_other": "Ligado — {{count}} ferramentas descobertas",
       "fail": "Falha na conexão"
     }
   },

--- a/src/i18n/locales/pt/customMcpServers.json
+++ b/src/i18n/locales/pt/customMcpServers.json
@@ -191,6 +191,12 @@
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira do servidor como JSON cru.",
       "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
+    },
+    "test": {
+      "button": "Testar conexão",
+      "testing": "Testando…",
+      "ok": "Conectado — {{count}} ferramentas descobertas",
+      "fail": "Falha na conexão"
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customMcpServers.json
+++ b/src/i18n/locales/pt/customMcpServers.json
@@ -179,7 +179,18 @@
       "continue": "Continuar",
       "back": "Voltar",
       "create": "Criar servidor MCP",
-      "save": "Guardar alterações"
+      "save": "Guardar alterações",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edição",
+      "form": "Formulário",
+      "json": "JSON avançado"
+    },
+    "advanced": {
+      "title": "Configuração avançada (JSON)",
+      "subtitle": "Edite a configuração inteira do servidor como JSON cru.",
+      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customMcpServers.json
+++ b/src/i18n/locales/pt/customMcpServers.json
@@ -190,7 +190,20 @@
     "advanced": {
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira do servidor como JSON cru.",
-      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags."
+      "hint": "Campos: name, description, url, headers, timeout, retry_count, tags.",
+      "errors": {
+        "nameRequired": "O campo \"name\" é obrigatório e não pode ficar vazio.",
+        "nameType": "O campo \"name\" tem de ser texto.",
+        "descriptionType": "O campo \"description\" tem de ser texto.",
+        "urlRequired": "O campo \"url\" é obrigatório e não pode ficar vazio.",
+        "urlType": "O campo \"url\" tem de ser texto.",
+        "urlInvalid": "O campo \"url\" não é um URL válido (ex.: https://o-meu-servidor.com/mcp).",
+        "headersType": "O campo \"headers\" tem de ser um objeto.",
+        "headerValueType": "Os valores dos headers têm de ser texto: {{keys}}.",
+        "timeoutRange": "O campo \"timeout\" tem de ser um número inteiro entre {{min}} e {{max}}.",
+        "retryRange": "O campo \"retry_count\" tem de ser um número inteiro entre {{min}} e {{max}}.",
+        "tagsType": "O campo \"tags\" tem de ser uma lista de textos."
+      }
     },
     "test": {
       "button": "Testar conexão",

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -354,5 +354,10 @@
     "createDenied": "Você não tem permissão para criar ferramentas personalizadas",
     "editDenied": "Você não tem permissão para editar ferramentas personalizadas",
     "deleteDenied": "Você não tem permissão para excluir ferramentas personalizadas"
+  },
+  "advancedJson": {
+    "title": "JSON avançado",
+    "mustBeObject": "O JSON deve ser um objeto.",
+    "invalid": "JSON inválido."
   }
 }

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -274,14 +274,27 @@
       "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
       "helperText": "Exemplos são descrições curtas de como usar a tool.",
       "testHint": "Após criar, você poderá testar a tool contra o endpoint real.",
-      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele."
+      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele.",
+      "testHintDraft": "Use “Testar requisição” para experimentar o endpoint antes de salvar. O resultado reflete a config acima, incluindo path e query params."
     },
     "actions": {
       "continue": "Continuar",
       "back": "Voltar",
       "skip": "Pular",
       "create": "Criar tool",
-      "save": "Salvar alterações"
+      "save": "Salvar alterações",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edição",
+      "form": "Formulário",
+      "json": "JSON avançado"
+    },
+    "advanced": {
+      "title": "Configuração avançada (JSON)",
+      "subtitle": "Edite a configuração inteira da tool como JSON cru.",
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obrigatórios: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (use {} quando vazio).",
+      "missingFields": "Campos obrigatórios ausentes no JSON: {{fields}}. Adicione de volta antes de salvar."
     }
   },
   "modal": {

--- a/src/services/agents/customMcpServerService.ts
+++ b/src/services/agents/customMcpServerService.ts
@@ -5,6 +5,7 @@ import {
   CustomMcpServerCreate,
   CustomMcpServerUpdate,
   CustomMcpServerTestResponse,
+  CustomMcpServerTestConnectionResponse,
   ListCustomMcpServersParams,
 } from '@/types/ai';
 
@@ -75,4 +76,13 @@ export const testCustomMcpServer = async (
 ): Promise<CustomMcpServerTestResponse> => {
   const response = await evoaiApi.get(`/custom-mcp-servers/${serverId}/test`);
   return extractData<any>(response);
+};
+
+// EVO-1739: test an UNSAVED server's url/headers (test-before-save in the wizard).
+export const testCustomMcpServerConnection = async (
+  url: string,
+  headers: Record<string, unknown>,
+): Promise<CustomMcpServerTestConnectionResponse> => {
+  const response = await evoaiApi.post('/custom-mcp-servers/test-connection', { url, headers });
+  return extractData<CustomMcpServerTestConnectionResponse>(response);
 };

--- a/src/services/agents/customToolsService.ts
+++ b/src/services/agents/customToolsService.ts
@@ -67,6 +67,38 @@ export const deleteCustomTool = async (id: string): Promise<void> => {
 };
 
 // Testa ferramenta personalizada
+// EVO-1738: stateless test-before-save result (self-contained here to avoid the
+// duplicated CustomToolTestResponse declaration in types/ai/customTool.ts).
+export interface CustomToolTestPayloadResult {
+  error: string;
+  headers: Record<string, string>;
+  response_time: number;
+  status_code: number;
+  success: boolean;
+  body?: string;
+}
+
+// EVO-1738: the request-shaping subset of the tool config the test endpoint runs.
+// path_params/query_params are part of it: without them the test hits
+// `/users/{user_id}` literally and drops the query string, so a green result
+// would describe a request that carried none of the user's configuration.
+export interface CustomToolTestPayload {
+  method: string;
+  endpoint: string;
+  headers?: Record<string, unknown>;
+  path_params?: Record<string, unknown>;
+  query_params?: Record<string, unknown>;
+  body_params?: Record<string, unknown>;
+}
+
+// EVO-1738: test an UNSAVED tool's request (test-before-save in the wizard).
+export const testCustomToolPayload = async (
+  payload: CustomToolTestPayload,
+): Promise<{ test_result: CustomToolTestPayloadResult }> => {
+  const response = await evoaiApi.post('/custom-tools/test', payload);
+  return extractData<{ test_result: CustomToolTestPayloadResult }>(response);
+};
+
 export const testCustomTool = async (id: string): Promise<CustomToolTestResponse> => {
   const response = await evoaiApi.get(`/custom-tools/${id}/test`);
   return extractData<any>(response);
@@ -95,13 +127,29 @@ export const initialCustomToolsState: CustomToolsState = {
   searchQuery: '',
 };
 
-// Error handling utility
+// Error handling utility.
+// Core's error envelope is { success: false, error: { code, message, details }, meta }.
+// The previous guard tested `data.message`, which never exists in that envelope, so
+// `data.error.message` was unreachable and callers only ever saw axios's generic
+// "Request failed with status code 400".
 export const getErrorMessage = (error: any, defaultMessage: string = 'Erro desconhecido'): string => {
-  if (error?.response?.data?.message) {
-    // Usar formato padrão de erro: { success: false, error: { code, message, details }, meta }
-  return error.response.data.error?.message || error.response.data.message;
+  const data = error?.response?.data;
+  const base = data?.error?.message || data?.message;
+  if (!base) return error?.message || defaultMessage;
+
+  // Validation errors carry the offending field in details.fields[]; without it the
+  // user reads "Validation failed" and cannot tell what needs fixing.
+  const fields = data?.error?.details?.fields;
+  if (Array.isArray(fields) && fields.length > 0) {
+    const detail = fields
+      .map((f: { field?: string; message?: string }) =>
+        f?.field ? `${f.field}: ${f.message ?? ''}`.trim() : f?.message,
+      )
+      .filter(Boolean)
+      .join('; ');
+    if (detail) return `${base} (${detail})`;
   }
-  return error?.message || defaultMessage;
+  return base;
 };
 
 export default {

--- a/src/types/ai/customMcpServer.ts
+++ b/src/types/ai/customMcpServer.ts
@@ -62,6 +62,13 @@ export interface CustomMcpServerTestResponse {
   };
 }
 
+// EVO-1739: the stateless test-before-save result (no persisted server).
+export type McpTestResult = CustomMcpServerTestResponse['test_result'];
+
+export interface CustomMcpServerTestConnectionResponse {
+  test_result: McpTestResult;
+}
+
 export interface ListCustomMcpServersParams {
   page?: number;
   pageSize?: number;


### PR DESCRIPTION
## EVO-1739 (frontend) — modo avançado (JSON cru) + botão Testar no wizard de MCP

> O wizard de campos já existia (`f8d722b`). Faltavam **dois requisitos**: modo avançado JSON e botão Testar. Metade frontend; par com o backend **core-service #21** (`POST /custom-mcp-servers/test-connection`). **Deploy conjunto.**

### 1. Modo avançado (JSON cru) — `AdvancedJsonEditor` (compartilhado)
Toggle **Formulário ↔ JSON avançado** no header do wizard: edita a config inteira (`name/description/url/headers/timeout/retry_count/tags`) como JSON, com parse ao vivo e **bloqueio do submit** em JSON inválido/não-objeto. O `AdvancedJsonEditor` é um primitivo novo em `ai_agents/shared`, reutilizável pelo wizard de Custom Tools também.

### 2. Botão "Testar conexão" (test-before-save)
No passo de Conexão: valida a URL, chama `testCustomMcpServerConnection(url, headers)` → **novo endpoint stateless** → mostra spinner e o resultado do handshake MCP (**N ferramentas descobertas** no sucesso; message/error na falha). Antes só dava pra testar servidor **salvo**.

### Testes
`AdvancedJsonEditor.spec` — **4/4** (render JSON, edit válido→parsed+valid, malformado→invalid+sem onChange, array de topo rejeitado). `tsc --noEmit` **0 erros no projeto**. Step2 eslint-limpo (os erros de service/types são baseline do develop). i18n em **6 locales** (`wizard.mode/advanced/test`, `advancedJson`).

### Relacionado
Backend: **core-service #21**. Padrão de UI do teste: `channels/shared/ConnectionTest` (evolution-go).
