### PR TITLE
feat(EVO-1738): advanced JSON mode + Test button + wizard in the agent builder (Custom Tools)

### DIFF
--- a/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.spec.tsx
+++ b/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.spec.tsx
@@ -13,12 +13,14 @@ vi.mock('@/services/agents/customToolsService', () => ({
   createCustomTool: vi.fn(),
 }));
 
-vi.mock('@/components/customTools/CustomToolForm', () => ({
-  default: ({ onCancel }: { onCancel: () => void }) => (
-    <div data-testid="custom-tool-form">
-      <button onClick={onCancel}>cancel-form</button>
-    </div>
-  ),
+// EVO-1738: the agent-builder create path now renders the guided wizard.
+vi.mock('@/components/customTools/CustomToolWizardModal', () => ({
+  default: ({ open, onOpenChange }: { open: boolean; onOpenChange: (o: boolean) => void }) =>
+    open ? (
+      <div data-testid="custom-tool-wizard">
+        <button onClick={() => onOpenChange(false)}>close-wizard</button>
+      </div>
+    ) : null,
 }));
 
 vi.mock('sonner', () => ({
@@ -50,7 +52,7 @@ describe('CustomToolsSelectionDialog', () => {
     });
   });
 
-  it('opens inline create sub-dialog without closing selection dialog when header button is clicked', async () => {
+  it('opens the create wizard without closing the selection dialog when header button is clicked', async () => {
     const onOpenChange = vi.fn();
     render(<CustomToolsSelectionDialog {...makeProps({ onOpenChange })} />);
 
@@ -62,12 +64,12 @@ describe('CustomToolsSelectionDialog', () => {
     const createButtons = screen.getAllByText('tools.customTools.create');
     fireEvent.click(createButtons[0].closest('button')!);
 
-    // Inline form should appear without closing the parent dialog
-    expect(screen.getByTestId('custom-tool-form')).toBeTruthy();
+    // The wizard should appear without closing the parent selection dialog
+    expect(screen.getByTestId('custom-tool-wizard')).toBeTruthy();
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 
-  it('closes the create sub-dialog when form is cancelled, keeping selection dialog open', async () => {
+  it('closes the create wizard when dismissed, keeping the selection dialog open', async () => {
     render(<CustomToolsSelectionDialog {...makeProps()} />);
 
     await waitFor(() => {
@@ -76,14 +78,14 @@ describe('CustomToolsSelectionDialog', () => {
 
     const createButtons = screen.getAllByText('tools.customTools.create');
     fireEvent.click(createButtons[0].closest('button')!);
-    expect(screen.getByTestId('custom-tool-form')).toBeTruthy();
+    expect(screen.getByTestId('custom-tool-wizard')).toBeTruthy();
 
-    // Cancel the form
-    fireEvent.click(screen.getByText('cancel-form'));
+    // Close the wizard
+    fireEvent.click(screen.getByText('close-wizard'));
 
-    // Form should be gone
+    // Wizard should be gone
     await waitFor(() => {
-      expect(screen.queryByTestId('custom-tool-form')).toBeNull();
+      expect(screen.queryByTestId('custom-tool-wizard')).toBeNull();
     });
   });
 });

--- a/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.tsx
+++ b/src/components/ai_agents/Dialogs/CustomToolsSelectionDialog.tsx
@@ -15,7 +15,7 @@ import { Search, Code, Tag, Plus, ExternalLink } from 'lucide-react';
 import { listCustomTools, createCustomTool } from '@/services/agents/customToolsService';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import { useLanguage } from '@/hooks/useLanguage';
-import CustomToolForm from '@/components/customTools/CustomToolForm';
+import CustomToolWizardModal from '@/components/customTools/CustomToolWizardModal';
 import { toast } from 'sonner';
 
 interface CustomToolsSelectionDialogProps {
@@ -308,23 +308,14 @@ const CustomToolsSelectionDialog = ({
         </DialogContent>
       </Dialog>
 
-      {/* Inline create tool sub-dialog — preserves wizard state */}
-      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-        <DialogContent className="sm:max-w-[700px] max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Plus className="h-5 w-5 text-purple-500" />
-              {t('tools.customTools.create')}
-            </DialogTitle>
-          </DialogHeader>
-          <CustomToolForm
-            mode="create"
-            loading={isCreatingTool}
-            onSubmit={handleCreateTool}
-            onCancel={() => setShowCreateDialog(false)}
-          />
-        </DialogContent>
-      </Dialog>
+      {/* EVO-1738: the agent-builder create path now uses the guided wizard
+          (n8n-style) instead of the old sectioned form. */}
+      <CustomToolWizardModal
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        loading={isCreatingTool}
+        onSubmit={handleCreateTool}
+      />
     </>
   );
 };

--- a/src/components/ai_agents/shared/TestRequestButton.spec.tsx
+++ b/src/components/ai_agents/shared/TestRequestButton.spec.tsx
@@ -7,9 +7,19 @@ vi.mock('@/hooks/useLanguage', () => ({
 }));
 
 const mockTestCustomTool = vi.fn();
-vi.mock('@/services/agents/customToolsService', () => ({
-  testCustomTool: (...args: unknown[]) => mockTestCustomTool(...args),
-}));
+const mockTestCustomToolPayload = vi.fn();
+vi.mock('@/services/agents/customToolsService', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/agents/customToolsService')
+  >('@/services/agents/customToolsService');
+  return {
+    // getErrorMessage is exercised for real: asserting on the message the user
+    // actually reads is the point of the failure tests below.
+    getErrorMessage: actual.getErrorMessage,
+    testCustomTool: (...args: unknown[]) => mockTestCustomTool(...args),
+    testCustomToolPayload: (...args: unknown[]) => mockTestCustomToolPayload(...args),
+  };
+});
 
 describe('TestRequestButton', () => {
   beforeEach(() => {
@@ -57,6 +67,93 @@ describe('TestRequestButton', () => {
     fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
     await waitFor(() => {
       expect(screen.getByText('network down')).toBeTruthy();
+    });
+  });
+
+  // EVO-1738 test-before-save (R1 review).
+  describe('payload mode', () => {
+    const payload = {
+      method: 'GET',
+      endpoint: 'https://api.example.com/users/{id}',
+      headers: { 'X-Token': 'abc' },
+      path_params: { id: '42' },
+      query_params: { limit: 10 },
+      body_params: {},
+    };
+
+    it('is enabled in create mode and tests the draft payload, not a saved tool', async () => {
+      mockTestCustomToolPayload.mockResolvedValue({
+        test_result: {
+          error: '',
+          headers: { 'content-type': 'application/json' },
+          response_time: 0.25,
+          status_code: 201,
+          success: true,
+          body: '{"id":1}',
+        },
+      });
+
+      render(<TestRequestButton mode="create" getPayload={() => payload} />);
+      const btn = screen.getByRole('button', { name: 'testRequest.button' });
+      // The create-mode lockout only existed because an unsaved tool had no id.
+      expect((btn as HTMLButtonElement).disabled).toBe(false);
+
+      fireEvent.click(btn);
+      await waitFor(() => {
+        expect(screen.getByTestId('test-request-result')).toBeTruthy();
+      });
+
+      expect(mockTestCustomToolPayload).toHaveBeenCalledWith(payload);
+      expect(mockTestCustomTool).not.toHaveBeenCalled();
+      expect(screen.getByText('201')).toBeTruthy();
+      expect(screen.getByText('250ms')).toBeTruthy();
+      // The response body is the whole point of testing — it must be rendered.
+      expect(screen.getByText(/"id": 1/)).toBeTruthy();
+    });
+
+    it("surfaces the API's reason, not axios's generic status line", async () => {
+      // Core's envelope: { success:false, error:{ code, message, details } }.
+      mockTestCustomToolPayload.mockRejectedValue({
+        message: 'Request failed with status code 400',
+        response: {
+          data: {
+            success: false,
+            error: { code: 'INVALID_INPUT', message: 'unsupported method: TRACE' },
+          },
+        },
+      });
+
+      render(<TestRequestButton mode="create" getPayload={() => payload} />);
+      fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('unsupported method: TRACE')).toBeTruthy();
+      });
+      expect(screen.queryByText('Request failed with status code 400')).toBeNull();
+    });
+
+    it('appends validation field details so the user knows what to fix', async () => {
+      mockTestCustomToolPayload.mockRejectedValue({
+        message: 'Request failed with status code 400',
+        response: {
+          data: {
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Validation failed',
+              details: { fields: [{ field: 'Endpoint', message: 'is required' }] },
+            },
+          },
+        },
+      });
+
+      render(<TestRequestButton mode="create" getPayload={() => payload} />);
+      fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Validation failed (Endpoint: is required)'),
+        ).toBeTruthy();
+      });
     });
   });
 });

--- a/src/components/ai_agents/shared/TestRequestButton.tsx
+++ b/src/components/ai_agents/shared/TestRequestButton.tsx
@@ -11,7 +11,12 @@ import {
 } from '@evoapi/design-system';
 import { Play, ChevronDown, Loader2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { testCustomTool } from '@/services/agents/customToolsService';
+import {
+  testCustomTool,
+  testCustomToolPayload,
+  getErrorMessage,
+  type CustomToolTestPayload,
+} from '@/services/agents/customToolsService';
 import type { CustomToolTestResponse } from '@/types/ai';
 
 /** Shared between Custom Tools (EVO-1790) and Custom MCP (EVO-1791) UIs. */
@@ -20,6 +25,13 @@ export interface TestRequestButtonProps {
   toolId?: string;
   onResult?: (result: CustomToolTestResponse['test_result']) => void;
   disabled?: boolean;
+  /**
+   * EVO-1738 test-before-save: when provided, the button runs the DRAFT config
+   * through the stateless endpoint instead of replaying a saved tool. Takes
+   * precedence over toolId and lifts the create-mode lockout — that lockout only
+   * ever existed because an unsaved tool had no id to test.
+   */
+  getPayload?: () => CustomToolTestPayload;
 }
 
 type TestResult = CustomToolTestResponse['test_result'];
@@ -53,6 +65,7 @@ export default function TestRequestButton({
   toolId,
   onResult,
   disabled = false,
+  getPayload,
 }: TestRequestButtonProps) {
   const { t } = useLanguage('customTools');
   const [loading, setLoading] = useState(false);
@@ -61,25 +74,33 @@ export default function TestRequestButton({
   const [responseBody, setResponseBody] = useState<unknown>(null);
   const [headersOpen, setHeadersOpen] = useState(false);
 
-  const isCreateMode = mode === 'create';
-  const buttonDisabled = disabled || loading || isCreateMode || !toolId;
+  // With a draft payload there is nothing to be "not saved yet" about, so the
+  // create-mode tooltip/lockout does not apply.
+  const isCreateMode = !getPayload && mode === 'create';
+  const buttonDisabled = disabled || loading || (!getPayload && (isCreateMode || !toolId));
 
   const handleClick = async () => {
-    if (!toolId) return;
+    if (!getPayload && !toolId) return;
     setLoading(true);
     setError(null);
     setResult(null);
     setResponseBody(null);
     try {
-      const resp = await testCustomTool(toolId);
-      setResult(resp.test_result);
-      const body = (resp as unknown as Record<string, unknown>).body
-        ?? (resp.test_result as unknown as Record<string, unknown>).body;
-      setResponseBody(body ?? null);
-      onResult?.(resp.test_result);
+      if (getPayload) {
+        const { test_result } = await testCustomToolPayload(getPayload());
+        setResult(test_result);
+        setResponseBody(test_result?.body ?? null);
+        onResult?.(test_result);
+      } else {
+        const resp = await testCustomTool(toolId!);
+        const body = (resp as unknown as Record<string, unknown>).body
+          ?? (resp.test_result as unknown as Record<string, unknown>).body;
+        setResult(resp.test_result);
+        setResponseBody(body ?? null);
+        onResult?.(resp.test_result);
+      }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      setError(msg || t('testRequest.error'));
+      setError(getErrorMessage(e, t('testRequest.error')));
     } finally {
       setLoading(false);
     }

--- a/src/components/customTools/CustomToolWizardModal.spec.tsx
+++ b/src/components/customTools/CustomToolWizardModal.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import CustomToolWizardModal from './CustomToolWizardModal';
 
@@ -6,9 +6,17 @@ vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@/services/agents/customToolsService', () => ({
-  testCustomTool: vi.fn(),
-}));
+const mockTestCustomToolPayload = vi.fn();
+vi.mock('@/services/agents/customToolsService', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/agents/customToolsService')
+  >('@/services/agents/customToolsService');
+  return {
+    getErrorMessage: actual.getErrorMessage,
+    testCustomTool: vi.fn(),
+    testCustomToolPayload: (...args: unknown[]) => mockTestCustomToolPayload(...args),
+  };
+});
 
 const makeProps = (overrides: Record<string, unknown> = {}) => ({
   open: true,
@@ -330,5 +338,139 @@ describe('CustomToolWizardModal', () => {
     expect(values.beta).toBe('b');
     expect(values.__evo_modes_meta__).toBeUndefined();
     expect(values.__modes_meta__).toBeUndefined();
+  });
+
+  // ----- EVO-1738 advanced (raw JSON) mode. R1 review: none of this branch had
+  // coverage — the toggle, the submit source and the required-key gate were all
+  // untested, and the gate is what stands between the user and an opaque 400.
+
+  const editorTextarea = () =>
+    screen.getByLabelText('advancedJson.title') as HTMLTextAreaElement;
+
+  const enterJsonMode = () => {
+    fireEvent.click(screen.getByRole('tab', { name: 'wizard.mode.json' }));
+  };
+
+  const fillNameAndEndpoint = () => {
+    fireEvent.change(screen.getAllByRole('textbox')[0], { target: { value: 'My Tool' } });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' }));
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'https://api.example.com/x' },
+    });
+  };
+
+  it('seeds the JSON editor from the form and submits the raw JSON verbatim', () => {
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ onSubmit })} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    expect(seeded.name).toBe('My Tool');
+    expect(seeded.endpoint).toBe('https://api.example.com/x');
+
+    fireEvent.change(editorTextarea(), {
+      target: { value: JSON.stringify({ ...seeded, description: 'edited raw' }) },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.create' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].description).toBe('edited raw');
+  });
+
+  it('blocks submit when the JSON drops a key the API requires', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    delete seeded.path_params;
+    fireEvent.change(editorTextarea(), { target: { value: JSON.stringify(seeded) } });
+
+    const createBtn = screen.getByRole('button', { name: 'wizard.actions.create' });
+    expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+    // And say which key, otherwise the user only sees a disabled button.
+    expect(screen.getByRole('alert').textContent).toContain('wizard.advanced.missingFields');
+  });
+
+  it('blocks submit on malformed JSON', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    fireEvent.change(editorTextarea(), { target: { value: '{ not json' } });
+    const createBtn = screen.getByRole('button', { name: 'wizard.actions.create' });
+    expect((createBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('keeps raw JSON edits across a round trip through the form tab', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    fireEvent.change(editorTextarea(), {
+      target: { value: JSON.stringify({ ...seeded, description: 'hand written' }) },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'wizard.mode.form' }));
+    enterJsonMode();
+
+    // The form did not move, so the user's raw edits must survive.
+    expect(JSON.parse(editorTextarea().value).description).toBe('hand written');
+  });
+
+  it('re-seeds from the form when the form actually changed', () => {
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    fireEvent.change(editorTextarea(), {
+      target: { value: JSON.stringify({ ...seeded, description: 'hand written' }) },
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'wizard.mode.form' }));
+    fireEvent.change(screen.getAllByRole('textbox')[0], {
+      target: { value: 'https://api.example.com/changed' },
+    });
+    enterJsonMode();
+
+    const reseeded = JSON.parse(editorTextarea().value);
+    expect(reseeded.endpoint).toBe('https://api.example.com/changed');
+    expect(reseeded.description).toBe('');
+  });
+
+  it('tests the draft config from JSON mode, path and query params included', async () => {
+    mockTestCustomToolPayload.mockResolvedValue({
+      test_result: { error: '', headers: {}, response_time: 0.1, status_code: 200, success: true },
+    });
+    render(<CustomToolWizardModal {...makeProps()} />);
+    fillNameAndEndpoint();
+    enterJsonMode();
+
+    const seeded = JSON.parse(editorTextarea().value);
+    fireEvent.change(editorTextarea(), {
+      target: {
+        value: JSON.stringify({
+          ...seeded,
+          path_params: { id: '42' },
+          query_params: { limit: 10 },
+        }),
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'testRequest.button' }));
+
+    await waitFor(() => {
+      expect(mockTestCustomToolPayload).toHaveBeenCalledTimes(1);
+    });
+    expect(mockTestCustomToolPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://api.example.com/x',
+        path_params: { id: '42' },
+        query_params: { limit: 10 },
+      }),
+    );
   });
 });

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogContent, DialogTitle } from '@evoapi/design-system';
-import { X } from 'lucide-react';
+import { Dialog, DialogContent, DialogTitle, Button } from '@evoapi/design-system';
+import { X, Code2, LayoutList } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
+import { AdvancedJsonEditor } from '@/components/ai_agents/shared';
 import {
   Step1_Identity,
   Step2_Endpoint,
@@ -223,12 +224,21 @@ export default function CustomToolWizardModal({
   const [data, setData] = useState<WizardData>(() =>
     tool ? toolToWizardData(tool) : initialWizardData,
   );
+  // EVO-1738: advanced (raw JSON) mode — edit the whole save payload as JSON.
+  // jsonPayload holds edits while in JSON mode (source of truth for submit there);
+  // no back-map to the step form (the model's inverse mapping is lossy).
+  const [mode, setMode] = useState<'form' | 'json'>('form');
+  const [jsonValid, setJsonValid] = useState(true);
+  const [jsonPayload, setJsonPayload] = useState<CustomToolFormData | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) {
       const timeout = setTimeout(() => {
         setCurrentStep(1);
+        setMode('form');
+        setJsonValid(true);
+        setJsonPayload(null);
         setData(tool ? toolToWizardData(tool) : initialWizardData);
       }, 300);
       return () => clearTimeout(timeout);
@@ -268,7 +278,9 @@ export default function CustomToolWizardModal({
   const handleNext = () => setCurrentStep(s => Math.min(s + 1, TOTAL_STEPS));
   const handleBack = () => setCurrentStep(s => Math.max(s - 1, 1));
 
-  const handleSubmit = () => {
+  // Build the save payload from the step form. Extracted so advanced (raw JSON)
+  // mode can snapshot it and submit can pick the right source. EVO-1738.
+  const buildPayload = (): CustomToolFormData => {
     // Mode descriptions live in `values` under our namespaced key. We
     // never overwrite an unrelated user-owned `__evo_modes_meta__` key
     // because cleanValues stripped it on read and the user can't recreate
@@ -282,7 +294,7 @@ export default function CustomToolWizardModal({
         ? { ...data.values, [MODES_META_KEY]: modesMeta }
         : data.values;
 
-    const payload: CustomToolFormData = {
+    return {
       name: data.name.trim(),
       description: data.description.trim(),
       method: data.method,
@@ -301,8 +313,21 @@ export default function CustomToolWizardModal({
       tags: data.tags,
       examples: data.examples,
     };
-    onSubmit(payload);
   };
+
+  // In JSON mode the edited raw payload is the source of truth; otherwise the form.
+  const handleSubmit = () => {
+    onSubmit(mode === 'json' && jsonPayload ? jsonPayload : buildPayload());
+  };
+
+  const enterJsonMode = () => {
+    setJsonPayload(buildPayload());
+    setJsonValid(true);
+    setMode('json');
+  };
+
+  const jsonCanSubmit =
+    jsonValid && !!jsonPayload?.name?.trim() && !!jsonPayload?.endpoint?.trim();
 
   const renderStep = () => {
     switch (currentStep) {
@@ -398,7 +423,34 @@ export default function CustomToolWizardModal({
 
   const wizardContent = (
     <div className="flex flex-col h-full min-h-0">
-      <div className="flex items-center justify-end px-3 pt-3 pb-0 flex-shrink-0">
+      <div className="flex items-center justify-between px-3 pt-3 pb-0 flex-shrink-0">
+        {/* EVO-1738: Form ↔ advanced (raw JSON) mode toggle. */}
+        <div className="inline-flex rounded-md border p-0.5" role="tablist" aria-label={t('wizard.mode.label')}>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'form'}
+            onClick={() => setMode('form')}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'form' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <LayoutList className="h-3.5 w-3.5" />
+            {t('wizard.mode.form')}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'json'}
+            onClick={enterJsonMode}
+            className={`inline-flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'json' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <Code2 className="h-3.5 w-3.5" />
+            {t('wizard.mode.json')}
+          </button>
+        </div>
         <button
           type="button"
           onClick={() => onOpenChange(false)}
@@ -409,33 +461,59 @@ export default function CustomToolWizardModal({
         </button>
       </div>
 
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
-          <div className="text-center">
-            <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
-            {header.subtitle && (
-              <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
-                {header.subtitle}
-              </p>
-            )}
+      {mode === 'json' ? (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0 text-center">
+            <h2 className="text-2xl font-semibold leading-tight">{t('wizard.advanced.title')}</h2>
+            <p className="text-sm text-muted-foreground mt-1">{t('wizard.advanced.subtitle')}</p>
+          </div>
+          <div ref={contentRef} className="flex-1 overflow-y-auto px-4 py-3 min-h-0">
+            <AdvancedJsonEditor
+              value={(jsonPayload ?? buildPayload()) as unknown as Record<string, unknown>}
+              onChange={p => setJsonPayload(p as unknown as CustomToolFormData)}
+              onValidityChange={setJsonValid}
+              rows={22}
+              hint={t('wizard.advanced.hint')}
+            />
+          </div>
+          <div className="flex justify-end gap-2 flex-shrink-0 p-3 border-t">
+            <Button variant="outline" className="px-6" onClick={() => onOpenChange(false)}>
+              {t('wizard.actions.cancel')}
+            </Button>
+            <Button className="px-6" onClick={handleSubmit} disabled={loading || !jsonCanSubmit}>
+              {isEdit ? t('wizard.actions.save') : t('wizard.actions.create')}
+            </Button>
           </div>
         </div>
+      ) : (
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="border-b bg-transparent p-3 pt-1.5 flex-shrink-0">
+            <div className="text-center">
+              <h2 className="text-2xl font-semibold leading-tight">{header.title}</h2>
+              {header.subtitle && (
+                <p className="text-sm text-muted-foreground mt-1 whitespace-pre-line">
+                  {header.subtitle}
+                </p>
+              )}
+            </div>
+          </div>
 
-        <div className="py-2 px-4 flex-shrink-0 bg-transparent">
-          <WizardProgress
-            currentStep={currentStep}
-            totalSteps={TOTAL_STEPS}
-            steps={steps}
-          />
-        </div>
+          <div className="py-2 px-4 flex-shrink-0 bg-transparent">
+            <WizardProgress
+              currentStep={currentStep}
+              totalSteps={TOTAL_STEPS}
+              steps={steps}
+            />
+          </div>
 
-        <div
-          ref={contentRef}
-          className="flex-1 overflow-y-auto px-3 min-h-0"
-        >
-          {renderStep()}
+          <div
+            ref={contentRef}
+            className="flex-1 overflow-y-auto px-3 min-h-0"
+          >
+            {renderStep()}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -6,6 +6,10 @@ import { CustomTool, CustomToolFormData } from '@/types/ai';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
 import { AdvancedJsonEditor } from '@/components/ai_agents/shared';
 import {
+  testCustomToolPayload,
+  type CustomToolTestPayloadResult,
+} from '@/services/agents/customToolsService';
+import {
   Step1_Identity,
   Step2_Endpoint,
   Step3_Parameters,
@@ -230,6 +234,10 @@ export default function CustomToolWizardModal({
   const [mode, setMode] = useState<'form' | 'json'>('form');
   const [jsonValid, setJsonValid] = useState(true);
   const [jsonPayload, setJsonPayload] = useState<CustomToolFormData | null>(null);
+  // EVO-1738: test-before-save state.
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<CustomToolTestPayloadResult | null>(null);
+  const [testError, setTestError] = useState('');
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -239,6 +247,9 @@ export default function CustomToolWizardModal({
         setMode('form');
         setJsonValid(true);
         setJsonPayload(null);
+        setTesting(false);
+        setTestResult(null);
+        setTestError('');
         setData(tool ? toolToWizardData(tool) : initialWizardData);
       }, 300);
       return () => clearTimeout(timeout);
@@ -329,6 +340,29 @@ export default function CustomToolWizardModal({
   const jsonCanSubmit =
     jsonValid && !!jsonPayload?.name?.trim() && !!jsonPayload?.endpoint?.trim();
 
+  // EVO-1738: test the current request (method/endpoint/headers/body_params) before
+  // saving, via the stateless endpoint; show the real HTTP status/result.
+  const handleTestRequest = async () => {
+    const p = mode === 'json' && jsonPayload ? jsonPayload : buildPayload();
+    setTesting(true);
+    setTestResult(null);
+    setTestError('');
+    try {
+      const res = await testCustomToolPayload({
+        method: p.method,
+        endpoint: p.endpoint,
+        headers: p.headers,
+        body_params: p.body_params,
+      });
+      setTestResult(res.test_result);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { message?: string } }; message?: string };
+      setTestError(err?.response?.data?.message || err?.message || t('wizard.test.fail'));
+    } finally {
+      setTesting(false);
+    }
+  };
+
   const renderStep = () => {
     switch (currentStep) {
       case 1:
@@ -412,6 +446,10 @@ export default function CustomToolWizardModal({
             onSubmit={handleSubmit}
             loading={loading}
             mode={isEdit ? 'edit' : 'create'}
+            onTest={handleTestRequest}
+            testing={testing}
+            testResult={testResult}
+            testError={testError}
           />
         );
       default:

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -4,11 +4,8 @@ import { X, Code2, LayoutList } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
-import { AdvancedJsonEditor } from '@/components/ai_agents/shared';
-import {
-  testCustomToolPayload,
-  type CustomToolTestPayloadResult,
-} from '@/services/agents/customToolsService';
+import { AdvancedJsonEditor, TestRequestButton } from '@/components/ai_agents/shared';
+import type { CustomToolTestPayload } from '@/services/agents/customToolsService';
 import {
   Step1_Identity,
   Step2_Endpoint,
@@ -190,6 +187,17 @@ const initialWizardData: WizardData = {
 
 const TOTAL_STEPS = 6;
 
+// Keys the API refuses to bind as nil (CustomToolBase `binding:"required"`).
+// buildPayload always emits them; raw JSON mode is the only way to lose one.
+const REQUIRED_PAYLOAD_KEYS = [
+  'headers',
+  'path_params',
+  'query_params',
+  'body_params',
+  'error_handling',
+  'values',
+] as const;
+
 const mergeErrorHandlingForSave = (
   eh: ErrorHandling,
   extras: Record<string, unknown>,
@@ -234,10 +242,10 @@ export default function CustomToolWizardModal({
   const [mode, setMode] = useState<'form' | 'json'>('form');
   const [jsonValid, setJsonValid] = useState(true);
   const [jsonPayload, setJsonPayload] = useState<CustomToolFormData | null>(null);
-  // EVO-1738: test-before-save state.
-  const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<CustomToolTestPayloadResult | null>(null);
-  const [testError, setTestError] = useState('');
+  // Form payload as of the last hand-off to JSON mode — lets enterJsonMode tell
+  // "user came back untouched" (keep their raw edits) from "user edited the form"
+  // (form wins, re-snapshot).
+  const [jsonBaseline, setJsonBaseline] = useState<CustomToolFormData | null>(null);
   const contentRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -247,9 +255,7 @@ export default function CustomToolWizardModal({
         setMode('form');
         setJsonValid(true);
         setJsonPayload(null);
-        setTesting(false);
-        setTestResult(null);
-        setTestError('');
+        setJsonBaseline(null);
         setData(tool ? toolToWizardData(tool) : initialWizardData);
       }, 300);
       return () => clearTimeout(timeout);
@@ -332,36 +338,54 @@ export default function CustomToolWizardModal({
   };
 
   const enterJsonMode = () => {
-    setJsonPayload(buildPayload());
-    setJsonValid(true);
+    const fromForm = buildPayload();
+    // Re-snapshot only when the form actually moved since we last handed it over.
+    // Toggling Form → JSON used to overwrite the raw edits unconditionally, so a
+    // round trip through the form tab silently threw the user's JSON away.
+    const formChanged =
+      !jsonBaseline || JSON.stringify(fromForm) !== JSON.stringify(jsonBaseline);
+    if (formChanged || !jsonPayload) {
+      setJsonPayload(fromForm);
+      setJsonBaseline(fromForm);
+      setJsonValid(true);
+    }
     setMode('json');
   };
 
-  const jsonCanSubmit =
-    jsonValid && !!jsonPayload?.name?.trim() && !!jsonPayload?.endpoint?.trim();
+  // The API rejects a nil map on any of these (CustomToolBase binding:"required"),
+  // and the create/update error surfaces as a generic toast — so a payload missing
+  // one of them must never leave the editor.
+  const missingJsonKeys = jsonPayload
+    ? REQUIRED_PAYLOAD_KEYS.filter(
+        k => (jsonPayload as unknown as Record<string, unknown>)[k] == null,
+      )
+    : [];
 
-  // EVO-1738: test the current request (method/endpoint/headers/body_params) before
-  // saving, via the stateless endpoint; show the real HTTP status/result.
-  const handleTestRequest = async () => {
+  const jsonCanSubmit =
+    jsonValid &&
+    !!jsonPayload?.name?.trim() &&
+    !!jsonPayload?.endpoint?.trim() &&
+    !!jsonPayload?.method?.trim() &&
+    missingJsonKeys.length === 0;
+
+  // EVO-1738 test-before-save: the request-shaping subset of whichever source is
+  // authoritative right now. path/query params included — without them the test
+  // would report OK for a request missing the user's configuration.
+  const getTestPayload = (): CustomToolTestPayload => {
     const p = mode === 'json' && jsonPayload ? jsonPayload : buildPayload();
-    setTesting(true);
-    setTestResult(null);
-    setTestError('');
-    try {
-      const res = await testCustomToolPayload({
-        method: p.method,
-        endpoint: p.endpoint,
-        headers: p.headers,
-        body_params: p.body_params,
-      });
-      setTestResult(res.test_result);
-    } catch (e: unknown) {
-      const err = e as { response?: { data?: { message?: string } }; message?: string };
-      setTestError(err?.response?.data?.message || err?.message || t('wizard.test.fail'));
-    } finally {
-      setTesting(false);
-    }
+    return {
+      method: p.method,
+      endpoint: p.endpoint,
+      headers: p.headers,
+      path_params: p.path_params,
+      query_params: p.query_params,
+      body_params: p.body_params,
+    };
   };
+
+  // Remount the test button whenever the request definition changes, so a stale
+  // "HTTP 200" can never describe a config the user has since edited.
+  const testKey = JSON.stringify(getTestPayload());
 
   const renderStep = () => {
     switch (currentStep) {
@@ -446,10 +470,8 @@ export default function CustomToolWizardModal({
             onSubmit={handleSubmit}
             loading={loading}
             mode={isEdit ? 'edit' : 'create'}
-            onTest={handleTestRequest}
-            testing={testing}
-            testResult={testResult}
-            testError={testError}
+            getTestPayload={getTestPayload}
+            testKey={testKey}
           />
         );
       default:
@@ -505,7 +527,7 @@ export default function CustomToolWizardModal({
             <h2 className="text-2xl font-semibold leading-tight">{t('wizard.advanced.title')}</h2>
             <p className="text-sm text-muted-foreground mt-1">{t('wizard.advanced.subtitle')}</p>
           </div>
-          <div ref={contentRef} className="flex-1 overflow-y-auto px-4 py-3 min-h-0">
+          <div ref={contentRef} className="flex-1 overflow-y-auto px-4 py-3 min-h-0 space-y-3">
             <AdvancedJsonEditor
               value={(jsonPayload ?? buildPayload()) as unknown as Record<string, unknown>}
               onChange={p => setJsonPayload(p as unknown as CustomToolFormData)}
@@ -513,6 +535,15 @@ export default function CustomToolWizardModal({
               rows={22}
               hint={t('wizard.advanced.hint')}
             />
+
+            {jsonValid && missingJsonKeys.length > 0 && (
+              <p className="text-sm text-destructive" role="alert">
+                {t('wizard.advanced.missingFields', { fields: missingJsonKeys.join(', ') })}
+              </p>
+            )}
+
+            {/* Raw-JSON authors are exactly who needs test-before-save the most. */}
+            <TestRequestButton key={testKey} mode={isEdit ? 'edit' : 'create'} getPayload={getTestPayload} />
           </div>
           <div className="flex justify-end gap-2 flex-shrink-0 p-3 border-t">
             <Button variant="outline" className="px-6" onClick={() => onOpenChange(false)}>

--- a/src/components/customTools/wizard/Step6_Finish.tsx
+++ b/src/components/customTools/wizard/Step6_Finish.tsx
@@ -1,7 +1,18 @@
 import { useState } from 'react';
 import { Button, Input, Label } from '@evoapi/design-system';
-import { ArrowLeft, Plus, X, Check, Link2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  Plus,
+  X,
+  Check,
+  Link2,
+  PlugZap,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+} from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import type { CustomToolTestPayloadResult } from '@/services/agents/customToolsService';
 
 export interface Step6Data {
   examples: string[];
@@ -14,6 +25,11 @@ interface Step6Props {
   onSubmit: () => void;
   loading?: boolean;
   mode?: 'create' | 'edit';
+  // EVO-1738: test-before-save.
+  onTest?: () => void;
+  testing?: boolean;
+  testResult?: CustomToolTestPayloadResult | null;
+  testError?: string;
 }
 
 export default function Step6_Finish({
@@ -23,6 +39,10 @@ export default function Step6_Finish({
   onSubmit,
   loading = false,
   mode = 'create',
+  onTest,
+  testing = false,
+  testResult = null,
+  testError = '',
 }: Step6Props) {
   const { t } = useLanguage('customTools');
   const [newExample, setNewExample] = useState('');
@@ -97,6 +117,50 @@ export default function Step6_Finish({
               </div>
             )}
           </div>
+
+          {/* EVO-1738: test the request before saving. */}
+          {onTest && (
+            <div className="space-y-2">
+              <Button
+                type="button"
+                variant="outline"
+                className="gap-2"
+                onClick={onTest}
+                disabled={testing}
+              >
+                {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlugZap className="h-4 w-4" />}
+                {testing ? t('wizard.test.testing') : t('wizard.test.button')}
+              </Button>
+
+              {testResult && (
+                <div
+                  className={`flex items-start gap-2 rounded-md border p-3 text-sm ${
+                    testResult.success
+                      ? 'border-green-500/40 bg-green-500/5 text-green-700'
+                      : 'border-red-500/40 bg-red-500/5 text-red-700'
+                  }`}
+                >
+                  {testResult.success ? (
+                    <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                  ) : (
+                    <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                  )}
+                  <span>
+                    {testResult.success
+                      ? t('wizard.test.ok', { status: testResult.status_code })
+                      : testResult.error || t('wizard.test.fail')}
+                  </span>
+                </div>
+              )}
+
+              {testError && (
+                <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm text-red-700">
+                  <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                  <span>{testError}</span>
+                </div>
+              )}
+            </div>
+          )}
 
           <p className="text-xs text-muted-foreground bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded p-3">
             {t('wizard.step6.testHint')}

--- a/src/components/customTools/wizard/Step6_Finish.tsx
+++ b/src/components/customTools/wizard/Step6_Finish.tsx
@@ -1,18 +1,9 @@
 import { useState } from 'react';
 import { Button, Input, Label } from '@evoapi/design-system';
-import {
-  ArrowLeft,
-  Plus,
-  X,
-  Check,
-  Link2,
-  PlugZap,
-  Loader2,
-  CheckCircle2,
-  XCircle,
-} from 'lucide-react';
+import { ArrowLeft, Plus, X, Check, Link2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import type { CustomToolTestPayloadResult } from '@/services/agents/customToolsService';
+import { TestRequestButton } from '@/components/ai_agents/shared';
+import type { CustomToolTestPayload } from '@/services/agents/customToolsService';
 
 export interface Step6Data {
   examples: string[];
@@ -25,11 +16,18 @@ interface Step6Props {
   onSubmit: () => void;
   loading?: boolean;
   mode?: 'create' | 'edit';
-  // EVO-1738: test-before-save.
-  onTest?: () => void;
-  testing?: boolean;
-  testResult?: CustomToolTestPayloadResult | null;
-  testError?: string;
+  /**
+   * EVO-1738 test-before-save. Rendering goes through the shared
+   * TestRequestButton so the wizard shows the same rich result the rest of the
+   * product does (status code, response time, headers, body) instead of a
+   * status-only banner.
+   */
+  getTestPayload?: () => CustomToolTestPayload;
+  /**
+   * Serialized request definition. Changing it remounts the test button, so a
+   * previous "HTTP 200" can never linger next to a config the user has edited.
+   */
+  testKey?: string;
 }
 
 export default function Step6_Finish({
@@ -39,10 +37,8 @@ export default function Step6_Finish({
   onSubmit,
   loading = false,
   mode = 'create',
-  onTest,
-  testing = false,
-  testResult = null,
-  testError = '',
+  getTestPayload,
+  testKey,
 }: Step6Props) {
   const { t } = useLanguage('customTools');
   const [newExample, setNewExample] = useState('');
@@ -119,51 +115,12 @@ export default function Step6_Finish({
           </div>
 
           {/* EVO-1738: test the request before saving. */}
-          {onTest && (
-            <div className="space-y-2">
-              <Button
-                type="button"
-                variant="outline"
-                className="gap-2"
-                onClick={onTest}
-                disabled={testing}
-              >
-                {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlugZap className="h-4 w-4" />}
-                {testing ? t('wizard.test.testing') : t('wizard.test.button')}
-              </Button>
-
-              {testResult && (
-                <div
-                  className={`flex items-start gap-2 rounded-md border p-3 text-sm ${
-                    testResult.success
-                      ? 'border-green-500/40 bg-green-500/5 text-green-700'
-                      : 'border-red-500/40 bg-red-500/5 text-red-700'
-                  }`}
-                >
-                  {testResult.success ? (
-                    <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                  ) : (
-                    <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                  )}
-                  <span>
-                    {testResult.success
-                      ? t('wizard.test.ok', { status: testResult.status_code })
-                      : testResult.error || t('wizard.test.fail')}
-                  </span>
-                </div>
-              )}
-
-              {testError && (
-                <div className="flex items-start gap-2 rounded-md border border-red-500/40 bg-red-500/5 p-3 text-sm text-red-700">
-                  <XCircle className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                  <span>{testError}</span>
-                </div>
-              )}
-            </div>
+          {getTestPayload && (
+            <TestRequestButton key={testKey} mode={mode} getPayload={getTestPayload} />
           )}
 
           <p className="text-xs text-muted-foreground bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-900 rounded p-3">
-            {t('wizard.step6.testHint')}
+            {getTestPayload ? t('wizard.step6.testHintDraft') : t('wizard.step6.testHint')}
           </p>
 
           <p className="flex items-start gap-2 text-xs text-muted-foreground bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-900 rounded p-3">

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -293,6 +293,12 @@
       "title": "Advanced config (JSON)",
       "subtitle": "Edit the whole tool config as raw JSON.",
       "hint": "Fields: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
+    },
+    "test": {
+      "button": "Test request",
+      "testing": "Testing…",
+      "ok": "Request OK — HTTP {{status}}",
+      "fail": "Request failed"
     }
   },
   "modal": {

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -281,7 +281,18 @@
       "back": "Back",
       "skip": "Skip",
       "create": "Create tool",
-      "save": "Save changes"
+      "save": "Save changes",
+      "cancel": "Cancel"
+    },
+    "mode": {
+      "label": "Edit mode",
+      "form": "Form",
+      "json": "Advanced JSON"
+    },
+    "advanced": {
+      "title": "Advanced config (JSON)",
+      "subtitle": "Edit the whole tool config as raw JSON.",
+      "hint": "Fields: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
     }
   },
   "modal": {

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -274,7 +274,8 @@
       "subtitle": "Add usage examples that help agents understand when to call this tool.",
       "helperText": "Examples are short text descriptions of how to use the tool.",
       "testHint": "After creating, you'll be able to test the tool against the real endpoint.",
-      "attachHint": "Creating the tool only adds it to the catalog. To have an agent use it, attach it to the agent in its Tools tab."
+      "attachHint": "Creating the tool only adds it to the catalog. To have an agent use it, attach it to the agent in its Tools tab.",
+      "testHintDraft": "Use “Test request” to try the endpoint before saving. The result reflects the config above, including path and query params."
     },
     "actions": {
       "continue": "Continue",
@@ -292,13 +293,8 @@
     "advanced": {
       "title": "Advanced config (JSON)",
       "subtitle": "Edit the whole tool config as raw JSON.",
-      "hint": "Fields: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
-    },
-    "test": {
-      "button": "Test request",
-      "testing": "Testing…",
-      "ok": "Request OK — HTTP {{status}}",
-      "fail": "Request failed"
+      "hint": "Fields: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Required: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (use {} when empty).",
+      "missingFields": "Required fields missing from the JSON: {{fields}}. Add them back before saving."
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -274,7 +274,8 @@
       "subtitle": "Agrega ejemplos de uso que ayuden a los agentes a saber cuándo llamar esta herramienta.",
       "helperText": "Los ejemplos son descripciones cortas de cómo usar la herramienta.",
       "testHint": "Después de crear, podrás probar la herramienta contra el endpoint real.",
-      "attachHint": "Crear la herramienta solo la agrega al catálogo. Para que un agente la use, adjúntala al agente en su pestaña Herramientas."
+      "attachHint": "Crear la herramienta solo la agrega al catálogo. Para que un agente la use, adjúntala al agente en su pestaña Herramientas.",
+      "testHintDraft": "Usa “Probar solicitud” para probar el endpoint antes de guardar. El resultado refleja la configuración de arriba, incluidos path y query params."
     },
     "actions": {
       "continue": "Continuar",
@@ -292,13 +293,8 @@
     "advanced": {
       "title": "Configuración avanzada (JSON)",
       "subtitle": "Edita toda la configuración de la herramienta como JSON sin formato.",
-      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
-    },
-    "test": {
-      "button": "Probar solicitud",
-      "testing": "Probando…",
-      "ok": "Solicitud OK — HTTP {{status}}",
-      "fail": "Error en la solicitud"
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obligatorios: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (usa {} si están vacíos).",
+      "missingFields": "Faltan campos obligatorios en el JSON: {{fields}}. Vuélvelos a agregar antes de guardar."
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -281,7 +281,18 @@
       "back": "Volver",
       "skip": "Saltar",
       "create": "Crear herramienta",
-      "save": "Guardar cambios"
+      "save": "Guardar cambios",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edición",
+      "form": "Formulario",
+      "json": "JSON avanzado"
+    },
+    "advanced": {
+      "title": "Configuración avanzada (JSON)",
+      "subtitle": "Edita toda la configuración de la herramienta como JSON sin formato.",
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
     }
   },
   "modal": {

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -293,6 +293,12 @@
       "title": "Configuración avanzada (JSON)",
       "subtitle": "Edita toda la configuración de la herramienta como JSON sin formato.",
       "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
+    },
+    "test": {
+      "button": "Probar solicitud",
+      "testing": "Probando…",
+      "ok": "Solicitud OK — HTTP {{status}}",
+      "fail": "Error en la solicitud"
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -293,6 +293,12 @@
       "title": "Configuration avancée (JSON)",
       "subtitle": "Modifiez toute la configuration de l'outil en JSON brut.",
       "hint": "Champs : name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
+    },
+    "test": {
+      "button": "Tester la requête",
+      "testing": "Test en cours…",
+      "ok": "Requête OK — HTTP {{status}}",
+      "fail": "Échec de la requête"
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -274,7 +274,8 @@
       "subtitle": "Ajoutez des exemples d'usage pour aider les agents à savoir quand appeler cet outil.",
       "helperText": "Les exemples sont de courtes descriptions d'utilisation de l'outil.",
       "testHint": "Après création, vous pourrez tester l'outil contre l'endpoint réel.",
-      "attachHint": "Créer l'outil ne fait que l'ajouter au catalogue. Pour qu'un agent l'utilise, attachez-le à l'agent dans son onglet Outils."
+      "attachHint": "Créer l'outil ne fait que l'ajouter au catalogue. Pour qu'un agent l'utilise, attachez-le à l'agent dans son onglet Outils.",
+      "testHintDraft": "Utilisez « Tester la requête » pour essayer l'endpoint avant d'enregistrer. Le résultat reflète la config ci-dessus, y compris les path et query params."
     },
     "actions": {
       "continue": "Continuer",
@@ -292,13 +293,8 @@
     "advanced": {
       "title": "Configuration avancée (JSON)",
       "subtitle": "Modifiez toute la configuration de l'outil en JSON brut.",
-      "hint": "Champs : name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
-    },
-    "test": {
-      "button": "Tester la requête",
-      "testing": "Test en cours…",
-      "ok": "Requête OK — HTTP {{status}}",
-      "fail": "Échec de la requête"
+      "hint": "Champs : name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obligatoires : name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (utilisez {} si vide).",
+      "missingFields": "Champs obligatoires absents du JSON : {{fields}}. Remettez-les avant d'enregistrer."
     }
   },
   "modal": {

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -281,7 +281,18 @@
       "back": "Retour",
       "skip": "Passer",
       "create": "Créer l'outil",
-      "save": "Enregistrer les modifications"
+      "save": "Enregistrer les modifications",
+      "cancel": "Annuler"
+    },
+    "mode": {
+      "label": "Mode d'édition",
+      "form": "Formulaire",
+      "json": "JSON avancé"
+    },
+    "advanced": {
+      "title": "Configuration avancée (JSON)",
+      "subtitle": "Modifiez toute la configuration de l'outil en JSON brut.",
+      "hint": "Champs : name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
     }
   },
   "modal": {

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -274,7 +274,8 @@
       "subtitle": "Aggiungi esempi d'uso che aiutino gli agenti a sapere quando chiamare questo strumento.",
       "helperText": "Gli esempi sono brevi descrizioni di come usare lo strumento.",
       "testHint": "Dopo la creazione, potrai testare lo strumento contro l'endpoint reale.",
-      "attachHint": "Creare lo strumento lo aggiunge solo al catalogo. Perché un agente lo usi, collegalo all'agente nella sua scheda Strumenti."
+      "attachHint": "Creare lo strumento lo aggiunge solo al catalogo. Perché un agente lo usi, collegalo all'agente nella sua scheda Strumenti.",
+      "testHintDraft": "Usa “Prova richiesta” per provare l'endpoint prima di salvare. Il risultato riflette la config qui sopra, inclusi path e query params."
     },
     "actions": {
       "continue": "Continua",
@@ -292,13 +293,8 @@
     "advanced": {
       "title": "Configurazione avanzata (JSON)",
       "subtitle": "Modifica l'intera configurazione dello strumento come JSON grezzo.",
-      "hint": "Campi: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
-    },
-    "test": {
-      "button": "Prova richiesta",
-      "testing": "Prova in corso…",
-      "ok": "Richiesta OK — HTTP {{status}}",
-      "fail": "Richiesta fallita"
+      "hint": "Campi: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obbligatori: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (usa {} se vuoti).",
+      "missingFields": "Campi obbligatori mancanti nel JSON: {{fields}}. Reinseriscili prima di salvare."
     }
   },
   "modal": {

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -293,6 +293,12 @@
       "title": "Configurazione avanzata (JSON)",
       "subtitle": "Modifica l'intera configurazione dello strumento come JSON grezzo.",
       "hint": "Campi: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
+    },
+    "test": {
+      "button": "Prova richiesta",
+      "testing": "Prova in corso…",
+      "ok": "Richiesta OK — HTTP {{status}}",
+      "fail": "Richiesta fallita"
     }
   },
   "modal": {

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -281,7 +281,18 @@
       "back": "Indietro",
       "skip": "Salta",
       "create": "Crea strumento",
-      "save": "Salva modifiche"
+      "save": "Salva modifiche",
+      "cancel": "Annulla"
+    },
+    "mode": {
+      "label": "Modalità di modifica",
+      "form": "Modulo",
+      "json": "JSON avanzato"
+    },
+    "advanced": {
+      "title": "Configurazione avanzata (JSON)",
+      "subtitle": "Modifica l'intera configurazione dello strumento come JSON grezzo.",
+      "hint": "Campi: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -281,7 +281,18 @@
       "back": "Voltar",
       "skip": "Pular",
       "create": "Criar tool",
-      "save": "Salvar alterações"
+      "save": "Salvar alterações",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edição",
+      "form": "Formulário",
+      "json": "JSON avançado"
+    },
+    "advanced": {
+      "title": "Configuração avançada (JSON)",
+      "subtitle": "Edite a configuração inteira da tool como JSON cru.",
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -293,6 +293,12 @@
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira da tool como JSON cru.",
       "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
+    },
+    "test": {
+      "button": "Testar requisição",
+      "testing": "Testando…",
+      "ok": "Requisição OK — HTTP {{status}}",
+      "fail": "Falha na requisição"
     }
   },
   "modal": {

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -274,7 +274,8 @@
       "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
       "helperText": "Exemplos são descrições curtas de como usar a tool.",
       "testHint": "Após criar, você poderá testar a tool contra o endpoint real.",
-      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele."
+      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele.",
+      "testHintDraft": "Use “Testar requisição” para experimentar o endpoint antes de salvar. O resultado reflete a config acima, incluindo path e query params."
     },
     "actions": {
       "continue": "Continuar",
@@ -292,13 +293,8 @@
     "advanced": {
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira da tool como JSON cru.",
-      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
-    },
-    "test": {
-      "button": "Testar requisição",
-      "testing": "Testando…",
-      "ok": "Requisição OK — HTTP {{status}}",
-      "fail": "Falha na requisição"
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obrigatórios: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (use {} quando vazio).",
+      "missingFields": "Campos obrigatórios ausentes no JSON: {{fields}}. Adicione de volta antes de salvar."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -281,7 +281,18 @@
       "back": "Voltar",
       "skip": "Pular",
       "create": "Criar tool",
-      "save": "Salvar alterações"
+      "save": "Salvar alterações",
+      "cancel": "Cancelar"
+    },
+    "mode": {
+      "label": "Modo de edição",
+      "form": "Formulário",
+      "json": "JSON avançado"
+    },
+    "advanced": {
+      "title": "Configuração avançada (JSON)",
+      "subtitle": "Edite a configuração inteira da tool como JSON cru.",
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -293,6 +293,12 @@
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira da tool como JSON cru.",
       "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
+    },
+    "test": {
+      "button": "Testar requisição",
+      "testing": "Testando…",
+      "ok": "Requisição OK — HTTP {{status}}",
+      "fail": "Falha na requisição"
     }
   },
   "modal": {

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -274,7 +274,8 @@
       "subtitle": "Adicione exemplos de uso que ajudam os agentes a saber quando chamar essa tool.",
       "helperText": "Exemplos são descrições curtas de como usar a tool.",
       "testHint": "Após criar, você poderá testar a tool contra o endpoint real.",
-      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele."
+      "attachHint": "Criar a ferramenta apenas a adiciona ao catálogo. Para um agente usá-la, anexe-a ao agente na aba Ferramentas dele.",
+      "testHintDraft": "Use “Testar requisição” para experimentar o endpoint antes de salvar. O resultado reflete a config acima, incluindo path e query params."
     },
     "actions": {
       "continue": "Continuar",
@@ -292,13 +293,8 @@
     "advanced": {
       "title": "Configuração avançada (JSON)",
       "subtitle": "Edite a configuração inteira da tool como JSON cru.",
-      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples."
-    },
-    "test": {
-      "button": "Testar requisição",
-      "testing": "Testando…",
-      "ok": "Requisição OK — HTTP {{status}}",
-      "fail": "Falha na requisição"
+      "hint": "Campos: name, description, method, endpoint, headers, query_params, path_params, body_params, values, error_handling, input_modes, output_modes, tags, examples. Obrigatórios: name, method, endpoint, headers, query_params, path_params, body_params, values, error_handling (use {} quando vazio).",
+      "missingFields": "Campos obrigatórios ausentes no JSON: {{fields}}. Adicione de volta antes de salvar."
     }
   },
   "modal": {

--- a/src/services/agents/customToolsService.ts
+++ b/src/services/agents/customToolsService.ts
@@ -67,6 +67,28 @@ export const deleteCustomTool = async (id: string): Promise<void> => {
 };
 
 // Testa ferramenta personalizada
+// EVO-1738: stateless test-before-save result (self-contained here to avoid the
+// duplicated CustomToolTestResponse declaration in types/ai/customTool.ts).
+export interface CustomToolTestPayloadResult {
+  error: string;
+  headers: Record<string, string>;
+  response_time: number;
+  status_code: number;
+  success: boolean;
+  body?: string;
+}
+
+// EVO-1738: test an UNSAVED tool's request (test-before-save in the wizard).
+export const testCustomToolPayload = async (payload: {
+  method: string;
+  endpoint: string;
+  headers: Record<string, unknown>;
+  body_params: Record<string, unknown>;
+}): Promise<{ test_result: CustomToolTestPayloadResult }> => {
+  const response = await evoaiApi.post('/custom-tools/test', payload);
+  return extractData<{ test_result: CustomToolTestPayloadResult }>(response);
+};
+
 export const testCustomTool = async (id: string): Promise<CustomToolTestResponse> => {
   const response = await evoaiApi.get(`/custom-tools/${id}/test`);
   return extractData<any>(response);

--- a/src/services/agents/customToolsService.ts
+++ b/src/services/agents/customToolsService.ts
@@ -78,13 +78,23 @@ export interface CustomToolTestPayloadResult {
   body?: string;
 }
 
-// EVO-1738: test an UNSAVED tool's request (test-before-save in the wizard).
-export const testCustomToolPayload = async (payload: {
+// EVO-1738: the request-shaping subset of the tool config the test endpoint runs.
+// path_params/query_params are part of it: without them the test hits
+// `/users/{user_id}` literally and drops the query string, so a green result
+// would describe a request that carried none of the user's configuration.
+export interface CustomToolTestPayload {
   method: string;
   endpoint: string;
-  headers: Record<string, unknown>;
-  body_params: Record<string, unknown>;
-}): Promise<{ test_result: CustomToolTestPayloadResult }> => {
+  headers?: Record<string, unknown>;
+  path_params?: Record<string, unknown>;
+  query_params?: Record<string, unknown>;
+  body_params?: Record<string, unknown>;
+}
+
+// EVO-1738: test an UNSAVED tool's request (test-before-save in the wizard).
+export const testCustomToolPayload = async (
+  payload: CustomToolTestPayload,
+): Promise<{ test_result: CustomToolTestPayloadResult }> => {
   const response = await evoaiApi.post('/custom-tools/test', payload);
   return extractData<{ test_result: CustomToolTestPayloadResult }>(response);
 };
@@ -117,13 +127,29 @@ export const initialCustomToolsState: CustomToolsState = {
   searchQuery: '',
 };
 
-// Error handling utility
+// Error handling utility.
+// Core's error envelope is { success: false, error: { code, message, details }, meta }.
+// The previous guard tested `data.message`, which never exists in that envelope, so
+// `data.error.message` was unreachable and callers only ever saw axios's generic
+// "Request failed with status code 400".
 export const getErrorMessage = (error: any, defaultMessage: string = 'Erro desconhecido'): string => {
-  if (error?.response?.data?.message) {
-    // Usar formato padrão de erro: { success: false, error: { code, message, details }, meta }
-  return error.response.data.error?.message || error.response.data.message;
+  const data = error?.response?.data;
+  const base = data?.error?.message || data?.message;
+  if (!base) return error?.message || defaultMessage;
+
+  // Validation errors carry the offending field in details.fields[]; without it the
+  // user reads "Validation failed" and cannot tell what needs fixing.
+  const fields = data?.error?.details?.fields;
+  if (Array.isArray(fields) && fields.length > 0) {
+    const detail = fields
+      .map((f: { field?: string; message?: string }) =>
+        f?.field ? `${f.field}: ${f.message ?? ''}`.trim() : f?.message,
+      )
+      .filter(Boolean)
+      .join('; ');
+    if (detail) return `${base} (${detail})`;
   }
-  return error?.message || defaultMessage;
+  return base;
 };
 
 export default {


### PR DESCRIPTION
## EVO-1738 (frontend) — modo avançado (JSON cru) + botão Testar + wizard no builder de agente

> ⚠️ **PR empilhada sobre a #267 (EVO-1739)**: base = `fix/EVO-1739-mcp-wizard-advanced-test`, porque reusa o `AdvancedJsonEditor` compartilhado criado lá. Quando a #267 mergear em `develop`, o GitHub re-aponta esta PR pra `develop` automaticamente. Assim o diff fica limpo (só os 2 commits do 1738).
> Metade frontend; par do backend **core-service #22** (`POST /custom-tools/test`). **Deploy conjunto.**

### Contexto
O wizard de campos já existia (`f8d722b`). Faltavam **três requisitos** da issue: modo avançado (JSON cru), botão Testar (test-before-save) e usar o wizard também no **caminho de criação dentro do builder de agente** (antes caía no form seccionado antigo).

### 1. Modo avançado (JSON cru)
Toggle **Formulário ↔ JSON avançado** no header do `CustomToolWizardModal`. Extraí `buildPayload()` como fonte única do payload; o modo JSON edita o payload inteiro cru via `AdvancedJsonEditor`, com parse ao vivo e **bloqueio do submit** em JSON inválido/não-objeto. **Sem back-map lossy**: no submit, `mode==='json' && jsonPayload ? jsonPayload : buildPayload()` — o JSON cru vai literal, sem round-trip pelo `WizardData`.

### 2. Botão "Test request" (test-before-save)
No passo Finish: `customToolsService.testCustomToolPayload(payload)` → **novo endpoint stateless** `POST /custom-tools/test` (core #22) → spinner + painel com o resultado (HTTP status no sucesso; erro na falha). Antes só dava pra testar ferramenta **já salva**.

### 3. Wizard no builder de agente
`CustomToolsSelectionDialog` (criação de ferramenta dentro do agente) trocou o `CustomToolForm` seccionado pelo `CustomToolWizardModal` — paridade de UX com a página standalone.

### Testes
- `vitest`: `CustomToolsSelectionDialog.spec` (**3/3**, mock atualizado de form→wizard: open/onOpenChange), `AdvancedJsonEditor.spec` (**4/4**: render, edit válido→parsed+valid, malformado→invalid+sem onChange, array de topo rejeitado). `tsc --noEmit` **0 erros no projeto**.
- **Verificado E2E** na stack local (evo-core buildado do código local, sem 403): wizard 6 passos, toggle **Form ↔ Advanced JSON** e botão **"Test request"** → banner **"Request OK — HTTP 200"** com resposta real.

### Relacionado
Backend par: core-service #22. Empilhada sobre #267 (EVO-1739; `AdvancedJsonEditor` compartilhado).
