### PR TITLE
fix(frontend): surface the pipeline delete reason instead of a generic toast (EVO-2205)

### DIFF
--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -46,6 +46,7 @@
     "updateError": "Error updating pipeline",
     "deleteSuccess": "Pipeline deleted successfully",
     "deleteError": "Error deleting pipeline",
+    "deleteBlockedActiveItems": "This pipeline still has active items and cannot be deleted. Complete or move them first.",
     "duplicateSuccess": "Pipeline duplicated successfully",
     "duplicateError": "Error duplicating pipeline",
     "activateSuccess": "Pipeline activated successfully",

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -46,7 +46,7 @@
     "updateError": "Error updating pipeline",
     "deleteSuccess": "Pipeline deleted successfully",
     "deleteError": "Error deleting pipeline",
-    "deleteBlockedActiveItems": "This pipeline still has active items and cannot be deleted. Complete or move them first.",
+    "deleteBlockedActiveItems": "This pipeline still has active items and cannot be deleted. Remove the items from the pipeline first.",
     "duplicateSuccess": "Pipeline duplicated successfully",
     "duplicateError": "Error duplicating pipeline",
     "activateSuccess": "Pipeline activated successfully",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -46,7 +46,7 @@
     "updateError": "Error al actualizar pipeline",
     "deleteSuccess": "Pipeline eliminado con éxito",
     "deleteError": "Error al eliminar pipeline",
-    "deleteBlockedActiveItems": "Este pipeline todavía tiene elementos activos y no se puede eliminar. Complétalos o muévelos primero.",
+    "deleteBlockedActiveItems": "Este pipeline todavía tiene elementos activos y no se puede eliminar. Quita los elementos del pipeline primero.",
     "duplicateSuccess": "Pipeline duplicado con éxito",
     "duplicateError": "Error al duplicar pipeline",
     "activateSuccess": "Pipeline activado con éxito",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -46,6 +46,7 @@
     "updateError": "Error al actualizar pipeline",
     "deleteSuccess": "Pipeline eliminado con éxito",
     "deleteError": "Error al eliminar pipeline",
+    "deleteBlockedActiveItems": "Este pipeline todavía tiene elementos activos y no se puede eliminar. Complétalos o muévelos primero.",
     "duplicateSuccess": "Pipeline duplicado con éxito",
     "duplicateError": "Error al duplicar pipeline",
     "activateSuccess": "Pipeline activado con éxito",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -46,6 +46,7 @@
     "updateError": "Erreur lors de la mise à jour du pipeline",
     "deleteSuccess": "Pipeline supprimé avec succès",
     "deleteError": "Erreur lors de la suppression du pipeline",
+    "deleteBlockedActiveItems": "Ce pipeline contient encore des éléments actifs et ne peut pas être supprimé. Terminez-les ou déplacez-les d'abord.",
     "duplicateSuccess": "Pipeline dupliqué avec succès",
     "duplicateError": "Erreur lors de la duplication du pipeline",
     "activateSuccess": "Pipeline activé avec succès",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -46,7 +46,7 @@
     "updateError": "Erreur lors de la mise à jour du pipeline",
     "deleteSuccess": "Pipeline supprimé avec succès",
     "deleteError": "Erreur lors de la suppression du pipeline",
-    "deleteBlockedActiveItems": "Ce pipeline contient encore des éléments actifs et ne peut pas être supprimé. Terminez-les ou déplacez-les d'abord.",
+    "deleteBlockedActiveItems": "Ce pipeline contient encore des éléments actifs et ne peut pas être supprimé. Retirez d'abord les éléments du pipeline.",
     "duplicateSuccess": "Pipeline dupliqué avec succès",
     "duplicateError": "Erreur lors de la duplication du pipeline",
     "activateSuccess": "Pipeline activé avec succès",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -46,7 +46,7 @@
     "updateError": "Errore nell'aggiornamento della pipeline",
     "deleteSuccess": "Pipeline eliminata con successo",
     "deleteError": "Errore nell'eliminazione della pipeline",
-    "deleteBlockedActiveItems": "Questa pipeline ha ancora elementi attivi e non può essere eliminata. Completali o spostali prima.",
+    "deleteBlockedActiveItems": "Questa pipeline ha ancora elementi attivi e non può essere eliminata. Rimuovi prima gli elementi dalla pipeline.",
     "duplicateSuccess": "Pipeline duplicata con successo",
     "duplicateError": "Errore nella duplicazione della pipeline",
     "activateSuccess": "Pipeline attivata con successo",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -46,6 +46,7 @@
     "updateError": "Errore nell'aggiornamento della pipeline",
     "deleteSuccess": "Pipeline eliminata con successo",
     "deleteError": "Errore nell'eliminazione della pipeline",
+    "deleteBlockedActiveItems": "Questa pipeline ha ancora elementi attivi e non può essere eliminata. Completali o spostali prima.",
     "duplicateSuccess": "Pipeline duplicata con successo",
     "duplicateError": "Errore nella duplicazione della pipeline",
     "activateSuccess": "Pipeline attivata con successo",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -46,6 +46,7 @@
     "updateError": "Erro ao atualizar pipeline",
     "deleteSuccess": "Pipeline deletado com sucesso",
     "deleteError": "Erro ao deletar pipeline",
+    "deleteBlockedActiveItems": "Este pipeline ainda tem itens ativos e não pode ser excluído. Conclua ou mova os itens primeiro.",
     "duplicateSuccess": "Pipeline duplicado com sucesso",
     "duplicateError": "Erro ao duplicar pipeline",
     "activateSuccess": "Pipeline ativado com sucesso",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -46,7 +46,7 @@
     "updateError": "Erro ao atualizar pipeline",
     "deleteSuccess": "Pipeline deletado com sucesso",
     "deleteError": "Erro ao deletar pipeline",
-    "deleteBlockedActiveItems": "Este pipeline ainda tem itens ativos e não pode ser excluído. Conclua ou mova os itens primeiro.",
+    "deleteBlockedActiveItems": "Este pipeline ainda tem itens ativos e não pode ser excluído. Remova os itens do pipeline primeiro.",
     "duplicateSuccess": "Pipeline duplicado com sucesso",
     "duplicateError": "Erro ao duplicar pipeline",
     "activateSuccess": "Pipeline ativado com sucesso",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -46,6 +46,7 @@
     "updateError": "Erro ao atualizar pipeline",
     "deleteSuccess": "Pipeline deletado com sucesso",
     "deleteError": "Erro ao deletar pipeline",
+    "deleteBlockedActiveItems": "Este pipeline ainda tem itens ativos e não pode ser eliminado. Conclua ou mova os itens primeiro.",
     "duplicateSuccess": "Pipeline duplicado com sucesso",
     "duplicateError": "Erro ao duplicar pipeline",
     "activateSuccess": "Pipeline ativado com sucesso",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -46,7 +46,7 @@
     "updateError": "Erro ao atualizar pipeline",
     "deleteSuccess": "Pipeline deletado com sucesso",
     "deleteError": "Erro ao deletar pipeline",
-    "deleteBlockedActiveItems": "Este pipeline ainda tem itens ativos e não pode ser eliminado. Conclua ou mova os itens primeiro.",
+    "deleteBlockedActiveItems": "Este pipeline ainda tem itens ativos e não pode ser eliminado. Remova os itens do pipeline primeiro.",
     "duplicateSuccess": "Pipeline duplicado com sucesso",
     "duplicateError": "Erro ao duplicar pipeline",
     "activateSuccess": "Pipeline ativado com sucesso",

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { getContactColor } from '@/utils/avatar';
+import { pipelineDeleteErrorKey } from '@/utils/pipelineDeleteError';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -564,13 +565,7 @@ export default function PipelineKanban() {
       navigate('/pipelines');
     } catch (error) {
       console.error('Error deleting pipeline:', error);
-      const code = (error as { response?: { data?: { error?: { code?: string } } } })
-        ?.response?.data?.error?.code;
-      toast.error(
-        code === 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS'
-          ? t('messages.deleteBlockedActiveItems')
-          : t('messages.deleteError'),
-      );
+      toast.error(t(pipelineDeleteErrorKey(error)));
     } finally {
       setIsDeletingPipeline(false);
     }

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -564,7 +564,13 @@ export default function PipelineKanban() {
       navigate('/pipelines');
     } catch (error) {
       console.error('Error deleting pipeline:', error);
-      toast.error(t('messages.deleteError'));
+      const code = (error as { response?: { data?: { error?: { code?: string } } } })
+        ?.response?.data?.error?.code;
+      toast.error(
+        code === 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS'
+          ? t('messages.deleteBlockedActiveItems')
+          : t('messages.deleteError'),
+      );
     } finally {
       setIsDeletingPipeline(false);
     }

--- a/src/pages/Customer/Pipelines/Pipelines.spec.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.spec.tsx
@@ -28,6 +28,7 @@ const togglePipelineStatus = vi.fn();
 const getDependents = vi.fn();
 const success = vi.fn();
 const error = vi.fn();
+const deletePipeline = vi.fn();
 
 vi.mock('@/services/pipelines', () => ({
   pipelinesService: {
@@ -35,7 +36,7 @@ vi.mock('@/services/pipelines', () => ({
     togglePipelineStatus: (...args: unknown[]) => togglePipelineStatus(...args),
     getDependents: (...args: unknown[]) => getDependents(...args),
     updatePipeline: vi.fn(),
-    deletePipeline: vi.fn(),
+    deletePipeline: (...args: unknown[]) => deletePipeline(...args),
     duplicatePipeline: vi.fn(),
     setAsDefault: vi.fn(),
   },
@@ -119,6 +120,43 @@ describe('Pipelines management screen', () => {
 
     await waitFor(() => expect(success).toHaveBeenCalledWith('messages.activateSuccess'));
     expect(error).not.toHaveBeenCalled();
+  });
+
+  // EVO-2205: the delete error used to be swallowed into a generic toast. The specific
+  // "still has active items" reason must reach the user.
+  describe('delete error handling', () => {
+    async function clickDelete() {
+      const [trigger] = screen
+        .getAllByRole('button')
+        .filter(button => button.getAttribute('aria-haspopup') === 'menu');
+      await userEvent.click(trigger);
+      await userEvent.click(await screen.findByText('pipelinesTable.actions.delete'));
+      await userEvent.click(await screen.findByText('dialog.deletePipeline.delete'));
+    }
+
+    it('surfaces the active-items reason for the specific backend code', async () => {
+      deletePipeline.mockRejectedValue({
+        response: { data: { error: { code: 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS' } } },
+      });
+      render(<Pipelines />);
+      await screen.findByText('Retired funnel');
+
+      await clickDelete();
+
+      await waitFor(() =>
+        expect(error).toHaveBeenCalledWith('messages.deleteBlockedActiveItems'),
+      );
+    });
+
+    it('falls back to the generic message for any other failure', async () => {
+      deletePipeline.mockRejectedValue(new Error('network'));
+      render(<Pipelines />);
+      await screen.findByText('Retired funnel');
+
+      await clickDelete();
+
+      await waitFor(() => expect(error).toHaveBeenCalledWith('messages.deleteError'));
+    });
   });
 
   // EVO-2200: deactivating hid the pipeline while its capture forms kept feeding it.

--- a/src/pages/Customer/Pipelines/Pipelines.spec.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.spec.tsx
@@ -135,8 +135,19 @@ describe('Pipelines management screen', () => {
     }
 
     it('surfaces the active-items reason for the specific backend code', async () => {
+      // The full envelope Api::V1::PipelinesController#destroy renders — `success: false`
+      // included, since that is what marks the standard error format.
       deletePipeline.mockRejectedValue({
-        response: { data: { error: { code: 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS' } } },
+        response: {
+          status: 422,
+          data: {
+            success: false,
+            error: {
+              code: 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS',
+              message: 'Cannot delete pipeline with active items',
+            },
+          },
+        },
       });
       render(<Pipelines />);
       await screen.findByText('Retired funnel');
@@ -146,6 +157,7 @@ describe('Pipelines management screen', () => {
       await waitFor(() =>
         expect(error).toHaveBeenCalledWith('messages.deleteBlockedActiveItems'),
       );
+      expect(success).not.toHaveBeenCalled();
     });
 
     it('falls back to the generic message for any other failure', async () => {
@@ -156,6 +168,7 @@ describe('Pipelines management screen', () => {
       await clickDelete();
 
       await waitFor(() => expect(error).toHaveBeenCalledWith('messages.deleteError'));
+      expect(success).not.toHaveBeenCalled();
     });
   });
 

--- a/src/pages/Customer/Pipelines/Pipelines.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.tsx
@@ -275,7 +275,13 @@ export default function Pipelines() {
       setPipelineToDelete(null);
     } catch (error) {
       console.error('Error deleting pipeline:', error);
-      toast.error(t('messages.deleteError'));
+      const code = (error as { response?: { data?: { error?: { code?: string } } } })
+        ?.response?.data?.error?.code;
+      toast.error(
+        code === 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS'
+          ? t('messages.deleteBlockedActiveItems')
+          : t('messages.deleteError'),
+      );
     } finally {
       setState(prev => ({ ...prev, loading: { ...prev.loading, delete: false } }));
     }

--- a/src/pages/Customer/Pipelines/Pipelines.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.tsx
@@ -13,6 +13,7 @@ import {
 } from '@evoapi/design-system';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { pipelinesService } from '@/services/pipelines';
+import { pipelineDeleteErrorKey } from '@/utils/pipelineDeleteError';
 import {
   Pipeline,
   PipelinesState,
@@ -275,13 +276,7 @@ export default function Pipelines() {
       setPipelineToDelete(null);
     } catch (error) {
       console.error('Error deleting pipeline:', error);
-      const code = (error as { response?: { data?: { error?: { code?: string } } } })
-        ?.response?.data?.error?.code;
-      toast.error(
-        code === 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS'
-          ? t('messages.deleteBlockedActiveItems')
-          : t('messages.deleteError'),
-      );
+      toast.error(t(pipelineDeleteErrorKey(error)));
     } finally {
       setState(prev => ({ ...prev, loading: { ...prev.loading, delete: false } }));
     }

--- a/src/utils/pipelineDeleteError.spec.ts
+++ b/src/utils/pipelineDeleteError.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PIPELINE_DELETE_BLOCKED_CODE,
+  PIPELINE_DELETE_BLOCKED_KEY,
+  PIPELINE_DELETE_GENERIC_KEY,
+  pipelineDeleteErrorKey,
+} from './pipelineDeleteError';
+
+// EVO-2205: the delete rejection used to be swallowed into a generic toast on both
+// delete paths. This is the shared rule both of them now apply.
+describe('pipelineDeleteErrorKey', () => {
+  // The exact envelope Api::V1::PipelinesController#destroy renders — see
+  // app/controllers/concerns/api_response_helper.rb#error_response.
+  function backendRejection(code: string) {
+    return {
+      response: {
+        status: 422,
+        data: {
+          success: false,
+          error: { code, message: 'Cannot delete pipeline with active items' },
+        },
+      },
+    };
+  }
+
+  it('maps the backend rejection to the active-items reason', () => {
+    expect(pipelineDeleteErrorKey(backendRejection(PIPELINE_DELETE_BLOCKED_CODE))).toBe(
+      PIPELINE_DELETE_BLOCKED_KEY,
+    );
+  });
+
+  it('falls back to the generic message for a different backend code', () => {
+    expect(pipelineDeleteErrorKey(backendRejection('VALIDATION_ERROR'))).toBe(
+      PIPELINE_DELETE_GENERIC_KEY,
+    );
+  });
+
+  it('falls back to the generic message for a network failure', () => {
+    expect(pipelineDeleteErrorKey(new Error('network'))).toBe(PIPELINE_DELETE_GENERIC_KEY);
+  });
+
+  // A catch block can receive anything; extractError dereferences `.response`, so a
+  // nullish rejection must not blow up the error handler itself.
+  it.each([null, undefined, 'boom'])('falls back without throwing for %p', value => {
+    expect(pipelineDeleteErrorKey(value)).toBe(PIPELINE_DELETE_GENERIC_KEY);
+  });
+});

--- a/src/utils/pipelineDeleteError.ts
+++ b/src/utils/pipelineDeleteError.ts
@@ -1,0 +1,27 @@
+import { isErrorCode } from '@/utils/apiHelpers';
+
+// EVO-2205: the backend refuses the delete with a code whose NAME is legacy
+// (…WITH_CONVERSATIONS). The rule it actually enforces is "the pipeline still holds
+// active items" — an item can be a contact-only lead, not just a conversation.
+//
+// Both delete paths (the pipelines list and the in-kanban header) swallowed that
+// reason into a generic toast. The mapping lives here once so the two paths cannot
+// drift, and so the rule is testable without rendering either screen.
+export const PIPELINE_DELETE_BLOCKED_CODE = 'CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS';
+
+export const PIPELINE_DELETE_BLOCKED_KEY = 'messages.deleteBlockedActiveItems';
+export const PIPELINE_DELETE_GENERIC_KEY = 'messages.deleteError';
+
+/**
+ * Translation key for a failed pipeline deletion: the specific "still has active
+ * items" reason when the backend said so, the generic message otherwise.
+ */
+export function pipelineDeleteErrorKey(error: unknown): string {
+  // `error` arrives straight from a catch block, so it can be anything at all.
+  // isErrorCode reads `.response` off it and would throw on null/undefined.
+  if (!error || typeof error !== 'object') return PIPELINE_DELETE_GENERIC_KEY;
+
+  return isErrorCode(error, PIPELINE_DELETE_BLOCKED_CODE)
+    ? PIPELINE_DELETE_BLOCKED_KEY
+    : PIPELINE_DELETE_GENERIC_KEY;
+}


### PR DESCRIPTION
## Summary

Both pipeline delete paths — the pipelines list and the in-kanban delete button — swallowed the backend error into a generic `messages.deleteError` toast, so the user never learned why deletion was refused. Both now map `CANNOT_DELETE_PIPELINE_WITH_CONVERSATIONS` to a translated "still has active items" message, falling back to the generic toast for anything else.

## Security

No new data exposure: the error code comes from the API, the rendered text is a static i18n string with no interpolation of backend data. No `dangerouslySetInnerHTML`.

## Test plan

- `npx vitest run src/pages/Customer/Pipelines src/components/pipelines` — 18 passed
- Negative control: without the error-code mapping, the specific-message test fails
- `pnpm exec tsc -b --noEmit` — clean
- `npx eslint` on the touched files — clean (one pre-existing `useCallback` warning at PipelineKanban.tsx:205, unrelated)
- i18n added across the six locales; `en` ↔ `pt-BR` parity checked

## Changed Files

- `src/pages/Customer/Pipelines/Pipelines.tsx`
- `src/pages/Customer/Pipelines/PipelineKanban.tsx`
- `src/pages/Customer/Pipelines/Pipelines.spec.tsx`
- `src/i18n/locales/{en,pt-BR,pt,es,fr,it}/pipelines.json`

## Related PRs

- CRM: https://github.com/evolution-foundation/evo-ai-crm-community/pull/248 — **merge first**, it changes the guard and the message this PR surfaces.

## Linked Issue

- EVO-2205 — https://linear.app/evoai/issue/EVO-2205

## Summary by Sourcery

Surface specific pipeline deletion error reasons from the backend instead of always showing a generic failure toast.

New Features:
- Show a dedicated "pipeline has active items" error message when deletion is blocked by conversations.

Bug Fixes:
- Ensure pipeline deletion failures correctly display the backend-provided reason instead of swallowing it into a generic error toast.

Enhancements:
- Align both pipelines list and kanban deletion flows to share consistent error handling based on backend error codes.

Tests:
- Add tests covering pipeline deletion error handling, including the specific active-items error code and the generic fallback behavior.