### PR TITLE
fix(EVO-2207): type a form lead as the contact, with the deal optional

### DIFF
--- a/src/pages/Customer/Settings/CrmForms/CrmForms.spec.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import CrmForms from './CrmForms';
-import type { CrmForm } from '@/types/crmForms';
+import type { CrmForm, FormLead } from '@/types/crmForms';
 import type { Pipeline } from '@/types/analytics/pipelines';
 
 // EVO-2200: a capture form whose destination pipeline was archived used to resolve to
@@ -25,6 +25,7 @@ function buildForm(overrides: Partial<CrmForm> = {}): CrmForm {
 
 const list = vi.fn();
 const getPipelines = vi.fn();
+const getLeads = vi.fn();
 
 vi.mock('@/services/crmForms/crmFormsService', () => ({
   crmFormsService: {
@@ -32,7 +33,7 @@ vi.mock('@/services/crmForms/crmFormsService', () => ({
     create: vi.fn(),
     update: vi.fn(),
     remove: vi.fn(),
-    getLeads: vi.fn(),
+    getLeads: (...args: unknown[]) => getLeads(...args),
   },
 }));
 
@@ -152,5 +153,67 @@ describe('Capture forms screen', () => {
     expect(await screen.findByText('Website Contact')).toBeInTheDocument();
     await waitFor(() => expect(getPipelines).toHaveBeenCalled());
     expect(screen.queryByText('status.archivedPipeline')).not.toBeInTheDocument();
+  });
+
+  // EVO-2207: a lead is the contact, and its deal is optional — deleting the kanban card
+  // leaves pipeline_item_id/pipeline_id/pipeline_stage_id null. The row still has to
+  // render the person; only the destination column degrades.
+  describe('leads dialog', () => {
+    const LIVE_LEAD: FormLead = {
+      id: 'contact-live',
+      contact_id: 'contact-live',
+      pipeline_item_id: 'item-1',
+      contact: { id: 'contact-live', name: 'Ana Lima', email: 'ana@example.com' },
+      pipeline_id: ACTIVE_PIPELINE.id,
+      pipeline_stage_id: 'stage-1',
+      created_at: '2026-07-20T10:00:00Z',
+    };
+
+    const DELETED_CARD_LEAD: FormLead = {
+      id: 'contact-orphan',
+      contact_id: 'contact-orphan',
+      pipeline_item_id: null,
+      contact: { id: 'contact-orphan', name: 'Bruno Sá', email: 'bruno@example.com' },
+      pipeline_id: null,
+      pipeline_stage_id: null,
+      created_at: '2026-07-21T10:00:00Z',
+    };
+
+    async function openLeadsDialog() {
+      list.mockResolvedValue({
+        data: [buildForm({ leads_count: 2 })],
+        meta: { page: 1, page_size: 25, total: 1 },
+      });
+
+      render(<CrmForms />);
+
+      const counter = await screen.findByRole('button', { name: '2' });
+      // openLeads resolves the fetch after the click returns; act() flushes it so the
+      // dialog state settles inside the test instead of warning about it.
+      await act(async () => {
+        fireEvent.click(counter);
+      });
+    }
+
+    it('renders a lead whose card was deleted, with the destination degraded', async () => {
+      getLeads.mockResolvedValue({ leads: [DELETED_CARD_LEAD, LIVE_LEAD], count: 2 });
+
+      await openLeadsDialog();
+
+      expect(await screen.findByText('Bruno Sá')).toBeInTheDocument();
+      expect(screen.getByText('bruno@example.com')).toBeInTheDocument();
+      // the live lead still resolves its pipeline, so '—' is degradation, not a blank screen
+      expect(screen.getByText(ACTIVE_PIPELINE.name)).toBeInTheDocument();
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+
+    it('does not fall back to the empty state when every card was deleted', async () => {
+      getLeads.mockResolvedValue({ leads: [DELETED_CARD_LEAD], count: 1 });
+
+      await openLeadsDialog();
+
+      expect(await screen.findByText('Bruno Sá')).toBeInTheDocument();
+      expect(screen.queryByText('leads.empty')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.spec.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.spec.tsx
@@ -155,9 +155,8 @@ describe('Capture forms screen', () => {
     expect(screen.queryByText('status.archivedPipeline')).not.toBeInTheDocument();
   });
 
-  // EVO-2207: a lead is the contact, and its deal is optional — deleting the kanban card
-  // leaves pipeline_item_id/pipeline_id/pipeline_stage_id null. The row still has to
-  // render the person; only the destination column degrades.
+  // EVO-2207: deleting the kanban card nulls every deal field. The person still renders;
+  // only the destination column degrades.
   describe('leads dialog', () => {
     const LIVE_LEAD: FormLead = {
       id: 'contact-live',
@@ -188,8 +187,7 @@ describe('Capture forms screen', () => {
       render(<CrmForms />);
 
       const counter = await screen.findByRole('button', { name: '2' });
-      // openLeads resolves the fetch after the click returns; act() flushes it so the
-      // dialog state settles inside the test instead of warning about it.
+      // openLeads resolves its fetch after the click returns; act() flushes that update
       await act(async () => {
         fireEvent.click(counter);
       });
@@ -202,7 +200,7 @@ describe('Capture forms screen', () => {
 
       expect(await screen.findByText('Bruno Sá')).toBeInTheDocument();
       expect(screen.getByText('bruno@example.com')).toBeInTheDocument();
-      // the live lead still resolves its pipeline, so '—' is degradation, not a blank screen
+      // the live lead still resolves its pipeline, so '—' is degradation, not a blank tab
       expect(screen.getByText(ACTIVE_PIPELINE.name)).toBeInTheDocument();
       expect(screen.getByText('—')).toBeInTheDocument();
     });

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -388,7 +388,7 @@ export default function CrmForms() {
                 </thead>
                 <tbody>
                   {leads.map(lead => (
-                    <tr key={lead.contact_id} className="border-b border-sidebar-border last:border-0">
+                    <tr key={lead.id} className="border-b border-sidebar-border last:border-0">
                       <td className="px-4 py-3">
                         <div className="font-medium text-sidebar-foreground">{lead.contact?.name || '—'}</div>
                         <div className="text-xs text-sidebar-foreground/60">{lead.contact?.email}</div>

--- a/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
+++ b/src/pages/Customer/Settings/CrmForms/CrmForms.tsx
@@ -388,7 +388,7 @@ export default function CrmForms() {
                 </thead>
                 <tbody>
                   {leads.map(lead => (
-                    <tr key={lead.id} className="border-b border-sidebar-border last:border-0">
+                    <tr key={lead.contact_id} className="border-b border-sidebar-border last:border-0">
                       <td className="px-4 py-3">
                         <div className="font-medium text-sidebar-foreground">{lead.contact?.name || '—'}</div>
                         <div className="text-xs text-sidebar-foreground/60">{lead.contact?.email}</div>

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -57,11 +57,17 @@ export interface PaginationMeta {
   has_previous_page?: boolean;
 }
 
+// EVO-2207: a captured lead is the CONTACT that filled the form. The deal it opened is
+// optional and does not survive a kanban delete, so every deal field can come back null.
+// `id` now carries the contact, not the pipeline item it used to: prefer `contact_id` /
+// `pipeline_item_id`, which say which entity they point at.
 export interface FormLead {
   id: string;
+  contact_id: string;
+  pipeline_item_id?: string | null;
   contact?: { id: string; name?: string; email?: string } | null;
-  pipeline_id?: string;
-  pipeline_stage_id?: string;
+  pipeline_id?: string | null;
+  pipeline_stage_id?: string | null;
   created_at?: string;
 }
 

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -57,11 +57,9 @@ export interface PaginationMeta {
   has_previous_page?: boolean;
 }
 
-// EVO-2207: a captured lead is the CONTACT that filled the form. The deal it opened is
-// optional and does not survive a kanban delete, so every deal field can come back null.
-// `id` now carries the contact rather than the pipeline item it used to, which is why the
-// row key stays on it: unique per row under either payload. Anything that needs to know
-// WHICH entity it is holding reads contact_id / pipeline_item_id instead.
+// EVO-2207: a lead is the contact; its deal does not survive a kanban delete, so every
+// deal field can come back null. `id` switched from the pipeline item to the contact —
+// anything that needs to know which entity it holds reads the explicit fields.
 export interface FormLead {
   id: string;
   contact_id: string;

--- a/src/types/crmForms.ts
+++ b/src/types/crmForms.ts
@@ -59,8 +59,9 @@ export interface PaginationMeta {
 
 // EVO-2207: a captured lead is the CONTACT that filled the form. The deal it opened is
 // optional and does not survive a kanban delete, so every deal field can come back null.
-// `id` now carries the contact, not the pipeline item it used to: prefer `contact_id` /
-// `pipeline_item_id`, which say which entity they point at.
+// `id` now carries the contact rather than the pipeline item it used to, which is why the
+// row key stays on it: unique per row under either payload. Anything that needs to know
+// WHICH entity it is holding reads contact_id / pipeline_item_id instead.
 export interface FormLead {
   id: string;
   contact_id: string;


### PR DESCRIPTION
Front do EVO-2207. O backend passou a derivar os leads de um form do **contato** (crm [#245](https://github.com/evolution-foundation/evo-ai-crm-community/pull/245)), para a atribuição sobreviver ao delete do card no kanban. O tipo `FormLead` ainda descrevia o payload antigo.

## O que estava errado

- **`id` mudou de significado sem ninguém registrar.** Era o id do pipeline item; agora é o do contato.
- **`contact_id` e `pipeline_item_id` não existiam no tipo**, então a informação do deal ficou inalcançável pela tela mesmo estando na resposta.
- **`pipeline_id` e `pipeline_stage_id` estavam tipados como nunca-nulos**, e um lead de card deletado manda `null` nos dois.

## O que mudou

- `src/types/crmForms.ts`: `contact_id` e `pipeline_item_id` entram; os campos do deal aceitam `null`.
- `src/pages/Customer/Settings/CrmForms/CrmForms.spec.tsx`: dois casos novos — a aba renderiza um lead cujo card foi deletado (a pessoa aparece, só a coluna de destino degrada para `—`), e não cai no estado vazio quando todos os cards sumiram. Esse caminho não tinha cobertura nenhuma.

A key da linha **fica em `id` de propósito**. Cheguei a trocar para `contact_id` e voltei: `contact_id` só existe na resposta a partir do crm #245, então essa troca deixaria toda key `undefined` se o front subisse antes da API. `id` é único por linha nos dois payloads.

## Verificação

- `vitest src/pages/Customer/Settings/CrmForms` — **8 passando**.
- **Controle negativo:** fazendo `stageLabel` deixar de degradar, os **2 casos novos falham** com `TypeError: Cannot read properties of undefined (reading 'name')`.
- `tsc -b` limpo · `eslint` sem ofensa nos arquivos tocados.
- **Ressalva:** `tsconfig.app.json` exclui `*.spec.tsx`, e nenhum código de produção referencia `contact_id` ainda — então o `tsc` não exercita os campos novos. Eles são o contrato para quem for consumir o id do deal; o que está coberto por teste é a degradação dos campos nulos.

Não depende do crm #245 para não quebrar — os campos novos simplesmente chegam `undefined` até ele subir, e nada os lê.