### PR TITLE
fix(EVO-2152): Roles editor read-only for system roles (view yes, edit no)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,12 @@ jobs:
 
       # Scoped, opt-in list: a spec earns a line here when it guards a behaviour
       # we do not want silently reverted, is fully mocked, and runs fast.
-      #   - PermissionsContext / RoleDetail (EVO-2062): can() stays data-driven,
-      #     and the installation-owner role is read-only.
+      #   - PermissionsContext / RoleDetail (EVO-2062, EVO-2152): can() stays
+      #     data-driven; a system role's permission set is read-only; and the
+      #     duplicate-as-custom-role escape hatch the read-only notice names
+      #     keeps existing and keeps carrying the permissions over.
+      #   - RolesList (EVO-2152): the row action keeps saying which screen it
+      #     opens, and viewing keeps not requiring `roles.update`.
       #   - campaignsService (EVO-1838): the campaign endpoints keep their
       #     bare-body fallback when the backend skips the response envelope.
       # The whole list runs in ~10s and is deterministic.
@@ -49,4 +53,5 @@ jobs:
           npx vitest run --reporter=basic \
             src/contexts/PermissionsContext.spec.tsx \
             src/pages/Admin/Roles/RoleDetail.spec.tsx \
+            src/pages/Admin/Roles/RolesList.spec.tsx \
             src/services/campaigns/campaignsService.spec.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,12 +32,9 @@ jobs:
 
       # Scoped, opt-in list: a spec earns a line here when it guards a behaviour
       # we do not want silently reverted, is fully mocked, and runs fast.
-      #   - PermissionsContext / RoleDetail (EVO-2062, EVO-2152): can() stays
-      #     data-driven; a system role's permission set is read-only; and the
-      #     duplicate-as-custom-role escape hatch the read-only notice names
-      #     keeps existing and keeps carrying the permissions over.
-      #   - RolesList (EVO-2152): the row action keeps saying which screen it
-      #     opens, and viewing keeps not requiring `roles.update`.
+      #   - PermissionsContext / RoleDetail (EVO-2062): can() stays data-driven,
+      #     system roles stay read-only, and duplicating one keeps its permissions.
+      #   - RolesList: the row icon keeps matching what the detail screen allows.
       #   - campaignsService (EVO-1838): the campaign endpoints keep their
       #     bare-body fallback when the backend skips the response envelope.
       # The whole list runs in ~10s and is deterministic.

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -7,6 +7,7 @@
   },
   "addRole": "New Role",
   "editRole": "Edit Role",
+  "viewRole": "View permissions",
   "deleteRole": "Delete Role",
   "backToList": "Back to Roles",
   "savePermissions": "Save Permissions",

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -1,6 +1,6 @@
 {
   "title": "Roles & Permissions",
-  "description": "Manage roles and their permissions. System roles cannot be deleted, but their permissions can be edited.",
+  "description": "Manage roles and their permissions. System roles cannot be deleted and their permission set is read-only — duplicate one as a custom role to change it.",
   "header": {
     "subtitle": "{{count}} role(s) configured",
     "searchPlaceholder": "Search roles..."
@@ -40,7 +40,13 @@
     "others": "Others"
   },
   "detail": {
-    "systemReadOnly": "This is a system role — its permission set is read-only. Duplicate it as a custom role to change permissions.",
+    "systemReadOnly": "This is a system role — its permission set is read-only. Use \"Duplicate as custom role\" to get an editable copy with the same permissions.",
+    "duplicate": "Duplicate as custom role",
+    "duplicateSuffix": "(copy)",
+    "duplicateTitle": "Duplicate as custom role",
+    "duplicateDescription": "Creates a custom role with the same permissions as \"{{name}}\". The copy is fully editable.",
+    "duplicateConfirm": "Duplicate",
+    "duplicating": "Duplicating...",
     "permissionsTitle": "Permissions",
     "permissionsDescription": "Check the permissions this role should have. Changes take effect on the user's next session refresh.",
     "permissionsSelected": "permissions selected",
@@ -94,6 +100,8 @@
     "deleteError": "Failed to delete role",
     "permissionsSuccess": "Permissions saved successfully",
     "permissionsError": "Failed to save permissions",
+    "duplicateSuccess": "Custom role created with the same permissions",
+    "duplicatePartial": "Role created, but its permissions could not be copied. Set them on the new role.",
     "loadError": "Failed to load roles",
     "systemRoleCannotDelete": "System roles cannot be deleted",
     "roleHasUsers": "Cannot delete a role that has assigned users"

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -40,6 +40,7 @@
     "others": "Others"
   },
   "detail": {
+    "systemReadOnly": "This is a system role — its permission set is read-only. Duplicate it as a custom role to change permissions.",
     "permissionsTitle": "Permissions",
     "permissionsDescription": "Check the permissions this role should have. Changes take effect on the user's next session refresh.",
     "permissionsSelected": "permissions selected",

--- a/src/i18n/locales/es/roles.json
+++ b/src/i18n/locales/es/roles.json
@@ -40,6 +40,7 @@
     "others": "Otros"
   },
   "detail": {
+    "systemReadOnly": "Este es un perfil del sistema — su conjunto de permisos es de solo lectura. Duplícalo como perfil personalizado para cambiar los permisos.",
     "permissionsTitle": "Permisos",
     "permissionsDescription": "Marca los permisos que debe tener este perfil. Los cambios tienen efecto en el próximo acceso del usuario.",
     "permissionsSelected": "permisos seleccionados",

--- a/src/i18n/locales/es/roles.json
+++ b/src/i18n/locales/es/roles.json
@@ -7,6 +7,7 @@
   },
   "addRole": "Nuevo Perfil",
   "editRole": "Editar Perfil",
+  "viewRole": "Ver permisos",
   "deleteRole": "Eliminar Perfil",
   "backToList": "Volver a Perfiles",
   "savePermissions": "Guardar Permisos",

--- a/src/i18n/locales/es/roles.json
+++ b/src/i18n/locales/es/roles.json
@@ -1,6 +1,6 @@
 {
   "title": "Perfiles y Permisos",
-  "description": "Gestione perfiles y sus permisos. Los perfiles del sistema no pueden eliminarse, pero sus permisos pueden editarse.",
+  "description": "Gestione perfiles y sus permisos. Los perfiles del sistema no pueden eliminarse y su conjunto de permisos es de solo lectura — duplique uno como perfil personalizado para cambiarlo.",
   "header": {
     "subtitle": "{{count}} perfil(es) configurado(s)",
     "searchPlaceholder": "Buscar perfiles..."
@@ -40,7 +40,13 @@
     "others": "Otros"
   },
   "detail": {
-    "systemReadOnly": "Este es un perfil del sistema — su conjunto de permisos es de solo lectura. Duplícalo como perfil personalizado para cambiar los permisos.",
+    "systemReadOnly": "Este es un perfil del sistema — su conjunto de permisos es de solo lectura. Use \"Duplicar como perfil personalizado\" para obtener una copia editable con los mismos permisos.",
+    "duplicate": "Duplicar como perfil personalizado",
+    "duplicateSuffix": "(copia)",
+    "duplicateTitle": "Duplicar como perfil personalizado",
+    "duplicateDescription": "Crea un perfil personalizado con los mismos permisos que \"{{name}}\". La copia es totalmente editable.",
+    "duplicateConfirm": "Duplicar",
+    "duplicating": "Duplicando...",
     "permissionsTitle": "Permisos",
     "permissionsDescription": "Marca los permisos que debe tener este perfil. Los cambios tienen efecto en el próximo acceso del usuario.",
     "permissionsSelected": "permisos seleccionados",
@@ -94,6 +100,8 @@
     "deleteError": "Error al eliminar el perfil",
     "permissionsSuccess": "Permisos guardados exitosamente",
     "permissionsError": "Error al guardar los permisos",
+    "duplicateSuccess": "Perfil personalizado creado con los mismos permisos",
+    "duplicatePartial": "Perfil creado, pero no se pudieron copiar sus permisos. Configúrelos en el nuevo perfil.",
     "loadError": "Error al cargar los perfiles",
     "systemRoleCannotDelete": "Los perfiles del sistema no pueden eliminarse",
     "roleHasUsers": "No se puede eliminar un perfil con usuarios asignados"

--- a/src/i18n/locales/fr/roles.json
+++ b/src/i18n/locales/fr/roles.json
@@ -7,6 +7,7 @@
   },
   "addRole": "Nouveau Profil",
   "editRole": "Modifier le Profil",
+  "viewRole": "Voir les permissions",
   "deleteRole": "Supprimer le Profil",
   "backToList": "Retour aux Profils",
   "savePermissions": "Enregistrer les Permissions",

--- a/src/i18n/locales/fr/roles.json
+++ b/src/i18n/locales/fr/roles.json
@@ -40,6 +40,7 @@
     "others": "Autres"
   },
   "detail": {
+    "systemReadOnly": "Ceci est un profil système — son ensemble de permissions est en lecture seule. Dupliquez-le en tant que profil personnalisé pour modifier les permissions.",
     "permissionsTitle": "Permissions",
     "permissionsDescription": "Cochez les permissions que ce profil doit avoir. Les modifications prennent effet à la prochaine connexion de l'utilisateur.",
     "permissionsSelected": "permissions sélectionnées",

--- a/src/i18n/locales/fr/roles.json
+++ b/src/i18n/locales/fr/roles.json
@@ -1,6 +1,6 @@
 {
   "title": "Profils et Permissions",
-  "description": "Gérez les profils et leurs permissions. Les profils système ne peuvent pas être supprimés, mais leurs permissions peuvent être modifiées.",
+  "description": "Gérez les profils et leurs permissions. Les profils système ne peuvent pas être supprimés et leur ensemble de permissions est en lecture seule — dupliquez-en un en tant que profil personnalisé pour le modifier.",
   "header": {
     "subtitle": "{{count}} profil(s) configuré(s)",
     "searchPlaceholder": "Rechercher des profils..."
@@ -40,7 +40,13 @@
     "others": "Autres"
   },
   "detail": {
-    "systemReadOnly": "Ceci est un profil système — son ensemble de permissions est en lecture seule. Dupliquez-le en tant que profil personnalisé pour modifier les permissions.",
+    "systemReadOnly": "Ceci est un profil système — son ensemble de permissions est en lecture seule. Utilisez « Dupliquer en profil personnalisé » pour obtenir une copie modifiable avec les mêmes permissions.",
+    "duplicate": "Dupliquer en profil personnalisé",
+    "duplicateSuffix": "(copie)",
+    "duplicateTitle": "Dupliquer en profil personnalisé",
+    "duplicateDescription": "Crée un profil personnalisé avec les mêmes permissions que « {{name}} ». La copie est entièrement modifiable.",
+    "duplicateConfirm": "Dupliquer",
+    "duplicating": "Duplication...",
     "permissionsTitle": "Permissions",
     "permissionsDescription": "Cochez les permissions que ce profil doit avoir. Les modifications prennent effet à la prochaine connexion de l'utilisateur.",
     "permissionsSelected": "permissions sélectionnées",
@@ -94,6 +100,8 @@
     "deleteError": "Échec de la suppression du profil",
     "permissionsSuccess": "Permissions enregistrées avec succès",
     "permissionsError": "Échec de l'enregistrement des permissions",
+    "duplicateSuccess": "Profil personnalisé créé avec les mêmes permissions",
+    "duplicatePartial": "Profil créé, mais ses permissions n'ont pas pu être copiées. Définissez-les sur le nouveau profil.",
     "loadError": "Échec du chargement des profils",
     "systemRoleCannotDelete": "Les profils système ne peuvent pas être supprimés",
     "roleHasUsers": "Impossible de supprimer un profil avec des utilisateurs assignés"

--- a/src/i18n/locales/it/roles.json
+++ b/src/i18n/locales/it/roles.json
@@ -40,6 +40,7 @@
     "others": "Altri"
   },
   "detail": {
+    "systemReadOnly": "Questo è un profilo di sistema — il set di permessi è di sola lettura. Duplicalo come profilo personalizzato per modificare i permessi.",
     "permissionsTitle": "Permessi",
     "permissionsDescription": "Seleziona i permessi che questo profilo deve avere. Le modifiche hanno effetto al prossimo accesso dell'utente.",
     "permissionsSelected": "permessi selezionati",

--- a/src/i18n/locales/it/roles.json
+++ b/src/i18n/locales/it/roles.json
@@ -1,6 +1,6 @@
 {
   "title": "Profili e Permessi",
-  "description": "Gestisci i profili e i loro permessi. I profili di sistema non possono essere eliminati, ma i loro permessi possono essere modificati.",
+  "description": "Gestisci i profili e i loro permessi. I profili di sistema non possono essere eliminati e il loro set di permessi è di sola lettura — duplicane uno come profilo personalizzato per modificarlo.",
   "header": {
     "subtitle": "{{count}} profilo(i) configurato(i)",
     "searchPlaceholder": "Cerca profili..."
@@ -40,7 +40,13 @@
     "others": "Altri"
   },
   "detail": {
-    "systemReadOnly": "Questo è un profilo di sistema — il set di permessi è di sola lettura. Duplicalo come profilo personalizzato per modificare i permessi.",
+    "systemReadOnly": "Questo è un profilo di sistema — il set di permessi è di sola lettura. Usa \"Duplica come profilo personalizzato\" per ottenere una copia modificabile con gli stessi permessi.",
+    "duplicate": "Duplica come profilo personalizzato",
+    "duplicateSuffix": "(copia)",
+    "duplicateTitle": "Duplica come profilo personalizzato",
+    "duplicateDescription": "Crea un profilo personalizzato con gli stessi permessi di \"{{name}}\". La copia è completamente modificabile.",
+    "duplicateConfirm": "Duplica",
+    "duplicating": "Duplicazione...",
     "permissionsTitle": "Permessi",
     "permissionsDescription": "Seleziona i permessi che questo profilo deve avere. Le modifiche hanno effetto al prossimo accesso dell'utente.",
     "permissionsSelected": "permessi selezionati",
@@ -94,6 +100,8 @@
     "deleteError": "Errore nell'eliminazione del profilo",
     "permissionsSuccess": "Permessi salvati con successo",
     "permissionsError": "Errore nel salvataggio dei permessi",
+    "duplicateSuccess": "Profilo personalizzato creato con gli stessi permessi",
+    "duplicatePartial": "Profilo creato, ma non è stato possibile copiare i permessi. Impostali sul nuovo profilo.",
     "loadError": "Errore nel caricamento dei profili",
     "systemRoleCannotDelete": "I profili di sistema non possono essere eliminati",
     "roleHasUsers": "Impossibile eliminare un profilo con utenti assegnati"

--- a/src/i18n/locales/it/roles.json
+++ b/src/i18n/locales/it/roles.json
@@ -7,6 +7,7 @@
   },
   "addRole": "Nuovo Profilo",
   "editRole": "Modifica Profilo",
+  "viewRole": "Visualizza permessi",
   "deleteRole": "Elimina Profilo",
   "backToList": "Torna ai Profili",
   "savePermissions": "Salva Permessi",

--- a/src/i18n/locales/pt-BR/roles.json
+++ b/src/i18n/locales/pt-BR/roles.json
@@ -40,6 +40,7 @@
     "others": "Outros"
   },
   "detail": {
+    "systemReadOnly": "Este é um perfil de sistema — o conjunto de permissões é somente leitura. Duplique-o como perfil personalizado para alterar as permissões.",
     "permissionsTitle": "Permissões",
     "permissionsDescription": "Marque as permissões que este perfil deve ter. As alterações entram em vigor no próximo acesso do usuário.",
     "permissionsSelected": "permissões selecionadas",

--- a/src/i18n/locales/pt-BR/roles.json
+++ b/src/i18n/locales/pt-BR/roles.json
@@ -7,6 +7,7 @@
   },
   "addRole": "Novo Perfil",
   "editRole": "Editar Perfil",
+  "viewRole": "Ver permissões",
   "deleteRole": "Excluir Perfil",
   "backToList": "Voltar para Perfis",
   "savePermissions": "Salvar Permissões",

--- a/src/i18n/locales/pt-BR/roles.json
+++ b/src/i18n/locales/pt-BR/roles.json
@@ -1,6 +1,6 @@
 {
   "title": "Perfis e Permissões",
-  "description": "Gerencie perfis e suas permissões. Perfis do sistema não podem ser excluídos, mas suas permissões podem ser editadas.",
+  "description": "Gerencie perfis e suas permissões. Perfis do sistema não podem ser excluídos e seu conjunto de permissões é somente leitura — duplique um como perfil personalizado para alterá-lo.",
   "header": {
     "subtitle": "{{count}} perfil(is) configurado(s)",
     "searchPlaceholder": "Buscar perfis..."
@@ -40,7 +40,13 @@
     "others": "Outros"
   },
   "detail": {
-    "systemReadOnly": "Este é um perfil de sistema — o conjunto de permissões é somente leitura. Duplique-o como perfil personalizado para alterar as permissões.",
+    "systemReadOnly": "Este é um perfil de sistema — o conjunto de permissões é somente leitura. Use \"Duplicar como perfil personalizado\" para obter uma cópia editável com as mesmas permissões.",
+    "duplicate": "Duplicar como perfil personalizado",
+    "duplicateSuffix": "(cópia)",
+    "duplicateTitle": "Duplicar como perfil personalizado",
+    "duplicateDescription": "Cria um perfil personalizado com as mesmas permissões de \"{{name}}\". A cópia é totalmente editável.",
+    "duplicateConfirm": "Duplicar",
+    "duplicating": "Duplicando...",
     "permissionsTitle": "Permissões",
     "permissionsDescription": "Marque as permissões que este perfil deve ter. As alterações entram em vigor no próximo acesso do usuário.",
     "permissionsSelected": "permissões selecionadas",
@@ -94,6 +100,8 @@
     "deleteError": "Falha ao excluir perfil",
     "permissionsSuccess": "Permissões salvas com sucesso",
     "permissionsError": "Falha ao salvar permissões",
+    "duplicateSuccess": "Perfil personalizado criado com as mesmas permissões",
+    "duplicatePartial": "Perfil criado, mas não foi possível copiar as permissões. Configure-as no novo perfil.",
     "loadError": "Falha ao carregar perfis",
     "systemRoleCannotDelete": "Perfis do sistema não podem ser excluídos",
     "roleHasUsers": "Não é possível excluir um perfil com usuários atribuídos"

--- a/src/i18n/locales/pt/roles.json
+++ b/src/i18n/locales/pt/roles.json
@@ -40,6 +40,7 @@
     "others": "Outros"
   },
   "detail": {
+    "systemReadOnly": "Este é um perfil de sistema — o conjunto de permissões é somente leitura. Duplique-o como perfil personalizado para alterar as permissões.",
     "permissionsTitle": "Permissões",
     "permissionsDescription": "Marque as permissões que este perfil deve ter. As alterações entram em vigor no próximo acesso do usuário.",
     "permissionsSelected": "permissões selecionadas",

--- a/src/i18n/locales/pt/roles.json
+++ b/src/i18n/locales/pt/roles.json
@@ -7,6 +7,7 @@
   },
   "addRole": "Novo Perfil",
   "editRole": "Editar Perfil",
+  "viewRole": "Ver permissões",
   "deleteRole": "Excluir Perfil",
   "backToList": "Voltar para Perfis",
   "savePermissions": "Salvar Permissões",

--- a/src/i18n/locales/pt/roles.json
+++ b/src/i18n/locales/pt/roles.json
@@ -1,6 +1,6 @@
 {
   "title": "Perfis e Permissões",
-  "description": "Gerencie perfis e suas permissões. Perfis do sistema não podem ser excluídos, mas suas permissões podem ser editadas.",
+  "description": "Gerencie perfis e suas permissões. Perfis do sistema não podem ser excluídos e seu conjunto de permissões é somente leitura — duplique um como perfil personalizado para alterá-lo.",
   "header": {
     "subtitle": "{{count}} perfil(is) configurado(s)",
     "searchPlaceholder": "Buscar perfis..."
@@ -40,7 +40,13 @@
     "others": "Outros"
   },
   "detail": {
-    "systemReadOnly": "Este é um perfil de sistema — o conjunto de permissões é somente leitura. Duplique-o como perfil personalizado para alterar as permissões.",
+    "systemReadOnly": "Este é um perfil de sistema — o conjunto de permissões é somente leitura. Use \"Duplicar como perfil personalizado\" para obter uma cópia editável com as mesmas permissões.",
+    "duplicate": "Duplicar como perfil personalizado",
+    "duplicateSuffix": "(cópia)",
+    "duplicateTitle": "Duplicar como perfil personalizado",
+    "duplicateDescription": "Cria um perfil personalizado com as mesmas permissões de \"{{name}}\". A cópia é totalmente editável.",
+    "duplicateConfirm": "Duplicar",
+    "duplicating": "Duplicando...",
     "permissionsTitle": "Permissões",
     "permissionsDescription": "Marque as permissões que este perfil deve ter. As alterações entram em vigor no próximo acesso do usuário.",
     "permissionsSelected": "permissões selecionadas",
@@ -94,6 +100,8 @@
     "deleteError": "Falha ao excluir perfil",
     "permissionsSuccess": "Permissões salvas com sucesso",
     "permissionsError": "Falha ao salvar permissões",
+    "duplicateSuccess": "Perfil personalizado criado com as mesmas permissões",
+    "duplicatePartial": "Perfil criado, mas não foi possível copiar as permissões. Configure-as no novo perfil.",
     "loadError": "Falha ao carregar perfis",
     "systemRoleCannotDelete": "Perfis do sistema não podem ser excluídos",
     "roleHasUsers": "Não é possível excluir um perfil com usuários atribuídos"

--- a/src/pages/Admin/Roles/RoleDetail.spec.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.spec.tsx
@@ -31,8 +31,7 @@ vi.mock('@/contexts/PermissionsContext', () => ({
 
 // Mutable so each test can seed the role's real grants before rendering.
 let rolePermissions: Record<string, string[]> = { labels: ['create'] };
-// Which role is being edited, and whether it is a system role. EVO-2152: a system
-// role's permission set is read-only; a custom (non-system) role's is editable.
+// Which role is being edited, and whether it is a system role.
 let roleKey = 'agent';
 let roleSystem = false;
 
@@ -215,14 +214,10 @@ beforeEach(() => {
 
 const cb = (key: string) => document.getElementById(key) as HTMLButtonElement | null;
 
-// EVO-2152 (PM ruling — Option A). A system role's permission set is immutable
-// (FR18): auth answers 403 on bulk_update_permissions for ANY system role, not just
-// the installation owner. The editor renders it read-only — the grid stays visible
-// (view yes) but with no toggles, no Save, and a lock notice. A checkbox that saves
-// nothing (or, before the backend guard, was silently reverted by the next seed) is
-// exactly the lying control this screen exists to eliminate. A custom role stays fully
-// editable.
-describe('RoleDetail — system roles are read-only (EVO-2152)', () => {
+// Auth answers 403 on bulk_update_permissions for any system role, so the editor
+// renders one read-only: grid visible, no toggles, no Save, lock notice. A checkbox
+// whose save is refused is the lying control this screen exists to eliminate.
+describe('RoleDetail — system roles are read-only', () => {
   it('offers no Save button for a system role', async () => {
     roleSystem = true;
     render(<RoleDetail />);
@@ -240,9 +235,8 @@ describe('RoleDetail — system roles are read-only (EVO-2152)', () => {
     expect(screen.getByTestId('system-role-readonly-notice')).toBeTruthy();
   });
 
-  // The installation owner is the case EVO-2062 pinned and the one the backend
-  // guard regressed on, so it gets its own example rather than riding on the
-  // generic system-role one.
+  // Pinned separately from the generic system-role case: it is the one the backend
+  // guard is keyed on.
   it('is read-only for the installation owner specifically', async () => {
     roleKey = 'super_admin';
     roleSystem = true;
@@ -265,10 +259,8 @@ describe('RoleDetail — system roles are read-only (EVO-2152)', () => {
   });
 });
 
-// EVO-2152. Read-only is only defensible because there IS a way out: duplicating
-// the role as a custom one. The notice names that action, so the action has to
-// exist and has to carry the permissions over — a copy that starts empty sends
-// the admin back to re-checking ~67 boxes by hand.
+// The read-only notice names this action, so it has to exist and has to carry the
+// source permissions over.
 describe('RoleDetail — duplicating a system role as a custom one', () => {
   const openDialog = async () => {
     roleSystem = true;

--- a/src/pages/Admin/Roles/RoleDetail.spec.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.spec.tsx
@@ -30,8 +30,10 @@ vi.mock('@/contexts/PermissionsContext', () => ({
 
 // Mutable so each test can seed the role's real grants before rendering.
 let rolePermissions: Record<string, string[]> = { labels: ['create'] };
-// Which role is being edited. Only the installation owner is read-only.
+// Which role is being edited, and whether it is a system role. EVO-2152: a system
+// role's permission set is read-only; a custom (non-system) role's is editable.
 let roleKey = 'agent';
+let roleSystem = false;
 
 vi.mock('@/services/roles/rolesService', () => ({
   rolesService: {
@@ -39,6 +41,7 @@ vi.mock('@/services/roles/rolesService', () => ({
       Promise.resolve({
         id: 'r1',
         key: roleKey,
+        system: roleSystem,
         name: 'Agent',
         description: '',
         permissions_by_resource: rolePermissions,
@@ -203,38 +206,43 @@ beforeEach(() => {
   bulkUpdateMock.mockClear();
   rolePermissions = { labels: ['create'] };
   roleKey = 'agent';
+  roleSystem = false;
 });
 
 const cb = (key: string) => document.getElementById(key) as HTMLButtonElement | null;
 
-// EVO-2062. The installation owner's grant set is an invariant, not a
-// preference: auth reconciles it against the whole catalog on every boot and
-// `bulk_update_permissions` answers 403 for it. The editor must render it
-// read-only — checkboxes that save nothing (or, before the backend guard, saved
-// and were silently reverted by the next deploy) are exactly the lying control
-// this screen exists to eliminate.
-describe('RoleDetail — the installation owner is read-only', () => {
-  it('offers no Save button for super_admin', async () => {
-    roleKey = 'super_admin';
+// EVO-2152 (PM ruling — Option A). A system role's permission set is immutable
+// (FR18): auth answers 403 on bulk_update_permissions for ANY system role, not just
+// the installation owner. The editor renders it read-only — the grid stays visible
+// (view yes) but with no toggles, no Save, and a lock notice. A checkbox that saves
+// nothing (or, before the backend guard, was silently reverted by the next seed) is
+// exactly the lying control this screen exists to eliminate. A custom role stays fully
+// editable.
+describe('RoleDetail — system roles are read-only (EVO-2152)', () => {
+  it('offers no Save button for a system role', async () => {
+    roleSystem = true;
     render(<RoleDetail />);
     await waitFor(() => expect(cb('group-labels-write')).not.toBeNull());
 
     expect(screen.queryByText('savePermissions')).toBeNull();
   });
 
-  it('renders its checkboxes disabled', async () => {
-    roleKey = 'super_admin';
+  it('renders its checkboxes disabled and shows the read-only notice, grid still visible', async () => {
+    roleSystem = true;
     render(<RoleDetail />);
     await waitFor(() => expect(cb('group-labels-write')).not.toBeNull());
 
     expect(cb('group-labels-write')).toBeDisabled();
+    expect(screen.getByTestId('system-role-readonly-notice')).toBeTruthy();
   });
 
-  it('still lets every other role be edited and saved', async () => {
+  it('still lets a custom (non-system) role be edited and saved', async () => {
+    roleSystem = false;
     render(<RoleDetail />);
     await waitFor(() => expect(cb('group-labels-write')).not.toBeNull());
 
     expect(cb('group-labels-write')).not.toBeDisabled();
+    expect(screen.queryByTestId('system-role-readonly-notice')).toBeNull();
     await userEvent.click(screen.getByText('savePermissions'));
     await waitFor(() => expect(bulkUpdateMock).toHaveBeenCalled());
   });

--- a/src/pages/Admin/Roles/RoleDetail.spec.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.spec.tsx
@@ -10,6 +10,7 @@ import userEvent from '@testing-library/user-event';
 // never reach the save payload.
 
 const bulkUpdateMock = vi.fn().mockResolvedValue({ id: 'r1', permissions_by_resource: {} });
+const createMock = vi.fn().mockResolvedValue({ id: 'r2', key: 'agent_copy', system: false, name: 'Agent (copy)' });
 
 // Stable references: loadData depends on [id, t, navigate]; fresh identities
 // each render would re-fire the effect in a loop (stuck loading).
@@ -48,6 +49,7 @@ vi.mock('@/services/roles/rolesService', () => ({
       }),
     ),
     bulkUpdatePermissions: (...args: unknown[]) => bulkUpdateMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
   },
 }));
 
@@ -204,6 +206,8 @@ beforeAll(() => {
 
 beforeEach(() => {
   bulkUpdateMock.mockClear();
+  createMock.mockClear();
+  navigateStub.mockClear();
   rolePermissions = { labels: ['create'] };
   roleKey = 'agent';
   roleSystem = false;
@@ -236,6 +240,19 @@ describe('RoleDetail — system roles are read-only (EVO-2152)', () => {
     expect(screen.getByTestId('system-role-readonly-notice')).toBeTruthy();
   });
 
+  // The installation owner is the case EVO-2062 pinned and the one the backend
+  // guard regressed on, so it gets its own example rather than riding on the
+  // generic system-role one.
+  it('is read-only for the installation owner specifically', async () => {
+    roleKey = 'super_admin';
+    roleSystem = true;
+    render(<RoleDetail />);
+    await waitFor(() => expect(cb('group-labels-write')).not.toBeNull());
+
+    expect(screen.queryByText('savePermissions')).toBeNull();
+    expect(cb('group-labels-write')).toBeDisabled();
+  });
+
   it('still lets a custom (non-system) role be edited and saved', async () => {
     roleSystem = false;
     render(<RoleDetail />);
@@ -245,6 +262,54 @@ describe('RoleDetail — system roles are read-only (EVO-2152)', () => {
     expect(screen.queryByTestId('system-role-readonly-notice')).toBeNull();
     await userEvent.click(screen.getByText('savePermissions'));
     await waitFor(() => expect(bulkUpdateMock).toHaveBeenCalled());
+  });
+});
+
+// EVO-2152. Read-only is only defensible because there IS a way out: duplicating
+// the role as a custom one. The notice names that action, so the action has to
+// exist and has to carry the permissions over — a copy that starts empty sends
+// the admin back to re-checking ~67 boxes by hand.
+describe('RoleDetail — duplicating a system role as a custom one', () => {
+  const openDialog = async () => {
+    roleSystem = true;
+    render(<RoleDetail />);
+    await waitFor(() => expect(cb('group-labels-write')).not.toBeNull());
+    await userEvent.click(screen.getByText('detail.duplicate'));
+  };
+
+  it('offers the duplicate action on a system role and not on a custom one', async () => {
+    await openDialog();
+    expect(screen.getByText('detail.duplicateTitle')).toBeTruthy();
+  });
+
+  it('creates the copy and carries the source permissions over', async () => {
+    await openDialog();
+    await userEvent.click(screen.getByText('detail.duplicateConfirm'));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalled());
+    // The copy is written by id of the NEW role, never the source.
+    const [newId, keys] = bulkUpdateMock.mock.calls.at(-1) as [string, string[]];
+    expect(newId).toBe('r2');
+    expect(keys).toContain('labels.create');
+    // …and the user lands on the copy, which is editable.
+    await waitFor(() => expect(navigateStub).toHaveBeenCalledWith('/settings/roles/r2'));
+  });
+
+  it('keeps the created role and still navigates when copying the permissions fails', async () => {
+    bulkUpdateMock.mockRejectedValueOnce(new Error('403'));
+    await openDialog();
+    await userEvent.click(screen.getByText('detail.duplicateConfirm'));
+
+    await waitFor(() => expect(navigateStub).toHaveBeenCalledWith('/settings/roles/r2'));
+    expect(createMock).toHaveBeenCalled();
+  });
+
+  it('does not offer it on a custom role — that one is editable in place', async () => {
+    roleSystem = false;
+    render(<RoleDetail />);
+    await waitFor(() => expect(cb('group-labels-write')).not.toBeNull());
+
+    expect(screen.queryByText('detail.duplicate')).toBeNull();
   });
 });
 

--- a/src/pages/Admin/Roles/RoleDetail.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.tsx
@@ -6,11 +6,17 @@ import {
   Badge,
   Button,
   Checkbox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   Input,
   Label,
   Textarea,
 } from '@evoapi/design-system';
-import { ArrowLeft, ChevronDown, ChevronRight, Loader2, Lock, Pencil, Save, X } from 'lucide-react';
+import { ArrowLeft, ChevronDown, ChevronRight, Copy, Loader2, Lock, Pencil, Save, X } from 'lucide-react';
 import BaseHeader from '@/components/base/BaseHeader';
 import { TooltipInfo } from '@/components/base/TooltipInfo';
 import { rolesService, type Role } from '@/services/roles/rolesService';
@@ -50,6 +56,7 @@ export default function RoleDetail() {
   const [editingMeta, setEditingMeta] = useState(false);
   const [metaForm, setMetaForm] = useState({ name: '', description: '' });
   const [savingMeta, setSavingMeta] = useState(false);
+  const [duplicate, setDuplicate] = useState({ open: false, name: '', running: false });
 
   const loadData = useCallback(async () => {
     if (!id) return;
@@ -247,6 +254,63 @@ export default function RoleDetail() {
     }
   };
 
+  const startDuplicate = () => {
+    if (!role) return;
+    setDuplicate({ open: true, name: `${role.name} ${t('detail.duplicateSuffix')}`, running: false });
+  };
+
+  // EVO-2152. A system role's permission set is immutable, so "duplicate as a
+  // custom role" is the only supported way to get a tuned one — the read-only
+  // notice points here, and a notice pointing at an action that does not exist is
+  // just a nicer dead end. Two existing endpoints, no new backend: create (which
+  // always yields `system: false`) then bulk_update_permissions on the copy.
+  const handleDuplicate = async () => {
+    if (!role || !resourceActions || !duplicate.name.trim()) return;
+    setDuplicate(prev => ({ ...prev, running: true }));
+
+    let created: Role;
+    try {
+      created = await rolesService.create({
+        name: duplicate.name.trim(),
+        description: role.description ?? undefined,
+      });
+    } catch (err: unknown) {
+      const apiErr = (err as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error;
+      toast.error(apiErr?.message ?? t('messages.createError'));
+      setDuplicate(prev => ({ ...prev, running: false }));
+      return;
+    }
+
+    // Copy only grants the live catalog still defines. A role can hold keys a
+    // later release dropped (RbacGrantReconciler tracks exactly this as
+    // `stale_keys`), and the endpoint 422s the whole batch on the first unknown
+    // one — a stale grant on the source would otherwise cost the user every
+    // permission in the copy.
+    const keys = Object.entries(role.permissions_by_resource)
+      .flatMap(([resource, actions]) => (actions as string[]).map(action => `${resource}.${action}`))
+      .filter(key => {
+        const [resource, action] = key.split('.');
+        return resourceActions.resources[resource]?.actions?.[action] !== undefined;
+      });
+
+    try {
+      await rolesService.bulkUpdatePermissions(created.id, keys);
+      toast.success(t('messages.duplicateSuccess'));
+    } catch (err: unknown) {
+      // The role exists and carries a name the user chose; deleting it behind
+      // their back can fail too and destroys that. Land them on the copy with the
+      // reason instead — an empty custom role is editable, so it is recoverable.
+      // The likely cause is the anti-escalation gate: copying a role whose grants
+      // exceed the caller's own is refused key by key.
+      const apiErr = (err as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error;
+      toast.error(apiErr?.message ?? t('messages.duplicatePartial'));
+    }
+
+    permissionsService.clearPermissionsCache();
+    setDuplicate({ open: false, name: '', running: false });
+    navigate(`/settings/roles/${created.id}`);
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -266,6 +330,9 @@ export default function RoleDetail() {
   const isSystemRole = role.system === true;
   const canEdit = can('roles', 'bulk_update_permissions') && !isSystemRole;
   const canUpdate = can('roles', 'update');
+  // Needs both halves of the flow: create the copy, then write its permissions.
+  const canDuplicate =
+    isSystemRole && can('roles', 'create') && can('roles', 'bulk_update_permissions');
   const resources = resourceActions.resources;
 
   const term = filter.trim().toLowerCase();
@@ -518,7 +585,16 @@ export default function RoleDetail() {
                 onClick: handleSave,
                 disabled: saving,
               }
-            : undefined
+            : canDuplicate
+              ? {
+                  // A read-only screen still gets a primary action — the one thing
+                  // the user CAN do from here.
+                  label: t('detail.duplicate'),
+                  icon: <Copy className="h-4 w-4" />,
+                  onClick: startDuplicate,
+                  disabled: duplicate.running,
+                }
+              : undefined
         }
         secondaryActions={[
           {
@@ -688,6 +764,44 @@ export default function RoleDetail() {
           </div>
         )}
       </div>
+
+      <Dialog
+        open={duplicate.open}
+        onOpenChange={open => !open && !duplicate.running && setDuplicate({ open: false, name: '', running: false })}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('detail.duplicateTitle')}</DialogTitle>
+            <DialogDescription>{t('detail.duplicateDescription', { name: role.name })}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5 py-2">
+            <Label htmlFor="duplicate-name">{t('createModal.nameLabel')}</Label>
+            <Input
+              id="duplicate-name"
+              value={duplicate.name}
+              onChange={e => setDuplicate(prev => ({ ...prev, name: e.target.value }))}
+              onKeyDown={e => e.key === 'Enter' && handleDuplicate()}
+              disabled={duplicate.running}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDuplicate({ open: false, name: '', running: false })}
+              disabled={duplicate.running}
+            >
+              {t('createModal.cancel')}
+            </Button>
+            <Button onClick={handleDuplicate} disabled={duplicate.running || !duplicate.name.trim()}>
+              {duplicate.running ? (
+                <><Loader2 className="h-4 w-4 mr-2 animate-spin" />{t('detail.duplicating')}</>
+              ) : (
+                <><Copy className="h-4 w-4 mr-2" />{t('detail.duplicateConfirm')}</>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/pages/Admin/Roles/RoleDetail.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.tsx
@@ -10,7 +10,7 @@ import {
   Label,
   Textarea,
 } from '@evoapi/design-system';
-import { ArrowLeft, ChevronDown, ChevronRight, Loader2, Pencil, Save, X } from 'lucide-react';
+import { ArrowLeft, ChevronDown, ChevronRight, Loader2, Lock, Pencil, Save, X } from 'lucide-react';
 import BaseHeader from '@/components/base/BaseHeader';
 import { TooltipInfo } from '@/components/base/TooltipInfo';
 import { rolesService, type Role } from '@/services/roles/rolesService';
@@ -26,7 +26,6 @@ import {
   type ActionGroup,
   RESOURCE_NESTING,
 } from '@/config/permissionDomains';
-import { ROLE_KEYS } from '@/constants/roles';
 
 // Nested resource -> i18n key for its sub-label inside the parent card (AC6).
 const NESTED_LABEL_KEYS: Record<string, string> = {
@@ -258,14 +257,14 @@ export default function RoleDetail() {
 
   if (!role || !resourceActions) return null;
 
-  // The installation owner's grant set is an invariant, not a preference: auth
-  // reconciles it against the whole permission catalog on every boot and
-  // `bulk_update_permissions` answers 403 for this role. Render it read-only —
-  // offering checkboxes and a Save button whose request is refused (or, before
-  // the backend guard existed, silently reverted by the next deploy) is exactly
-  // the lying control this screen must not have.
-  const isInstallationOwner = role.key === ROLE_KEYS.SUPER_ADMIN;
-  const canEdit = can('roles', 'bulk_update_permissions') && !isInstallationOwner;
+  // EVO-2152 (PM ruling): a system role's permission set is immutable (FR18) — auth
+  // answers 403 on bulk_update_permissions for ANY system role, not just the
+  // installation owner it reconciles every boot. Render it read-only: the grid and
+  // every permission stay VISIBLE (view yes), but no toggles / select-all / Save.
+  // Offering a Save whose request is refused — or, before the backend guard, silently
+  // reverted by the next seed — is exactly the lying control this screen must not have.
+  const isSystemRole = role.system === true;
+  const canEdit = can('roles', 'bulk_update_permissions') && !isSystemRole;
   const canUpdate = can('roles', 'update');
   const resources = resourceActions.resources;
 
@@ -549,6 +548,16 @@ export default function RoleDetail() {
           )}
         </div>
       </BaseHeader>
+
+      {isSystemRole && (
+        <div
+          data-testid="system-role-readonly-notice"
+          className="mt-4 flex items-start gap-2 rounded-md border border-sidebar-border bg-sidebar/60 p-3 text-sm text-sidebar-foreground/80"
+        >
+          <Lock className="h-4 w-4 mt-0.5 flex-shrink-0" />
+          <span>{t('detail.systemReadOnly')}</span>
+        </div>
+      )}
 
       {editingMeta && (
         <div className="mt-4 mb-2 rounded-md border border-sidebar-border bg-sidebar p-4 space-y-3">

--- a/src/pages/Admin/Roles/RoleDetail.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.tsx
@@ -259,11 +259,9 @@ export default function RoleDetail() {
     setDuplicate({ open: true, name: `${role.name} ${t('detail.duplicateSuffix')}`, running: false });
   };
 
-  // EVO-2152. A system role's permission set is immutable, so "duplicate as a
-  // custom role" is the only supported way to get a tuned one — the read-only
-  // notice points here, and a notice pointing at an action that does not exist is
-  // just a nicer dead end. Two existing endpoints, no new backend: create (which
-  // always yields `system: false`) then bulk_update_permissions on the copy.
+  // The only supported way to get a tuned copy of a system role, and what the
+  // read-only notice points at. `create` always yields `system: false`, so the copy
+  // accepts bulk_update_permissions.
   const handleDuplicate = async () => {
     if (!role || !resourceActions || !duplicate.name.trim()) return;
     setDuplicate(prev => ({ ...prev, running: true }));
@@ -281,11 +279,8 @@ export default function RoleDetail() {
       return;
     }
 
-    // Copy only grants the live catalog still defines. A role can hold keys a
-    // later release dropped (RbacGrantReconciler tracks exactly this as
-    // `stale_keys`), and the endpoint 422s the whole batch on the first unknown
-    // one — a stale grant on the source would otherwise cost the user every
-    // permission in the copy.
+    // Only grants the live catalog still defines: a role can hold keys a later
+    // release dropped, and the endpoint 422s the whole batch on the first one.
     const keys = Object.entries(role.permissions_by_resource)
       .flatMap(([resource, actions]) => (actions as string[]).map(action => `${resource}.${action}`))
       .filter(key => {
@@ -297,11 +292,8 @@ export default function RoleDetail() {
       await rolesService.bulkUpdatePermissions(created.id, keys);
       toast.success(t('messages.duplicateSuccess'));
     } catch (err: unknown) {
-      // The role exists and carries a name the user chose; deleting it behind
-      // their back can fail too and destroys that. Land them on the copy with the
-      // reason instead — an empty custom role is editable, so it is recoverable.
-      // The likely cause is the anti-escalation gate: copying a role whose grants
-      // exceed the caller's own is refused key by key.
+      // Keep the created role: it carries a name the user chose, and an empty custom
+      // role is editable. Usual cause is the anti-escalation gate.
       const apiErr = (err as { response?: { data?: { error?: { message?: string } } } })?.response?.data?.error;
       toast.error(apiErr?.message ?? t('messages.duplicatePartial'));
     }
@@ -321,12 +313,9 @@ export default function RoleDetail() {
 
   if (!role || !resourceActions) return null;
 
-  // EVO-2152 (PM ruling): a system role's permission set is immutable (FR18) — auth
-  // answers 403 on bulk_update_permissions for ANY system role, not just the
-  // installation owner it reconciles every boot. Render it read-only: the grid and
-  // every permission stay VISIBLE (view yes), but no toggles / select-all / Save.
-  // Offering a Save whose request is refused — or, before the backend guard, silently
-  // reverted by the next seed — is exactly the lying control this screen must not have.
+  // Auth answers 403 on bulk_update_permissions for any system role, so the grid and
+  // every permission stay visible but nothing is writable: no toggles, no select-all,
+  // no Save. A Save whose request is refused is the lying control to avoid.
   const isSystemRole = role.system === true;
   const canEdit = can('roles', 'bulk_update_permissions') && !isSystemRole;
   const canUpdate = can('roles', 'update');
@@ -587,8 +576,6 @@ export default function RoleDetail() {
               }
             : canDuplicate
               ? {
-                  // A read-only screen still gets a primary action — the one thing
-                  // the user CAN do from here.
                   label: t('detail.duplicate'),
                   icon: <Copy className="h-4 w-4" />,
                   onClick: startDuplicate,

--- a/src/pages/Admin/Roles/RolesList.spec.tsx
+++ b/src/pages/Admin/Roles/RolesList.spec.tsx
@@ -1,12 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
-// EVO-2152. The row action is the ONLY way into a role's detail screen — the row
-// itself does not navigate — so what it promises has to match what that screen
-// delivers. A system role is read-only there no matter what the caller holds, so
-// it gets an eye, not a pencil; and the entry is gated on `read`, not `update`,
-// or a read-only viewer cannot reach the one thing this card says is always
-// allowed.
+// The row action is the only way into a role's detail screen, so its icon must
+// match what that screen allows, and `read` alone must be enough to open it.
 
 const navigateStub = vi.fn();
 vi.mock('react-router-dom', () => ({

--- a/src/pages/Admin/Roles/RolesList.spec.tsx
+++ b/src/pages/Admin/Roles/RolesList.spec.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// EVO-2152. The row action is the ONLY way into a role's detail screen — the row
+// itself does not navigate — so what it promises has to match what that screen
+// delivers. A system role is read-only there no matter what the caller holds, so
+// it gets an eye, not a pencil; and the entry is gated on `read`, not `update`,
+// or a read-only viewer cannot reach the one thing this card says is always
+// allowed.
+
+const navigateStub = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateStub,
+}));
+
+const tStub = (k: string) => k;
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: tStub, currentLanguage: 'en' }),
+}));
+
+// Which permissions the caller holds, per test.
+let granted = new Set<string>(['roles.read', 'roles.update', 'roles.bulk_update_permissions', 'roles.create', 'roles.delete']);
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => granted.has(`${resource}.${action}`),
+    isReady: true,
+    loading: false,
+  }),
+}));
+
+const role = (over: Partial<Record<string, unknown>>) => ({
+  id: 'r1',
+  key: 'agent',
+  name: 'Agent',
+  description: '',
+  system: false,
+  type: 'account',
+  permissions_by_resource: {},
+  permissions_count: 3,
+  users_count: 0,
+  created_at: '',
+  updated_at: '',
+  ...over,
+});
+
+let listed: unknown[] = [];
+vi.mock('@/services/roles/rolesService', () => ({
+  rolesService: {
+    list: vi.fn().mockImplementation(() => Promise.resolve(listed)),
+    create: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/permissions', () => ({
+  permissionsService: { clearPermissionsCache: vi.fn() },
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import RolesList from './RolesList';
+
+beforeEach(() => {
+  navigateStub.mockClear();
+  granted = new Set(['roles.read', 'roles.update', 'roles.bulk_update_permissions', 'roles.create', 'roles.delete']);
+  listed = [];
+});
+
+const rowAction = () => screen.queryByTitle('editRole') ?? screen.queryByTitle('viewRole');
+
+describe('RolesList — the row action tells the truth about the detail screen', () => {
+  it('offers "view", not "edit", on a system role even to a full admin', async () => {
+    listed = [role({ id: 'sys', system: true })];
+    render(<RolesList />);
+
+    await waitFor(() => expect(rowAction()).not.toBeNull());
+    expect(screen.queryByTitle('editRole')).toBeNull();
+    expect(screen.getByTitle('viewRole')).toBeTruthy();
+  });
+
+  it('offers "edit" on a custom role the caller can actually change', async () => {
+    listed = [role({ id: 'custom', system: false })];
+    render(<RolesList />);
+
+    await waitFor(() => expect(rowAction()).not.toBeNull());
+    expect(screen.getByTitle('editRole')).toBeTruthy();
+  });
+
+  it('falls back to "view" on a custom role when the caller holds neither write grant', async () => {
+    granted = new Set(['roles.read']);
+    listed = [role({ id: 'custom', system: false })];
+    render(<RolesList />);
+
+    await waitFor(() => expect(rowAction()).not.toBeNull());
+    expect(screen.getByTitle('viewRole')).toBeTruthy();
+  });
+
+  it('still lets a read-only caller open the detail screen at all', async () => {
+    granted = new Set(['roles.read']);
+    listed = [role({ id: 'sys', system: true })];
+    render(<RolesList />);
+
+    await waitFor(() => expect(rowAction()).not.toBeNull());
+    screen.getByTitle('viewRole').click();
+    expect(navigateStub).toHaveBeenCalledWith('/settings/roles/sys');
+  });
+
+  it('never offers delete on a system role', async () => {
+    listed = [role({ id: 'sys', system: true })];
+    render(<RolesList />);
+
+    await waitFor(() => expect(rowAction()).not.toBeNull());
+    expect(screen.queryByTitle('deleteRole')).toBeNull();
+  });
+});

--- a/src/pages/Admin/Roles/RolesList.tsx
+++ b/src/pages/Admin/Roles/RolesList.tsx
@@ -55,16 +55,9 @@ export default function RolesList() {
     loadRoles();
   }, [loadRoles]);
 
-  // EVO-2152. The row action opens the detail screen; the icon has to say which
-  // screen the user is about to get. A system role's permission set is immutable
-  // and its name/description are locked too, so the detail is read-only no matter
-  // what the caller holds — a pencil there promises an edit that does not exist.
-  // For a custom role it depends on the caller: either grant reaches an editable
-  // control (`update` the name/description, `bulk_update_permissions` the grid).
-  //
-  // The entry itself now only needs `read`. It used to require `update`, which
-  // locked a read-only viewer out of the one thing this card says is always
-  // allowed — viewing. This button is the only way in; the row does not navigate.
+  // Picks the row icon: pencil or eye. A system role's detail screen is read-only
+  // whatever the caller holds; for a custom one, either grant reaches an editable
+  // control. The button is the only way in — the row itself does not navigate.
   const rowIsEditable = (role: Role) =>
     !role.system && (can('roles', 'update') || can('roles', 'bulk_update_permissions'));
 

--- a/src/pages/Admin/Roles/RolesList.tsx
+++ b/src/pages/Admin/Roles/RolesList.tsx
@@ -15,7 +15,7 @@ import {
   Label,
   Textarea,
 } from '@evoapi/design-system';
-import { Plus, Pencil, Trash2, Loader2, ShieldCheck } from 'lucide-react';
+import { Plus, Eye, Pencil, Trash2, Loader2, ShieldCheck } from 'lucide-react';
 import BaseHeader from '@/components/base/BaseHeader';
 import EmptyState from '@/components/base/EmptyState';
 import { rolesService, type Role } from '@/services/roles/rolesService';
@@ -54,6 +54,19 @@ export default function RolesList() {
   useEffect(() => {
     loadRoles();
   }, [loadRoles]);
+
+  // EVO-2152. The row action opens the detail screen; the icon has to say which
+  // screen the user is about to get. A system role's permission set is immutable
+  // and its name/description are locked too, so the detail is read-only no matter
+  // what the caller holds — a pencil there promises an edit that does not exist.
+  // For a custom role it depends on the caller: either grant reaches an editable
+  // control (`update` the name/description, `bulk_update_permissions` the grid).
+  //
+  // The entry itself now only needs `read`. It used to require `update`, which
+  // locked a read-only viewer out of the one thing this card says is always
+  // allowed — viewing. This button is the only way in; the row does not navigate.
+  const rowIsEditable = (role: Role) =>
+    !role.system && (can('roles', 'update') || can('roles', 'bulk_update_permissions'));
 
   const filtered = roles.filter(r =>
     r.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -179,15 +192,15 @@ export default function RolesList() {
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
-                        {can('roles', 'update') && (
+                        {can('roles', 'read') && (
                           <Button
                             variant="ghost"
                             size="icon"
                             className="h-8 w-8 text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent"
                             onClick={() => navigate(`/settings/roles/${role.id}`)}
-                            title={t('editRole')}
+                            title={rowIsEditable(role) ? t('editRole') : t('viewRole')}
                           >
-                            <Pencil className="h-4 w-4" />
+                            {rowIsEditable(role) ? <Pencil className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                           </Button>
                         )}
                         {can('roles', 'delete') && !role.system && (


### PR DESCRIPTION
## EVO-2152 (frontend) — editor de Roles em read-only para roles system

> Metade frontend. Par do backend **auth #73** (`bulk_update_permissions` → 403 para role system). **Deploy conjunto.**

### Contexto
PM ruling (Opção A): o permission set de um role system é imutável (FR18). O editor do CRM não travava em role system — só na key `super_admin`. Para os demais roles system, os checkboxes ficavam ativos e o Salvar habilitado → **403 no clique** (beco sem saída), e antes do guard do backend, o `db:seed` revertia silenciosamente.

### Mudança
- `canEdit` passa a exigir **`!role.system`** (antes só `!== super_admin`). Read-only: a grade **continua visível** e lista todas as permissões (**ver sim**), mas sem toggles, sem select-all e sem Salvar. **Nunca esconde a grade nem bloqueia a rota** ("ver sim, editar não").
- **Aviso com cadeado** apontando a saída ("duplique como perfil personalizado"), i18n em **6 locales** (`detail.systemReadOnly`).
- Remove o import órfão `ROLE_KEYS`.

### Testes
`RoleDetail.spec`: o mock passa a expor `role.system`; o bloco read-only testa um role system (sem Save, checkboxes disabled, aviso presente) e mantém o custom editável. **vitest: 26/26 · tsc --noEmit 0.** Prova negativa: sem `!isSystemRole` os 2 testes de read-only falham (Save aparece).

### Relacionado
Backend par: auth #73.

## Summary by Sourcery

Make system roles read-only in the roles editor while keeping permissions visible and communicating the constraint to users.

New Features:
- Add a read-only lock notice for system roles in the roles editor, guiding users to duplicate as custom roles.
- Localize the system-role read-only message across all supported locales.

Enhancements:
- Change the roles editor editability logic to treat all system roles as immutable permission sets, not just the installation owner.
- Remove an unused ROLE_KEYS import from the roles detail page.

Tests:
- Extend RoleDetail tests to cover system-role read-only behavior and ensure custom roles remain editable.