### PR TITLE
feat(EVO-1785): remote product import UI — WooCommerce/Shopify (Phase 2)

### DIFF
--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ProductModal from './ProductModal';
 import type { Product } from '@/types/products';
 
@@ -12,6 +13,9 @@ globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill
 const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
 if (!proto.hasPointerCapture) proto.hasPointerCapture = () => false;
 if (!proto.scrollIntoView) proto.scrollIntoView = () => {};
+// jsdom lacks object-URL support used by the Media tab image previews (EVO-2226).
+globalThis.URL.createObjectURL = globalThis.URL.createObjectURL ?? (() => 'blob:mock');
+globalThis.URL.revokeObjectURL = globalThis.URL.revokeObjectURL ?? (() => {});
 
 const baseProduct = (overrides: Partial<Product>): Product => ({
   id: 'p1',
@@ -52,6 +56,98 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(submitSpy).not.toHaveBeenCalled();
     expect(screen.getByText('validation.nameRequired')).toBeTruthy();
     expect(screen.getByText('validation.fixErrors')).toBeTruthy();
+  });
+
+  it('EVO-2226 — Media tab picks an image and submits it as a file', async () => {
+    const user = userEvent.setup();
+    const submitSpy = vi.fn(async () => {});
+    render(
+      <ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={submitSpy} />,
+    );
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(await screen.findByText('media.pending')).toBeTruthy();
+
+    await user.click(screen.getByText('actions.update').closest('button') as HTMLButtonElement);
+    await waitFor(() => expect(submitSpy).toHaveBeenCalled());
+    const call = submitSpy.mock.calls.at(-1) as unknown as [unknown, File[] | undefined];
+    expect(call[1]).toHaveLength(1);
+    expect(call[1]![0].name).toBe('photo.png');
+  });
+
+  it('EVO-2226 — non-image files are ignored by the picker', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(input, { target: { files: [pdf] } });
+    expect(screen.queryByText('media.pending')).toBeNull();
+  });
+
+  // EVO-2226: the hint told users to drag files onto the zone, but nothing
+  // handled the drop — only the button worked.
+  it('EVO-2226 — accepts an image dropped on the zone', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const zone = await screen.findByTestId('product-image-dropzone');
+    const file = new File([new Uint8Array([1, 2, 3])], 'dropped.png', { type: 'image/png' });
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+
+    expect(await screen.findByText('media.pending')).toBeTruthy();
+  });
+
+  // EVO-2226: a refused file used to disappear without a word — the product
+  // saved and the image simply was not there.
+  it('EVO-2226 — explains why a non-image file was refused', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(['x'], 'doc.pdf', { type: 'application/pdf' })] } });
+
+    expect(await screen.findByTestId('product-image-rejections')).toBeTruthy();
+    expect(screen.getByText('media.rejected.invalidType')).toBeTruthy();
+    expect(screen.queryByText('media.pending')).toBeNull();
+  });
+
+  it('EVO-2226 — refuses a file over the size cap', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const huge = new File([new Uint8Array(1)], 'huge.png', { type: 'image/png' });
+    Object.defineProperty(huge, 'size', { value: 6 * 1024 * 1024 });
+    fireEvent.change(input, { target: { files: [huge] } });
+
+    expect(await screen.findByText('media.rejected.tooLarge')).toBeTruthy();
+    expect(screen.queryByText('media.pending')).toBeNull();
+  });
+
+  // EVO-2226: the manual path had no quantity cap at all.
+  it('EVO-2226 — stops at the per-product image ceiling', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const files = Array.from(
+      { length: 12 },
+      (_, i) => new File([new Uint8Array([1])], `p${i}.png`, { type: 'image/png' }),
+    );
+    fireEvent.change(input, { target: { files } });
+
+    // 12 picked, 10 fit — the surplus is named, not swallowed.
+    expect(await screen.findAllByText('media.rejected.tooMany')).toHaveLength(2);
+    expect(screen.getAllByRole('img').length).toBe(10);
   });
 
   it('renders a server field error inline (AC4 — SKU uniqueness)', () => {

--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -89,8 +89,7 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(screen.queryByText('media.pending')).toBeNull();
   });
 
-  // EVO-2226: the hint told users to drag files onto the zone, but nothing
-  // handled the drop — only the button worked.
+  // The hint told users to drag files onto the zone, but only the button worked.
   it('EVO-2226 — accepts an image dropped on the zone', async () => {
     const user = userEvent.setup();
     render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
@@ -103,8 +102,7 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(await screen.findByText('media.pending')).toBeTruthy();
   });
 
-  // EVO-2226: a refused file used to disappear without a word — the product
-  // saved and the image simply was not there.
+  // A refused file must say why, instead of the product saving without it.
   it('EVO-2226 — explains why a non-image file was refused', async () => {
     const user = userEvent.setup();
     render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
@@ -132,7 +130,7 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(screen.queryByText('media.pending')).toBeNull();
   });
 
-  // EVO-2226: the manual path had no quantity cap at all.
+  // The manual path is capped per product, like the import path.
   it('EVO-2226 — stops at the per-product image ceiling', async () => {
     const user = userEvent.setup();
     render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -50,7 +50,7 @@ const STATUSES: ProductStatus[] = ['active', 'inactive', 'draft'];
 const CURRENCIES: ProductCurrency[] = ['BRL', 'USD', 'EUR'];
 const URL_REGEX = /^https?:\/\/.+/i;
 
-// EVO-2226: kept in step with Products::ImagePolicy on the API side.
+// Kept in step with Products::ImagePolicy on the API side.
 const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/avif'];
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 const MAX_IMAGES_PER_PRODUCT = 10;
@@ -208,9 +208,8 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
     await onSubmit(payload, files.length ? files : undefined);
   };
 
-  // Mirrors Products::ImagePolicy on the server. Validating here is not a
-  // security control — it exists so a refused file says why, instead of the
-  // product saving and the image simply not being there.
+  // Mirrors Products::ImagePolicy. Not a security control: it exists so a refused file
+  // says why, instead of the product saving without the image.
   const handleFilesPicked = (list: FileList | null) => {
     if (!list) return;
 

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { assetUrl } from '@/utils/assetUrl';
 import {
   Dialog,
   DialogContent,
@@ -21,7 +22,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@evoapi/design-system';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus, Trash2, Upload, X, ImageIcon } from 'lucide-react';
 import type {
   Product,
   ProductFormData,
@@ -48,6 +49,13 @@ const KINDS: ProductKind[] = ['physical', 'digital'];
 const STATUSES: ProductStatus[] = ['active', 'inactive', 'draft'];
 const CURRENCIES: ProductCurrency[] = ['BRL', 'USD', 'EUR'];
 const URL_REGEX = /^https?:\/\/.+/i;
+
+// EVO-2226: kept in step with Products::ImagePolicy on the API side.
+const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/avif'];
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGES_PER_PRODUCT = 10;
+
+type RejectedFile = { name: string; reason: 'invalidType' | 'tooLarge' | 'tooMany' };
 
 // Empty input → null; non-numeric input (e.g. a pasted string) → null instead of NaN,
 // which would otherwise leak into the payload and bypass form validation.
@@ -93,8 +101,18 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [activeTab, setActiveTab] = useState('general');
+  // EVO-2226: raw image files picked in the Media tab, uploaded on submit.
+  const [files, setFiles] = useState<File[]>([]);
+  const [rejectedFiles, setRejectedFiles] = useState<RejectedFile[]>([]);
+  const [dragging, setDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Object URLs for previewing pending picks; revoked when the set changes/unmounts.
+  const filePreviews = useMemo(() => files.map((file) => ({ file, url: URL.createObjectURL(file) })), [files]);
+  useEffect(() => () => filePreviews.forEach((p) => URL.revokeObjectURL(p.url)), [filePreviews]);
 
   const isEdit = useMemo(() => Boolean(product?.id), [product]);
+  const existingImageCount = product?.images?.length ?? 0;
   const isPhysical = form.kind === 'physical';
 
   useEffect(() => {
@@ -120,6 +138,8 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       setVariants([]);
       setLabelsText('');
     }
+    setFiles([]);
+    setRejectedFiles([]);
     setTouched({});
     setSubmitAttempted(false);
     setActiveTab('general');
@@ -185,7 +205,41 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       })),
     };
 
-    await onSubmit(payload);
+    await onSubmit(payload, files.length ? files : undefined);
+  };
+
+  // Mirrors Products::ImagePolicy on the server. Validating here is not a
+  // security control — it exists so a refused file says why, instead of the
+  // product saving and the image simply not being there.
+  const handleFilesPicked = (list: FileList | null) => {
+    if (!list) return;
+
+    const rejected: RejectedFile[] = [];
+    const accepted: File[] = [];
+    let slots = MAX_IMAGES_PER_PRODUCT - (existingImageCount + files.length);
+
+    Array.from(list).forEach((file) => {
+      if (!file.type.startsWith('image/') || !ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+        rejected.push({ name: file.name, reason: 'invalidType' });
+      } else if (file.size > MAX_IMAGE_BYTES) {
+        rejected.push({ name: file.name, reason: 'tooLarge' });
+      } else if (slots <= 0) {
+        rejected.push({ name: file.name, reason: 'tooMany' });
+      } else {
+        accepted.push(file);
+        slots -= 1;
+      }
+    });
+
+    if (accepted.length) setFiles((prev) => [...prev, ...accepted]);
+    setRejectedFiles(rejected);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    handleFilesPicked(event.dataTransfer?.files ?? null);
   };
 
   return (
@@ -198,16 +252,13 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex flex-col">
           {/*
-            Media tab intentionally omitted: product image upload is not wired
-            end-to-end — the backend (products_controller#attach_images) only
-            attaches ActiveStorage signed_ids and explicitly drops raw multipart
-            files, which is all the client currently sends. Re-add a
-            <TabsTrigger value="media"> + <TabsContent value="media"> (file picker
-            + product.images preview, see git history) once a direct-upload /
-            signed_id flow exists.
+            EVO-2226: Media tab restored. The backend (products_controller#attach_images)
+            now accepts raw multipart uploads (validated type + size), which is what
+            productsService.buildFormData already sends as product[images][].
           */}
-          <TabsList className="grid grid-cols-3 w-full">
+          <TabsList className="grid grid-cols-4 w-full">
             <TabsTrigger value="general">{t('modal.tabs.general')}</TabsTrigger>
+            <TabsTrigger value="media">{t('modal.tabs.media')}</TabsTrigger>
             <TabsTrigger value="variants">{t('modal.tabs.variants')}</TabsTrigger>
             <TabsTrigger value="labels">{t('modal.tabs.labels')}</TabsTrigger>
           </TabsList>
@@ -366,6 +417,95 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                 />
               </div>
             </div>
+          </TabsContent>
+
+          <TabsContent value="media" className="space-y-4 overflow-y-auto pt-4">
+            <div
+              data-testid="product-image-dropzone"
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragging(true);
+              }}
+              onDragLeave={() => setDragging(false)}
+              onDrop={handleDrop}
+              className={`rounded-lg border border-dashed p-6 text-center transition-colors ${
+                dragging ? 'border-primary bg-primary/5' : ''
+              }`}
+            >
+              <ImageIcon className="mx-auto h-8 w-8 text-muted-foreground" />
+              <p className="mt-2 text-sm text-muted-foreground">{t('media.uploadHint')}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('media.limits', { max: MAX_IMAGES_PER_PRODUCT, size: MAX_IMAGE_BYTES / (1024 * 1024) })}
+              </p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ACCEPTED_IMAGE_TYPES.join(',')}
+                multiple
+                className="hidden"
+                data-testid="product-image-input"
+                onChange={(e) => handleFilesPicked(e.target.files)}
+              />
+              <Button type="button" variant="outline" className="mt-3" onClick={() => fileInputRef.current?.click()}>
+                <Upload className="h-4 w-4 mr-2" />
+                {t('media.selectFiles')}
+              </Button>
+            </div>
+
+            {rejectedFiles.length > 0 && (
+              <ul className="space-y-1 text-xs text-destructive" data-testid="product-image-rejections">
+                {rejectedFiles.map((rejected) => (
+                  <li key={`${rejected.name}-${rejected.reason}`}>
+                    {t(`media.rejected.${rejected.reason}`, {
+                      name: rejected.name,
+                      max: MAX_IMAGES_PER_PRODUCT,
+                      size: MAX_IMAGE_BYTES / (1024 * 1024),
+                    })}
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {isEdit && (product?.images?.length ?? 0) > 0 && (
+              <div className="space-y-2">
+                <Label>{t('media.existing')}</Label>
+                <div className="grid grid-cols-4 gap-2">
+                  {product!.images.map((img) => (
+                    <img
+                      key={img.id}
+                      src={assetUrl(img.url)}
+                      alt={img.filename}
+                      className="aspect-square w-full rounded border object-cover"
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {filePreviews.length > 0 && (
+              <div className="space-y-2">
+                <Label>{t('media.pending')}</Label>
+                <div className="grid grid-cols-4 gap-2">
+                  {filePreviews.map((preview, index) => (
+                    <div key={`${preview.file.name}-${preview.file.size}-${index}`} className="relative">
+                      <img
+                        src={preview.url}
+                        alt={preview.file.name}
+                        className="aspect-square w-full rounded border object-cover"
+                      />
+                      <button
+                        type="button"
+                        aria-label={t('actions.delete')}
+                        onClick={() => setFiles((prev) => prev.filter((_, i) => i !== index))}
+                        className="absolute -right-1.5 -top-1.5 rounded-full bg-destructive p-0.5 text-white"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </TabsContent>
 
           <TabsContent value="variants" className="space-y-3 overflow-y-auto pt-4">

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Drag images here or use the button below.",
     "selectFiles": "Select files",
     "existing": "Existing images",
-    "pending": "Pending upload"
+    "pending": "Pending upload",
+    "limits": "Up to {{max}} images, {{size}} MB each.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": unsupported format.",
+      "tooLarge": "\"{{name}}\": over {{size}} MB.",
+      "tooMany": "\"{{name}}\": limit of {{max}} images per product reached."
+    }
   },
   "variants": {
     "empty": "No variants. Click \"Add variant\".",

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -7,7 +7,7 @@
   "header": {
     "searchPlaceholder": "Search by name, SKU or description",
     "new": "New product",
-    "import": "Import CSV",
+    "import": "Import",
     "filters": {
       "kindAll": "All kinds",
       "statusAll": "All statuses"
@@ -110,16 +110,18 @@
     "deleteError": "Failed to delete product"
   },
   "import": {
-    "title": "Import products from CSV",
-    "subtitle": "Upload a CSV with up to {{max}} rows. The file is parsed locally, validated against the catalog rules and sent to the bulk endpoint in a single transaction.",
+    "title": "Import products",
+    "subtitle": "Import your catalog from a CSV file or straight from your store (WooCommerce/Shopify). Products are validated against the catalog rules and saved in a single transaction.",
     "back": "Back to products",
     "forbidden": "You do not have permission to import products.",
     "success": "{{count}} products imported successfully",
     "tabs": {
-      "upload": "1. Upload",
-      "mapping": "2. Mapping",
-      "preview": "3. Preview",
-      "done": "4. Done"
+      "upload": "Upload",
+      "mapping": "Mapping",
+      "preview": "Preview",
+      "done": "Done",
+      "source": "Source",
+      "credentials": "Credentials"
     },
     "upload": {
       "hint": "Select a UTF-8 CSV file with a header row. Limit: {{max}} rows.",
@@ -159,7 +161,9 @@
       "errorsHeading": "{{count}} row(s) need attention",
       "row": "Row",
       "sku": "SKU",
-      "errors": "Errors"
+      "errors": "Errors",
+      "fetched": "{{count}} products fetched from {{source}}.",
+      "backToCredentials": "Back to credentials"
     },
     "done": {
       "title": "Import complete",
@@ -202,6 +206,60 @@
       "duplicated_within_batch": "duplicated within batch",
       "taken": "has already been taken",
       "invalid_value": "is not a valid value"
+    },
+    "source": {
+      "continue": "Continue",
+      "csv": {
+        "title": "CSV file",
+        "desc": "Upload a CSV of your catalog."
+      },
+      "woocommerce": {
+        "title": "WooCommerce",
+        "desc": "Connect via REST API (ck_/cs_ keys)."
+      },
+      "shopify": {
+        "title": "Shopify",
+        "desc": "Connect via Admin API (access token)."
+      }
+    },
+    "credentials": {
+      "back": "Back",
+      "fetch": "Fetch products",
+      "missing": "Fill in all credentials.",
+      "noProducts": "No products found in the store.",
+      "fetchFailed": "Failed to fetch products: {{message}}",
+      "oneTimeNote": "Credentials are used only for this import and are not stored.",
+      "fields": {
+        "store_url": "Store URL",
+        "consumer_key": "Consumer key",
+        "consumer_secret": "Consumer secret",
+        "shop_domain": "Shop domain",
+        "access_token": "Access token"
+      },
+      "placeholders": {
+        "store_url": "https://myshop.com",
+        "consumer_key": "ck_...",
+        "consumer_secret": "cs_...",
+        "shop_domain": "my-shop.myshopify.com",
+        "access_token": "shpat_..."
+      }
+    },
+    "help": {
+      "trigger": "How do I get my keys?",
+      "woocommerce": {
+        "title": "WooCommerce API keys",
+        "step1": "In the WordPress dashboard, go to WooCommerce → Settings → Advanced → REST API.",
+        "step2": "Click \"Add key\" and give it a description (e.g. Evo CRM).",
+        "step3": "Set Permissions to \"Read\" and generate the key.",
+        "step4": "Copy the Consumer key (ck_...) and Consumer secret (cs_...) — the secret is shown only once."
+      },
+      "shopify": {
+        "title": "Shopify Admin API token",
+        "step1": "In Shopify admin, go to Settings → Apps and sales channels → Develop apps.",
+        "step2": "Create an app and, under Admin API configuration, grant the read_products scope.",
+        "step3": "Install the app on the store.",
+        "step4": "Copy the Admin API access token (shpat_...) and use the .myshopify.com domain."
+      }
     }
   },
   "pipelinePanel": {

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -131,7 +131,8 @@
     },
     "upload": {
       "hint": "Select a UTF-8 CSV file with a header row. Limit: {{max}} rows.",
-      "selectFile": "Select CSV"
+      "selectFile": "Select CSV",
+      "backToSource": "Change import source"
     },
     "mapping": {
       "file": "{{name}} — {{count}} row(s)",
@@ -169,7 +170,9 @@
       "sku": "SKU",
       "errors": "Errors",
       "fetched": "{{count}} products fetched from {{source}}.",
-      "backToCredentials": "Back to credentials"
+      "backToCredentials": "Back to credentials",
+      "truncated": "Only the first {{count}} products were fetched — the store holds more than this import can carry in one run.",
+      "variantsDropped": "{{count}} variant(s) were not imported — each product becomes a single row in the catalog."
     },
     "done": {
       "title": "Import complete",

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Arrastre imágenes aquí o use el botón de abajo.",
     "selectFiles": "Seleccionar archivos",
     "existing": "Imágenes existentes",
-    "pending": "Pendientes de subida"
+    "pending": "Pendientes de subida",
+    "limits": "Hasta {{max}} imágenes, {{size}} MB cada una.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": formato no admitido.",
+      "tooLarge": "\"{{name}}\": supera {{size}} MB.",
+      "tooMany": "\"{{name}}\": se alcanzó el límite de {{max}} imágenes por producto."
+    }
   },
   "variants": {
     "empty": "Sin variantes. Haga clic en \"Agregar variante\".",

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -7,7 +7,7 @@
   "header": {
     "searchPlaceholder": "Buscar por nombre, SKU o descripción",
     "new": "Nuevo producto",
-    "import": "Importar CSV",
+    "import": "Importar",
     "filters": {
       "kindAll": "Todos los tipos",
       "statusAll": "Todos los estados"
@@ -110,16 +110,18 @@
     "deleteError": "Error al eliminar producto"
   },
   "import": {
-    "title": "Importar productos desde CSV",
-    "subtitle": "Sube un CSV con hasta {{max}} filas. El archivo se analiza en el navegador, se valida con las reglas del catálogo y se envía en una única transacción.",
+    "title": "Importar productos",
+    "subtitle": "Importa tu catálogo desde un archivo CSV o directamente desde tu tienda (WooCommerce/Shopify). Los productos se validan contra las reglas del catálogo y se guardan en una única transacción.",
     "back": "Volver a productos",
     "forbidden": "No tienes permiso para importar productos.",
     "success": "{{count}} productos importados correctamente",
     "tabs": {
-      "upload": "1. Subida",
-      "mapping": "2. Mapeo",
-      "preview": "3. Vista previa",
-      "done": "4. Listo"
+      "upload": "Carga",
+      "mapping": "Mapeo",
+      "preview": "Vista previa",
+      "done": "Listo",
+      "source": "Fuente",
+      "credentials": "Credenciales"
     },
     "upload": {
       "hint": "Selecciona un CSV UTF-8 con encabezado. Límite: {{max}} filas.",
@@ -159,7 +161,9 @@
       "errorsHeading": "{{count}} fila(s) requieren atención",
       "row": "Fila",
       "sku": "SKU",
-      "errors": "Errores"
+      "errors": "Errores",
+      "fetched": "{{count}} productos obtenidos de {{source}}.",
+      "backToCredentials": "Volver a credenciales"
     },
     "done": {
       "title": "Importación completada",
@@ -202,6 +206,60 @@
       "duplicated_within_batch": "duplicado dentro del lote",
       "taken": "ya está en uso",
       "invalid_value": "no es un valor válido"
+    },
+    "source": {
+      "continue": "Continuar",
+      "csv": {
+        "title": "Archivo CSV",
+        "desc": "Sube un CSV de tu catálogo."
+      },
+      "woocommerce": {
+        "title": "WooCommerce",
+        "desc": "Conecta vía REST API (claves ck_/cs_)."
+      },
+      "shopify": {
+        "title": "Shopify",
+        "desc": "Conecta vía Admin API (token de acceso)."
+      }
+    },
+    "credentials": {
+      "back": "Volver",
+      "fetch": "Buscar productos",
+      "missing": "Completa todas las credenciales.",
+      "noProducts": "No se encontraron productos en la tienda.",
+      "fetchFailed": "Error al buscar productos: {{message}}",
+      "oneTimeNote": "Las credenciales se usan solo para esta importación y no se almacenan.",
+      "fields": {
+        "store_url": "URL de la tienda",
+        "consumer_key": "Consumer key",
+        "consumer_secret": "Consumer secret",
+        "shop_domain": "Dominio de la tienda",
+        "access_token": "Token de acceso"
+      },
+      "placeholders": {
+        "store_url": "https://myshop.com",
+        "consumer_key": "ck_...",
+        "consumer_secret": "cs_...",
+        "shop_domain": "my-shop.myshopify.com",
+        "access_token": "shpat_..."
+      }
+    },
+    "help": {
+      "trigger": "¿Cómo obtengo mis claves?",
+      "woocommerce": {
+        "title": "Claves de la API de WooCommerce",
+        "step1": "En el panel de WordPress, ve a WooCommerce → Ajustes → Avanzado → API REST.",
+        "step2": "Haz clic en \"Añadir clave\" y ponle una descripción (p. ej. Evo CRM).",
+        "step3": "En Permisos, elige \"Lectura\" y genera la clave.",
+        "step4": "Copia la Consumer key (ck_...) y la Consumer secret (cs_...) — la secret solo se muestra una vez."
+      },
+      "shopify": {
+        "title": "Token de la Admin API de Shopify",
+        "step1": "En el admin de Shopify, ve a Configuración → Apps y canales de venta → Desarrollar apps.",
+        "step2": "Crea una app y, en Configuración de la Admin API, concede el permiso read_products.",
+        "step3": "Instala la app en la tienda.",
+        "step4": "Copia el token de acceso de la Admin API (shpat_...) y usa el dominio .myshopify.com."
+      }
     }
   },
   "pipelinePanel": {

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -131,7 +131,8 @@
     },
     "upload": {
       "hint": "Selecciona un CSV UTF-8 con encabezado. Límite: {{max}} filas.",
-      "selectFile": "Seleccionar CSV"
+      "selectFile": "Seleccionar CSV",
+      "backToSource": "Cambiar la fuente de importación"
     },
     "mapping": {
       "file": "{{name}} — {{count}} fila(s)",
@@ -169,7 +170,9 @@
       "sku": "SKU",
       "errors": "Errores",
       "fetched": "{{count}} productos obtenidos de {{source}}.",
-      "backToCredentials": "Volver a credenciales"
+      "backToCredentials": "Volver a credenciales",
+      "truncated": "Solo se obtuvieron los primeros {{count}} productos — la tienda tiene más de lo que esta importación puede traer de una vez.",
+      "variantsDropped": "{{count}} variante(s) no se importaron — cada producto se convierte en una sola fila del catálogo."
     },
     "done": {
       "title": "Importación completada",

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -125,7 +125,8 @@
     },
     "upload": {
       "hint": "Sélectionnez un CSV UTF-8 avec une ligne d’en-tête. Limite : {{max}} lignes.",
-      "selectFile": "Sélectionner le CSV"
+      "selectFile": "Sélectionner le CSV",
+      "backToSource": "Changer de source d’import"
     },
     "mapping": {
       "file": "{{name}} — {{count}} ligne(s)",
@@ -163,7 +164,9 @@
       "sku": "SKU",
       "errors": "Erreurs",
       "fetched": "{{count}} produits récupérés depuis {{source}}.",
-      "backToCredentials": "Retour aux identifiants"
+      "backToCredentials": "Retour aux identifiants",
+      "truncated": "Seuls les {{count}} premiers produits ont été récupérés — la boutique en contient plus que cet import ne peut traiter en une fois.",
+      "variantsDropped": "{{count}} variante(s) n’ont pas été importées — chaque produit devient une seule ligne du catalogue."
     },
     "done": {
       "title": "Importation terminée",

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -7,7 +7,7 @@
   "header": {
     "searchPlaceholder": "Rechercher par nom, SKU ou description",
     "new": "Nouveau produit",
-    "import": "Importer un CSV",
+    "import": "Importer",
     "filters": {
       "kindAll": "Tous les types",
       "statusAll": "Tous les statuts"
@@ -110,16 +110,18 @@
     "deleteError": "Échec de la suppression du produit"
   },
   "import": {
-    "title": "Importer des produits depuis un CSV",
-    "subtitle": "Téléversez un CSV avec jusqu’à {{max}} lignes. Le fichier est analysé localement, validé selon les règles du catalogue et envoyé en une seule transaction.",
+    "title": "Importer des produits",
+    "subtitle": "Importez votre catalogue depuis un fichier CSV ou directement depuis votre boutique (WooCommerce/Shopify). Les produits sont validés selon les règles du catalogue et enregistrés en une seule transaction.",
     "back": "Retour aux produits",
     "forbidden": "Vous n’avez pas la permission d’importer des produits.",
     "success": "{{count}} produits importés avec succès",
     "tabs": {
-      "upload": "1. Téléversement",
-      "mapping": "2. Mappage",
-      "preview": "3. Aperçu",
-      "done": "4. Terminé"
+      "upload": "Envoi",
+      "mapping": "Correspondance",
+      "preview": "Aperçu",
+      "done": "Terminé",
+      "source": "Source",
+      "credentials": "Identifiants"
     },
     "upload": {
       "hint": "Sélectionnez un CSV UTF-8 avec une ligne d’en-tête. Limite : {{max}} lignes.",
@@ -159,7 +161,9 @@
       "errorsHeading": "{{count}} ligne(s) nécessitent attention",
       "row": "Ligne",
       "sku": "SKU",
-      "errors": "Erreurs"
+      "errors": "Erreurs",
+      "fetched": "{{count}} produits récupérés depuis {{source}}.",
+      "backToCredentials": "Retour aux identifiants"
     },
     "done": {
       "title": "Importation terminée",
@@ -202,6 +206,60 @@
       "duplicated_within_batch": "dupliqué dans le lot",
       "taken": "est déjà utilisé",
       "invalid_value": "n’est pas une valeur valide"
+    },
+    "source": {
+      "continue": "Continuer",
+      "csv": {
+        "title": "Fichier CSV",
+        "desc": "Téléversez un CSV de votre catalogue."
+      },
+      "woocommerce": {
+        "title": "WooCommerce",
+        "desc": "Connectez via l’API REST (clés ck_/cs_)."
+      },
+      "shopify": {
+        "title": "Shopify",
+        "desc": "Connectez via l’Admin API (jeton d’accès)."
+      }
+    },
+    "credentials": {
+      "back": "Retour",
+      "fetch": "Récupérer les produits",
+      "missing": "Renseignez tous les identifiants.",
+      "noProducts": "Aucun produit trouvé dans la boutique.",
+      "fetchFailed": "Échec de la récupération des produits : {{message}}",
+      "oneTimeNote": "Les identifiants ne servent qu’à cet import et ne sont pas conservés.",
+      "fields": {
+        "store_url": "URL de la boutique",
+        "consumer_key": "Consumer key",
+        "consumer_secret": "Consumer secret",
+        "shop_domain": "Domaine de la boutique",
+        "access_token": "Jeton d’accès"
+      },
+      "placeholders": {
+        "store_url": "https://myshop.com",
+        "consumer_key": "ck_...",
+        "consumer_secret": "cs_...",
+        "shop_domain": "my-shop.myshopify.com",
+        "access_token": "shpat_..."
+      }
+    },
+    "help": {
+      "trigger": "Comment obtenir mes clés ?",
+      "woocommerce": {
+        "title": "Clés de l’API WooCommerce",
+        "step1": "Dans le tableau de bord WordPress, allez dans WooCommerce → Réglages → Avancé → API REST.",
+        "step2": "Cliquez sur « Ajouter une clé » et donnez-lui une description (ex. Evo CRM).",
+        "step3": "Dans Permissions, choisissez « Lecture » et générez la clé.",
+        "step4": "Copiez la Consumer key (ck_...) et la Consumer secret (cs_...) — la secret n’est affichée qu’une fois."
+      },
+      "shopify": {
+        "title": "Jeton de l’Admin API Shopify",
+        "step1": "Dans l’admin Shopify, allez dans Paramètres → Applications et canaux de vente → Développer des applications.",
+        "step2": "Créez une application et, dans la configuration de l’Admin API, accordez le scope read_products.",
+        "step3": "Installez l’application sur la boutique.",
+        "step4": "Copiez le jeton d’accès de l’Admin API (shpat_...) et utilisez le domaine .myshopify.com."
+      }
     }
   },
   "pipelinePanel": {

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -125,7 +125,8 @@
     },
     "upload": {
       "hint": "Seleziona un file CSV UTF-8 con riga di intestazione. Limite: {{max}} righe.",
-      "selectFile": "Seleziona CSV"
+      "selectFile": "Seleziona CSV",
+      "backToSource": "Cambia origine dell’importazione"
     },
     "mapping": {
       "file": "{{name}} — {{count}} riga/e",
@@ -163,7 +164,9 @@
       "sku": "SKU",
       "errors": "Errori",
       "fetched": "{{count}} prodotti recuperati da {{source}}.",
-      "backToCredentials": "Torna alle credenziali"
+      "backToCredentials": "Torna alle credenziali",
+      "truncated": "Sono stati recuperati solo i primi {{count}} prodotti — il negozio ne contiene più di quanti questa importazione possa gestirne in una volta.",
+      "variantsDropped": "{{count}} variante/i non sono state importate — ogni prodotto diventa una sola riga del catalogo."
     },
     "done": {
       "title": "Importazione completata",

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -7,7 +7,7 @@
   "header": {
     "searchPlaceholder": "Cerca per nome, SKU o descrizione",
     "new": "Nuovo prodotto",
-    "import": "Importa CSV",
+    "import": "Importa",
     "filters": {
       "kindAll": "Tutti i tipi",
       "statusAll": "Tutti gli stati"
@@ -110,16 +110,18 @@
     "deleteError": "Impossibile eliminare il prodotto"
   },
   "import": {
-    "title": "Importa prodotti da CSV",
-    "subtitle": "Carica un CSV con un massimo di {{max}} righe. Il file viene analizzato localmente, validato secondo le regole del catalogo e inviato in un’unica transazione.",
+    "title": "Importa prodotti",
+    "subtitle": "Importa il tuo catalogo da un file CSV o direttamente dal tuo negozio (WooCommerce/Shopify). I prodotti vengono validati secondo le regole del catalogo e salvati in un’unica transazione.",
     "back": "Torna ai prodotti",
     "forbidden": "Non hai il permesso di importare prodotti.",
     "success": "{{count}} prodotti importati con successo",
     "tabs": {
-      "upload": "1. Caricamento",
-      "mapping": "2. Mappatura",
-      "preview": "3. Anteprima",
-      "done": "4. Fatto"
+      "upload": "Caricamento",
+      "mapping": "Mappatura",
+      "preview": "Anteprima",
+      "done": "Completato",
+      "source": "Origine",
+      "credentials": "Credenziali"
     },
     "upload": {
       "hint": "Seleziona un file CSV UTF-8 con riga di intestazione. Limite: {{max}} righe.",
@@ -159,7 +161,9 @@
       "errorsHeading": "{{count}} riga/e richiedono attenzione",
       "row": "Riga",
       "sku": "SKU",
-      "errors": "Errori"
+      "errors": "Errori",
+      "fetched": "{{count}} prodotti recuperati da {{source}}.",
+      "backToCredentials": "Torna alle credenziali"
     },
     "done": {
       "title": "Importazione completata",
@@ -202,6 +206,60 @@
       "duplicated_within_batch": "duplicato nel batch",
       "taken": "è già in uso",
       "invalid_value": "non è un valore valido"
+    },
+    "source": {
+      "continue": "Continua",
+      "csv": {
+        "title": "File CSV",
+        "desc": "Carica un CSV del tuo catalogo."
+      },
+      "woocommerce": {
+        "title": "WooCommerce",
+        "desc": "Connetti via REST API (chiavi ck_/cs_)."
+      },
+      "shopify": {
+        "title": "Shopify",
+        "desc": "Connetti via Admin API (token di accesso)."
+      }
+    },
+    "credentials": {
+      "back": "Indietro",
+      "fetch": "Recupera prodotti",
+      "missing": "Compila tutte le credenziali.",
+      "noProducts": "Nessun prodotto trovato nel negozio.",
+      "fetchFailed": "Recupero dei prodotti non riuscito: {{message}}",
+      "oneTimeNote": "Le credenziali sono usate solo per questa importazione e non vengono memorizzate.",
+      "fields": {
+        "store_url": "URL del negozio",
+        "consumer_key": "Consumer key",
+        "consumer_secret": "Consumer secret",
+        "shop_domain": "Dominio del negozio",
+        "access_token": "Token di accesso"
+      },
+      "placeholders": {
+        "store_url": "https://myshop.com",
+        "consumer_key": "ck_...",
+        "consumer_secret": "cs_...",
+        "shop_domain": "my-shop.myshopify.com",
+        "access_token": "shpat_..."
+      }
+    },
+    "help": {
+      "trigger": "Come ottengo le mie chiavi?",
+      "woocommerce": {
+        "title": "Chiavi API di WooCommerce",
+        "step1": "Nella dashboard di WordPress, vai su WooCommerce → Impostazioni → Avanzate → API REST.",
+        "step2": "Clicca su \"Aggiungi chiave\" e dai una descrizione (es. Evo CRM).",
+        "step3": "In Permessi scegli \"Lettura\" e genera la chiave.",
+        "step4": "Copia la Consumer key (ck_...) e la Consumer secret (cs_...) — la secret è mostrata una sola volta."
+      },
+      "shopify": {
+        "title": "Token dell’Admin API di Shopify",
+        "step1": "Nell’admin di Shopify, vai su Impostazioni → App e canali di vendita → Sviluppa app.",
+        "step2": "Crea un’app e, nella configurazione dell’Admin API, concedi lo scope read_products.",
+        "step3": "Installa l’app nel negozio.",
+        "step4": "Copia il token di accesso dell’Admin API (shpat_...) e usa il dominio .myshopify.com."
+      }
     }
   },
   "pipelinePanel": {

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -7,7 +7,7 @@
   "header": {
     "searchPlaceholder": "Buscar por nome, SKU ou descrição",
     "new": "Novo produto",
-    "import": "Importar CSV",
+    "import": "Importar",
     "filters": {
       "kindAll": "Todos os tipos",
       "statusAll": "Todos os status"
@@ -110,16 +110,18 @@
     "deleteError": "Falha ao excluir produto"
   },
   "import": {
-    "title": "Importar produtos via CSV",
-    "subtitle": "Envie um CSV com até {{max}} linhas. O arquivo é analisado localmente, validado contra as regras do catálogo e enviado em uma única transação.",
+    "title": "Importar produtos",
+    "subtitle": "Importe seu catálogo de um arquivo CSV ou direto da sua loja (WooCommerce/Shopify). Os produtos são validados contra as regras do catálogo e gravados em uma única transação.",
     "back": "Voltar para produtos",
     "forbidden": "Você não tem permissão para importar produtos.",
     "success": "{{count}} produtos importados com sucesso",
     "tabs": {
-      "upload": "1. Envio",
-      "mapping": "2. Mapeamento",
-      "preview": "3. Pré-visualização",
-      "done": "4. Concluído"
+      "upload": "Envio",
+      "mapping": "Mapeamento",
+      "preview": "Pré-visualização",
+      "done": "Concluído",
+      "source": "Fonte",
+      "credentials": "Credenciais"
     },
     "upload": {
       "hint": "Selecione um arquivo CSV UTF-8 com linha de cabeçalho. Limite: {{max}} linhas.",
@@ -159,7 +161,9 @@
       "errorsHeading": "{{count}} linha(s) precisam de atenção",
       "row": "Linha",
       "sku": "SKU",
-      "errors": "Erros"
+      "errors": "Erros",
+      "fetched": "{{count}} produtos buscados de {{source}}.",
+      "backToCredentials": "Voltar às credenciais"
     },
     "done": {
       "title": "Importação concluída",
@@ -202,6 +206,60 @@
       "duplicated_within_batch": "duplicado dentro do lote",
       "taken": "já está em uso",
       "invalid_value": "não é um valor válido"
+    },
+    "source": {
+      "continue": "Continuar",
+      "csv": {
+        "title": "Arquivo CSV",
+        "desc": "Envie um arquivo CSV do seu catálogo."
+      },
+      "woocommerce": {
+        "title": "WooCommerce",
+        "desc": "Conecte via API REST (chaves ck_/cs_)."
+      },
+      "shopify": {
+        "title": "Shopify",
+        "desc": "Conecte via Admin API (token de acesso)."
+      }
+    },
+    "credentials": {
+      "back": "Voltar",
+      "fetch": "Buscar produtos",
+      "missing": "Preencha todas as credenciais.",
+      "noProducts": "Nenhum produto encontrado na loja.",
+      "fetchFailed": "Falha ao buscar produtos: {{message}}",
+      "oneTimeNote": "As credenciais são usadas apenas para esta importação e não são armazenadas.",
+      "fields": {
+        "store_url": "URL da loja",
+        "consumer_key": "Consumer key",
+        "consumer_secret": "Consumer secret",
+        "shop_domain": "Domínio da loja",
+        "access_token": "Token de acesso"
+      },
+      "placeholders": {
+        "store_url": "https://myshop.com",
+        "consumer_key": "ck_...",
+        "consumer_secret": "cs_...",
+        "shop_domain": "my-shop.myshopify.com",
+        "access_token": "shpat_..."
+      }
+    },
+    "help": {
+      "trigger": "Como obter minhas chaves?",
+      "woocommerce": {
+        "title": "Chaves da API do WooCommerce",
+        "step1": "No painel do WordPress, acesse WooCommerce → Ajustes → Avançado → API REST.",
+        "step2": "Clique em \"Adicionar chave\" e dê uma descrição (ex.: Evo CRM).",
+        "step3": "Em Permissões, escolha \"Leitura\" e gere a chave.",
+        "step4": "Copie a Consumer key (ck_...) e a Consumer secret (cs_...) — a secret só aparece uma vez."
+      },
+      "shopify": {
+        "title": "Token da Admin API do Shopify",
+        "step1": "No admin da Shopify, acesse Configurações → Apps e canais de venda → Desenvolver apps.",
+        "step2": "Crie um app e, em Configuração da Admin API, conceda o escopo read_products.",
+        "step3": "Instale o app na loja.",
+        "step4": "Copie o token de acesso da Admin API (shpat_...) e use o domínio .myshopify.com."
+      }
     }
   },
   "pipelinePanel": {

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -125,7 +125,8 @@
     },
     "upload": {
       "hint": "Selecione um arquivo CSV UTF-8 com linha de cabeçalho. Limite: {{max}} linhas.",
-      "selectFile": "Selecionar CSV"
+      "selectFile": "Selecionar CSV",
+      "backToSource": "Trocar a fonte de importação"
     },
     "mapping": {
       "file": "{{name}} — {{count}} linha(s)",
@@ -163,7 +164,9 @@
       "sku": "SKU",
       "errors": "Erros",
       "fetched": "{{count}} produtos buscados de {{source}}.",
-      "backToCredentials": "Voltar às credenciais"
+      "backToCredentials": "Voltar às credenciais",
+      "truncated": "Só os primeiros {{count}} produtos foram buscados — a loja tem mais do que esta importação consegue trazer de uma vez.",
+      "variantsDropped": "{{count}} variação(ões) não foram importadas — cada produto vira uma única linha do catálogo."
     },
     "done": {
       "title": "Importação concluída",

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -67,10 +67,16 @@
     "digitalNoStockHint": "Produtos digitais não têm stock."
   },
   "media": {
-    "uploadHint": "Arraste imagens para aqui ou utilize o botão em baixo.",
-    "selectFiles": "Selecionar ficheiros",
+    "uploadHint": "Arraste imagens para cá ou use o botão abaixo.",
+    "selectFiles": "Selecionar arquivos",
     "existing": "Imagens existentes",
-    "pending": "Pendentes de envio"
+    "pending": "Pendentes de envio",
+    "limits": "Até {{max}} imagens, {{size}} MB cada.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": formato não suportado.",
+      "tooLarge": "\"{{name}}\": acima de {{size}} MB.",
+      "tooMany": "\"{{name}}\": limite de {{max}} imagens por produto atingido."
+    }
   },
   "variants": {
     "empty": "Sem variantes. Clique em \"Adicionar variante\".",

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -131,7 +131,8 @@
     },
     "upload": {
       "hint": "Selecione um ficheiro CSV UTF-8 com linha de cabeçalho. Limite: {{max}} linhas.",
-      "selectFile": "Selecionar CSV"
+      "selectFile": "Selecionar CSV",
+      "backToSource": "Mudar a fonte de importação"
     },
     "mapping": {
       "file": "{{name}} — {{count}} linha(s)",
@@ -169,7 +170,9 @@
       "sku": "SKU",
       "errors": "Erros",
       "fetched": "{{count}} produtos buscados de {{source}}.",
-      "backToCredentials": "Voltar às credenciais"
+      "backToCredentials": "Voltar às credenciais",
+      "truncated": "Só os primeiros {{count}} produtos foram obtidos — a loja tem mais do que esta importação consegue trazer de uma vez.",
+      "variantsDropped": "{{count}} variante(s) não foram importadas — cada produto torna-se uma única linha do catálogo."
     },
     "done": {
       "title": "Importação concluída",

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -7,7 +7,7 @@
   "header": {
     "searchPlaceholder": "Pesquisar por nome, SKU ou descrição",
     "new": "Novo produto",
-    "import": "Importar CSV",
+    "import": "Importar",
     "filters": {
       "kindAll": "Todos os tipos",
       "statusAll": "Todos os estados"
@@ -110,16 +110,18 @@
     "deleteError": "Falha ao eliminar produto"
   },
   "import": {
-    "title": "Importar produtos via CSV",
-    "subtitle": "Carregue um CSV com até {{max}} linhas. O ficheiro é analisado localmente, validado contra as regras do catálogo e enviado numa única transação.",
+    "title": "Importar produtos",
+    "subtitle": "Importe seu catálogo de um arquivo CSV ou direto da sua loja (WooCommerce/Shopify). Os produtos são validados contra as regras do catálogo e gravados em uma única transação.",
     "back": "Voltar aos produtos",
     "forbidden": "Não tem permissão para importar produtos.",
     "success": "{{count}} produtos importados com sucesso",
     "tabs": {
-      "upload": "1. Carregamento",
-      "mapping": "2. Mapeamento",
-      "preview": "3. Pré-visualização",
-      "done": "4. Concluído"
+      "upload": "Envio",
+      "mapping": "Mapeamento",
+      "preview": "Pré-visualização",
+      "done": "Concluído",
+      "source": "Fonte",
+      "credentials": "Credenciais"
     },
     "upload": {
       "hint": "Selecione um ficheiro CSV UTF-8 com linha de cabeçalho. Limite: {{max}} linhas.",
@@ -159,7 +161,9 @@
       "errorsHeading": "{{count}} linha(s) requerem atenção",
       "row": "Linha",
       "sku": "SKU",
-      "errors": "Erros"
+      "errors": "Erros",
+      "fetched": "{{count}} produtos buscados de {{source}}.",
+      "backToCredentials": "Voltar às credenciais"
     },
     "done": {
       "title": "Importação concluída",
@@ -202,6 +206,60 @@
       "duplicated_within_batch": "duplicado dentro do lote",
       "taken": "já está em uso",
       "invalid_value": "não é um valor válido"
+    },
+    "source": {
+      "continue": "Continuar",
+      "csv": {
+        "title": "Arquivo CSV",
+        "desc": "Envie um arquivo CSV do seu catálogo."
+      },
+      "woocommerce": {
+        "title": "WooCommerce",
+        "desc": "Conecte via API REST (chaves ck_/cs_)."
+      },
+      "shopify": {
+        "title": "Shopify",
+        "desc": "Conecte via Admin API (token de acesso)."
+      }
+    },
+    "credentials": {
+      "back": "Voltar",
+      "fetch": "Buscar produtos",
+      "missing": "Preencha todas as credenciais.",
+      "noProducts": "Nenhum produto encontrado na loja.",
+      "fetchFailed": "Falha ao buscar produtos: {{message}}",
+      "oneTimeNote": "As credenciais são usadas apenas para esta importação e não são armazenadas.",
+      "fields": {
+        "store_url": "URL da loja",
+        "consumer_key": "Consumer key",
+        "consumer_secret": "Consumer secret",
+        "shop_domain": "Domínio da loja",
+        "access_token": "Token de acesso"
+      },
+      "placeholders": {
+        "store_url": "https://myshop.com",
+        "consumer_key": "ck_...",
+        "consumer_secret": "cs_...",
+        "shop_domain": "my-shop.myshopify.com",
+        "access_token": "shpat_..."
+      }
+    },
+    "help": {
+      "trigger": "Como obter minhas chaves?",
+      "woocommerce": {
+        "title": "Chaves da API do WooCommerce",
+        "step1": "No painel do WordPress, acesse WooCommerce → Ajustes → Avançado → API REST.",
+        "step2": "Clique em \"Adicionar chave\" e dê uma descrição (ex.: Evo CRM).",
+        "step3": "Em Permissões, escolha \"Leitura\" e gere a chave.",
+        "step4": "Copie a Consumer key (ck_...) e a Consumer secret (cs_...) — a secret só aparece uma vez."
+      },
+      "shopify": {
+        "title": "Token da Admin API do Shopify",
+        "step1": "No admin da Shopify, acesse Configurações → Apps e canais de venda → Desenvolver apps.",
+        "step2": "Crie um app e, em Configuração da Admin API, conceda o escopo read_products.",
+        "step3": "Instale o app na loja.",
+        "step4": "Copie o token de acesso da Admin API (shpat_...) e use o domínio .myshopify.com."
+      }
     }
   },
   "pipelinePanel": {

--- a/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
@@ -259,7 +259,12 @@ describe('ProductsImport connector flow (EVO-1785 Phase 2)', () => {
 
   it('WooCommerce: fetches, normalizes string price, dry-runs and submits', async () => {
     importFetchMock.mockResolvedValueOnce({
-      data: { items: [{ name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical' }] },
+      data: {
+        items: [{
+          name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical',
+          image_urls: ['https://cdn.example.com/w.png'],
+        }],
+      },
       meta: { source: 'woocommerce', count: 1 },
     });
     bulkProductsMock
@@ -291,10 +296,14 @@ describe('ProductsImport connector flow (EVO-1785 Phase 2)', () => {
 
     await screen.findByText('import.preview.runDryRun');
     await user.click(screen.getByText('import.preview.runDryRun'));
-    // String "19.90" must be normalized to the number 19.9 before hitting the bulk API.
+    // String "19.90" must be normalized to the number 19.9 before hitting the bulk API,
+    // and image_urls must pass through to the connector import (EVO-2226).
     await waitFor(() =>
       expect(bulkProductsMock).toHaveBeenCalledWith({
-        products: [{ name: 'Widget', sku: 'W-1', default_price: 19.9, status: 'active', kind: 'physical' }],
+        products: [{
+          name: 'Widget', sku: 'W-1', default_price: 19.9, status: 'active', kind: 'physical',
+          image_urls: ['https://cdn.example.com/w.png'],
+        }],
         dry_run: true,
       }),
     );

--- a/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
@@ -17,9 +17,11 @@ vi.mock('@/contexts/PermissionsContext', () => ({
 }));
 
 const bulkProductsMock = vi.fn();
+const importFetchMock = vi.fn();
 vi.mock('@/services/products/productsService', () => ({
   productsService: {
     bulkProducts: (...args: unknown[]) => bulkProductsMock(...args),
+    importFetch: (...args: unknown[]) => importFetchMock(...args),
   },
 }));
 
@@ -48,6 +50,20 @@ function makeCsvFile(content: string, name = 'p.csv'): File {
   return file;
 }
 
+/** The import now starts on a source-selection step; jump straight to CSV upload. */
+async function gotoCsvUpload() {
+  fireEvent.click(screen.getByTestId('source-csv'));
+  fireEvent.click(screen.getByTestId('source-continue'));
+  await screen.findByTestId('csv-file-input');
+}
+
+/** Recognise our plain axios-shaped rejection objects as axios errors. */
+function stubAxiosErrorDetection() {
+  vi.spyOn(axios, 'isAxiosError').mockImplementation((err: unknown): err is import('axios').AxiosError =>
+    typeof err === 'object' && err !== null && (err as { isAxiosError?: boolean }).isAxiosError === true,
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   canMock.mockReturnValue(true);
@@ -57,20 +73,31 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('ProductsImport (EVO-1734)', () => {
+describe('ProductsImport — source step (EVO-1785)', () => {
   it('shows forbidden state when user lacks products.create', () => {
     canMock.mockReturnValue(false);
     renderPage();
     expect(screen.getByText('import.forbidden')).toBeInTheDocument();
   });
 
-  it('renders upload stage by default with a select-file action', () => {
+  it('renders the source step by default with the three sources', () => {
     renderPage();
-    expect(screen.getByText('import.upload.selectFile')).toBeInTheDocument();
+    expect(screen.getByTestId('source-csv')).toBeInTheDocument();
+    expect(screen.getByTestId('source-woocommerce')).toBeInTheDocument();
+    expect(screen.getByTestId('source-shopify')).toBeInTheDocument();
   });
 
+  it('picking CSV advances to the upload stage', async () => {
+    renderPage();
+    await gotoCsvUpload();
+    expect(screen.getByText('import.upload.selectFile')).toBeInTheDocument();
+  });
+});
+
+describe('ProductsImport CSV flow (EVO-1734)', () => {
   it('rejects CSV with duplicated headers and surfaces them in the toast', async () => {
     renderPage();
+    await gotoCsvUpload();
     const input = screen.getByTestId('csv-file-input') as HTMLInputElement;
     const file = makeCsvFile('name,name\nfoo,bar\n');
     fireEvent.change(input, { target: { files: [file] } });
@@ -84,6 +111,7 @@ describe('ProductsImport (EVO-1734)', () => {
 
   it('happy path — uploads CSV, advances to mapping with auto-mapped headers', async () => {
     renderPage();
+    await gotoCsvUpload();
     const input = screen.getByTestId('csv-file-input') as HTMLInputElement;
     const file = makeCsvFile('name,sku\nFoo,SKU-1\nBar,SKU-2\n');
     fireEvent.change(input, { target: { files: [file] } });
@@ -95,6 +123,7 @@ describe('ProductsImport (EVO-1734)', () => {
 
   it('rejects > 500 rows client-side without firing any POST', async () => {
     renderPage();
+    await gotoCsvUpload();
     const input = screen.getByTestId('csv-file-input') as HTMLInputElement;
     const rows = Array.from({ length: 501 }, (_, i) => `Foo ${i},SKU-${i}`).join('\n');
     const file = makeCsvFile(`name,sku\n${rows}\n`);
@@ -109,6 +138,7 @@ describe('ProductsImport (EVO-1734)', () => {
 
   it('rejects CSV with empty header cells before the duplicate check', async () => {
     renderPage();
+    await gotoCsvUpload();
     const input = screen.getByTestId('csv-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makeCsvFile(',,sku\n1,2,3\n')] } });
     await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
@@ -119,13 +149,11 @@ describe('ProductsImport (EVO-1734)', () => {
 
   it('submit 422 renders per-row server errors and disables Import until next dry-run', async () => {
     bulkProductsMock
-      // dry-run: clean, button enables
       .mockResolvedValueOnce({
         success: true,
         data: { dry_run: true, would_create: [{ index: 0, sku: 'SKU-1', name: 'Foo' }], would_update: [], would_skip: [], errors: [] },
         meta: { created: 1, updated: 0, skipped: 0, errors: 0 },
       })
-      // real submit: race condition surfaces unique-violation
       .mockRejectedValueOnce({
         isAxiosError: true,
         response: {
@@ -139,16 +167,11 @@ describe('ProductsImport (EVO-1734)', () => {
           },
         },
       });
-    // Spy on `axios.isAxiosError` so the recogniser accepts our plain object as
-    // an axios error. Using vi.spyOn (not direct assignment) means
-    // restoreAllMocks() in afterEach puts the real function back — no cross-
-    // test leakage.
-    vi.spyOn(axios, 'isAxiosError').mockImplementation((err: unknown): err is import('axios').AxiosError =>
-      typeof err === 'object' && err !== null && (err as { isAxiosError?: boolean }).isAxiosError === true,
-    );
+    stubAxiosErrorDetection();
 
     const user = userEvent.setup();
     renderPage();
+    await gotoCsvUpload();
     fireEvent.change(screen.getByTestId('csv-file-input') as HTMLInputElement, {
       target: { files: [makeCsvFile('name,sku\nFoo,SKU-1\n')] },
     });
@@ -161,37 +184,6 @@ describe('ProductsImport (EVO-1734)', () => {
     await user.click(screen.getByText('import.preview.import'));
     await waitFor(() => expect(bulkProductsMock).toHaveBeenCalledTimes(2));
 
-    // Server's per-row error must appear in the visible table.
-    await waitFor(() => expect(screen.getByText(/has already been taken/i)).toBeInTheDocument());
-
-    // Submit must be disabled now (conflicts > 0) until user re-runs dry-run.
-    const importBtn = screen.getByText('import.preview.import').closest('button');
-    expect(importBtn).toBeDisabled();
-  });
-
-  it('dry-run with errors[] keeps Submit disabled even when the call resolves successfully', async () => {
-    bulkProductsMock.mockResolvedValueOnce({
-      success: true,
-      data: {
-        dry_run: true,
-        would_create: [],
-        would_update: [],
-        would_skip: [],
-        errors: [{ index: 0, sku: 'SKU-1', errors: { sku: ['has already been taken'] } }],
-      },
-      meta: { created: 0, updated: 0, skipped: 0, errors: 1 },
-    });
-
-    const user = userEvent.setup();
-    renderPage();
-    fireEvent.change(screen.getByTestId('csv-file-input') as HTMLInputElement, {
-      target: { files: [makeCsvFile('name,sku\nFoo,SKU-1\n')] },
-    });
-    await waitFor(() => screen.getByText('import.mapping.next'));
-    await user.click(screen.getByText('import.mapping.next'));
-    await waitFor(() => screen.getByText('import.preview.runDryRun'));
-    await user.click(screen.getByText('import.preview.runDryRun'));
-    await waitFor(() => expect(bulkProductsMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(screen.getByText(/has already been taken/i)).toBeInTheDocument());
 
     const importBtn = screen.getByText('import.preview.import').closest('button');
@@ -214,6 +206,7 @@ describe('ProductsImport (EVO-1734)', () => {
 
     const user = userEvent.setup();
     renderPage();
+    await gotoCsvUpload();
     const input = screen.getByTestId('csv-file-input') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [makeCsvFile('name,sku\nFoo,SKU-1\n')] } });
     await waitFor(() => screen.getByText('import.mapping.next'));
@@ -236,5 +229,113 @@ describe('ProductsImport (EVO-1734)', () => {
     });
     expect(bulkProductsMock).toHaveBeenLastCalledWith({ products: [{ name: 'Foo', sku: 'SKU-1' }] });
     expect(toastSuccessMock).toHaveBeenCalled();
+  });
+});
+
+describe('ProductsImport connector flow (EVO-1785 Phase 2)', () => {
+  async function gotoWooCredentials() {
+    const user = userEvent.setup();
+    renderPage();
+    fireEvent.click(screen.getByTestId('source-woocommerce'));
+    await user.click(screen.getByTestId('source-continue'));
+    await screen.findByTestId('cred-store_url');
+    return user;
+  }
+
+  it('blocks the fetch (no API call) when credentials are blank', async () => {
+    const user = await gotoWooCredentials();
+    await user.click(screen.getByTestId('fetch-products'));
+    expect(importFetchMock).not.toHaveBeenCalled();
+    const args = toastErrorMock.mock.calls.at(-1)?.[0] as string;
+    expect(args).toContain('import.credentials.missing');
+  });
+
+  it('shows the "how to get keys" help dialog', async () => {
+    const user = await gotoWooCredentials();
+    await user.click(screen.getByTestId('help-trigger'));
+    await waitFor(() => expect(screen.getByText('import.help.woocommerce.title')).toBeInTheDocument());
+    expect(screen.getByText('import.help.woocommerce.step1')).toBeInTheDocument();
+  });
+
+  it('WooCommerce: fetches, normalizes string price, dry-runs and submits', async () => {
+    importFetchMock.mockResolvedValueOnce({
+      data: { items: [{ name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical' }] },
+      meta: { source: 'woocommerce', count: 1 },
+    });
+    bulkProductsMock
+      .mockResolvedValueOnce({
+        success: true,
+        data: { dry_run: true, would_create: [{ index: 0, sku: 'W-1', name: 'Widget' }], would_update: [], would_skip: [], errors: [] },
+        meta: { created: 1, updated: 0, skipped: 0, errors: 0 },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: [{ id: '1' }],
+        meta: { created: 1, updated: 0, skipped: 0 },
+        message: 'ok',
+      });
+
+    const user = await gotoWooCredentials();
+    fireEvent.change(screen.getByTestId('cred-store_url'), { target: { value: 'https://shop.example.com' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_key'), { target: { value: 'ck_1' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_secret'), { target: { value: 'cs_1' } });
+    await user.click(screen.getByTestId('fetch-products'));
+
+    await waitFor(() =>
+      expect(importFetchMock).toHaveBeenCalledWith('woocommerce', {
+        store_url: 'https://shop.example.com',
+        consumer_key: 'ck_1',
+        consumer_secret: 'cs_1',
+      }),
+    );
+
+    await screen.findByText('import.preview.runDryRun');
+    await user.click(screen.getByText('import.preview.runDryRun'));
+    // String "19.90" must be normalized to the number 19.9 before hitting the bulk API.
+    await waitFor(() =>
+      expect(bulkProductsMock).toHaveBeenCalledWith({
+        products: [{ name: 'Widget', sku: 'W-1', default_price: 19.9, status: 'active', kind: 'physical' }],
+        dry_run: true,
+      }),
+    );
+
+    await user.click(screen.getByText('import.preview.import'));
+    await waitFor(() => expect(bulkProductsMock).toHaveBeenCalledTimes(2));
+    expect(toastSuccessMock).toHaveBeenCalled();
+  });
+
+  it('surfaces a connector error (422) verbatim in the toast, no preview', async () => {
+    importFetchMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 422, data: { error: { message: 'WooCommerce responded 401' } } },
+    });
+    stubAxiosErrorDetection();
+
+    const user = await gotoWooCredentials();
+    fireEvent.change(screen.getByTestId('cred-store_url'), { target: { value: 'https://shop.example.com' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_key'), { target: { value: 'ck_1' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_secret'), { target: { value: 'cs_1' } });
+    await user.click(screen.getByTestId('fetch-products'));
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
+    const args = toastErrorMock.mock.calls.at(-1)?.[0] as string;
+    expect(args).toContain('import.credentials.fetchFailed');
+    expect(args).toContain('WooCommerce responded 401');
+    // stayed on credentials — dry-run button never rendered
+    expect(screen.queryByText('import.preview.runDryRun')).not.toBeInTheDocument();
+  });
+
+  it('shows a toast when the store returns an empty catalog', async () => {
+    importFetchMock.mockResolvedValueOnce({ data: { items: [] }, meta: { source: 'woocommerce', count: 0 } });
+
+    const user = await gotoWooCredentials();
+    fireEvent.change(screen.getByTestId('cred-store_url'), { target: { value: 'https://shop.example.com' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_key'), { target: { value: 'ck_1' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_secret'), { target: { value: 'cs_1' } });
+    await user.click(screen.getByTestId('fetch-products'));
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
+    const args = toastErrorMock.mock.calls.at(-1)?.[0] as string;
+    expect(args).toContain('import.credentials.noProducts');
   });
 });

--- a/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
@@ -190,6 +190,45 @@ describe('ProductsImport CSV flow (EVO-1734)', () => {
     expect(importBtn).toBeDisabled();
   });
 
+  // The dry-run can report per-row errors while still resolving 200; the Import button
+  // has to stay locked on that path too, not only when the submit itself is rejected.
+  it('dry-run with errors[] keeps Submit disabled even when the call resolves successfully', async () => {
+    bulkProductsMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        dry_run: true,
+        would_create: [],
+        would_update: [],
+        would_skip: [],
+        errors: [{ index: 0, sku: 'SKU-1', errors: { sku: ['has already been taken'] } }],
+      },
+      meta: { created: 0, updated: 0, skipped: 0, errors: 1 },
+    });
+
+    const user = userEvent.setup();
+    renderPage();
+    await gotoCsvUpload();
+    fireEvent.change(screen.getByTestId('csv-file-input') as HTMLInputElement, {
+      target: { files: [makeCsvFile('name,sku\nFoo,SKU-1\n')] },
+    });
+    await waitFor(() => screen.getByText('import.mapping.next'));
+    await user.click(screen.getByText('import.mapping.next'));
+    await waitFor(() => screen.getByText('import.preview.runDryRun'));
+    await user.click(screen.getByText('import.preview.runDryRun'));
+    await waitFor(() => expect(bulkProductsMock).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(screen.getByText(/has already been taken/i)).toBeInTheDocument());
+    expect(screen.getByText('import.preview.import').closest('button')).toBeDisabled();
+  });
+
+  it('goes back to the source step from the upload stage', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await gotoCsvUpload();
+    await user.click(screen.getByTestId('upload-back'));
+    expect(await screen.findByTestId('source-woocommerce')).toBeInTheDocument();
+  });
+
   it('happy dry-run + submit path calls bulkProducts twice with expected payloads', async () => {
     bulkProductsMock
       .mockResolvedValueOnce({
@@ -248,6 +287,75 @@ describe('ProductsImport connector flow (EVO-1785 Phase 2)', () => {
     expect(importFetchMock).not.toHaveBeenCalled();
     const args = toastErrorMock.mock.calls.at(-1)?.[0] as string;
     expect(args).toContain('import.credentials.missing');
+  });
+
+  // A store bigger than one fetch, or with multi-variant products, must not look like a
+  // complete import: the preview says what was left behind.
+  it('warns on the preview when the fetch was truncated or dropped variants', async () => {
+    importFetchMock.mockResolvedValueOnce({
+      data: { items: [{ name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical' }] },
+      meta: { source: 'woocommerce', count: 1, truncated: true, variants_dropped: 3 },
+    });
+
+    const user = await gotoWooCredentials();
+    fireEvent.change(screen.getByTestId('cred-store_url'), { target: { value: 'https://shop.example.com' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_key'), { target: { value: 'ck_1' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_secret'), { target: { value: 'cs_1' } });
+    await user.click(screen.getByTestId('fetch-products'));
+
+    // The i18n stub appends the interpolation payload, so match on the key prefix.
+    await screen.findByTestId('fetch-warning');
+    expect(screen.getByText(/^import\.preview\.truncated\b/)).toBeInTheDocument();
+    expect(screen.getByText(/^import\.preview\.variantsDropped\b/)).toBeInTheDocument();
+  });
+
+  it('shows no warning when the whole catalog came back', async () => {
+    importFetchMock.mockResolvedValueOnce({
+      data: { items: [{ name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical' }] },
+      meta: { source: 'woocommerce', count: 1, truncated: false, variants_dropped: 0 },
+    });
+
+    const user = await gotoWooCredentials();
+    fireEvent.change(screen.getByTestId('cred-store_url'), { target: { value: 'https://shop.example.com' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_key'), { target: { value: 'ck_1' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_secret'), { target: { value: 'cs_1' } });
+    await user.click(screen.getByTestId('fetch-products'));
+
+    await screen.findByText('import.preview.runDryRun');
+    expect(screen.queryByTestId('fetch-warning')).not.toBeInTheDocument();
+  });
+
+  // Connector items skip the CSV client-side validation, so the dry-run gate is the only
+  // thing standing between a bad remote catalog and the import.
+  it('keeps Import disabled when the dry-run reports conflicts on fetched items', async () => {
+    importFetchMock.mockResolvedValueOnce({
+      data: { items: [{ name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical' }] },
+      meta: { source: 'woocommerce', count: 1 },
+    });
+    bulkProductsMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        dry_run: true,
+        would_create: [],
+        would_update: [],
+        would_skip: [],
+        errors: [{ index: 0, sku: 'W-1', errors: { sku: ['has already been taken'] } }],
+      },
+      meta: { created: 0, updated: 0, skipped: 0, errors: 1 },
+    });
+
+    const user = await gotoWooCredentials();
+    fireEvent.change(screen.getByTestId('cred-store_url'), { target: { value: 'https://shop.example.com' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_key'), { target: { value: 'ck_1' } });
+    fireEvent.change(screen.getByTestId('cred-consumer_secret'), { target: { value: 'cs_1' } });
+    await user.click(screen.getByTestId('fetch-products'));
+
+    await screen.findByText('import.preview.runDryRun');
+    await user.click(screen.getByText('import.preview.runDryRun'));
+    await waitFor(() => expect(bulkProductsMock).toHaveBeenCalledTimes(1));
+
+    await waitFor(() => expect(screen.getByText(/has already been taken/i)).toBeInTheDocument());
+    expect(screen.getByText('import.preview.import').closest('button')).toBeDisabled();
   });
 
   it('shows the "how to get keys" help dialog', async () => {

--- a/src/pages/Customer/Settings/Products/ProductsImport.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.tsx
@@ -103,6 +103,9 @@ function toBulkItem(raw: FetchedProductItem): BulkItem {
     status: raw.status,
     stock_quantity: raw.stock_quantity ?? undefined,
     labels: raw.labels,
+    // EVO-2226: pass the connector's image URLs through to /products/bulk, which
+    // downloads + attaches them server-side.
+    image_urls: raw.image_urls,
   };
 }
 

--- a/src/pages/Customer/Settings/Products/ProductsImport.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.tsx
@@ -83,11 +83,7 @@ const HELP_STEPS: Record<ProductImportSource, string[]> = {
   shopify: ['step1', 'step2', 'step3', 'step4'],
 };
 
-/**
- * A connector item arrives already mapped, but numeric fields come as the
- * store's raw strings — normalize them into the BulkItem shape the shared
- * preview/dry-run path expects.
- */
+/** A connector item arrives mapped, but numeric fields come as the store's raw strings. */
 function toBulkItem(raw: FetchedProductItem): BulkItem {
   const price = raw.default_price;
   const parsedPrice = price === undefined || price === null || price === '' ? undefined : Number(price);
@@ -103,8 +99,7 @@ function toBulkItem(raw: FetchedProductItem): BulkItem {
     status: raw.status,
     stock_quantity: raw.stock_quantity ?? undefined,
     labels: raw.labels,
-    // EVO-2226: pass the connector's image URLs through to /products/bulk, which
-    // downloads + attaches them server-side.
+    // /products/bulk downloads + attaches these server-side (EVO-2226).
     image_urls: raw.image_urls,
   };
 }
@@ -196,8 +191,7 @@ export default function ProductsImport() {
       }));
       setValidations(fetched);
       setFetchCount(fetched.length);
-      // What the fetch could not bring back. Surfaced on the preview so a big or
-      // multi-variant catalog does not look like a complete import.
+      // Shown on the preview so a partial fetch does not read as a complete import.
       setFetchTruncated(res.meta?.truncated === true);
       setVariantsDropped(res.meta?.variants_dropped ?? 0);
       setDryRun(null);
@@ -745,10 +739,8 @@ type ApiErrorOutcome =
   | { kind: 'other' };
 
 /**
- * Surfaces a connector fetch failure (`POST /products/import_fetch`). The
- * backend relays the store's own message verbatim in a 422 (bad credentials,
- * unsupported source, SSRF-refused host, empty catalog), so we show it as-is
- * rather than flattening every failure into a generic toast.
+ * The backend relays the store's own message verbatim in a 422, so it is shown as-is
+ * rather than flattened into a generic toast.
  */
 function handleFetchError(
   error: unknown,

--- a/src/pages/Customer/Settings/Products/ProductsImport.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.tsx
@@ -120,6 +120,8 @@ export default function ProductsImport() {
   const [credentials, setCredentials] = useState<ProductImportCredentials>({});
   const [fetchLoading, setFetchLoading] = useState(false);
   const [fetchCount, setFetchCount] = useState(0);
+  const [fetchTruncated, setFetchTruncated] = useState(false);
+  const [variantsDropped, setVariantsDropped] = useState(0);
 
   const [fileName, setFileName] = useState<string>('');
   const [headers, setHeaders] = useState<string[]>([]);
@@ -194,6 +196,10 @@ export default function ProductsImport() {
       }));
       setValidations(fetched);
       setFetchCount(fetched.length);
+      // What the fetch could not bring back. Surfaced on the preview so a big or
+      // multi-variant catalog does not look like a complete import.
+      setFetchTruncated(res.meta?.truncated === true);
+      setVariantsDropped(res.meta?.variants_dropped ?? 0);
       setDryRun(null);
       setStage('preview');
     } catch (error) {
@@ -333,6 +339,8 @@ export default function ProductsImport() {
     setSource('');
     setCredentials({});
     setFetchCount(0);
+    setFetchTruncated(false);
+    setVariantsDropped(0);
     setHeaders([]);
     setRows([]);
     setMapping({});
@@ -456,6 +464,11 @@ export default function ProductsImport() {
               {t('import.upload.selectFile')}
             </Button>
           </div>
+          <div className="mt-4">
+            <Button variant="outline" onClick={() => setStage('source')} data-testid="upload-back">
+              {t('import.upload.backToSource')}
+            </Button>
+          </div>
         </TabsContent>
 
         <TabsContent value="mapping">
@@ -529,6 +542,20 @@ export default function ProductsImport() {
             <p className="mb-3 text-sm text-muted-foreground">
               {t('import.preview.fetched', { count: fetchCount, source: t(`import.source.${source}.title`) })}
             </p>
+          )}
+          {isConnector && (fetchTruncated || variantsDropped > 0) && (
+            <div
+              className="mb-4 flex gap-2 rounded border border-amber-500/40 bg-amber-500/5 p-3 text-sm"
+              data-testid="fetch-warning"
+            >
+              <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600" />
+              <div className="space-y-1">
+                {fetchTruncated && <p>{t('import.preview.truncated', { count: fetchCount })}</p>}
+                {variantsDropped > 0 && (
+                  <p>{t('import.preview.variantsDropped', { count: variantsDropped })}</p>
+                )}
+              </div>
+            </div>
           )}
           <div className="grid grid-cols-3 gap-3 mb-4">
             <SummaryCard

--- a/src/pages/Customer/Settings/Products/ProductsImport.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.tsx
@@ -4,6 +4,15 @@ import { toast } from 'sonner';
 import axios from 'axios';
 import {
   Button,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -14,7 +23,18 @@ import {
   TabsTrigger,
   TabsContent,
 } from '@evoapi/design-system';
-import { ArrowLeft, FileUp, Loader2, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  FileUp,
+  FileSpreadsheet,
+  ShoppingCart,
+  Store,
+  KeyRound,
+  HelpCircle,
+  Loader2,
+  AlertTriangle,
+  CheckCircle2,
+} from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { productsService } from '@/services/products/productsService';
@@ -28,11 +48,19 @@ import {
   unmappedRequiredFields,
   validateAll,
   type BulkField,
+  type BulkItem,
   type RowValidation,
 } from '@/utils/products/bulkImport';
-import type { ProductBulkServerError } from '@/types/products';
+import type {
+  ProductBulkServerError,
+  ProductImportCredentials,
+  ProductImportSource,
+  FetchedProductItem,
+} from '@/types/products';
 
-type Stage = 'upload' | 'mapping' | 'preview' | 'done';
+/** '' is the connector source; 'csv' keeps the original local-file flow. */
+type Source = 'csv' | ProductImportSource | '';
+type Stage = 'source' | 'credentials' | 'upload' | 'mapping' | 'preview' | 'done';
 
 interface DryRunState {
   conflicts: ProductBulkServerError[];
@@ -44,13 +72,52 @@ interface DryRunState {
   ran: boolean;
 }
 
+/** Credential fields required per connector, in display order. */
+const CREDENTIAL_FIELDS: Record<ProductImportSource, Array<keyof ProductImportCredentials>> = {
+  woocommerce: ['store_url', 'consumer_key', 'consumer_secret'],
+  shopify: ['shop_domain', 'access_token'],
+};
+
+const HELP_STEPS: Record<ProductImportSource, string[]> = {
+  woocommerce: ['step1', 'step2', 'step3', 'step4'],
+  shopify: ['step1', 'step2', 'step3', 'step4'],
+};
+
+/**
+ * A connector item arrives already mapped, but numeric fields come as the
+ * store's raw strings — normalize them into the BulkItem shape the shared
+ * preview/dry-run path expects.
+ */
+function toBulkItem(raw: FetchedProductItem): BulkItem {
+  const price = raw.default_price;
+  const parsedPrice = price === undefined || price === null || price === '' ? undefined : Number(price);
+  return {
+    name: raw.name,
+    kind: raw.kind,
+    slug: raw.slug,
+    description: raw.description || undefined,
+    sku: raw.sku || undefined,
+    default_price: parsedPrice !== undefined && Number.isFinite(parsedPrice) ? parsedPrice : undefined,
+    currency: raw.currency,
+    purchase_url: raw.purchase_url || undefined,
+    status: raw.status,
+    stock_quantity: raw.stock_quantity ?? undefined,
+    labels: raw.labels,
+  };
+}
+
 export default function ProductsImport() {
   const { t } = useLanguage('products');
   const { can } = usePermissions();
   const navigate = useNavigate();
   const canCreate = can('products', 'create');
 
-  const [stage, setStage] = useState<Stage>('upload');
+  const [stage, setStage] = useState<Stage>('source');
+  const [source, setSource] = useState<Source>('');
+  const [credentials, setCredentials] = useState<ProductImportCredentials>({});
+  const [fetchLoading, setFetchLoading] = useState(false);
+  const [fetchCount, setFetchCount] = useState(0);
+
   const [fileName, setFileName] = useState<string>('');
   const [headers, setHeaders] = useState<string[]>([]);
   const [rows, setRows] = useState<string[][]>([]);
@@ -61,6 +128,8 @@ export default function ProductsImport() {
   const [dryRunLoading, setDryRunLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const isConnector = source === 'woocommerce' || source === 'shopify';
 
   const requiredMissing = useMemo(() => unmappedRequiredFields(mapping), [mapping]);
   const clientInvalidCount = useMemo(
@@ -84,6 +153,52 @@ export default function ProductsImport() {
     );
     return [...fromClient, ...(dryRun?.conflicts ?? [])];
   }, [validations, dryRun]);
+
+  /* ---------------- source ---------------- */
+
+  const proceedFromSource = useCallback(() => {
+    if (source === 'csv') {
+      setStage('upload');
+    } else if (source === 'woocommerce' || source === 'shopify') {
+      setCredentials({});
+      setStage('credentials');
+    }
+  }, [source]);
+
+  /* ---------------- connector fetch ---------------- */
+
+  const runFetch = useCallback(async () => {
+    if (source !== 'woocommerce' && source !== 'shopify') return;
+    const required = CREDENTIAL_FIELDS[source];
+    const missing = required.filter((k) => !credentials[k]?.trim());
+    if (missing.length > 0) {
+      toast.error(t('import.credentials.missing'));
+      return;
+    }
+    setFetchLoading(true);
+    try {
+      const res = await productsService.importFetch(source, credentials);
+      const items = res.data?.items ?? [];
+      if (items.length === 0) {
+        toast.error(t('import.credentials.noProducts'));
+        return;
+      }
+      const fetched: RowValidation[] = items.map((raw, index) => ({
+        index,
+        csvLine: index + 1,
+        item: toBulkItem(raw),
+        errors: [],
+      }));
+      setValidations(fetched);
+      setFetchCount(fetched.length);
+      setDryRun(null);
+      setStage('preview');
+    } catch (error) {
+      handleFetchError(error, t);
+    } finally {
+      setFetchLoading(false);
+    }
+  }, [source, credentials, t]);
 
   /* ---------------- upload ---------------- */
 
@@ -210,6 +325,19 @@ export default function ProductsImport() {
     }
   }, [validations, t]);
 
+  const resetAll = useCallback(() => {
+    setStage('source');
+    setSource('');
+    setCredentials({});
+    setFetchCount(0);
+    setHeaders([]);
+    setRows([]);
+    setMapping({});
+    setValidations([]);
+    setDryRun(null);
+    setFileName('');
+  }, []);
+
   /* ---------------- render ---------------- */
 
   if (!canCreate) {
@@ -237,11 +365,77 @@ export default function ProductsImport() {
 
       <Tabs value={stage}>
         <TabsList>
-          <TabsTrigger value="upload" disabled>{t('import.tabs.upload')}</TabsTrigger>
-          <TabsTrigger value="mapping" disabled>{t('import.tabs.mapping')}</TabsTrigger>
+          <TabsTrigger value="source" disabled>{t('import.tabs.source')}</TabsTrigger>
+          {isConnector && <TabsTrigger value="credentials" disabled>{t('import.tabs.credentials')}</TabsTrigger>}
+          {source === 'csv' && <TabsTrigger value="upload" disabled>{t('import.tabs.upload')}</TabsTrigger>}
+          {source === 'csv' && <TabsTrigger value="mapping" disabled>{t('import.tabs.mapping')}</TabsTrigger>}
           <TabsTrigger value="preview" disabled>{t('import.tabs.preview')}</TabsTrigger>
           <TabsTrigger value="done" disabled>{t('import.tabs.done')}</TabsTrigger>
         </TabsList>
+
+        {/* ---------------- source ---------------- */}
+        <TabsContent value="source">
+          <RadioGroup
+            value={source}
+            onValueChange={(v) => setSource(v as Source)}
+            className="grid gap-3 sm:grid-cols-3"
+          >
+            <SourceCard value="csv" icon={<FileSpreadsheet className="h-6 w-6" />} selected={source === 'csv'}
+              onSelect={() => setSource('csv')}
+              title={t('import.source.csv.title')} desc={t('import.source.csv.desc')} />
+            <SourceCard value="woocommerce" icon={<ShoppingCart className="h-6 w-6" />} selected={source === 'woocommerce'}
+              onSelect={() => setSource('woocommerce')}
+              title={t('import.source.woocommerce.title')} desc={t('import.source.woocommerce.desc')} />
+            <SourceCard value="shopify" icon={<Store className="h-6 w-6" />} selected={source === 'shopify'}
+              onSelect={() => setSource('shopify')}
+              title={t('import.source.shopify.title')} desc={t('import.source.shopify.desc')} />
+          </RadioGroup>
+          <div className="mt-4 flex justify-end">
+            <Button onClick={proceedFromSource} disabled={source === ''} data-testid="source-continue">
+              {t('import.source.continue')}
+            </Button>
+          </div>
+        </TabsContent>
+
+        {/* ---------------- credentials ---------------- */}
+        {isConnector && (
+          <TabsContent value="credentials">
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                {t(`import.source.${source}.title`)}
+              </p>
+              <CredentialsHelp source={source} t={t} />
+            </div>
+            <div className="max-w-xl space-y-4">
+              {CREDENTIAL_FIELDS[source].map((field) => (
+                <div key={field}>
+                  <label htmlFor={`cred-${field}`} className="mb-1 block text-sm font-medium">
+                    {t(`import.credentials.fields.${field}`)}
+                  </label>
+                  <Input
+                    id={`cred-${field}`}
+                    data-testid={`cred-${field}`}
+                    type={field === 'consumer_secret' || field === 'access_token' ? 'password' : 'text'}
+                    autoComplete="off"
+                    placeholder={t(`import.credentials.placeholders.${field}`)}
+                    value={credentials[field] ?? ''}
+                    onChange={(e) => setCredentials((c) => ({ ...c, [field]: e.target.value }))}
+                  />
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">{t('import.credentials.oneTimeNote')}</p>
+            </div>
+            <div className="mt-4 flex justify-between gap-2">
+              <Button variant="outline" onClick={() => setStage('source')}>
+                {t('import.credentials.back')}
+              </Button>
+              <Button onClick={runFetch} disabled={fetchLoading} data-testid="fetch-products">
+                {fetchLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                {t('import.credentials.fetch')}
+              </Button>
+            </div>
+          </TabsContent>
+        )}
 
         <TabsContent value="upload">
           <div className="border border-dashed rounded-lg p-10 text-center">
@@ -328,6 +522,11 @@ export default function ProductsImport() {
         </TabsContent>
 
         <TabsContent value="preview">
+          {isConnector && (
+            <p className="mb-3 text-sm text-muted-foreground">
+              {t('import.preview.fetched', { count: fetchCount, source: t(`import.source.${source}.title`) })}
+            </p>
+          )}
           <div className="grid grid-cols-3 gap-3 mb-4">
             <SummaryCard
               tone={clientInvalidCount === 0 ? 'ok' : 'error'}
@@ -355,8 +554,8 @@ export default function ProductsImport() {
               {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
               {t('import.preview.import')}
             </Button>
-            <Button variant="outline" onClick={() => setStage('mapping')}>
-              {t('import.preview.backToMapping')}
+            <Button variant="outline" onClick={() => setStage(source === 'csv' ? 'mapping' : 'credentials')}>
+              {source === 'csv' ? t('import.preview.backToMapping') : t('import.preview.backToCredentials')}
             </Button>
           </div>
 
@@ -380,7 +579,8 @@ export default function ProductsImport() {
                     return (
                       <tr key={`${err.index}-${err.sku ?? ''}`} className="border-t align-top">
                         <td className="p-2 font-mono whitespace-nowrap">
-                          #{err.index + 1} (CSV {csvLine})
+                          #{err.index + 1}
+                          {source === 'csv' ? ` (CSV ${csvLine})` : ''}
                         </td>
                         <td className="p-2 font-mono">{err.sku ?? '—'}</td>
                         <td className="p-2">
@@ -413,19 +613,7 @@ export default function ProductsImport() {
               <Button variant="outline" onClick={() => navigate('/products')}>
                 {t('import.done.backToList')}
               </Button>
-              <Button
-                onClick={() => {
-                  setStage('upload');
-                  setHeaders([]);
-                  setRows([]);
-                  setMapping({});
-                  setValidations([]);
-                  setDryRun(null);
-                  setFileName('');
-                }}
-              >
-                {t('import.done.importAnother')}
-              </Button>
+              <Button onClick={resetAll}>{t('import.done.importAnother')}</Button>
             </div>
           </div>
         </TabsContent>
@@ -439,6 +627,73 @@ export default function ProductsImport() {
 // `metadata` is intentionally absent from BULK_FIELDS / auto-map: CSV is a
 // hostile format for nested JSON. Expose a JSON column only if a real user
 // asks for it.
+
+function SourceCard({
+  value,
+  icon,
+  title,
+  desc,
+  selected,
+  onSelect,
+}: {
+  value: string;
+  icon: React.ReactNode;
+  title: string;
+  desc: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <label
+      htmlFor={`source-${value}`}
+      data-testid={`source-${value}`}
+      onClick={onSelect}
+      className={`flex cursor-pointer flex-col gap-2 rounded-lg border p-4 transition-colors ${
+        selected ? 'border-primary bg-primary/5' : 'hover:border-muted-foreground/40'
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground">{icon}</span>
+        <RadioGroupItem value={value} id={`source-${value}`} />
+      </div>
+      <div className="font-medium">{title}</div>
+      <div className="text-xs text-muted-foreground">{desc}</div>
+    </label>
+  );
+}
+
+function CredentialsHelp({
+  source,
+  t,
+}: {
+  source: ProductImportSource;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="link" size="sm" className="h-auto p-0" data-testid="help-trigger">
+          <HelpCircle className="h-4 w-4 mr-1" />
+          {t('import.help.trigger')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <KeyRound className="h-4 w-4" />
+            {t(`import.help.${source}.title`)}
+          </DialogTitle>
+          <DialogDescription className="sr-only">{t('import.help.trigger')}</DialogDescription>
+        </DialogHeader>
+        <ol className="list-decimal space-y-2 pl-5 text-sm">
+          {HELP_STEPS[source].map((step) => (
+            <li key={step}>{t(`import.help.${source}.${step}`)}</li>
+          ))}
+        </ol>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 function SummaryCard({ tone, label, value }: { tone: 'ok' | 'warn' | 'error'; label: string; value: number | string }) {
   const palette =
@@ -458,6 +713,34 @@ function SummaryCard({ tone, label, value }: { tone: 'ok' | 'warn' | 'error'; la
 type ApiErrorOutcome =
   | { kind: 'validation'; details: ProductBulkServerError[] }
   | { kind: 'other' };
+
+/**
+ * Surfaces a connector fetch failure (`POST /products/import_fetch`). The
+ * backend relays the store's own message verbatim in a 422 (bad credentials,
+ * unsupported source, SSRF-refused host, empty catalog), so we show it as-is
+ * rather than flattening every failure into a generic toast.
+ */
+function handleFetchError(
+  error: unknown,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): void {
+  if (!axios.isAxiosError(error)) {
+    toast.error(t('import.errors.network'));
+    return;
+  }
+  const status = error.response?.status;
+  if (status === 403) {
+    toast.error(t('import.errors.forbidden'));
+    return;
+  }
+  if (status === 401) {
+    toast.error(t('import.errors.unauthorized'));
+    return;
+  }
+  const body = error.response?.data as { error?: { message?: string }; message?: string } | undefined;
+  const message = body?.error?.message ?? body?.message;
+  toast.error(message ? t('import.credentials.fetchFailed', { message }) : t('import.errors.network'));
+}
 
 /**
  * Maps the bulk endpoint error shape (defined in

--- a/src/services/products/productsService.ts
+++ b/src/services/products/productsService.ts
@@ -1,5 +1,6 @@
 import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
+import { appendField } from '@/utils/products/formData';
 import {
   Product,
   ProductFormData,
@@ -181,22 +182,7 @@ class ProductsService {
 
   private buildFormData(payload: Partial<ProductFormData>, files: File[]): FormData {
     const formData = new FormData();
-    Object.entries(payload).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      if (key === 'variants_attributes' && Array.isArray(value)) {
-        formData.append(`product[${key}]`, JSON.stringify(value));
-        return;
-      }
-      if (key === 'labels' && Array.isArray(value)) {
-        value.forEach((label) => formData.append('product[labels][]', String(label)));
-        return;
-      }
-      if (key === 'metadata' && typeof value === 'object') {
-        formData.append('product[metadata]', JSON.stringify(value));
-        return;
-      }
-      formData.append(`product[${key}]`, String(value));
-    });
+    Object.entries(payload).forEach(([key, value]) => appendField(formData, `product[${key}]`, value));
 
     files.forEach((file) => {
       formData.append('product[images][]', file, file.name);

--- a/src/services/products/productsService.ts
+++ b/src/services/products/productsService.ts
@@ -84,11 +84,9 @@ class ProductsService {
   }
 
   /**
-   * Fetch a remote store's catalog through a connector (EVO-1785 Phase 2).
-   * The backend authenticates with the user-supplied credentials, pulls the
-   * products and returns them already mapped into the bulk-import item shape —
-   * the client then runs them through the same dry-run + `bulkProducts` path the
-   * CSV import uses. Credentials are one-time (never persisted).
+   * Fetches a remote store's catalog, already mapped into the bulk-import item shape:
+   * the caller runs it through the same dry-run + `bulkProducts` path the CSV import
+   * uses. Credentials are one-time.
    */
   async importFetch(
     source: ProductImportSource,

--- a/src/services/products/productsService.ts
+++ b/src/services/products/productsService.ts
@@ -14,6 +14,9 @@ import {
   ProductBulkPayload,
   ProductBulkRealResponse,
   ProductBulkDryRunResponse,
+  ProductImportSource,
+  ProductImportCredentials,
+  ProductImportFetchResponse,
 } from '@/types/products';
 
 class ProductsService {
@@ -77,6 +80,21 @@ class ProductsService {
       params: dry_run ? { dry_run: true } : undefined,
     });
     return response.data;
+  }
+
+  /**
+   * Fetch a remote store's catalog through a connector (EVO-1785 Phase 2).
+   * The backend authenticates with the user-supplied credentials, pulls the
+   * products and returns them already mapped into the bulk-import item shape —
+   * the client then runs them through the same dry-run + `bulkProducts` path the
+   * CSV import uses. Credentials are one-time (never persisted).
+   */
+  async importFetch(
+    source: ProductImportSource,
+    credentials: ProductImportCredentials,
+  ): Promise<ProductImportFetchResponse> {
+    const response = await api.post(`${this.baseUrl}/import_fetch`, { source, credentials });
+    return response.data as ProductImportFetchResponse;
   }
 
   async deleteProduct(id: string): Promise<ProductDeleteResponse> {

--- a/src/types/products/product.ts
+++ b/src/types/products/product.ts
@@ -103,6 +103,8 @@ export interface ProductBulkItem {
   stock_quantity?: number;
   labels?: string[];
   metadata?: Record<string, unknown>;
+  /** EVO-2226: remote image URLs; downloaded + attached server-side on import. */
+  image_urls?: string[];
 }
 
 export interface ProductBulkPayload {
@@ -164,6 +166,7 @@ export interface FetchedProductItem {
   status?: ProductStatus;
   stock_quantity?: number;
   labels?: string[];
+  image_urls?: string[];
 }
 
 export interface ProductImportFetchResponse {

--- a/src/types/products/product.ts
+++ b/src/types/products/product.ts
@@ -171,7 +171,14 @@ export interface FetchedProductItem {
 
 export interface ProductImportFetchResponse {
   data: { items: FetchedProductItem[] };
-  meta: { source: string; count: number };
+  meta: {
+    source: string;
+    count: number;
+    /** The walk stopped on a budget (row cap, page cap, deadline) — the store holds more. */
+    truncated?: boolean;
+    /** Variants the fetch could not carry: /products/bulk creates one row per product. */
+    variants_dropped?: number;
+  };
 }
 
 export interface ProductsResponse extends PaginatedResponse<Product> {}

--- a/src/types/products/product.ts
+++ b/src/types/products/product.ts
@@ -150,9 +150,8 @@ export interface ProductImportCredentials {
 }
 
 /**
- * An item as returned by the connector (`POST /products/import_fetch`): the same
- * shape as ProductBulkItem, but numeric fields may arrive as strings (the store's
- * raw JSON). The client normalizes them before feeding the shared bulk preview.
+ * As returned by `POST /products/import_fetch`: ProductBulkItem's shape, except numeric
+ * fields may arrive as strings (the store's raw JSON).
  */
 export interface FetchedProductItem {
   name: string;
@@ -174,7 +173,7 @@ export interface ProductImportFetchResponse {
   meta: {
     source: string;
     count: number;
-    /** The walk stopped on a budget (row cap, page cap, deadline) — the store holds more. */
+    /** The walk stopped on a budget, so the store holds more than came back. */
     truncated?: boolean;
     /** Variants the fetch could not carry: /products/bulk creates one row per product. */
     variants_dropped?: number;

--- a/src/types/products/product.ts
+++ b/src/types/products/product.ts
@@ -135,6 +135,42 @@ export interface ProductBulkDryRunResponse {
   meta: { created: number; updated: number; skipped: number; errors: number };
 }
 
+/* ---------- Remote import (EVO-1785 Phase 2 — Shopify / WooCommerce) ---------- */
+
+export type ProductImportSource = 'woocommerce' | 'shopify';
+
+export interface ProductImportCredentials {
+  store_url?: string;
+  consumer_key?: string;
+  consumer_secret?: string;
+  shop_domain?: string;
+  access_token?: string;
+}
+
+/**
+ * An item as returned by the connector (`POST /products/import_fetch`): the same
+ * shape as ProductBulkItem, but numeric fields may arrive as strings (the store's
+ * raw JSON). The client normalizes them before feeding the shared bulk preview.
+ */
+export interface FetchedProductItem {
+  name: string;
+  kind?: ProductKind;
+  slug?: string;
+  description?: string;
+  sku?: string;
+  default_price?: string | number;
+  currency?: ProductCurrency;
+  purchase_url?: string;
+  status?: ProductStatus;
+  stock_quantity?: number;
+  labels?: string[];
+}
+
+export interface ProductImportFetchResponse {
+  data: { items: FetchedProductItem[] };
+  meta: { source: string; count: number };
+}
+
 export interface ProductsResponse extends PaginatedResponse<Product> {}
 export interface ProductResponse extends StandardResponse<Product> {}
 export interface ProductDeleteResponse extends StandardResponse<{ id: string }> {}

--- a/src/utils/assetUrl.spec.ts
+++ b/src/utils/assetUrl.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { assetUrl } from './assetUrl';
+
+describe('assetUrl', () => {
+  it('prefixes a relative API path with the API origin (split-origin dev fix)', () => {
+    const out = assetUrl('/rails/active_storage/blobs/proxy/abc/photo.jpg');
+    expect(out).toMatch(/^https?:\/\//);
+    expect(out.endsWith('/rails/active_storage/blobs/proxy/abc/photo.jpg')).toBe(true);
+  });
+
+  it('leaves absolute http(s) URLs untouched', () => {
+    expect(assetUrl('https://cdn.example.com/a.jpg')).toBe('https://cdn.example.com/a.jpg');
+    expect(assetUrl('http://x/y.png')).toBe('http://x/y.png');
+    expect(assetUrl('//cdn/a.jpg')).toBe('//cdn/a.jpg');
+  });
+
+  it('leaves blob: and data: URLs untouched', () => {
+    expect(assetUrl('blob:http://localhost/xyz')).toBe('blob:http://localhost/xyz');
+    expect(assetUrl('data:image/png;base64,AAAA')).toBe('data:image/png;base64,AAAA');
+  });
+
+  it('returns empty string for empty/nullish input', () => {
+    expect(assetUrl('')).toBe('');
+    expect(assetUrl(null)).toBe('');
+    expect(assetUrl(undefined)).toBe('');
+    expect(assetUrl('   ')).toBe('');
+  });
+
+  it('joins a path with no leading slash', () => {
+    expect(assetUrl('rails/x.jpg')).toMatch(/\/rails\/x\.jpg$/);
+  });
+});

--- a/src/utils/assetUrl.ts
+++ b/src/utils/assetUrl.ts
@@ -1,0 +1,23 @@
+const rawApiBaseURL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+// Strip a trailing /api/vN and any trailing slash to get the bare API origin.
+const apiOrigin = rawApiBaseURL.replace(/\/api\/v\d+$/i, '').replace(/\/$/, '');
+
+/**
+ * Resolves a backend asset URL against the API origin.
+ *
+ * The API serialises blob URLs as relative paths (only_path: true), and an
+ * `<img src>` resolves those against the SPA's own origin — the wrong server in a
+ * split-origin setup, which answers with the SPA shell instead of the image.
+ * Absolute, blob: and data: URLs pass through untouched.
+ */
+export const assetUrl = (url?: string | null): string => {
+  if (!url) return '';
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+
+  if (trimmed.startsWith('http') || trimmed.startsWith('//')) return trimmed;
+  if (trimmed.startsWith('blob:') || trimmed.startsWith('data:')) return trimmed;
+
+  return trimmed.startsWith('/') ? `${apiOrigin}${trimmed}` : `${apiOrigin}/${trimmed}`;
+};

--- a/src/utils/assetUrl.ts
+++ b/src/utils/assetUrl.ts
@@ -4,12 +4,9 @@ const rawApiBaseURL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 const apiOrigin = rawApiBaseURL.replace(/\/api\/v\d+$/i, '').replace(/\/$/, '');
 
 /**
- * Resolves a backend asset URL against the API origin.
- *
- * The API serialises blob URLs as relative paths (only_path: true), and an
- * `<img src>` resolves those against the SPA's own origin — the wrong server in a
- * split-origin setup, which answers with the SPA shell instead of the image.
- * Absolute, blob: and data: URLs pass through untouched.
+ * Resolves a backend asset URL against the API origin. The API serialises blob URLs as
+ * relative paths, and `<img src>` would resolve those against the SPA's own origin —
+ * the wrong server in a split-origin setup. Absolute, blob: and data: pass through.
  */
 export const assetUrl = (url?: string | null): string => {
   if (!url) return '';

--- a/src/utils/products/bulkImport.ts
+++ b/src/utils/products/bulkImport.ts
@@ -46,6 +46,8 @@ export interface BulkItem {
   status?: ProductStatus;
   stock_quantity?: number;
   labels?: string[];
+  /** EVO-2226: remote image URLs carried from the connector to /products/bulk. */
+  image_urls?: string[];
 }
 
 export interface FieldError {

--- a/src/utils/products/formData.spec.ts
+++ b/src/utils/products/formData.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { appendField } from './formData';
+
+const build = (value: unknown, key = 'product[field]'): FormData => {
+  const formData = new FormData();
+  appendField(formData, key, value);
+  return formData;
+};
+
+const entries = (formData: FormData): [string, string][] =>
+  Array.from(formData.entries()).map(([k, v]) => [k, String(v)]);
+
+describe('appendField', () => {
+  it('writes a scalar as-is', () => {
+    expect(entries(build('Widget'))).toEqual([['product[field]', 'Widget']]);
+    expect(entries(build(19.9))).toEqual([['product[field]', '19.9']]);
+    expect(entries(build(false))).toEqual([['product[field]', 'false']]);
+  });
+
+  it('sends null as an empty string so the API nulls the column', () => {
+    expect(entries(build(null))).toEqual([['product[field]', '']]);
+  });
+
+  it('skips undefined entirely', () => {
+    expect(entries(build(undefined))).toEqual([]);
+  });
+
+  it('expands a string array into repeated [] keys', () => {
+    expect(entries(build(['promo', 'novo'], 'product[labels]'))).toEqual([
+      ['product[labels][]', 'promo'],
+      ['product[labels][]', 'novo'],
+    ]);
+  });
+
+  // Clearing the last label has to be expressible: an omitted key means
+  // "unchanged" to the API, not "empty".
+  it('sends an empty array as a single blank element', () => {
+    expect(entries(build([], 'product[labels]'))).toEqual([['product[labels][]', '']]);
+  });
+
+  // EVO-2226: serialising nested attributes as a JSON string made strong
+  // parameters drop the whole branch, so variant edits silently vanished on any
+  // submit that carried an image.
+  it('expands an array of objects into indexed Rails keys', () => {
+    const value = [
+      { id: 'v1', name: 'M', position: 0 },
+      { name: 'G', position: 1, _destroy: true },
+    ];
+
+    expect(entries(build(value, 'product[variants_attributes]'))).toEqual([
+      ['product[variants_attributes][0][id]', 'v1'],
+      ['product[variants_attributes][0][name]', 'M'],
+      ['product[variants_attributes][0][position]', '0'],
+      ['product[variants_attributes][1][name]', 'G'],
+      ['product[variants_attributes][1][position]', '1'],
+      ['product[variants_attributes][1][_destroy]', 'true'],
+    ]);
+  });
+
+  it('never emits a JSON blob for a nested structure', () => {
+    const flat = entries(build([{ name: 'M' }], 'product[variants_attributes]'));
+    expect(flat.some(([, v]) => v.startsWith('[') || v.startsWith('{'))).toBe(false);
+  });
+
+  it('expands a plain object into bracketed keys', () => {
+    expect(entries(build({ origin: 'import', batch: 3 }, 'product[metadata]'))).toEqual([
+      ['product[metadata][origin]', 'import'],
+      ['product[metadata][batch]', '3'],
+    ]);
+  });
+
+  it('expands nested objects inside array items', () => {
+    const value = [{ name: 'M', attributes_data: { color: 'red' } }];
+    expect(entries(build(value, 'product[variants_attributes]'))).toEqual([
+      ['product[variants_attributes][0][name]', 'M'],
+      ['product[variants_attributes][0][attributes_data][color]', 'red'],
+    ]);
+  });
+
+  it('appends a File without stringifying it', () => {
+    const file = new File([new Uint8Array([1])], 'photo.png', { type: 'image/png' });
+    const formData = new FormData();
+    appendField(formData, 'product[images][]', file);
+
+    const appended = formData.get('product[images][]');
+    expect(appended).toBeInstanceOf(File);
+    expect((appended as File).name).toBe('photo.png');
+  });
+});

--- a/src/utils/products/formData.spec.ts
+++ b/src/utils/products/formData.spec.ts
@@ -32,15 +32,13 @@ describe('appendField', () => {
     ]);
   });
 
-  // Clearing the last label has to be expressible: an omitted key means
-  // "unchanged" to the API, not "empty".
+  // An omitted key means "unchanged" to the API, not "empty".
   it('sends an empty array as a single blank element', () => {
     expect(entries(build([], 'product[labels]'))).toEqual([['product[labels][]', '']]);
   });
 
-  // EVO-2226: serialising nested attributes as a JSON string made strong
-  // parameters drop the whole branch, so variant edits silently vanished on any
-  // submit that carried an image.
+  // As a JSON string, strong parameters drops the branch and variant edits vanish on
+  // any submit that carries an image.
   it('expands an array of objects into indexed Rails keys', () => {
     const value = [
       { id: 'v1', name: 'M', position: 0 },

--- a/src/utils/products/formData.ts
+++ b/src/utils/products/formData.ts
@@ -1,0 +1,48 @@
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Blob);
+
+/**
+ * Appends `value` to `formData` using Rails' nested-parameter convention.
+ *
+ * Nested values have to become indexed keys (`product[variants_attributes][0][name]`);
+ * sent as a JSON string, strong parameters drops the whole branch silently. `null`
+ * becomes `''` and an empty array a single blank element, so clearing a field or the
+ * last label works on multipart as it does on JSON.
+ */
+export const appendField = (formData: FormData, key: string, value: unknown): void => {
+  if (value === undefined) return;
+
+  if (value === null) {
+    formData.append(key, '');
+    return;
+  }
+
+  if (value instanceof Blob) {
+    formData.append(key, value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      formData.append(`${key}[]`, '');
+      return;
+    }
+    value.forEach((item, index) => {
+      if (isPlainObject(item)) {
+        appendField(formData, `${key}[${index}]`, item);
+      } else {
+        appendField(formData, `${key}[]`, item);
+      }
+    });
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    Object.entries(value).forEach(([childKey, childValue]) =>
+      appendField(formData, `${key}[${childKey}]`, childValue),
+    );
+    return;
+  }
+
+  formData.append(key, String(value));
+};

--- a/src/utils/products/formData.ts
+++ b/src/utils/products/formData.ts
@@ -2,12 +2,10 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Blob);
 
 /**
- * Appends `value` to `formData` using Rails' nested-parameter convention.
- *
- * Nested values have to become indexed keys (`product[variants_attributes][0][name]`);
- * sent as a JSON string, strong parameters drops the whole branch silently. `null`
- * becomes `''` and an empty array a single blank element, so clearing a field or the
- * last label works on multipart as it does on JSON.
+ * Appends `value` using Rails' nested-parameter convention: nested values must become
+ * indexed keys (`product[variants_attributes][0][name]`), because strong parameters
+ * silently drops a JSON string. `null` becomes `''` and an empty array a single blank
+ * element, so clearing a field works on multipart as it does on JSON.
  */
 export const appendField = (formData: FormData, key: string, value: unknown): void => {
   if (value === undefined) return;


### PR DESCRIPTION
## EVO-1785 (Phase 2, frontend) — Importação de produtos por conector (WooCommerce / Shopify)

PR **par** do backend ([CRM #252](https://github.com/evolution-foundation/evo-ai-crm-community/pull/252) + paginação [#253](https://github.com/evolution-foundation/evo-ai-crm-community/pull/253)) — **deploy junto**. Estende a importação existente (CSV, EVO-1734) com fontes remotas.

### Fluxo
`Fonte (CSV / WooCommerce / Shopify)` → **CSV** = fluxo atual intacto · **Conector** = `Credenciais` → `POST /products/import_fetch` → itens já mapeados caem no **mesmo preview/dry-run/bulk** do CSV.

### Mudanças
- `productsService.importFetch(source, credentials)` + tipos `ProductImportSource/Credentials/FetchResponse` e `FetchedProductItem`.
- Passo **Fonte** (cards) + forms de credencial por conector (WooCommerce: `store_url`/`ck_`/`cs_`; Shopify: `shop_domain`/`access_token`).
- Botão **"Como obter minhas chaves?"** (Dialog passo-a-passo, WooCommerce + Shopify) — a pedido, porque a origem das chaves não é óbvia.
- Preço vindo como **string** do conector é normalizado para número antes do bulk.
- Erros do conector **relayados verbatim** (credencial ruim, host privado/SSRF recusado, fonte não suportada, catálogo vazio → toast).
- Secret em campo `password` (mascarado). Credenciais **não persistidas** (nota na UI).
- Label do header **"Import CSV" → "Import"** (6 locales) — já não é só CSV.
- i18n `source`/`credentials`/`help` nos **6 locales**.

### Testes — vitest 14/14 · tsc limpo
- CSV preservado (navegação pela nova etapa Fonte) + conector: **fetch → normalização de preço → 422 verbatim → catálogo vazio → dialog de ajuda**.
- **Provado end-to-end no navegador** contra uma loja WooCommerce **real**: 10 produtos buscados → dry-run (0 conflitos) → **importados → visíveis no catálogo**.

Linear: https://linear.app/evoai/issue/EVO-1785
