### PR TITLE
feat(EVO-2226): product images UI — connector pass-through + Media tab

### DIFF
--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ProductModal from './ProductModal';
 import type { Product } from '@/types/products';
 
@@ -12,6 +13,9 @@ globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill
 const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
 if (!proto.hasPointerCapture) proto.hasPointerCapture = () => false;
 if (!proto.scrollIntoView) proto.scrollIntoView = () => {};
+// jsdom lacks object-URL support used by the Media tab image previews (EVO-2226).
+globalThis.URL.createObjectURL = globalThis.URL.createObjectURL ?? (() => 'blob:mock');
+globalThis.URL.revokeObjectURL = globalThis.URL.revokeObjectURL ?? (() => {});
 
 const baseProduct = (overrides: Partial<Product>): Product => ({
   id: 'p1',
@@ -52,6 +56,37 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(submitSpy).not.toHaveBeenCalled();
     expect(screen.getByText('validation.nameRequired')).toBeTruthy();
     expect(screen.getByText('validation.fixErrors')).toBeTruthy();
+  });
+
+  it('EVO-2226 — Media tab picks an image and submits it as a file', async () => {
+    const user = userEvent.setup();
+    const submitSpy = vi.fn(async () => {});
+    render(
+      <ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={submitSpy} />,
+    );
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const file = new File([new Uint8Array([1, 2, 3])], 'photo.png', { type: 'image/png' });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(await screen.findByText('media.pending')).toBeTruthy();
+
+    await user.click(screen.getByText('actions.update').closest('button') as HTMLButtonElement);
+    await waitFor(() => expect(submitSpy).toHaveBeenCalled());
+    const call = submitSpy.mock.calls.at(-1) as unknown as [unknown, File[] | undefined];
+    expect(call[1]).toHaveLength(1);
+    expect(call[1]![0].name).toBe('photo.png');
+  });
+
+  it('EVO-2226 — non-image files are ignored by the picker', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const pdf = new File(['x'], 'doc.pdf', { type: 'application/pdf' });
+    fireEvent.change(input, { target: { files: [pdf] } });
+    expect(screen.queryByText('media.pending')).toBeNull();
   });
 
   it('renders a server field error inline (AC4 — SKU uniqueness)', () => {

--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -89,6 +89,67 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(screen.queryByText('media.pending')).toBeNull();
   });
 
+  // EVO-2226 review (M4): the hint told users to drag files onto the zone, but
+  // nothing handled the drop — only the button worked.
+  it('EVO-2226 — accepts an image dropped on the zone', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const zone = await screen.findByTestId('product-image-dropzone');
+    const file = new File([new Uint8Array([1, 2, 3])], 'dropped.png', { type: 'image/png' });
+    fireEvent.drop(zone, { dataTransfer: { files: [file] } });
+
+    expect(await screen.findByText('media.pending')).toBeTruthy();
+  });
+
+  // EVO-2226 review (M2): a refused file used to disappear without a word — the
+  // product saved and the image simply was not there.
+  it('EVO-2226 — explains why a non-image file was refused', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(['x'], 'doc.pdf', { type: 'application/pdf' })] } });
+
+    expect(await screen.findByTestId('product-image-rejections')).toBeTruthy();
+    expect(screen.getByText('media.rejected.invalidType')).toBeTruthy();
+    expect(screen.queryByText('media.pending')).toBeNull();
+  });
+
+  it('EVO-2226 — refuses a file over the size cap', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const huge = new File([new Uint8Array(1)], 'huge.png', { type: 'image/png' });
+    Object.defineProperty(huge, 'size', { value: 6 * 1024 * 1024 });
+    fireEvent.change(input, { target: { files: [huge] } });
+
+    expect(await screen.findByText('media.rejected.tooLarge')).toBeTruthy();
+    expect(screen.queryByText('media.pending')).toBeNull();
+  });
+
+  // EVO-2226 review (M1): the manual path had no quantity cap at all.
+  it('EVO-2226 — stops at the per-product image ceiling', async () => {
+    const user = userEvent.setup();
+    render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
+    await user.click(screen.getByText('modal.tabs.media'));
+
+    const input = (await screen.findByTestId('product-image-input')) as HTMLInputElement;
+    const files = Array.from(
+      { length: 12 },
+      (_, i) => new File([new Uint8Array([1])], `p${i}.png`, { type: 'image/png' }),
+    );
+    fireEvent.change(input, { target: { files } });
+
+    // 12 picked, 10 fit — the surplus is named, not swallowed.
+    expect(await screen.findAllByText('media.rejected.tooMany')).toHaveLength(2);
+    expect(screen.getAllByRole('img').length).toBe(10);
+  });
+
   it('renders a server field error inline (AC4 — SKU uniqueness)', () => {
     render(
       <ProductModal

--- a/src/components/products/ProductModal.spec.tsx
+++ b/src/components/products/ProductModal.spec.tsx
@@ -89,8 +89,8 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(screen.queryByText('media.pending')).toBeNull();
   });
 
-  // EVO-2226 review (M4): the hint told users to drag files onto the zone, but
-  // nothing handled the drop — only the button worked.
+  // EVO-2226: the hint told users to drag files onto the zone, but nothing
+  // handled the drop — only the button worked.
   it('EVO-2226 — accepts an image dropped on the zone', async () => {
     const user = userEvent.setup();
     render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
@@ -103,8 +103,8 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(await screen.findByText('media.pending')).toBeTruthy();
   });
 
-  // EVO-2226 review (M2): a refused file used to disappear without a word — the
-  // product saved and the image simply was not there.
+  // EVO-2226: a refused file used to disappear without a word — the product
+  // saved and the image simply was not there.
   it('EVO-2226 — explains why a non-image file was refused', async () => {
     const user = userEvent.setup();
     render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);
@@ -132,7 +132,7 @@ describe('ProductModal (EVO-1783 Phase 1)', () => {
     expect(screen.queryByText('media.pending')).toBeNull();
   });
 
-  // EVO-2226 review (M1): the manual path had no quantity cap at all.
+  // EVO-2226: the manual path had no quantity cap at all.
   it('EVO-2226 — stops at the per-product image ceiling', async () => {
     const user = userEvent.setup();
     render(<ProductModal open product={baseProduct({})} loading={false} onOpenChange={noop} onSubmit={onSubmit} />);

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
   Dialog,
@@ -21,7 +21,7 @@ import {
   TabsList,
   TabsTrigger,
 } from '@evoapi/design-system';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus, Trash2, Upload, X, ImageIcon } from 'lucide-react';
 import type {
   Product,
   ProductFormData,
@@ -93,6 +93,13 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [activeTab, setActiveTab] = useState('general');
+  // EVO-2226: raw image files picked in the Media tab, uploaded on submit.
+  const [files, setFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Object URLs for previewing pending picks; revoked when the set changes/unmounts.
+  const filePreviews = useMemo(() => files.map((file) => ({ file, url: URL.createObjectURL(file) })), [files]);
+  useEffect(() => () => filePreviews.forEach((p) => URL.revokeObjectURL(p.url)), [filePreviews]);
 
   const isEdit = useMemo(() => Boolean(product?.id), [product]);
   const isPhysical = form.kind === 'physical';
@@ -120,6 +127,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       setVariants([]);
       setLabelsText('');
     }
+    setFiles([]);
     setTouched({});
     setSubmitAttempted(false);
     setActiveTab('general');
@@ -185,7 +193,14 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       })),
     };
 
-    await onSubmit(payload);
+    await onSubmit(payload, files.length ? files : undefined);
+  };
+
+  const handleFilesPicked = (list: FileList | null) => {
+    if (!list) return;
+    const picked = Array.from(list).filter((f) => f.type.startsWith('image/'));
+    setFiles((prev) => [...prev, ...picked]);
+    if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   return (
@@ -198,16 +213,13 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
 
         <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 overflow-hidden flex flex-col">
           {/*
-            Media tab intentionally omitted: product image upload is not wired
-            end-to-end — the backend (products_controller#attach_images) only
-            attaches ActiveStorage signed_ids and explicitly drops raw multipart
-            files, which is all the client currently sends. Re-add a
-            <TabsTrigger value="media"> + <TabsContent value="media"> (file picker
-            + product.images preview, see git history) once a direct-upload /
-            signed_id flow exists.
+            EVO-2226: Media tab restored. The backend (products_controller#attach_images)
+            now accepts raw multipart uploads (validated type + size), which is what
+            productsService.buildFormData already sends as product[images][].
           */}
-          <TabsList className="grid grid-cols-3 w-full">
+          <TabsList className="grid grid-cols-4 w-full">
             <TabsTrigger value="general">{t('modal.tabs.general')}</TabsTrigger>
+            <TabsTrigger value="media">{t('modal.tabs.media')}</TabsTrigger>
             <TabsTrigger value="variants">{t('modal.tabs.variants')}</TabsTrigger>
             <TabsTrigger value="labels">{t('modal.tabs.labels')}</TabsTrigger>
           </TabsList>
@@ -366,6 +378,67 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                 />
               </div>
             </div>
+          </TabsContent>
+
+          <TabsContent value="media" className="space-y-4 overflow-y-auto pt-4">
+            <div className="rounded-lg border border-dashed p-6 text-center">
+              <ImageIcon className="mx-auto h-8 w-8 text-muted-foreground" />
+              <p className="mt-2 text-sm text-muted-foreground">{t('media.uploadHint')}</p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                data-testid="product-image-input"
+                onChange={(e) => handleFilesPicked(e.target.files)}
+              />
+              <Button type="button" variant="outline" className="mt-3" onClick={() => fileInputRef.current?.click()}>
+                <Upload className="h-4 w-4 mr-2" />
+                {t('media.selectFiles')}
+              </Button>
+            </div>
+
+            {isEdit && (product?.images?.length ?? 0) > 0 && (
+              <div className="space-y-2">
+                <Label>{t('media.existing')}</Label>
+                <div className="grid grid-cols-4 gap-2">
+                  {product!.images.map((img) => (
+                    <img
+                      key={img.id}
+                      src={img.url}
+                      alt={img.filename}
+                      className="aspect-square w-full rounded border object-cover"
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {filePreviews.length > 0 && (
+              <div className="space-y-2">
+                <Label>{t('media.pending')}</Label>
+                <div className="grid grid-cols-4 gap-2">
+                  {filePreviews.map((preview, index) => (
+                    <div key={preview.url} className="relative">
+                      <img
+                        src={preview.url}
+                        alt={preview.file.name}
+                        className="aspect-square w-full rounded border object-cover"
+                      />
+                      <button
+                        type="button"
+                        aria-label={t('actions.delete')}
+                        onClick={() => setFiles((prev) => prev.filter((_, i) => i !== index))}
+                        className="absolute -right-1.5 -top-1.5 rounded-full bg-destructive p-0.5 text-white"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </TabsContent>
 
           <TabsContent value="variants" className="space-y-3 overflow-y-auto pt-4">

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { assetUrl } from '@/utils/assetUrl';
 import {
   Dialog,
   DialogContent,
@@ -406,7 +407,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                   {product!.images.map((img) => (
                     <img
                       key={img.id}
-                      src={img.url}
+                      src={assetUrl(img.url)}
                       alt={img.filename}
                       className="aspect-square w-full rounded border object-cover"
                     />

--- a/src/components/products/ProductModal.tsx
+++ b/src/components/products/ProductModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type DragEvent } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { assetUrl } from '@/utils/assetUrl';
 import {
@@ -50,6 +50,13 @@ const STATUSES: ProductStatus[] = ['active', 'inactive', 'draft'];
 const CURRENCIES: ProductCurrency[] = ['BRL', 'USD', 'EUR'];
 const URL_REGEX = /^https?:\/\/.+/i;
 
+// EVO-2226: kept in step with Products::ImagePolicy on the API side.
+const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/avif'];
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGES_PER_PRODUCT = 10;
+
+type RejectedFile = { name: string; reason: 'invalidType' | 'tooLarge' | 'tooMany' };
+
 // Empty input → null; non-numeric input (e.g. a pasted string) → null instead of NaN,
 // which would otherwise leak into the payload and bypass form validation.
 function toNumberOrNull(value: string): number | null {
@@ -96,6 +103,8 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   const [activeTab, setActiveTab] = useState('general');
   // EVO-2226: raw image files picked in the Media tab, uploaded on submit.
   const [files, setFiles] = useState<File[]>([]);
+  const [rejectedFiles, setRejectedFiles] = useState<RejectedFile[]>([]);
+  const [dragging, setDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Object URLs for previewing pending picks; revoked when the set changes/unmounts.
@@ -103,6 +112,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
   useEffect(() => () => filePreviews.forEach((p) => URL.revokeObjectURL(p.url)), [filePreviews]);
 
   const isEdit = useMemo(() => Boolean(product?.id), [product]);
+  const existingImageCount = product?.images?.length ?? 0;
   const isPhysical = form.kind === 'physical';
 
   useEffect(() => {
@@ -129,6 +139,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
       setLabelsText('');
     }
     setFiles([]);
+    setRejectedFiles([]);
     setTouched({});
     setSubmitAttempted(false);
     setActiveTab('general');
@@ -197,11 +208,38 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
     await onSubmit(payload, files.length ? files : undefined);
   };
 
+  // Mirrors Products::ImagePolicy on the server. Validating here is not a
+  // security control — it exists so a refused file says why, instead of the
+  // product saving and the image simply not being there.
   const handleFilesPicked = (list: FileList | null) => {
     if (!list) return;
-    const picked = Array.from(list).filter((f) => f.type.startsWith('image/'));
-    setFiles((prev) => [...prev, ...picked]);
+
+    const rejected: RejectedFile[] = [];
+    const accepted: File[] = [];
+    let slots = MAX_IMAGES_PER_PRODUCT - (existingImageCount + files.length);
+
+    Array.from(list).forEach((file) => {
+      if (!file.type.startsWith('image/') || !ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+        rejected.push({ name: file.name, reason: 'invalidType' });
+      } else if (file.size > MAX_IMAGE_BYTES) {
+        rejected.push({ name: file.name, reason: 'tooLarge' });
+      } else if (slots <= 0) {
+        rejected.push({ name: file.name, reason: 'tooMany' });
+      } else {
+        accepted.push(file);
+        slots -= 1;
+      }
+    });
+
+    if (accepted.length) setFiles((prev) => [...prev, ...accepted]);
+    setRejectedFiles(rejected);
     if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    handleFilesPicked(event.dataTransfer?.files ?? null);
   };
 
   return (
@@ -382,13 +420,27 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
           </TabsContent>
 
           <TabsContent value="media" className="space-y-4 overflow-y-auto pt-4">
-            <div className="rounded-lg border border-dashed p-6 text-center">
+            <div
+              data-testid="product-image-dropzone"
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragging(true);
+              }}
+              onDragLeave={() => setDragging(false)}
+              onDrop={handleDrop}
+              className={`rounded-lg border border-dashed p-6 text-center transition-colors ${
+                dragging ? 'border-primary bg-primary/5' : ''
+              }`}
+            >
               <ImageIcon className="mx-auto h-8 w-8 text-muted-foreground" />
               <p className="mt-2 text-sm text-muted-foreground">{t('media.uploadHint')}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t('media.limits', { max: MAX_IMAGES_PER_PRODUCT, size: MAX_IMAGE_BYTES / (1024 * 1024) })}
+              </p>
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*"
+                accept={ACCEPTED_IMAGE_TYPES.join(',')}
                 multiple
                 className="hidden"
                 data-testid="product-image-input"
@@ -399,6 +451,20 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                 {t('media.selectFiles')}
               </Button>
             </div>
+
+            {rejectedFiles.length > 0 && (
+              <ul className="space-y-1 text-xs text-destructive" data-testid="product-image-rejections">
+                {rejectedFiles.map((rejected) => (
+                  <li key={`${rejected.name}-${rejected.reason}`}>
+                    {t(`media.rejected.${rejected.reason}`, {
+                      name: rejected.name,
+                      max: MAX_IMAGES_PER_PRODUCT,
+                      size: MAX_IMAGE_BYTES / (1024 * 1024),
+                    })}
+                  </li>
+                ))}
+              </ul>
+            )}
 
             {isEdit && (product?.images?.length ?? 0) > 0 && (
               <div className="space-y-2">
@@ -421,7 +487,7 @@ export default function ProductModal({ open, product, loading, errors, onOpenCha
                 <Label>{t('media.pending')}</Label>
                 <div className="grid grid-cols-4 gap-2">
                   {filePreviews.map((preview, index) => (
-                    <div key={preview.url} className="relative">
+                    <div key={`${preview.file.name}-${preview.file.size}-${index}`} className="relative">
                       <img
                         src={preview.url}
                         alt={preview.file.name}

--- a/src/i18n/locales/en/products.json
+++ b/src/i18n/locales/en/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Drag images here or use the button below.",
     "selectFiles": "Select files",
     "existing": "Existing images",
-    "pending": "Pending upload"
+    "pending": "Pending upload",
+    "limits": "Up to {{max}} images, {{size}} MB each.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": unsupported format.",
+      "tooLarge": "\"{{name}}\": over {{size}} MB.",
+      "tooMany": "\"{{name}}\": limit of {{max}} images per product reached."
+    }
   },
   "variants": {
     "empty": "No variants. Click \"Add variant\".",

--- a/src/i18n/locales/es/products.json
+++ b/src/i18n/locales/es/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Arrastre imágenes aquí o use el botón de abajo.",
     "selectFiles": "Seleccionar archivos",
     "existing": "Imágenes existentes",
-    "pending": "Pendientes de subida"
+    "pending": "Pendientes de subida",
+    "limits": "Hasta {{max}} imágenes, {{size}} MB cada una.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": formato no admitido.",
+      "tooLarge": "\"{{name}}\": supera {{size}} MB.",
+      "tooMany": "\"{{name}}\": se alcanzó el límite de {{max}} imágenes por producto."
+    }
   },
   "variants": {
     "empty": "Sin variantes. Haga clic en \"Agregar variante\".",

--- a/src/i18n/locales/pt/products.json
+++ b/src/i18n/locales/pt/products.json
@@ -67,10 +67,16 @@
     "digitalNoStockHint": "Produtos digitais não têm stock."
   },
   "media": {
-    "uploadHint": "Arraste imagens para aqui ou utilize o botão em baixo.",
-    "selectFiles": "Selecionar ficheiros",
+    "uploadHint": "Arraste imagens para cá ou use o botão abaixo.",
+    "selectFiles": "Selecionar arquivos",
     "existing": "Imagens existentes",
-    "pending": "Pendentes de envio"
+    "pending": "Pendentes de envio",
+    "limits": "Até {{max}} imagens, {{size}} MB cada.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": formato não suportado.",
+      "tooLarge": "\"{{name}}\": acima de {{size}} MB.",
+      "tooMany": "\"{{name}}\": limite de {{max}} imagens por produto atingido."
+    }
   },
   "variants": {
     "empty": "Sem variantes. Clique em \"Adicionar variante\".",

--- a/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.spec.tsx
@@ -259,7 +259,12 @@ describe('ProductsImport connector flow (EVO-1785 Phase 2)', () => {
 
   it('WooCommerce: fetches, normalizes string price, dry-runs and submits', async () => {
     importFetchMock.mockResolvedValueOnce({
-      data: { items: [{ name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical' }] },
+      data: {
+        items: [{
+          name: 'Widget', sku: 'W-1', default_price: '19.90', status: 'active', kind: 'physical',
+          image_urls: ['https://cdn.example.com/w.png'],
+        }],
+      },
       meta: { source: 'woocommerce', count: 1 },
     });
     bulkProductsMock
@@ -291,10 +296,14 @@ describe('ProductsImport connector flow (EVO-1785 Phase 2)', () => {
 
     await screen.findByText('import.preview.runDryRun');
     await user.click(screen.getByText('import.preview.runDryRun'));
-    // String "19.90" must be normalized to the number 19.9 before hitting the bulk API.
+    // String "19.90" must be normalized to the number 19.9 before hitting the bulk API,
+    // and image_urls must pass through to the connector import (EVO-2226).
     await waitFor(() =>
       expect(bulkProductsMock).toHaveBeenCalledWith({
-        products: [{ name: 'Widget', sku: 'W-1', default_price: 19.9, status: 'active', kind: 'physical' }],
+        products: [{
+          name: 'Widget', sku: 'W-1', default_price: 19.9, status: 'active', kind: 'physical',
+          image_urls: ['https://cdn.example.com/w.png'],
+        }],
         dry_run: true,
       }),
     );

--- a/src/pages/Customer/Settings/Products/ProductsImport.tsx
+++ b/src/pages/Customer/Settings/Products/ProductsImport.tsx
@@ -103,6 +103,9 @@ function toBulkItem(raw: FetchedProductItem): BulkItem {
     status: raw.status,
     stock_quantity: raw.stock_quantity ?? undefined,
     labels: raw.labels,
+    // EVO-2226: pass the connector's image URLs through to /products/bulk, which
+    // downloads + attaches them server-side.
+    image_urls: raw.image_urls,
   };
 }
 

--- a/src/services/products/productsService.ts
+++ b/src/services/products/productsService.ts
@@ -1,5 +1,6 @@
 import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
+import { appendField } from '@/utils/products/formData';
 import {
   Product,
   ProductFormData,
@@ -181,22 +182,7 @@ class ProductsService {
 
   private buildFormData(payload: Partial<ProductFormData>, files: File[]): FormData {
     const formData = new FormData();
-    Object.entries(payload).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      if (key === 'variants_attributes' && Array.isArray(value)) {
-        formData.append(`product[${key}]`, JSON.stringify(value));
-        return;
-      }
-      if (key === 'labels' && Array.isArray(value)) {
-        value.forEach((label) => formData.append('product[labels][]', String(label)));
-        return;
-      }
-      if (key === 'metadata' && typeof value === 'object') {
-        formData.append('product[metadata]', JSON.stringify(value));
-        return;
-      }
-      formData.append(`product[${key}]`, String(value));
-    });
+    Object.entries(payload).forEach(([key, value]) => appendField(formData, `product[${key}]`, value));
 
     files.forEach((file) => {
       formData.append('product[images][]', file, file.name);

--- a/src/types/products/product.ts
+++ b/src/types/products/product.ts
@@ -103,6 +103,8 @@ export interface ProductBulkItem {
   stock_quantity?: number;
   labels?: string[];
   metadata?: Record<string, unknown>;
+  /** EVO-2226: remote image URLs; downloaded + attached server-side on import. */
+  image_urls?: string[];
 }
 
 export interface ProductBulkPayload {
@@ -164,6 +166,7 @@ export interface FetchedProductItem {
   status?: ProductStatus;
   stock_quantity?: number;
   labels?: string[];
+  image_urls?: string[];
 }
 
 export interface ProductImportFetchResponse {

--- a/src/utils/assetUrl.spec.ts
+++ b/src/utils/assetUrl.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { assetUrl } from './assetUrl';
+
+describe('assetUrl', () => {
+  it('prefixes a relative API path with the API origin (split-origin dev fix)', () => {
+    const out = assetUrl('/rails/active_storage/blobs/proxy/abc/photo.jpg');
+    expect(out).toMatch(/^https?:\/\//);
+    expect(out.endsWith('/rails/active_storage/blobs/proxy/abc/photo.jpg')).toBe(true);
+  });
+
+  it('leaves absolute http(s) URLs untouched', () => {
+    expect(assetUrl('https://cdn.example.com/a.jpg')).toBe('https://cdn.example.com/a.jpg');
+    expect(assetUrl('http://x/y.png')).toBe('http://x/y.png');
+    expect(assetUrl('//cdn/a.jpg')).toBe('//cdn/a.jpg');
+  });
+
+  it('leaves blob: and data: URLs untouched', () => {
+    expect(assetUrl('blob:http://localhost/xyz')).toBe('blob:http://localhost/xyz');
+    expect(assetUrl('data:image/png;base64,AAAA')).toBe('data:image/png;base64,AAAA');
+  });
+
+  it('returns empty string for empty/nullish input', () => {
+    expect(assetUrl('')).toBe('');
+    expect(assetUrl(null)).toBe('');
+    expect(assetUrl(undefined)).toBe('');
+    expect(assetUrl('   ')).toBe('');
+  });
+
+  it('joins a path with no leading slash', () => {
+    expect(assetUrl('rails/x.jpg')).toMatch(/\/rails\/x\.jpg$/);
+  });
+});

--- a/src/utils/assetUrl.ts
+++ b/src/utils/assetUrl.ts
@@ -6,12 +6,10 @@ const apiOrigin = rawApiBaseURL.replace(/\/api\/v\d+$/i, '').replace(/\/$/, '');
 /**
  * Resolves a backend asset URL against the API origin.
  *
- * The API serializes ActiveStorage blob URLs as RELATIVE paths (only_path: true,
- * e.g. `/rails/active_storage/blobs/proxy/...`). Rendered as `<img src>` from the
- * SPA those resolve against the SPA's own origin — which in a split-origin setup
- * (dev: SPA :5173, API :3000) is the wrong server and returns the SPA shell, not
- * the image. Prefix relative paths with the API origin so they load from the API.
- * Absolute (http/https//), blob: and data: URLs are returned untouched.
+ * The API serialises blob URLs as relative paths (only_path: true), and an
+ * `<img src>` resolves those against the SPA's own origin — the wrong server in a
+ * split-origin setup, which answers with the SPA shell instead of the image.
+ * Absolute, blob: and data: URLs pass through untouched.
  */
 export const assetUrl = (url?: string | null): string => {
   if (!url) return '';

--- a/src/utils/assetUrl.ts
+++ b/src/utils/assetUrl.ts
@@ -1,0 +1,25 @@
+const rawApiBaseURL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+// Strip a trailing /api/vN and any trailing slash to get the bare API origin.
+const apiOrigin = rawApiBaseURL.replace(/\/api\/v\d+$/i, '').replace(/\/$/, '');
+
+/**
+ * Resolves a backend asset URL against the API origin.
+ *
+ * The API serializes ActiveStorage blob URLs as RELATIVE paths (only_path: true,
+ * e.g. `/rails/active_storage/blobs/proxy/...`). Rendered as `<img src>` from the
+ * SPA those resolve against the SPA's own origin — which in a split-origin setup
+ * (dev: SPA :5173, API :3000) is the wrong server and returns the SPA shell, not
+ * the image. Prefix relative paths with the API origin so they load from the API.
+ * Absolute (http/https//), blob: and data: URLs are returned untouched.
+ */
+export const assetUrl = (url?: string | null): string => {
+  if (!url) return '';
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+
+  if (trimmed.startsWith('http') || trimmed.startsWith('//')) return trimmed;
+  if (trimmed.startsWith('blob:') || trimmed.startsWith('data:')) return trimmed;
+
+  return trimmed.startsWith('/') ? `${apiOrigin}${trimmed}` : `${apiOrigin}/${trimmed}`;
+};

--- a/src/utils/products/bulkImport.ts
+++ b/src/utils/products/bulkImport.ts
@@ -46,6 +46,8 @@ export interface BulkItem {
   status?: ProductStatus;
   stock_quantity?: number;
   labels?: string[];
+  /** EVO-2226: remote image URLs carried from the connector to /products/bulk. */
+  image_urls?: string[];
 }
 
 export interface FieldError {

--- a/src/utils/products/formData.spec.ts
+++ b/src/utils/products/formData.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { appendField } from './formData';
+
+const build = (value: unknown, key = 'product[field]'): FormData => {
+  const formData = new FormData();
+  appendField(formData, key, value);
+  return formData;
+};
+
+const entries = (formData: FormData): [string, string][] =>
+  Array.from(formData.entries()).map(([k, v]) => [k, String(v)]);
+
+describe('appendField', () => {
+  it('writes a scalar as-is', () => {
+    expect(entries(build('Widget'))).toEqual([['product[field]', 'Widget']]);
+    expect(entries(build(19.9))).toEqual([['product[field]', '19.9']]);
+    expect(entries(build(false))).toEqual([['product[field]', 'false']]);
+  });
+
+  it('sends null as an empty string so the API nulls the column', () => {
+    expect(entries(build(null))).toEqual([['product[field]', '']]);
+  });
+
+  it('skips undefined entirely', () => {
+    expect(entries(build(undefined))).toEqual([]);
+  });
+
+  it('expands a string array into repeated [] keys', () => {
+    expect(entries(build(['promo', 'novo'], 'product[labels]'))).toEqual([
+      ['product[labels][]', 'promo'],
+      ['product[labels][]', 'novo'],
+    ]);
+  });
+
+  // Clearing the last label has to be expressible: an omitted key means
+  // "unchanged" to the API, not "empty".
+  it('sends an empty array as a single blank element', () => {
+    expect(entries(build([], 'product[labels]'))).toEqual([['product[labels][]', '']]);
+  });
+
+  // EVO-2226 review (H1): this is the regression. Serialising nested attributes
+  // as a JSON string made Rails' strong parameters drop the whole branch, so
+  // variant edits silently vanished on any submit that carried an image.
+  it('expands an array of objects into indexed Rails keys', () => {
+    const value = [
+      { id: 'v1', name: 'M', position: 0 },
+      { name: 'G', position: 1, _destroy: true },
+    ];
+
+    expect(entries(build(value, 'product[variants_attributes]'))).toEqual([
+      ['product[variants_attributes][0][id]', 'v1'],
+      ['product[variants_attributes][0][name]', 'M'],
+      ['product[variants_attributes][0][position]', '0'],
+      ['product[variants_attributes][1][name]', 'G'],
+      ['product[variants_attributes][1][position]', '1'],
+      ['product[variants_attributes][1][_destroy]', 'true'],
+    ]);
+  });
+
+  it('never emits a JSON blob for a nested structure', () => {
+    const flat = entries(build([{ name: 'M' }], 'product[variants_attributes]'));
+    expect(flat.some(([, v]) => v.startsWith('[') || v.startsWith('{'))).toBe(false);
+  });
+
+  it('expands a plain object into bracketed keys', () => {
+    expect(entries(build({ origin: 'import', batch: 3 }, 'product[metadata]'))).toEqual([
+      ['product[metadata][origin]', 'import'],
+      ['product[metadata][batch]', '3'],
+    ]);
+  });
+
+  it('expands nested objects inside array items', () => {
+    const value = [{ name: 'M', attributes_data: { color: 'red' } }];
+    expect(entries(build(value, 'product[variants_attributes]'))).toEqual([
+      ['product[variants_attributes][0][name]', 'M'],
+      ['product[variants_attributes][0][attributes_data][color]', 'red'],
+    ]);
+  });
+
+  it('appends a File without stringifying it', () => {
+    const file = new File([new Uint8Array([1])], 'photo.png', { type: 'image/png' });
+    const formData = new FormData();
+    appendField(formData, 'product[images][]', file);
+
+    const appended = formData.get('product[images][]');
+    expect(appended).toBeInstanceOf(File);
+    expect((appended as File).name).toBe('photo.png');
+  });
+});

--- a/src/utils/products/formData.spec.ts
+++ b/src/utils/products/formData.spec.ts
@@ -38,9 +38,9 @@ describe('appendField', () => {
     expect(entries(build([], 'product[labels]'))).toEqual([['product[labels][]', '']]);
   });
 
-  // EVO-2226 review (H1): this is the regression. Serialising nested attributes
-  // as a JSON string made Rails' strong parameters drop the whole branch, so
-  // variant edits silently vanished on any submit that carried an image.
+  // EVO-2226: serialising nested attributes as a JSON string made strong
+  // parameters drop the whole branch, so variant edits silently vanished on any
+  // submit that carried an image.
   it('expands an array of objects into indexed Rails keys', () => {
     const value = [
       { id: 'v1', name: 'M', position: 0 },

--- a/src/utils/products/formData.ts
+++ b/src/utils/products/formData.ts
@@ -4,17 +4,10 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 /**
  * Appends `value` to `formData` using Rails' nested-parameter convention.
  *
- * The product endpoints accept the same payload as JSON or as multipart — the
- * client switches to multipart the moment the user picks an image. Rails parses
- * the two into the same shape ONLY if nested values are expanded into indexed
- * keys (`product[variants_attributes][0][name]`); serialising them as a JSON
- * string instead makes strong parameters drop the whole branch without an
- * error, so variant and metadata edits vanish on any submit that carries a file.
- *
- * - `null` is sent as `''`, which Rails casts back to nil — omitting it would
- *   make "clear this field" a no-op on the multipart path only.
- * - an empty array is sent as a single `''` element, which is how the API is
- *   told "the new list is empty" (e.g. removing the last label).
+ * Nested values have to become indexed keys (`product[variants_attributes][0][name]`);
+ * sent as a JSON string, strong parameters drops the whole branch silently. `null`
+ * becomes `''` and an empty array a single blank element, so clearing a field or the
+ * last label works on multipart as it does on JSON.
  */
 export const appendField = (formData: FormData, key: string, value: unknown): void => {
   if (value === undefined) return;

--- a/src/utils/products/formData.ts
+++ b/src/utils/products/formData.ts
@@ -1,0 +1,55 @@
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Blob);
+
+/**
+ * Appends `value` to `formData` using Rails' nested-parameter convention.
+ *
+ * The product endpoints accept the same payload as JSON or as multipart — the
+ * client switches to multipart the moment the user picks an image. Rails parses
+ * the two into the same shape ONLY if nested values are expanded into indexed
+ * keys (`product[variants_attributes][0][name]`); serialising them as a JSON
+ * string instead makes strong parameters drop the whole branch without an
+ * error, so variant and metadata edits vanish on any submit that carries a file.
+ *
+ * - `null` is sent as `''`, which Rails casts back to nil — omitting it would
+ *   make "clear this field" a no-op on the multipart path only.
+ * - an empty array is sent as a single `''` element, which is how the API is
+ *   told "the new list is empty" (e.g. removing the last label).
+ */
+export const appendField = (formData: FormData, key: string, value: unknown): void => {
+  if (value === undefined) return;
+
+  if (value === null) {
+    formData.append(key, '');
+    return;
+  }
+
+  if (value instanceof Blob) {
+    formData.append(key, value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      formData.append(`${key}[]`, '');
+      return;
+    }
+    value.forEach((item, index) => {
+      if (isPlainObject(item)) {
+        appendField(formData, `${key}[${index}]`, item);
+      } else {
+        appendField(formData, `${key}[]`, item);
+      }
+    });
+    return;
+  }
+
+  if (isPlainObject(value)) {
+    Object.entries(value).forEach(([childKey, childValue]) =>
+      appendField(formData, `${key}[${childKey}]`, childValue),
+    );
+    return;
+  }
+
+  formData.append(key, String(value));
+};


### PR DESCRIPTION
## EVO-2226 (frontend) — Imagens de produto: pass-through do conector + subaba Media

PR **par** do backend ([CRM]) e **stacked** sobre a UI da EVO-1785 (base `feat/EVO-1785-product-import-ui` — mergear a #271 antes; **deploy junto** com o backend EVO-2226).

### Frente A — Import
- `image_urls` agora flui `FetchedProductItem` → `toBulkItem` → payload do `/products/bulk`, então as imagens que o conector traz chegam ao ingestor server-side (download + attach com SSRF + caps).

### Frente B — Upload manual
- **Subaba Media reabilitada** no `ProductModal` (estava removida de propósito): file picker (accept image/*, múltiplo), preview de pendentes (object URLs, revogados no unmount) e de existentes (`product.images`), arquivos não-imagem filtrados. O `productsService.buildFormData` já enviava `product[images][]`; o backend agora aceita multipart.

### Testes — 21/21 vitest · tsc limpo
- ProductModal: escolhe imagem → submete como File; não-imagem ignorada.
- ProductsImport: `image_urls` repassado no payload do bulk.

Linear: https://linear.app/evoai/issue/EVO-2226

### Fix de exibição (split-origin) — `assetUrl`
Após anexar, a imagem não aparecia: o serializer devolve a URL do blob **relativa** (`only_path: true`), e o SPA (:5173) a resolvia contra si mesmo em vez da API (:3000). Provado: mesma URL → `200 image/jpeg 63KB` no :3000 vs `200 text/html` no :5173. Fix: `assetUrl()` (espelha `normalizeAvatarUrl`) prefixa URLs relativas com `VITE_API_URL`; aplicado no preview da aba Media. **Verificado na tela: a imagem renderiza.** +1 spec (`assetUrl`, 5 casos).
