### PR TITLE
feat(credentials): tela unificada de IA + cofre de integrações (EVO-2250)

### DIFF
--- a/src/components/ApiKeysModal.spec.tsx
+++ b/src/components/ApiKeysModal.spec.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiKeysModal, AI_CREDENTIALS_ROUTE } from './ApiKeysModal';
+
+// EVO-2250 story 1.1 (AC6): the modal stopped owning a parallel CRUD and now
+// points at the AI Credentials page. Selecting a credential still lives in the
+// callers, and three of them (GeneralTab, LLMConfigForm, Step6_ApiKeyModel)
+// reload their selectable list through onApiKeysChange — dropping that callback
+// leaves the agent forms showing a stale list after a credential is created.
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ApiKeysModal — points at the unified page (AC6)', () => {
+  it('navigates to the AI Credentials route instead of editing inline', async () => {
+    const user = userEvent.setup();
+    render(<ApiKeysModal open onOpenChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /title/i }));
+
+    expect(navigate).toHaveBeenCalledWith(AI_CREDENTIALS_ROUTE);
+  });
+
+  it('notifies the caller so its credential list reloads', async () => {
+    const user = userEvent.setup();
+    const onApiKeysChange = vi.fn();
+    render(<ApiKeysModal open onOpenChange={vi.fn()} onApiKeysChange={onApiKeysChange} />);
+
+    await user.click(screen.getByRole('button', { name: /title/i }));
+
+    expect(onApiKeysChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes itself before navigating away', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<ApiKeysModal open onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole('button', { name: /title/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('works without the optional callback', async () => {
+    const user = userEvent.setup();
+    render(<ApiKeysModal open onOpenChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /title/i }));
+
+    expect(navigate).toHaveBeenCalledWith(AI_CREDENTIALS_ROUTE);
+  });
+
+  it('no longer renders a credential form (the CRUD moved out)', () => {
+    render(<ApiKeysModal open onOpenChange={vi.fn()} />);
+
+    expect(screen.queryByLabelText('form.labels.key')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('form.labels.provider')).not.toBeInTheDocument();
+  });
+
+  it('cancel closes without navigating', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<ApiKeysModal open onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'actions.cancel' }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ApiKeysModal.tsx
+++ b/src/components/ApiKeysModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
   Button,
@@ -8,20 +8,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Input,
-  Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Badge,
-  Checkbox,
 } from '@evoapi/design-system';
-import { Edit, Eye, Key, Plus, Trash2, X, Loader2 } from 'lucide-react';
-import { toast } from 'sonner';
-import { ApiKey, ApiKeyCreate, ApiKeyUpdate } from '@/types/agents';
-import { createApiKey, listApiKeys, updateApiKey, deleteApiKey } from '@/services/agents';
+import { ExternalLink, KeyRound } from 'lucide-react';
+
+export const AI_CREDENTIALS_ROUTE = '/settings/ai-credentials';
 
 interface ApiKeysModalProps {
   open: boolean;
@@ -29,426 +19,49 @@ interface ApiKeysModalProps {
   onApiKeysChange?: () => void;
 }
 
-const CUSTOM_OPENAI_PROVIDER = 'custom_openai_compatible';
-
-// Providers disponíveis
-const availableProviders = [
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'anthropic', label: 'Anthropic' },
-  { value: 'gemini', label: 'Google Gemini' },
-  { value: 'azure', label: 'Azure OpenAI' },
-  { value: 'groq', label: 'Groq' },
-  { value: 'mistral', label: 'Mistral AI' },
-  { value: 'cohere', label: 'Cohere' },
-  { value: 'openrouter', label: 'OpenRouter' },
-  { value: 'deepseek', label: 'DeepSeek' },
-  { value: 'together_ai', label: 'Together AI' },
-  { value: 'fireworks_ai', label: 'Fireworks AI' },
-  { value: 'perplexity', label: 'Perplexity' },
-  { value: 'bedrock', label: 'AWS Bedrock' },
-  { value: 'vertex_ai', label: 'Google Vertex AI' },
-  { value: CUSTOM_OPENAI_PROVIDER, label: 'Custom (OpenAI-compatible)' },
-];
-
+/**
+ * Credentials are registered on the AI Credentials settings page, the single
+ * source of truth. This modal used to keep its own CRUD against the same
+ * registry, which is exactly the duplication EVO-2250 removes. Selecting a
+ * credential still happens in the callers, so only the CRUD moved.
+ */
 export function ApiKeysModal({ open, onOpenChange, onApiKeysChange }: ApiKeysModalProps) {
-  const { t } = useLanguage('apiKeys');
-  const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [isAddingKey, setIsAddingKey] = useState(false);
-  const [isEditingKey, setIsEditingKey] = useState(false);
-  const [currentApiKey, setCurrentApiKey] = useState<
-    Partial<ApiKey & { key_value?: string; base_url?: string }>
-  >({});
-  const [keyToDelete, setKeyToDelete] = useState<ApiKey | null>(null);
-  const [isKeyVisible, setIsKeyVisible] = useState(false);
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const { t } = useLanguage('aiCredentials');
+  const navigate = useNavigate();
 
-  const getProviderLabel = (providerValue: string) => {
-    return availableProviders.find(provider => provider.value === providerValue)?.label || providerValue;
-  };
-
-  const loadApiKeys = useCallback(async () => {
-    try {
-      setLoading(true);
-      const keys = await listApiKeys();
-      setApiKeys(keys);
-    } catch (error) {
-      console.error('Erro ao carregar chaves API:', error);
-      toast.error(t('messages.loadError'));
-    } finally {
-      setLoading(false);
-    }
-  }, [t]);
-
-  useEffect(() => {
-    if (open) {
-      loadApiKeys();
-    }
-  }, [open, loadApiKeys]);
-
-  const handleAddClick = () => {
-    setCurrentApiKey({});
-    setIsAddingKey(true);
-    setIsEditingKey(false);
-  };
-
-  const handleEditClick = (apiKey: ApiKey) => {
-    setCurrentApiKey({ ...apiKey, key_value: '' });
-    setIsAddingKey(true);
-    setIsEditingKey(true);
-  };
-
-  const handleDeleteClick = (apiKey: ApiKey) => {
-    setKeyToDelete(apiKey);
-    setShowDeleteDialog(true);
-  };
-
-  const handleSaveApiKey = async () => {
-    const isCustomProvider = currentApiKey.provider === CUSTOM_OPENAI_PROVIDER;
-
-    if (
-      !currentApiKey.name ||
-      !currentApiKey.provider ||
-      (isCustomProvider && !currentApiKey.base_url?.trim()) ||
-      (!isCustomProvider && !isEditingKey && !currentApiKey.key_value)
-    ) {
-      toast.error(t('messages.requiredFields'));
-      return;
-    }
-
-    try {
-      setLoading(true);
-
-      if (currentApiKey.id) {
-        const updateData: ApiKeyUpdate = {
-          name: currentApiKey.name,
-          provider: currentApiKey.provider,
-          base_url: currentApiKey.base_url,
-          is_active: currentApiKey.is_active !== false,
-        };
-
-        if (currentApiKey.key_value) {
-          updateData.key_value = currentApiKey.key_value;
-        }
-
-        await updateApiKey(currentApiKey.id, updateData);
-        toast.success(t('messages.updateSuccess'));
-      } else {
-        const createData: ApiKeyCreate = {
-          name: currentApiKey.name,
-          provider: currentApiKey.provider,
-          key_value: currentApiKey.key_value,
-          base_url: currentApiKey.base_url,
-        };
-
-        await createApiKey(createData);
-        toast.success(t('messages.createSuccess'));
-      }
-
-      setCurrentApiKey({});
-      setIsAddingKey(false);
-      setIsEditingKey(false);
-      loadApiKeys();
-
-      // Notificar o componente pai que as chaves foram alteradas
-      if (onApiKeysChange) {
-        onApiKeysChange();
-      }
-    } catch (error) {
-      console.error('Erro ao salvar chave API:', error);
-      toast.error(t('messages.saveError'));
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleDeleteConfirm = async () => {
-    if (!keyToDelete) {
-      return;
-    }
-
-    try {
-      setLoading(true);
-      await deleteApiKey(keyToDelete.id);
-      toast.success(t('messages.deleteSuccess'));
-      setKeyToDelete(null);
-      setShowDeleteDialog(false);
-      loadApiKeys();
-
-      // Notificar o componente pai que as chaves foram alteradas
-      if (onApiKeysChange) {
-        onApiKeysChange();
-      }
-    } catch (error) {
-      console.error('Erro ao deletar chave API:', error);
-      toast.error(t('messages.deleteError'));
-    } finally {
-      setLoading(false);
-    }
+  // Callers reload their selectable credentials through this callback. Leaving
+  // for the credentials page is the moment the list can go stale, so signal it.
+  const goToCredentials = () => {
+    onOpenChange(false);
+    onApiKeysChange?.();
+    navigate(AI_CREDENTIALS_ROUTE);
   };
 
   return (
-    <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden">
-          <DialogHeader>
-            <DialogTitle>{t('title')}</DialogTitle>
-            <DialogDescription>
-              {t('description')}
-            </DialogDescription>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('title')}</DialogTitle>
+          <DialogDescription>{t('description')}</DialogDescription>
+        </DialogHeader>
 
-          <div className="flex-1 overflow-auto">
-            {isAddingKey ? (
-              <div className="space-y-4 p-4 border rounded-lg">
-                <div className="flex justify-between items-center">
-                  <h3 className="text-lg font-medium">
-                    {isEditingKey ? t('form.title.edit') : t('form.title.new')}
-                  </h3>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      setIsAddingKey(false);
-                      setIsEditingKey(false);
-                      setCurrentApiKey({});
-                    }}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
-                </div>
+        <div className="flex flex-col items-center gap-4 py-6 text-center">
+          <KeyRound className="h-12 w-12 text-muted-foreground/60" />
+          <p className="text-sm text-muted-foreground max-w-sm">
+            {t('empty.description')}
+          </p>
+        </div>
 
-                <div className="grid gap-4">
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="name">{t('form.labels.name')}</Label>
-                    <Input
-                      id="name"
-                      value={currentApiKey.name || ''}
-                      onChange={e =>
-                        setCurrentApiKey({
-                          ...currentApiKey,
-                          name: e.target.value,
-                        })
-                      }
-                      className="col-span-3"
-                      placeholder={t('form.placeholders.name')}
-                    />
-                  </div>
-
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="provider">{t('form.labels.provider')}</Label>
-                    <Select
-                      value={currentApiKey.provider}
-                      onValueChange={value =>
-                        setCurrentApiKey({
-                          ...currentApiKey,
-                          provider: value,
-                          ...(value !== CUSTOM_OPENAI_PROVIDER ? { base_url: '' } : {}),
-                        })
-                      }
-                    >
-                      <SelectTrigger className="col-span-3">
-                        <SelectValue placeholder={t('form.placeholders.provider')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {availableProviders.map(provider => (
-                          <SelectItem key={provider.value} value={provider.value}>
-                            {provider.label}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  {currentApiKey.provider === CUSTOM_OPENAI_PROVIDER && (
-                    <div className="grid grid-cols-4 items-center gap-4">
-                      <Label htmlFor="base_url">Base URL</Label>
-                      <Input
-                        id="base_url"
-                        value={currentApiKey.base_url || ''}
-                        onChange={e =>
-                          setCurrentApiKey({
-                            ...currentApiKey,
-                            base_url: e.target.value,
-                          })
-                        }
-                        className="col-span-3"
-                        placeholder="https://api.example.com/v1"
-                      />
-                    </div>
-                  )}
-
-                  <div className="grid grid-cols-4 items-center gap-4">
-                    <Label htmlFor="key_value">
-                      {t('form.labels.key')}
-                      {currentApiKey.provider !== CUSTOM_OPENAI_PROVIDER && (
-                        <span className="text-red-500 ml-1">*</span>
-                      )}
-                    </Label>
-                    <div className="col-span-3 relative">
-                      <Input
-                        id="key_value"
-                        value={currentApiKey.key_value || ''}
-                        onChange={e =>
-                          setCurrentApiKey({
-                            ...currentApiKey,
-                            key_value: e.target.value,
-                          })
-                        }
-                        className="pr-10"
-                        type={isKeyVisible ? 'text' : 'password'}
-                        placeholder={
-                          isEditingKey
-                            ? t('form.placeholders.keyEdit')
-                            : t('form.placeholders.keyNew')
-                        }
-                      />
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        type="button"
-                        className="absolute right-2 top-1/2 transform -translate-y-1/2 h-7 w-7 p-0"
-                        onClick={() => setIsKeyVisible(!isKeyVisible)}
-                      >
-                        <Eye className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-
-                  {isEditingKey && (
-                    <div className="grid grid-cols-4 items-center gap-4">
-                      <Label htmlFor="is_active">{t('form.labels.status')}</Label>
-                      <div className="col-span-3 flex items-center space-x-2">
-                        <Checkbox
-                          id="is_active"
-                          checked={currentApiKey.is_active !== false}
-                          onCheckedChange={checked =>
-                            setCurrentApiKey({
-                              ...currentApiKey,
-                              is_active: !!checked,
-                            })
-                          }
-                        />
-                        <Label htmlFor="is_active">{t('form.labels.active')}</Label>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex justify-end gap-2 pt-4">
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      setIsAddingKey(false);
-                      setIsEditingKey(false);
-                      setCurrentApiKey({});
-                    }}
-                  >
-                    {t('actions.cancel')}
-                  </Button>
-                  <Button onClick={handleSaveApiKey} disabled={loading}>
-                    {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                    {isEditingKey ? t('actions.update') : t('actions.save')}
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <>
-                <div className="flex justify-between items-center mb-4">
-                  <h3 className="text-lg font-medium">{t('list.title')}</h3>
-                  <Button onClick={handleAddClick}>
-                    <Plus className="mr-2 h-4 w-4" />
-                    {t('actions.add')}
-                  </Button>
-                </div>
-
-                {loading ? (
-                  <div className="flex items-center justify-center h-40">
-                    <Loader2 className="h-8 w-8 animate-spin" />
-                  </div>
-                ) : apiKeys.length > 0 ? (
-                  <div className="space-y-3">
-                    {apiKeys.map(apiKey => (
-                      <div
-                        key={apiKey.id}
-                        className="flex items-center justify-between p-4 border rounded-lg"
-                      >
-                        <div>
-                          <p className="font-medium">{apiKey.name}</p>
-                          <div className="flex items-center gap-2 mt-1">
-                            {apiKey.base_url && (
-                              <span className="text-sm text-muted-foreground">
-                                {apiKey.base_url}
-                              </span>
-                            )}
-                            <Badge variant="outline">{getProviderLabel(apiKey.provider)}</Badge>
-                            <span className="text-sm text-muted-foreground">
-                              {t('list.createdAt')} {new Date(apiKey.created_at).toLocaleDateString('pt-BR')}
-                            </span>
-                            {!apiKey.is_active && <Badge variant="destructive">{t('list.inactive')}</Badge>}
-                          </div>
-                        </div>
-
-                        <div className="flex gap-2">
-                          <Button variant="ghost" size="sm" onClick={() => handleEditClick(apiKey)}>
-                            <Edit className="h-4 w-4" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDeleteClick(apiKey)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                ) : (
-                  <div className="text-center py-12 border border-dashed rounded-lg">
-                    <Key className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-                    <h3 className="text-lg font-medium mb-2">{t('empty.title')}</h3>
-                    <p className="text-muted-foreground mb-4">
-                      {t('empty.description')}
-                    </p>
-                    <Button onClick={handleAddClick}>
-                      <Plus className="mr-2 h-4 w-4" />
-                      {t('actions.addFirst')}
-                    </Button>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-
-          <DialogFooter>
-            <Button variant="outline" onClick={() => onOpenChange(false)}>
-              {t('actions.close')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Dialog de confirmação de exclusão */}
-      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t('deleteDialog.title')}</DialogTitle>
-            <DialogDescription>
-              {t('deleteDialog.description', { name: keyToDelete?.name })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
-              {t('deleteDialog.cancel')}
-            </Button>
-            <Button variant="destructive" onClick={handleDeleteConfirm} disabled={loading}>
-              {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t('deleteDialog.confirm')}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('actions.cancel')}
+          </Button>
+          <Button onClick={goToCredentials}>
+            <ExternalLink className="mr-2 h-4 w-4" />
+            {t('title')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/agents/ExternalAgentConfig.spec.tsx
+++ b/src/components/agents/ExternalAgentConfig.spec.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ExternalAgentConfig, { type ExternalAgentConfigData } from './ExternalAgentConfig';
+
+// EVO-2250 story 2.3 (front): the external agent points at a vault credential
+// by credential_id, and the inline secret keeps travelling as the fallback.
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const getIntegration = vi.fn();
+const upsertIntegration = vi.fn();
+
+vi.mock('@/services/agents/integrationService', () => ({
+  default: {
+    getIntegration: (...args: unknown[]) => getIntegration(...args),
+    upsertIntegration: (...args: unknown[]) => upsertIntegration(...args),
+  },
+}));
+
+const listIntegrationCredentials = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listIntegrationCredentials.mockResolvedValue([]);
+  getIntegration.mockResolvedValue({ config: {} });
+  upsertIntegration.mockResolvedValue({});
+});
+
+function renderConfig(data: ExternalAgentConfigData, onChange = vi.fn()) {
+  const onValidationChange = vi.fn();
+  const utils = render(
+    <ExternalAgentConfig
+      mode="edit"
+      agentId="agent-1"
+      data={data}
+      onChange={onChange}
+      onValidationChange={onValidationChange}
+    />,
+  );
+  return { ...utils, onChange, onValidationChange };
+}
+
+describe('ExternalAgentConfig — vault credential selector (2.3 AC7)', () => {
+  it('renders the selector for providers with a credential', async () => {
+    renderConfig({ provider: 'dify', dify_apiUrl: 'https://api.dify.ai/v1', dify_apiKey: 'app-x' });
+
+    await waitFor(() =>
+      expect(document.getElementById('external-agent-credential')).not.toBeNull(),
+    );
+  });
+
+  it('never offers the selector for typebot, which has no credential (AC6, negative proof)', async () => {
+    renderConfig({ provider: 'typebot', typebot_url: 'https://t.io', typebot_typebot: 'bot' });
+
+    await screen.findByText('edit.configuration.sections.externalIntegration.providerConfig.title');
+    expect(document.getElementById('external-agent-credential')).toBeNull();
+    // No vault fetch either: the hook stays disabled for typebot.
+    expect(listIntegrationCredentials).not.toHaveBeenCalled();
+  });
+
+  it('saves credential_id ALONGSIDE the inline key (fallback preserved, negative proof)', async () => {
+    const user = userEvent.setup();
+    renderConfig({
+      provider: 'dify',
+      credential_id: 'cred-dify',
+      dify_apiUrl: 'https://api.dify.ai/v1',
+      dify_apiKey: 'app-inline',
+      dify_botType: 'chatBot',
+    });
+
+    await user.click(await screen.findByText('edit.configuration.sections.externalIntegration.providerConfig.save'));
+
+    await waitFor(() => expect(upsertIntegration).toHaveBeenCalled());
+    const [, payload] = upsertIntegration.mock.calls[0];
+    expect(payload.config.credential_id).toBe('cred-dify');
+    // The wholesale upsert replaces config: dropping the inline key here would
+    // erase the stored fallback (the 1.6 data-loss path).
+    expect(payload.config.apiKey).toBe('app-inline');
+  });
+
+  it('omits credential_id from the payload when none is chosen', async () => {
+    const user = userEvent.setup();
+    renderConfig({
+      provider: 'dify',
+      dify_apiUrl: 'https://api.dify.ai/v1',
+      dify_apiKey: 'app-inline',
+    });
+
+    await user.click(await screen.findByText('edit.configuration.sections.externalIntegration.providerConfig.save'));
+
+    await waitFor(() => expect(upsertIntegration).toHaveBeenCalled());
+    const [, payload] = upsertIntegration.mock.calls[0];
+    expect(payload.config).not.toHaveProperty('credential_id');
+  });
+
+  it('accepts a vault reference in place of the inline key on validation', async () => {
+    const { onValidationChange } = renderConfig({
+      provider: 'dify',
+      credential_id: 'cred-dify',
+      dify_apiUrl: 'https://api.dify.ai/v1',
+      dify_apiKey: '',
+    });
+
+    await waitFor(() => expect(onValidationChange).toHaveBeenCalled());
+    const lastCall = onValidationChange.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe(true);
+  });
+
+  it('still requires a secret when neither inline nor vault is set (negative proof)', async () => {
+    const { onValidationChange } = renderConfig({
+      provider: 'dify',
+      dify_apiUrl: 'https://api.dify.ai/v1',
+      dify_apiKey: '',
+    });
+
+    await waitFor(() => expect(onValidationChange).toHaveBeenCalled());
+    const lastCall = onValidationChange.mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe(false);
+  });
+
+  it('loads the stored credential_id when editing', async () => {
+    getIntegration.mockResolvedValue({
+      config: { apiUrl: 'https://api.dify.ai/v1', apiKey: 'app-x', credential_id: 'cred-dify' },
+    });
+    const onChange = vi.fn();
+    renderConfig({ provider: 'dify' }, onChange);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange.mock.calls[0][0].credential_id).toBe('cred-dify');
+  });
+});

--- a/src/components/agents/ExternalAgentConfig.spec.tsx
+++ b/src/components/agents/ExternalAgentConfig.spec.tsx
@@ -21,9 +21,12 @@ vi.mock('@/services/agents/integrationService', () => ({
 }));
 
 const listIntegrationCredentials = vi.fn();
+const getIntegrationVaultMigrationState = vi.fn();
 
 vi.mock('@/services/agents', () => ({
   listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+  getIntegrationVaultMigrationState: (...args: unknown[]) =>
+    getIntegrationVaultMigrationState(...args),
 }));
 
 beforeAll(() => {
@@ -37,6 +40,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   listIntegrationCredentials.mockResolvedValue([]);
+  getIntegrationVaultMigrationState.mockResolvedValue({ retired: {} });
   getIntegration.mockResolvedValue({ config: {} });
   upsertIntegration.mockResolvedValue({});
 });
@@ -131,6 +135,119 @@ describe('ExternalAgentConfig — vault credential selector (2.3 AC7)', () => {
     await waitFor(() => expect(onValidationChange).toHaveBeenCalled());
     const lastCall = onValidationChange.mock.calls.at(-1);
     expect(lastCall?.[0]).toBe(false);
+  });
+
+  // EVO-2250 story 2.7 (gap closed): the inline key of the external agent
+  // retires behind the external_agents consumer of the migration guard.
+  describe('inline key retirement (2.7)', () => {
+    beforeEach(() => {
+      getIntegrationVaultMigrationState.mockResolvedValue({
+        retired: { external_agents: true },
+      });
+    });
+
+    it('locks the inline key input and shows the vault hint when retired', async () => {
+      renderConfig({
+        provider: 'dify',
+        dify_apiUrl: 'https://api.dify.ai/v1',
+        credential_id: 'cred-dify',
+      });
+
+      await waitFor(() =>
+        expect(document.getElementById('dify_apiKey')).toHaveProperty('disabled', true),
+      );
+      expect(screen.getByText('retirement.externalKeyLocked')).toBeInTheDocument();
+      // The address field is NOT a secret and stays editable.
+      expect(document.getElementById('dify_apiUrl')).toHaveProperty('disabled', false);
+    });
+
+    it('keeps an existing inline key travelling in the payload after retirement (negative proof)', async () => {
+      const user = userEvent.setup();
+      renderConfig({
+        provider: 'dify',
+        dify_apiUrl: 'https://api.dify.ai/v1',
+        dify_apiKey: 'app-preservada',
+        credential_id: 'cred-dify',
+      });
+
+      await user.click(
+        await screen.findByText('edit.configuration.sections.externalIntegration.providerConfig.save'),
+      );
+
+      await waitFor(() => expect(upsertIntegration).toHaveBeenCalled());
+      const [, payload] = upsertIntegration.mock.calls[0];
+      // This fails if retirement ever drops the inline value from the payload:
+      // the upsert replaces config wholesale and the fallback would be erased.
+      expect(payload.config.apiKey).toBe('app-preservada');
+      expect(payload.config.credential_id).toBe('cred-dify');
+    });
+
+    it('OMITS a blank key instead of sending it present-empty (negative proof of the erase path)', async () => {
+      const user = userEvent.setup();
+      getIntegration.mockResolvedValue({
+        // The sanitized GET: the saved key never comes back.
+        config: { apiUrl: 'https://api.dify.ai/v1', credential_id: 'cred-dify' },
+      });
+      renderConfig({
+        provider: 'dify',
+        dify_apiUrl: 'https://api.dify.ai/v1',
+        dify_apiKey: '',
+        credential_id: 'cred-dify',
+      });
+
+      await user.click(
+        await screen.findByText('edit.configuration.sections.externalIntegration.providerConfig.save'),
+      );
+
+      await waitFor(() => expect(upsertIntegration).toHaveBeenCalled());
+      const [, payload] = upsertIntegration.mock.calls[0];
+      // A PRESENT blank wins over the stored secret in the backend merge, so
+      // it must never travel: absence is what means "keep the stored value".
+      expect(payload.config).not.toHaveProperty('apiKey');
+    });
+
+    it('keeps everything editable while the guard says not migrated (AC3)', async () => {
+      getIntegrationVaultMigrationState.mockResolvedValue({ retired: {} });
+      renderConfig({
+        provider: 'dify',
+        dify_apiUrl: 'https://api.dify.ai/v1',
+        dify_apiKey: 'app-x',
+      });
+
+      await waitFor(() => expect(getIntegrationVaultMigrationState).toHaveBeenCalled());
+      expect(document.getElementById('dify_apiKey')).toHaveProperty('disabled', false);
+      expect(screen.queryByText('retirement.externalKeyLocked')).not.toBeInTheDocument();
+    });
+
+    it('keeps everything editable when the guard itself fails (fails closed)', async () => {
+      getIntegrationVaultMigrationState.mockRejectedValue(new Error('503'));
+      renderConfig({
+        provider: 'dify',
+        dify_apiUrl: 'https://api.dify.ai/v1',
+        dify_apiKey: 'app-x',
+      });
+
+      await waitFor(() => expect(getIntegrationVaultMigrationState).toHaveBeenCalled());
+      expect(document.getElementById('dify_apiKey')).toHaveProperty('disabled', false);
+      expect(screen.queryByText('retirement.externalKeyLocked')).not.toBeInTheDocument();
+    });
+
+    it('accepts a saved integration in place of a retyped key on validation', async () => {
+      getIntegration.mockResolvedValue({
+        config: { apiUrl: 'https://api.dify.ai/v1' },
+      });
+      const { onValidationChange } = renderConfig({
+        provider: 'dify',
+        dify_apiUrl: 'https://api.dify.ai/v1',
+        dify_apiKey: '',
+      });
+
+      await waitFor(() => expect(getIntegration).toHaveBeenCalled());
+      await waitFor(() => {
+        const lastCall = onValidationChange.mock.calls.at(-1);
+        expect(lastCall?.[0]).toBe(true);
+      });
+    });
   });
 
   it('loads the stored credential_id when editing', async () => {

--- a/src/components/agents/ExternalAgentConfig.tsx
+++ b/src/components/agents/ExternalAgentConfig.tsx
@@ -11,7 +11,11 @@ import { Settings, Save, Loader2, AlertCircle } from 'lucide-react';
 import integrationService from '@/services/agents/integrationService';
 import { useLanguage } from '@/hooks/useLanguage';
 import { Label } from '@evoapi/design-system';
-import { VaultCredentialSelect, useVaultCredentials } from '@/components/ai_agents/shared';
+import {
+  VaultCredentialSelect,
+  useVaultCredentials,
+  useVaultMigrationState,
+} from '@/components/ai_agents/shared';
 import { ProviderType } from './ProviderSelector';
 import {
   FlowiseConfigForm,
@@ -76,11 +80,22 @@ const ExternalAgentConfig = ({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  // Since story 2.3 the GET is sanitized: a saved key round-trips as blank.
+  // A loaded integration therefore satisfies the key requirement — blank means
+  // "keep the stored secret", never "there is no secret".
+  const [hasSavedIntegration, setHasSavedIntegration] = useState(false);
 
   // Typebot authenticates with nothing at all (story 2.3 AC6): no credential,
   // no selector, registered as a decision rather than an oversight.
   const providerHasCredential = Boolean(data.provider) && data.provider !== 'typebot';
   const vaultCredentials = useVaultCredentials(providerHasCredential);
+  // Story 2.7: once the guard says the external_agents consumer migrated, the
+  // inline key input retires and the vault reference is how a secret is
+  // registered. Guard failure reads as not retired: nothing is removed from a
+  // broken installation.
+  const migrationState = useVaultMigrationState(providerHasCredential);
+  const inlineKeyRetired =
+    providerHasCredential && Boolean(migrationState.retired.external_agents);
 
   // Load integration config when editing
   useEffect(() => {
@@ -96,6 +111,7 @@ const ExternalAgentConfig = ({
       setIsLoading(true);
       const integration = await integrationService.getIntegration(agentId, data.provider);
       const config = integration.config || {};
+      setHasSavedIntegration(Object.keys(config).length > 0);
 
       // Map config to form data based on provider
       const newData: ExternalAgentConfigData = { ...data };
@@ -154,13 +170,14 @@ const ExternalAgentConfig = ({
       if (!data.dify_apiUrl?.trim()) {
         newErrors.dify_apiUrl = t('edit.configuration.sections.externalIntegration.errors.apiUrlRequired');
       }
-      // A vault reference satisfies the key requirement: the runtime resolves
-      // the secret by credential_id (story 2.3), so inline is optional then.
-      if (!data.dify_apiKey?.trim() && !data.credential_id?.trim()) {
+      // A vault reference satisfies the key requirement (the runtime resolves
+      // by credential_id, story 2.3), and so does a SAVED integration: since
+      // 2.3 the GET is sanitized, so the stored key always round-trips blank.
+      if (!data.dify_apiKey?.trim() && !data.credential_id?.trim() && !hasSavedIntegration) {
         newErrors.dify_apiKey = t('edit.configuration.sections.externalIntegration.errors.apiKeyRequired');
       }
     } else if (data.provider === 'openai') {
-      if (!data.openai_apiKey?.trim() && !data.credential_id?.trim()) {
+      if (!data.openai_apiKey?.trim() && !data.credential_id?.trim() && !hasSavedIntegration) {
         newErrors.openai_apiKey = t('edit.configuration.sections.externalIntegration.errors.apiKeyRequired');
       }
       if (data.openai_botType === 'assistant' && !data.openai_assistantId?.trim()) {
@@ -179,7 +196,7 @@ const ExternalAgentConfig = ({
     }
 
     return newErrors;
-  }, [data]);
+  }, [data, hasSavedIntegration]);
 
   useEffect(() => {
     const newErrors = validateForm();
@@ -294,21 +311,33 @@ const ExternalAgentConfig = ({
     try {
       setIsSaving(true);
 
-      // Build config based on provider
+      // Build config based on provider.
+      //
+      // ⚠️ Secret fields are set ONLY when non-empty. The backend replaces the
+      // stored config wholesale and its MergePreservedSecrets keeps a secret
+      // whose key is ABSENT — but a PRESENT blank wins. Since story 2.3 the
+      // GET is sanitized (the key never comes back), so every edit round-trips
+      // a blank: sending it present would erase the stored fallback on save.
       const config: Record<string, any> = {};
+      const setSecret = (field: string, value?: string) => {
+        if (value?.trim()) {
+          config[field] = value;
+        }
+      };
+
       if (data.provider === 'flowise') {
         config.apiUrl = data.flowise_apiUrl;
-        config.apiKey = data.flowise_apiKey;
+        setSecret('apiKey', data.flowise_apiKey);
       } else if (data.provider === 'n8n') {
         config.webhookUrl = data.n8n_webhookUrl;
-        config.basicAuthUser = data.n8n_basicAuthUser;
-        config.basicAuthPass = data.n8n_basicAuthPass;
+        setSecret('basicAuthUser', data.n8n_basicAuthUser);
+        setSecret('basicAuthPass', data.n8n_basicAuthPass);
       } else if (data.provider === 'dify') {
         config.apiUrl = data.dify_apiUrl;
-        config.apiKey = data.dify_apiKey;
+        setSecret('apiKey', data.dify_apiKey);
         config.botType = data.dify_botType || 'chatBot';
       } else if (data.provider === 'openai') {
-        config.apiKey = data.openai_apiKey;
+        setSecret('apiKey', data.openai_apiKey);
         config.botType = data.openai_botType || 'assistant';
         config.assistantId = data.openai_assistantId;
         config.model = data.openai_model;
@@ -393,6 +422,8 @@ const ExternalAgentConfig = ({
               onChange={handleProviderConfigChange}
               errors={providerErrors}
               disabled={isReadOnly}
+              secretRetired={inlineKeyRetired}
+              secretRetiredHint={tVault('retirement.externalKeyLocked')}
             />
           );
         case 'n8n':
@@ -402,6 +433,8 @@ const ExternalAgentConfig = ({
               onChange={handleProviderConfigChange}
               errors={providerErrors}
               disabled={isReadOnly}
+              secretRetired={inlineKeyRetired}
+              secretRetiredHint={tVault('retirement.externalKeyLocked')}
             />
           );
         case 'dify':
@@ -411,6 +444,8 @@ const ExternalAgentConfig = ({
               onChange={handleProviderConfigChange}
               errors={providerErrors}
               disabled={isReadOnly}
+              secretRetired={inlineKeyRetired}
+              secretRetiredHint={tVault('retirement.externalKeyLocked')}
             />
           );
         case 'openai':
@@ -420,6 +455,8 @@ const ExternalAgentConfig = ({
               onChange={handleProviderConfigChange}
               errors={providerErrors}
               disabled={isReadOnly}
+              secretRetired={inlineKeyRetired}
+              secretRetiredHint={tVault('retirement.externalKeyLocked')}
             />
           );
         case 'typebot':

--- a/src/components/agents/ExternalAgentConfig.tsx
+++ b/src/components/agents/ExternalAgentConfig.tsx
@@ -10,6 +10,8 @@ import {
 import { Settings, Save, Loader2, AlertCircle } from 'lucide-react';
 import integrationService from '@/services/agents/integrationService';
 import { useLanguage } from '@/hooks/useLanguage';
+import { Label } from '@evoapi/design-system';
+import { VaultCredentialSelect, useVaultCredentials } from '@/components/ai_agents/shared';
 import { ProviderType } from './ProviderSelector';
 import {
   FlowiseConfigForm,
@@ -28,6 +30,9 @@ type AgentPageMode = 'create' | 'edit' | 'view';
 
 export interface ExternalAgentConfigData {
   provider?: ProviderType;
+  // EVO-2250 story 2.3: reference to the integration credential vault. The
+  // inline secret fields stay as the fallback until story 2.7 retires them.
+  credential_id?: string;
   // Flowise config
   flowise_apiUrl?: string;
   flowise_apiKey?: string;
@@ -67,9 +72,15 @@ const ExternalAgentConfig = ({
   onValidationChange,
 }: ExternalAgentConfigProps) => {
   const { t } = useLanguage('aiAgents');
+  const { t: tVault } = useLanguage('integrationCredentials');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+
+  // Typebot authenticates with nothing at all (story 2.3 AC6): no credential,
+  // no selector, registered as a decision rather than an oversight.
+  const providerHasCredential = Boolean(data.provider) && data.provider !== 'typebot';
+  const vaultCredentials = useVaultCredentials(providerHasCredential);
 
   // Load integration config when editing
   useEffect(() => {
@@ -88,7 +99,9 @@ const ExternalAgentConfig = ({
 
       // Map config to form data based on provider
       const newData: ExternalAgentConfigData = { ...data };
-      
+
+      newData.credential_id = config.credential_id || '';
+
       if (data.provider === 'flowise') {
         newData.flowise_apiUrl = config.apiUrl || '';
         newData.flowise_apiKey = config.apiKey || '';
@@ -141,11 +154,13 @@ const ExternalAgentConfig = ({
       if (!data.dify_apiUrl?.trim()) {
         newErrors.dify_apiUrl = t('edit.configuration.sections.externalIntegration.errors.apiUrlRequired');
       }
-      if (!data.dify_apiKey?.trim()) {
+      // A vault reference satisfies the key requirement: the runtime resolves
+      // the secret by credential_id (story 2.3), so inline is optional then.
+      if (!data.dify_apiKey?.trim() && !data.credential_id?.trim()) {
         newErrors.dify_apiKey = t('edit.configuration.sections.externalIntegration.errors.apiKeyRequired');
       }
     } else if (data.provider === 'openai') {
-      if (!data.openai_apiKey?.trim()) {
+      if (!data.openai_apiKey?.trim() && !data.credential_id?.trim()) {
         newErrors.openai_apiKey = t('edit.configuration.sections.externalIntegration.errors.apiKeyRequired');
       }
       if (data.openai_botType === 'assistant' && !data.openai_assistantId?.trim()) {
@@ -304,6 +319,13 @@ const ExternalAgentConfig = ({
         config.apiVersion = data.typebot_apiVersion || 'latest';
       }
 
+      // The vault reference travels alongside the inline fields: the runtime
+      // prefers it and falls back to inline (story 2.3). Typebot never carries
+      // one — it has no credential at all.
+      if (providerHasCredential && data.credential_id?.trim()) {
+        config.credential_id = data.credential_id;
+      }
+
       await integrationService.upsertIntegration(agentId, {
         provider: data.provider,
         config,
@@ -348,55 +370,82 @@ const ExternalAgentConfig = ({
 
     const isReadOnly = mode === 'view';
 
-    switch (data.provider) {
-      case 'flowise':
-        return (
-          <FlowiseConfigForm
-            config={providerConfig as FlowiseConfig}
-            onChange={handleProviderConfigChange}
-            errors={providerErrors}
-            disabled={isReadOnly}
-          />
-        );
-      case 'n8n':
-        return (
-          <N8NConfigForm
-            config={providerConfig as N8NConfig}
-            onChange={handleProviderConfigChange}
-            errors={providerErrors}
-            disabled={isReadOnly}
-          />
-        );
-      case 'dify':
-        return (
-          <DifyConfigForm
-            config={providerConfig as DifyConfig}
-            onChange={handleProviderConfigChange}
-            errors={providerErrors}
-            disabled={isReadOnly}
-          />
-        );
-      case 'openai':
-        return (
-          <OpenAIConfigForm
-            config={providerConfig as OpenAIConfig}
-            onChange={handleProviderConfigChange}
-            errors={providerErrors}
-            disabled={isReadOnly}
-          />
-        );
-      case 'typebot':
-        return (
-          <TypebotConfigForm
-            config={providerConfig as TypebotConfig}
-            onChange={handleProviderConfigChange}
-            errors={providerErrors}
-            disabled={isReadOnly}
-          />
-        );
-      default:
-        return null;
+    const vaultSelector = providerHasCredential && (
+      <div className="space-y-2 pb-2">
+        <Label htmlFor="external-agent-credential">{tVault('refsEditor.nexusLabel')}</Label>
+        <VaultCredentialSelect
+          id="external-agent-credential"
+          value={data.credential_id?.trim() ? data.credential_id : undefined}
+          onChange={credentialId => onChange({ ...data, credential_id: credentialId ?? '' })}
+          disabled={isReadOnly}
+          credentials={vaultCredentials}
+        />
+        <p className="text-xs text-muted-foreground">{tVault('externalAgent.hint')}</p>
+      </div>
+    );
+
+    const providerForm = (() => {
+      switch (data.provider) {
+        case 'flowise':
+          return (
+            <FlowiseConfigForm
+              config={providerConfig as FlowiseConfig}
+              onChange={handleProviderConfigChange}
+              errors={providerErrors}
+              disabled={isReadOnly}
+            />
+          );
+        case 'n8n':
+          return (
+            <N8NConfigForm
+              config={providerConfig as N8NConfig}
+              onChange={handleProviderConfigChange}
+              errors={providerErrors}
+              disabled={isReadOnly}
+            />
+          );
+        case 'dify':
+          return (
+            <DifyConfigForm
+              config={providerConfig as DifyConfig}
+              onChange={handleProviderConfigChange}
+              errors={providerErrors}
+              disabled={isReadOnly}
+            />
+          );
+        case 'openai':
+          return (
+            <OpenAIConfigForm
+              config={providerConfig as OpenAIConfig}
+              onChange={handleProviderConfigChange}
+              errors={providerErrors}
+              disabled={isReadOnly}
+            />
+          );
+        case 'typebot':
+          return (
+            <TypebotConfigForm
+              config={providerConfig as TypebotConfig}
+              onChange={handleProviderConfigChange}
+              errors={providerErrors}
+              disabled={isReadOnly}
+            />
+          );
+        default:
+          return null;
+      }
+    })();
+
+    if (!providerForm) {
+      return null;
     }
+
+    return (
+      <>
+        {vaultSelector}
+        {providerForm}
+      </>
+    );
   };
 
   if (isLoading) {

--- a/src/components/agents/providerConfigs/DifyConfigForm.tsx
+++ b/src/components/agents/providerConfigs/DifyConfigForm.tsx
@@ -12,6 +12,10 @@ interface DifyConfigFormProps {
   onChange: (config: DifyConfig) => void;
   errors?: Record<string, string>;
   disabled?: boolean;
+  /** EVO-2250 story 2.7: the inline secret retired behind the migration
+   * guard. Only the secret input locks; address fields stay editable. */
+  secretRetired?: boolean;
+  secretRetiredHint?: string;
 }
 
 export const DifyConfigForm = ({
@@ -19,6 +23,8 @@ export const DifyConfigForm = ({
   onChange,
   errors = {},
   disabled = false,
+  secretRetired = false,
+  secretRetiredHint,
 }: DifyConfigFormProps) => {
   const { t } = useLanguage('aiAgents');
   
@@ -45,10 +51,13 @@ export const DifyConfigForm = ({
           value={config.apiKey || ''}
           onChange={(e) => onChange({ ...config, apiKey: e.target.value })}
           placeholder="app-..."
-          disabled={disabled}
+          disabled={disabled || secretRetired}
         />
         {errors.apiKey && (
           <p className="text-xs text-red-600">{errors.apiKey}</p>
+        )}
+        {secretRetired && secretRetiredHint && (
+          <p className="text-xs text-muted-foreground">{secretRetiredHint}</p>
         )}
       </div>
       <div className="space-y-2">

--- a/src/components/agents/providerConfigs/FlowiseConfigForm.tsx
+++ b/src/components/agents/providerConfigs/FlowiseConfigForm.tsx
@@ -11,6 +11,10 @@ interface FlowiseConfigFormProps {
   onChange: (config: FlowiseConfig) => void;
   errors?: Record<string, string>;
   disabled?: boolean;
+  /** EVO-2250 story 2.7: the inline secret retired behind the migration
+   * guard. Only the secret input locks; address fields stay editable. */
+  secretRetired?: boolean;
+  secretRetiredHint?: string;
 }
 
 export const FlowiseConfigForm = ({
@@ -18,6 +22,8 @@ export const FlowiseConfigForm = ({
   onChange,
   errors = {},
   disabled = false,
+  secretRetired = false,
+  secretRetiredHint,
 }: FlowiseConfigFormProps) => {
   const { t } = useLanguage('aiAgents');
   
@@ -44,8 +50,11 @@ export const FlowiseConfigForm = ({
           value={config.apiKey || ''}
           onChange={(e) => onChange({ ...config, apiKey: e.target.value })}
           placeholder="sk-..."
-          disabled={disabled}
+          disabled={disabled || secretRetired}
         />
+        {secretRetired && secretRetiredHint && (
+          <p className="text-xs text-muted-foreground">{secretRetiredHint}</p>
+        )}
       </div>
     </>
   );

--- a/src/components/agents/providerConfigs/N8NConfigForm.tsx
+++ b/src/components/agents/providerConfigs/N8NConfigForm.tsx
@@ -12,6 +12,10 @@ interface N8NConfigFormProps {
   onChange: (config: N8NConfig) => void;
   errors?: Record<string, string>;
   disabled?: boolean;
+  /** EVO-2250 story 2.7: the inline secret retired behind the migration
+   * guard. Only the secret input locks; address fields stay editable. */
+  secretRetired?: boolean;
+  secretRetiredHint?: string;
 }
 
 export const N8NConfigForm = ({
@@ -19,6 +23,8 @@ export const N8NConfigForm = ({
   onChange,
   errors = {},
   disabled = false,
+  secretRetired = false,
+  secretRetiredHint,
 }: N8NConfigFormProps) => {
   const { t } = useLanguage('aiAgents');
   
@@ -44,7 +50,7 @@ export const N8NConfigForm = ({
             id="n8n_basicAuthUser"
             value={config.basicAuthUser || ''}
             onChange={(e) => onChange({ ...config, basicAuthUser: e.target.value })}
-            disabled={disabled}
+            disabled={disabled || secretRetired}
           />
         </div>
         <div className="space-y-2">
@@ -54,9 +60,12 @@ export const N8NConfigForm = ({
             type="password"
             value={config.basicAuthPass || ''}
             onChange={(e) => onChange({ ...config, basicAuthPass: e.target.value })}
-            disabled={disabled}
+            disabled={disabled || secretRetired}
           />
-        </div>
+          {secretRetired && secretRetiredHint && (
+          <p className="text-xs text-muted-foreground">{secretRetiredHint}</p>
+        )}
+      </div>
       </div>
     </>
   );

--- a/src/components/agents/providerConfigs/OpenAIConfigForm.tsx
+++ b/src/components/agents/providerConfigs/OpenAIConfigForm.tsx
@@ -14,6 +14,10 @@ interface OpenAIConfigFormProps {
   onChange: (config: OpenAIConfig) => void;
   errors?: Record<string, string>;
   disabled?: boolean;
+  /** EVO-2250 story 2.7: the inline secret retired behind the migration
+   * guard. Only the secret input locks; address fields stay editable. */
+  secretRetired?: boolean;
+  secretRetiredHint?: string;
 }
 
 export const OpenAIConfigForm = ({
@@ -21,6 +25,8 @@ export const OpenAIConfigForm = ({
   onChange,
   errors = {},
   disabled = false,
+  secretRetired = false,
+  secretRetiredHint,
 }: OpenAIConfigFormProps) => {
   const { t } = useLanguage('aiAgents');
   
@@ -34,10 +40,13 @@ export const OpenAIConfigForm = ({
           value={config.apiKey || ''}
           onChange={(e) => onChange({ ...config, apiKey: e.target.value })}
           placeholder="sk-..."
-          disabled={disabled}
+          disabled={disabled || secretRetired}
         />
         {errors.apiKey && (
           <p className="text-xs text-red-600">{errors.apiKey}</p>
+        )}
+        {secretRetired && secretRetiredHint && (
+          <p className="text-xs text-muted-foreground">{secretRetiredHint}</p>
         )}
       </div>
       <div className="space-y-2">

--- a/src/components/ai_agents/Dialogs/MCPConfigDialog.spec.tsx
+++ b/src/components/ai_agents/Dialogs/MCPConfigDialog.spec.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MCPConfigDialog from './MCPConfigDialog';
+import type { MCPServer } from '@/types/ai';
+
+// EVO-2250 story 2.4 AC7: the WRITE end of "an official MCP server takes a
+// secret env var from the vault". The processor's resolution is inert without
+// it — a field nobody persists is a field nobody resolves, which is the defect
+// class that failed this card's review.
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const listIntegrationCredentials = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+}));
+
+const GITHUB_SERVER = {
+  id: 'srv-github',
+  name: 'GitHub',
+  description: 'GitHub MCP',
+  config_type: 'studio',
+  config_json: {},
+  environments: { GITHUB_PERSONAL_ACCESS_TOKEN: 'required' },
+  tools: [],
+} as unknown as MCPServer;
+
+const VAULT_CREDENTIAL = {
+  id: 'cred-github',
+  name: 'Token do GitHub',
+  provider: 'github',
+  kind: 'static' as const,
+  scope: 'account' as const,
+  is_active: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listIntegrationCredentials.mockResolvedValue([VAULT_CREDENTIAL]);
+});
+
+const renderDialog = (onSave = vi.fn(), initialConfig = null as never) =>
+  ({
+    onSave,
+    ...render(
+      <MCPConfigDialog
+        open
+        onOpenChange={() => {}}
+        onSave={onSave}
+        availableServers={[GITHUB_SERVER]}
+        initialConfig={initialConfig}
+      />,
+    ),
+  });
+
+describe('MCPConfigDialog — vault reference per env var (2.4 AC7)', () => {
+  // Editing an existing entry is the state that renders the env fields: in
+  // create mode the dialog starts on server selection, with no variables yet.
+  it('offers a vault selector next to every required env var', async () => {
+    const initial = {
+      id: 'srv-github',
+      name: 'GitHub',
+      type: 'studio',
+      environments: { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp-inline' },
+      tools: [],
+    } as never;
+    renderDialog(vi.fn(), initial);
+
+    await waitFor(() =>
+      expect(document.getElementById('env-cred-GITHUB_PERSONAL_ACCESS_TOKEN')).not.toBeNull(),
+    );
+    // The inline field stays: it is the fallback until story 2.7.
+    expect(document.getElementById('env-GITHUB_PERSONAL_ACCESS_TOKEN')).not.toBeNull();
+  });
+
+  it('loads a stored reference when editing (negative proof of the drop)', async () => {
+    const initial = {
+      id: 'srv-github',
+      name: 'GitHub',
+      type: 'studio',
+      environments: { GITHUB_PERSONAL_ACCESS_TOKEN: '' },
+      credential_refs: { GITHUB_PERSONAL_ACCESS_TOKEN: 'cred-github' },
+      tools: [],
+    } as never;
+    const { onSave } = renderDialog(vi.fn(), initial);
+    const user = userEvent.setup();
+
+    await screen.findByText('dialogs.mcpConfig.requiredConfig');
+    await user.click(screen.getByText('dialogs.mcpConfig.save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    // A dialog that dropped the field on load would save it away: the API
+    // replaces the entry, so the stored reference would be lost on any edit.
+    expect(onSave.mock.calls[0][0].credential_refs).toEqual({
+      GITHUB_PERSONAL_ACCESS_TOKEN: 'cred-github',
+    });
+  });
+
+  it('sends an empty map when no variable references the vault', async () => {
+    const initial = {
+      id: 'srv-github',
+      name: 'GitHub',
+      type: 'studio',
+      environments: { GITHUB_PERSONAL_ACCESS_TOKEN: 'ghp-inline' },
+      tools: [],
+    } as never;
+    const { onSave } = renderDialog(vi.fn(), initial);
+    const user = userEvent.setup();
+
+    await screen.findByText('dialogs.mcpConfig.requiredConfig');
+    await user.click(screen.getByText('dialogs.mcpConfig.save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const payload = onSave.mock.calls[0][0];
+    expect(payload.credential_refs).toEqual({});
+    // The inline value keeps travelling: it is the fallback the runtime uses.
+    expect(payload.environments.GITHUB_PERSONAL_ACCESS_TOKEN).toBe('ghp-inline');
+  });
+});

--- a/src/components/ai_agents/Dialogs/MCPConfigDialog.tsx
+++ b/src/components/ai_agents/Dialogs/MCPConfigDialog.tsx
@@ -20,6 +20,7 @@ import {
 import { MCPServer, MCPServerConfig } from '@/types/ai';
 import { Server, Settings, CheckCircle2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { VaultCredentialSelect, useVaultCredentials } from '@/components/ai_agents/shared';
 import { Tool } from '@/types';
 
 interface MCPConfigDialogProps {
@@ -46,8 +47,43 @@ const MCPConfigDialog = ({
   mcpServers = [],
 }: MCPConfigDialogProps) => {
   const { t } = useLanguage('aiAgents');
+  // Gated on `open`: the dialog mounts closed on the agent screens, and an
+  // eager fetch would be one vault listing (a 403 without the grant) per render.
+  const vaultCredentials = useVaultCredentials(open);
   const [selectedServer, setSelectedServer] = useState<MCPServer | null>(null);
   const [mcpEnvironments, setMcpEnvironments] = useState<Record<string, unknown>>({});
+  // EVO-2250 story 2.4 AC7: env var name -> vault credential id.
+  const [credentialRefs, setCredentialRefs] = useState<Record<string, string>>({});
+
+  // Resetting to a FRESH {} on every run of an effect whose deps are unstable
+  // (initialConfig and mcpServers arrive as new objects) re-renders forever.
+  // Keeping the identity when the value is already empty makes the reset a
+  // no-op, which is what it means.
+  const clearCredentialRefs = useCallback(() => {
+    setCredentialRefs(prev => (Object.keys(prev).length === 0 ? prev : {}));
+  }, []);
+
+  // Same reason for the environments map: the effect below depends on props
+  // that arrive as fresh objects, so a reset that always allocates keeps
+  // re-rendering. Pre-existing, and reachable as soon as a test renders this
+  // dialog with inline props.
+  const clearEnvironments = useCallback(() => {
+    setMcpEnvironments(prev => (Object.keys(prev).length === 0 ? prev : {}));
+  }, []);
+
+  // And the selection: setState with the SAME value is a no-op for React, but
+  // `null` here follows the two resets above, so keeping the whole reset path
+  // allocation-free is what actually stops the loop.
+  const clearSelectedServer = useCallback(() => {
+    setSelectedServer(prev => (prev === null ? prev : null));
+  }, []);
+
+  const applyCredentialRefs = useCallback((next?: Record<string, string>) => {
+    setCredentialRefs(prev => {
+      const incoming = next ?? {};
+      return JSON.stringify(prev) === JSON.stringify(incoming) ? prev : incoming;
+    });
+  }, []);
   const [toolIds, setToolIds] = useState<Record<string, string[]>>({});
 
   // Inicializar com configuração existente ou limpar
@@ -59,6 +95,7 @@ const MCPConfigDialog = ({
         if (server) {
           setSelectedServer(server);
           setMcpEnvironments(initialConfig.environments || {});
+          applyCredentialRefs(initialConfig.credential_refs);
 
           setToolIds(prev => {
             if (!prev[server.id]) {
@@ -75,15 +112,27 @@ const MCPConfigDialog = ({
         }
       } else {
         // Modo criação - limpar tudo sempre
-        setSelectedServer(null);
-        setMcpEnvironments({});
+        clearSelectedServer();
+        clearEnvironments();
+        clearCredentialRefs();
       }
     } else {
       // Quando fecha o dialog, sempre limpar o estado para evitar persistência
-      setSelectedServer(null);
-      setMcpEnvironments({});
+      clearSelectedServer();
+      clearEnvironments();
+      clearCredentialRefs();
     }
-  }, [open, initialConfig, availableServers, currentStep, mcpServers]);
+  }, [
+    open,
+    initialConfig,
+    availableServers,
+    currentStep,
+    mcpServers,
+    applyCredentialRefs,
+    clearCredentialRefs,
+    clearEnvironments,
+    clearSelectedServer,
+  ]);
 
   const handleSelectServer = useCallback(
     (serverId: string) => {
@@ -97,6 +146,7 @@ const MCPConfigDialog = ({
           initialEnvironments[key] = '';
         });
         setMcpEnvironments(initialEnvironments);
+        clearCredentialRefs();
 
         // Manter seleções existentes se for o mesmo servidor
         const existingConfig =
@@ -111,8 +161,22 @@ const MCPConfigDialog = ({
         }
       }
     },
-    [availableServers, initialConfig, mcpServers],
+    [availableServers, initialConfig, mcpServers, clearCredentialRefs],
   );
+
+  // A vault reference replaces the inline value for that ONE variable; an
+  // undefined selection drops the entry so the inline value takes over again.
+  const handleCredentialRefChange = useCallback((key: string, credentialId?: string) => {
+    setCredentialRefs(prev => {
+      const next = { ...prev };
+      if (credentialId) {
+        next[key] = credentialId;
+      } else {
+        delete next[key];
+      }
+      return next;
+    });
+  }, []);
 
   const handleEnvChange = useCallback((key: string, value: string) => {
     setMcpEnvironments(prev => ({
@@ -154,12 +218,16 @@ const MCPConfigDialog = ({
       name: selectedServer.name,
       type: selectedServer.config_type,
       environments: mcpEnvironments,
+      // Travels alongside the inline values: the runtime prefers the vault and
+      // falls back to inline, and the API replaces the entry wholesale, so
+      // dropping either half here loses it.
+      credential_refs: credentialRefs,
       tools: selectedTools,
       toolIds: toolIds[selectedServer.id] || [],
     };
 
     onSave(config);
-  }, [selectedServer, mcpEnvironments, toolIds, onSave]);
+  }, [selectedServer, mcpEnvironments, credentialRefs, toolIds, onSave]);
 
   const getTypeColor = (type: string) => {
     switch (type) {
@@ -176,10 +244,15 @@ const MCPConfigDialog = ({
     }
   };
 
+  // A required variable is satisfied by an inline value OR by a vault
+  // reference (EVO-2250 story 2.4 AC7). Demanding the inline value would leave
+  // the form permanently invalid for exactly the variables the vault exists to
+  // hold, since pointing at a credential is what stops you from typing one.
   const isFormValid =
     selectedServer &&
     Object.entries(selectedServer.environments || {}).every(
-      ([key]) => mcpEnvironments[key]?.toString().trim() !== '',
+      ([key]) =>
+        Boolean(credentialRefs[key]) || (mcpEnvironments[key]?.toString().trim() ?? '') !== '',
     );
 
   return (
@@ -277,6 +350,7 @@ const MCPConfigDialog = ({
                               value={mcpEnvironments[key]?.toString() || ''}
                               onChange={e => handleEnvChange(key, e.target.value)}
                               placeholder={t('dialogs.mcpConfig.enterValue', { key })}
+                              disabled={Boolean(credentialRefs[key])}
                               type={
                                 key.toLowerCase().includes('password') ||
                                 key.toLowerCase().includes('token') ||
@@ -284,6 +358,16 @@ const MCPConfigDialog = ({
                                   ? 'password'
                                   : 'text'
                               }
+                            />
+                            {/* EVO-2250 story 2.4 AC7: point this variable at a
+                                vault credential instead of typing the secret.
+                                The runtime prefers the reference and falls back
+                                to the inline value. */}
+                            <VaultCredentialSelect
+                              id={`env-cred-${key}`}
+                              value={credentialRefs[key]}
+                              onChange={credentialId => handleCredentialRefChange(key, credentialId)}
+                              credentials={vaultCredentials}
                             />
                             {typeof value === 'string' && value !== 'required' && (
                               <p className="text-xs text-muted-foreground">{value}</p>

--- a/src/components/ai_agents/shared/VaultCredentialRefs.spec.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.spec.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, renderHook, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CredentialRefsEditor } from './VaultCredentialRefs';
+import { useVaultCredentials } from './useVaultCredentials';
+import type { IntegrationCredential } from '@/types/agents';
+
+// EVO-2250 story 2.4: the vault pickers only ever offer static, active
+// credentials, and references are a MAP (name -> credential id), never a
+// scalar column.
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+const listIntegrationCredentials = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+}));
+
+const STATIC_ACTIVE: IntegrationCredential = {
+  id: 'cred-static',
+  name: 'Dify producao',
+  provider: 'dify',
+  kind: 'static',
+  scope: 'account',
+  is_active: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const STATIC_INACTIVE: IntegrationCredential = {
+  ...STATIC_ACTIVE,
+  id: 'cred-inactive',
+  name: 'Desativada',
+  is_active: false,
+};
+
+const OAUTH_ROW: IntegrationCredential = {
+  ...STATIC_ACTIVE,
+  id: 'cred-oauth',
+  name: 'GitHub',
+  provider: 'github',
+  kind: 'oauth',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listIntegrationCredentials.mockResolvedValue([STATIC_ACTIVE, STATIC_INACTIVE, OAUTH_ROW]);
+});
+
+describe('useVaultCredentials — only static active credentials are selectable', () => {
+  it('filters out oauth and inactive rows (negative proof)', async () => {
+    const { result } = renderHook(() => useVaultCredentials());
+
+    // An oauth row has no value in the vault: offering it as an injectable
+    // secret would put an empty credential on the wire. This fails if the
+    // filter ever drops.
+    await waitFor(() => expect(result.current).toHaveLength(1));
+    expect(result.current[0].id).toBe('cred-static');
+  });
+
+  it('leaves the list empty when the vault listing fails (advisory load)', async () => {
+    listIntegrationCredentials.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useVaultCredentials());
+
+    await waitFor(() => expect(listIntegrationCredentials).toHaveBeenCalled());
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe('CredentialRefsEditor — the reference is a map, never a scalar', () => {
+  it('renders one row per entry: two auth headers mean two credentials (negative proof)', async () => {
+    render(
+      <CredentialRefsEditor
+        id="refs"
+        value={{ Authorization: 'cred-static', 'X-API-Key': 'cred-other' }}
+        onChange={() => {}}
+      />,
+    );
+
+    // A scalar credential_id column could not represent this state at all.
+    const keyInputs = await screen.findAllByLabelText('refsEditor.keyLabel');
+    expect(keyInputs).toHaveLength(2);
+    expect(keyInputs[0]).toHaveValue('Authorization');
+    expect(keyInputs[1]).toHaveValue('X-API-Key');
+  });
+
+  it('emits the full map minus the removed entry on remove', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <CredentialRefsEditor
+        id="refs"
+        value={{ Authorization: 'cred-static', 'X-API-Key': 'cred-other' }}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click((await screen.findAllByLabelText('refsEditor.remove'))[0]);
+
+    expect(onChange).toHaveBeenCalledWith({ 'X-API-Key': 'cred-other' });
+  });
+
+  it('never emits an entry that lacks name or credential (draft stays local)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<CredentialRefsEditor id="refs" value={{}} onChange={onChange} />);
+
+    await user.click(screen.getByText('refsEditor.add'));
+    await user.type(screen.getByLabelText('refsEditor.keyLabel'), 'Authorization');
+
+    // Name typed but no credential picked: nothing reaches the map, so an
+    // half-filled row can never travel in a save payload.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ai_agents/shared/VaultCredentialRefs.spec.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.spec.tsx
@@ -117,6 +117,36 @@ describe('CredentialRefsEditor — the reference is a map, never a scalar', () =
     expect(onChange).toHaveBeenCalledWith({ 'X-API-Key': 'cred-other' });
   });
 
+  // Renaming a header goes through an EMPTY intermediate state (select-all +
+  // type, or backspacing to the end). The row must survive it with its
+  // credential intact: dropping the entry mid-keystroke loses the selection and
+  // silently drops auth if the user saves without noticing.
+  it('keeps the credential while a header name is being retyped', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <CredentialRefsEditor
+        id="refs"
+        value={{ Authorization: 'cred-static' }}
+        onChange={onChange}
+      />,
+    );
+
+    const nameInput = (await screen.findAllByLabelText('refsEditor.keyLabel'))[0];
+    await user.clear(nameInput);
+
+    // Mid-rename the map may legitimately drop the half-typed entry...
+    expect(onChange).toHaveBeenCalled();
+
+    // ...but the row must still be on screen, holding its credential, so the
+    // user can finish typing the new name.
+    expect(screen.getAllByLabelText('refsEditor.keyLabel')).toHaveLength(1);
+
+    await user.type(nameInput, 'X-Api-Key');
+
+    expect(onChange).toHaveBeenLastCalledWith({ 'X-Api-Key': 'cred-static' });
+  });
+
   it('never emits an entry that lacks name or credential (draft stays local)', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/src/components/ai_agents/shared/VaultCredentialRefs.spec.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.spec.tsx
@@ -68,6 +68,20 @@ describe('useVaultCredentials — only static active credentials are selectable'
     await waitFor(() => expect(listIntegrationCredentials).toHaveBeenCalled());
     expect(result.current).toEqual([]);
   });
+
+  // A host that mounts closed (the Nexus dialog sits on every agent screen)
+  // must not fire a vault listing: for a user without the read grant that was
+  // one 403 per screen render.
+  it('does not fetch while disabled, and fetches once enabled', async () => {
+    const { result, rerender } = renderHook(({ enabled }) => useVaultCredentials(enabled), {
+      initialProps: { enabled: false },
+    });
+
+    expect(listIntegrationCredentials).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current).toHaveLength(1));
+  });
 });
 
 describe('CredentialRefsEditor — the reference is a map, never a scalar', () => {

--- a/src/components/ai_agents/shared/VaultCredentialRefs.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.tsx
@@ -1,0 +1,203 @@
+import { useMemo, useState } from 'react';
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { Plus, X } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { useVaultCredentials } from './useVaultCredentials';
+import type { IntegrationCredential } from '@/types/agents';
+
+// EVO-2250 story 2.4: pickers for vault-backed secrets. The credential list
+// comes from useVaultCredentials, which already filters to static + active.
+
+const NONE_VALUE = '__none__';
+
+interface VaultCredentialSelectProps {
+  id?: string;
+  value?: string;
+  onChange: (credentialId: string | undefined) => void;
+  disabled?: boolean;
+  credentials: IntegrationCredential[];
+}
+
+export function VaultCredentialSelect({
+  id,
+  value,
+  onChange,
+  disabled,
+  credentials,
+}: VaultCredentialSelectProps) {
+  const { t } = useLanguage('integrationCredentials');
+
+  return (
+    <Select
+      value={value ?? NONE_VALUE}
+      onValueChange={selected => onChange(selected === NONE_VALUE ? undefined : selected)}
+      disabled={disabled}
+    >
+      <SelectTrigger id={id}>
+        <SelectValue placeholder={t('refsEditor.selectPlaceholder')} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={NONE_VALUE}>{t('refsEditor.none')}</SelectItem>
+        {credentials.map(credential => (
+          <SelectItem key={credential.id} value={credential.id}>
+            {credential.name} ({credential.provider})
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+interface CredentialRefsEditorProps {
+  id: string;
+  /** Map of header/env-var name -> vault credential id. Always a MAP: one
+   * credential per secret, so two auth headers mean two entries. */
+  value: Record<string, string>;
+  onChange: (refs: Record<string, string>) => void;
+  disabled?: boolean;
+  keyPlaceholder?: string;
+}
+
+interface RefRow {
+  key: string;
+  credentialId: string;
+}
+
+export function CredentialRefsEditor({
+  id,
+  value,
+  onChange,
+  disabled,
+  keyPlaceholder,
+}: CredentialRefsEditorProps) {
+  const { t } = useLanguage('integrationCredentials');
+  const credentials = useVaultCredentials();
+
+  const rows = useMemo<RefRow[]>(
+    () => Object.entries(value).map(([key, credentialId]) => ({ key, credentialId })),
+    [value],
+  );
+  // Rows being typed that don't have both halves yet live locally: an entry
+  // only reaches the map (and the payload) once name AND credential exist.
+  const [draftRow, setDraftRow] = useState<RefRow | null>(null);
+
+  const emit = (nextRows: RefRow[]) => {
+    const refs: Record<string, string> = {};
+    nextRows.forEach(row => {
+      if (row.key.trim() && row.credentialId) {
+        refs[row.key.trim()] = row.credentialId;
+      }
+    });
+    onChange(refs);
+  };
+
+  const updateRow = (index: number, patch: Partial<RefRow>) => {
+    const next = rows.map((row, i) => (i === index ? { ...row, ...patch } : row));
+    emit(next);
+  };
+
+  const removeRow = (index: number) => {
+    emit(rows.filter((_, i) => i !== index));
+  };
+
+  const commitDraft = (patch: Partial<RefRow>) => {
+    const next = { ...(draftRow ?? { key: '', credentialId: '' }), ...patch };
+    if (next.key.trim() && next.credentialId) {
+      emit([...rows, next]);
+      setDraftRow(null);
+    } else {
+      setDraftRow(next);
+    }
+  };
+
+  const renderRow = (
+    row: RefRow,
+    onKey: (key: string) => void,
+    onCredential: (credentialId: string | undefined) => void,
+    onRemove: () => void,
+    rowId: string,
+  ) => (
+    <div key={rowId} className="flex items-center gap-2">
+      <Input
+        aria-label={t('refsEditor.keyLabel')}
+        value={row.key}
+        placeholder={keyPlaceholder ?? t('refsEditor.keyPlaceholder')}
+        disabled={disabled}
+        onChange={event => onKey(event.target.value)}
+        className="flex-1"
+      />
+      <div className="flex-1">
+        <VaultCredentialSelect
+          value={row.credentialId || undefined}
+          onChange={credentialId => onCredential(credentialId)}
+          disabled={disabled}
+          credentials={credentials}
+        />
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label={t('refsEditor.remove')}
+        disabled={disabled}
+        onClick={onRemove}
+      >
+        <X className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+
+  return (
+    <div id={id} className="space-y-2">
+      <Label>{t('refsEditor.label')}</Label>
+      <p className="text-xs text-muted-foreground">{t('refsEditor.hint')}</p>
+
+      {rows.map((row, index) =>
+        renderRow(
+          row,
+          key => updateRow(index, { key }),
+          credentialId => {
+            if (credentialId) {
+              updateRow(index, { credentialId });
+            } else {
+              removeRow(index);
+            }
+          },
+          () => removeRow(index),
+          `${id}-row-${index}`,
+        ),
+      )}
+
+      {draftRow &&
+        renderRow(
+          draftRow,
+          key => commitDraft({ key }),
+          credentialId => commitDraft({ credentialId: credentialId ?? '' }),
+          () => setDraftRow(null),
+          `${id}-draft`,
+        )}
+
+      {!draftRow && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => setDraftRow({ key: '', credentialId: '' })}
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          {t('refsEditor.add')}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ai_agents/shared/VaultCredentialRefs.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Button,
   Input,
@@ -82,10 +82,24 @@ export function CredentialRefsEditor({
   const { t } = useLanguage('integrationCredentials');
   const credentials = useVaultCredentials();
 
-  const rows = useMemo<RefRow[]>(
-    () => Object.entries(value).map(([key, credentialId]) => ({ key, credentialId })),
-    [value],
+  // Rows are LOCAL state seeded from `value`, not derived from it. Renaming a
+  // header passes through an empty name, which `emit` legitimately drops from
+  // the map; if the rows were derived, the row would vanish from the DOM
+  // mid-keystroke and take the credential selection with it.
+  const [rows, setRows] = useState<RefRow[]>(() =>
+    Object.entries(value).map(([key, credentialId]) => ({ key, credentialId })),
   );
+
+  // Re-seed only when the incoming map genuinely differs from what the rows
+  // already express, so a parent re-render never clobbers a half-typed name.
+  const emittedRef = useRef<string>(JSON.stringify(value));
+  useEffect(() => {
+    const incoming = JSON.stringify(value);
+    if (incoming === emittedRef.current) return;
+
+    emittedRef.current = incoming;
+    setRows(Object.entries(value).map(([key, credentialId]) => ({ key, credentialId })));
+  }, [value]);
   // Rows being typed that don't have both halves yet live locally: an entry
   // only reaches the map (and the payload) once name AND credential exist.
   const [draftRow, setDraftRow] = useState<RefRow | null>(null);
@@ -97,22 +111,28 @@ export function CredentialRefsEditor({
         refs[row.key.trim()] = row.credentialId;
       }
     });
+    emittedRef.current = JSON.stringify(refs);
     onChange(refs);
   };
 
   const updateRow = (index: number, patch: Partial<RefRow>) => {
     const next = rows.map((row, i) => (i === index ? { ...row, ...patch } : row));
+    setRows(next);
     emit(next);
   };
 
   const removeRow = (index: number) => {
-    emit(rows.filter((_, i) => i !== index));
+    const next = rows.filter((_, i) => i !== index);
+    setRows(next);
+    emit(next);
   };
 
   const commitDraft = (patch: Partial<RefRow>) => {
     const next = { ...(draftRow ?? { key: '', credentialId: '' }), ...patch };
     if (next.key.trim() && next.credentialId) {
-      emit([...rows, next]);
+      const merged = [...rows, next];
+      setRows(merged);
+      emit(merged);
       setDraftRow(null);
     } else {
       setDraftRow(next);

--- a/src/components/ai_agents/shared/VaultCredentialRefs.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Button,
   Input,

--- a/src/components/ai_agents/shared/VaultCredentialRefs.tsx
+++ b/src/components/ai_agents/shared/VaultCredentialRefs.tsx
@@ -60,8 +60,10 @@ export function VaultCredentialSelect({
 interface CredentialRefsEditorProps {
   id: string;
   /** Map of header/env-var name -> vault credential id. Always a MAP: one
-   * credential per secret, so two auth headers mean two entries. */
-  value: Record<string, string>;
+   * credential per secret, so two auth headers mean two entries. Optional: a
+   * host that has not adopted the field yet renders an empty editor instead of
+   * crashing. */
+  value?: Record<string, string>;
   onChange: (refs: Record<string, string>) => void;
   disabled?: boolean;
   keyPlaceholder?: string;
@@ -70,6 +72,10 @@ interface CredentialRefsEditorProps {
 interface RefRow {
   key: string;
   credentialId: string;
+}
+
+function toRows(value?: Record<string, string>): RefRow[] {
+  return Object.entries(value ?? {}).map(([key, credentialId]) => ({ key, credentialId }));
 }
 
 export function CredentialRefsEditor({
@@ -86,19 +92,20 @@ export function CredentialRefsEditor({
   // header passes through an empty name, which `emit` legitimately drops from
   // the map; if the rows were derived, the row would vanish from the DOM
   // mid-keystroke and take the credential selection with it.
-  const [rows, setRows] = useState<RefRow[]>(() =>
-    Object.entries(value).map(([key, credentialId]) => ({ key, credentialId })),
-  );
+  // `value ?? {}` on every read: a host that has not adopted credential_refs yet
+  // (or an older stored record) passes undefined, and Object.entries would throw
+  // and take the whole step down with it.
+  const [rows, setRows] = useState<RefRow[]>(() => toRows(value));
 
   // Re-seed only when the incoming map genuinely differs from what the rows
   // already express, so a parent re-render never clobbers a half-typed name.
-  const emittedRef = useRef<string>(JSON.stringify(value));
+  const emittedRef = useRef<string>(JSON.stringify(value ?? {}));
   useEffect(() => {
-    const incoming = JSON.stringify(value);
+    const incoming = JSON.stringify(value ?? {});
     if (incoming === emittedRef.current) return;
 
     emittedRef.current = incoming;
-    setRows(Object.entries(value).map(([key, credentialId]) => ({ key, credentialId })));
+    setRows(toRows(value));
   }, [value]);
   // Rows being typed that don't have both halves yet live locally: an entry
   // only reaches the map (and the payload) once name AND credential exist.

--- a/src/components/ai_agents/shared/index.ts
+++ b/src/components/ai_agents/shared/index.ts
@@ -10,3 +10,9 @@ export { default as TagInput } from './TagInput';
 export type { TagInputProps } from './TagInput';
 export { CredentialRefsEditor, VaultCredentialSelect } from './VaultCredentialRefs';
 export { useVaultCredentials } from './useVaultCredentials';
+export {
+  isAuthHeaderName,
+  mergeRetiredHeaders,
+  splitAuthHeaders,
+  useVaultMigrationState,
+} from './vaultRetirement';

--- a/src/components/ai_agents/shared/index.ts
+++ b/src/components/ai_agents/shared/index.ts
@@ -8,3 +8,5 @@ export { default as TestRequestButton } from './TestRequestButton';
 export type { TestRequestButtonProps } from './TestRequestButton';
 export { default as TagInput } from './TagInput';
 export type { TagInputProps } from './TagInput';
+export { CredentialRefsEditor, VaultCredentialSelect } from './VaultCredentialRefs';
+export { useVaultCredentials } from './useVaultCredentials';

--- a/src/components/ai_agents/shared/useVaultCredentials.ts
+++ b/src/components/ai_agents/shared/useVaultCredentials.ts
@@ -5,10 +5,18 @@ import type { IntegrationCredential } from '@/types/agents';
 // EVO-2250 story 2.4: only static, active credentials are selectable — an
 // `oauth` row is a reference to the store that owns the token and has no
 // value a consumer could inject.
-export function useVaultCredentials() {
+//
+// `enabled` gates the fetch: a host that mounts closed (the Nexus dialog on
+// every agent screen) must not fire a vault listing — for a user without the
+// vault read grant that was one 403 per screen render.
+export function useVaultCredentials(enabled = true) {
   const [credentials, setCredentials] = useState<IntegrationCredential[]>([]);
 
   useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
     let cancelled = false;
 
     listIntegrationCredentials()
@@ -28,7 +36,7 @@ export function useVaultCredentials() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [enabled]);
 
   return credentials;
 }

--- a/src/components/ai_agents/shared/useVaultCredentials.ts
+++ b/src/components/ai_agents/shared/useVaultCredentials.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { listIntegrationCredentials } from '@/services/agents';
+import type { IntegrationCredential } from '@/types/agents';
+
+// EVO-2250 story 2.4: only static, active credentials are selectable — an
+// `oauth` row is a reference to the store that owns the token and has no
+// value a consumer could inject.
+export function useVaultCredentials() {
+  const [credentials, setCredentials] = useState<IntegrationCredential[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    listIntegrationCredentials()
+      .then(list => {
+        if (!cancelled) {
+          setCredentials(
+            list.filter(credential => credential.kind === 'static' && credential.is_active),
+          );
+        }
+      })
+      .catch(error => {
+        // Advisory load: a failure leaves the selector empty, it never blocks
+        // the host form (the inline secret keeps working as the fallback).
+        console.error('Error loading vault credentials:', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return credentials;
+}

--- a/src/components/ai_agents/shared/vaultRetirement.spec.ts
+++ b/src/components/ai_agents/shared/vaultRetirement.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  isAuthHeaderName,
+  mergeRetiredHeaders,
+  splitAuthHeaders,
+  useVaultMigrationState,
+} from './vaultRetirement';
+
+// EVO-2250 story 2.7: the retirement guard and the round-trip guarantee.
+
+const getIntegrationVaultMigrationState = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  getIntegrationVaultMigrationState: (...args: unknown[]) =>
+    getIntegrationVaultMigrationState(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useVaultMigrationState — guard fails closed towards keeping the inline fields', () => {
+  it('reports retired consumers as the backend states them', async () => {
+    getIntegrationVaultMigrationState.mockResolvedValue({ retired: { custom_tools: true } });
+    const { result } = renderHook(() => useVaultMigrationState());
+
+    await waitFor(() => expect(result.current.retired.custom_tools).toBe(true));
+    expect(result.current.retired.custom_mcp_servers).toBeUndefined();
+  });
+
+  it('reads a guard failure as NOT retired (nothing is removed on a broken installation)', async () => {
+    getIntegrationVaultMigrationState.mockRejectedValue(new Error('503'));
+    const { result } = renderHook(() => useVaultMigrationState());
+
+    await waitFor(() => expect(getIntegrationVaultMigrationState).toHaveBeenCalled());
+    expect(result.current.retired).toEqual({});
+  });
+
+  it('does not consult the guard while disabled', () => {
+    renderHook(() => useVaultMigrationState(false));
+    expect(getIntegrationVaultMigrationState).not.toHaveBeenCalled();
+  });
+});
+
+describe('splitAuthHeaders — the conservative heuristic of story 2.6', () => {
+  it('recognizes auth headers in any casing and leaves the rest editable', () => {
+    const { auth, others } = splitAuthHeaders({
+      Authorization: 'Bearer x',
+      'X-API-KEY': 'k',
+      'Content-Type': 'application/json',
+      'X-Custom': 'v',
+    });
+
+    expect(Object.keys(auth).sort()).toEqual(['Authorization', 'X-API-KEY']);
+    expect(Object.keys(others).sort()).toEqual(['Content-Type', 'X-Custom']);
+  });
+
+  it('errs towards editable: an unknown name is never locked', () => {
+    expect(isAuthHeaderName('X-Signature')).toBe(false);
+    expect(isAuthHeaderName('Authorization')).toBe(true);
+  });
+});
+
+describe('mergeRetiredHeaders — the round-trip guarantee (the 1.6 modal bug)', () => {
+  it('always carries the received auth entries into the merged map, byte-identical', () => {
+    const stored = { Authorization: 'Bearer secret-123', 'Content-Type': 'application/json' };
+
+    const merged = mergeRetiredHeaders(stored, { 'Content-Type': 'text/plain' });
+
+    // Dropping Authorization here would erase the migrated secret through the
+    // UI: the backend replaces the stored object wholesale on update.
+    expect(merged.Authorization).toBe('Bearer secret-123');
+    expect(merged['Content-Type']).toBe('text/plain');
+  });
+
+  it('drops a NEW auth-named entry typed into the editable half (registration is retired)', () => {
+    const stored = { 'Content-Type': 'application/json' };
+
+    const merged = mergeRetiredHeaders(stored, {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer typed-inline',
+    });
+
+    expect(merged).not.toHaveProperty('Authorization');
+  });
+});

--- a/src/components/ai_agents/shared/vaultRetirement.spec.ts
+++ b/src/components/ai_agents/shared/vaultRetirement.spec.ts
@@ -43,22 +43,31 @@ describe('useVaultMigrationState — guard fails closed towards keeping the inli
   });
 });
 
-describe('splitAuthHeaders — the conservative heuristic of story 2.6', () => {
-  it('recognizes auth headers in any casing and leaves the rest editable', () => {
+describe('splitAuthHeaders — classification mirrors the backend redaction', () => {
+  it('treats recognizable auth headers as server-managed, in any casing', () => {
     const { auth, others } = splitAuthHeaders({
       Authorization: 'Bearer x',
       'X-API-KEY': 'k',
       'Content-Type': 'application/json',
-      'X-Custom': 'v',
+      Accept: 'application/json',
     });
 
     expect(Object.keys(auth).sort()).toEqual(['Authorization', 'X-API-KEY']);
-    expect(Object.keys(others).sort()).toEqual(['Content-Type', 'X-Custom']);
+    expect(Object.keys(others).sort()).toEqual(['Accept', 'Content-Type']);
   });
 
-  it('errs towards editable: an unknown name is never locked', () => {
-    expect(isAuthHeaderName('X-Signature')).toBe(false);
+  // This used to assert the opposite ("errs towards editable: an unknown name
+  // is never locked"). That premise was wrong: the BACKEND redacts by a safe
+  // allowlist, so an unknown name arrives blank. Rendering it as an editable
+  // empty box misrepresented a configured secret as unset — and once an absent
+  // key started meaning deletion, tidying the box away destroyed the secret.
+  it('errs towards server-managed: an unknown name is redacted by the backend', () => {
+    expect(isAuthHeaderName('X-Signature')).toBe(true);
+    expect(isAuthHeaderName('X-Tenant-Auth')).toBe(true);
     expect(isAuthHeaderName('Authorization')).toBe(true);
+    // Safe-listed names keep their value on the wire, so they stay editable.
+    expect(isAuthHeaderName('Content-Type')).toBe(false);
+    expect(isAuthHeaderName('Accept')).toBe(false);
   });
 });
 
@@ -83,5 +92,38 @@ describe('mergeRetiredHeaders — the round-trip guarantee (the 1.6 modal bug)',
     });
 
     expect(merged).not.toHaveProperty('Authorization');
+  });
+});
+
+// A header whose VALUE the backend redacted must never render as an unset
+// editable field.
+//
+// The backend redacts by an allowlist of safe names (secretmerge.go): anything
+// outside it is server-managed and comes back blank. The front used to classify
+// by a 4-name auth list, so `X-Tenant-Auth` — the exact example named in the
+// backend's own comment — landed in the editable half as an empty box. Once
+// `KeepMissing` learned that an absent key means deletion, tidying away that
+// empty-looking row genuinely destroyed the stored secret.
+describe('server-managed header classification', () => {
+  it('treats any non-safe header name as server-managed, not editable', () => {
+    const { auth, others } = splitAuthHeaders({
+      Authorization: '',
+      'X-Tenant-Auth': '',
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    });
+
+    expect(Object.keys(auth).sort()).toEqual(['Authorization', 'X-Tenant-Auth']);
+    expect(Object.keys(others).sort()).toEqual(['Accept', 'Content-Type']);
+  });
+
+  it('carries a server-managed header through a merge even when the editor never saw it', () => {
+    const merged = mergeRetiredHeaders(
+      { 'X-Tenant-Auth': 'tk-secreto', 'Content-Type': 'application/json' },
+      { 'Content-Type': 'application/xml' },
+    );
+
+    expect(merged['X-Tenant-Auth']).toBe('tk-secreto');
+    expect(merged['Content-Type']).toBe('application/xml');
   });
 });

--- a/src/components/ai_agents/shared/vaultRetirement.ts
+++ b/src/components/ai_agents/shared/vaultRetirement.ts
@@ -45,13 +45,31 @@ export function useVaultMigrationState(enabled = true): IntegrationVaultMigratio
   return state;
 }
 
-// The conservative auth-name heuristic of story 2.6: recognizable auth headers
-// and nothing else. Retiring a header that is not a secret would lock plain
-// configuration behind the vault for no reason, so unknown names stay editable.
-const AUTH_HEADER_NAMES = new Set(['authorization', 'x-api-key', 'api-key', 'apikey']);
+// Mirrors `safeHeaderNames` in the backend's secretmerge package: the headers
+// whose VALUE the API returns. Everything else is redacted server-side and
+// arrives blank.
+//
+// The classification is derived from THIS list, inverted, rather than from a
+// separate list of auth-looking names. With two lists, a secret in a custom
+// header (`X-Tenant-Auth` is the backend's own example) was redacted by the
+// server but classified as editable by the screen, so it rendered as an empty
+// box — and once an absent key started meaning deletion, tidying that box away
+// destroyed the stored secret.
+const SAFE_HEADER_NAMES = new Set([
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'cache-control',
+  'content-type',
+  'user-agent',
+  'x-request-id',
+  'x-correlation-id',
+]);
 
+// Server-managed: the value lives in the vault (or is redacted on the way out),
+// so the screen shows a pointer and never an editable value.
 export function isAuthHeaderName(name: string): boolean {
-  return AUTH_HEADER_NAMES.has(name.trim().toLowerCase());
+  return !SAFE_HEADER_NAMES.has(name.trim().toLowerCase());
 }
 
 export interface SplitHeaders {

--- a/src/components/ai_agents/shared/vaultRetirement.ts
+++ b/src/components/ai_agents/shared/vaultRetirement.ts
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import {
+  getIntegrationVaultMigrationState,
+  type IntegrationVaultMigrationState,
+} from '@/services/agents';
+
+// EVO-2250 story 2.7: retirement of the inline secret fields, gated per
+// consumer by the migration guard. The rule the 1.6 retirement established and
+// this one repeats:
+//
+//   - The guard failing (network, permission, backend older than 2.7) reads as
+//     NOT retired. Removing an input on a broken installation is exactly the
+//     silent breakage the guard exists to prevent.
+//   - Retiring an input NEVER retires the payload. The backends replace the
+//     stored object wholesale on update, so a form that stops sending what it
+//     received erases the migrated secret through the UI (the 1.6 modal bug).
+
+const NOT_RETIRED: IntegrationVaultMigrationState = { retired: {} };
+
+export function useVaultMigrationState(enabled = true): IntegrationVaultMigrationState {
+  const [state, setState] = useState<IntegrationVaultMigrationState>(NOT_RETIRED);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    getIntegrationVaultMigrationState()
+      .then(fetched => {
+        if (!cancelled && fetched?.retired) {
+          setState(fetched);
+        }
+      })
+      .catch(error => {
+        console.error('Error loading vault migration state:', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return state;
+}
+
+// The conservative auth-name heuristic of story 2.6: recognizable auth headers
+// and nothing else. Retiring a header that is not a secret would lock plain
+// configuration behind the vault for no reason, so unknown names stay editable.
+const AUTH_HEADER_NAMES = new Set(['authorization', 'x-api-key', 'api-key', 'apikey']);
+
+export function isAuthHeaderName(name: string): boolean {
+  return AUTH_HEADER_NAMES.has(name.trim().toLowerCase());
+}
+
+export interface SplitHeaders {
+  auth: Record<string, unknown>;
+  others: Record<string, unknown>;
+}
+
+export function splitAuthHeaders(headers: Record<string, unknown>): SplitHeaders {
+  const auth: Record<string, unknown> = {};
+  const others: Record<string, unknown> = {};
+
+  Object.entries(headers ?? {}).forEach(([name, value]) => {
+    if (isAuthHeaderName(name)) {
+      auth[name] = value;
+    } else {
+      others[name] = value;
+    }
+  });
+
+  return { auth, others };
+}
+
+// Merges an edit made on the non-auth half back into the full map.
+//
+// The auth entries the form RECEIVED always survive untouched — that is the
+// round-trip guarantee (backends replace the object wholesale). New auth-named
+// entries typed into the editable half are dropped: with the consumer retired,
+// registering an inline secret is exactly what no longer exists, and the form
+// says so next to the editor.
+export function mergeRetiredHeaders(
+  storedHeaders: Record<string, unknown>,
+  editedOthers: Record<string, unknown>,
+): Record<string, unknown> {
+  const { auth } = splitAuthHeaders(storedHeaders);
+  const merged: Record<string, unknown> = { ...auth };
+
+  Object.entries(editedOthers ?? {}).forEach(([name, value]) => {
+    if (!isAuthHeaderName(name)) {
+      merged[name] = value;
+    }
+  });
+
+  return merged;
+}

--- a/src/components/channels/settings/helpers/agentBotHelpers.ts
+++ b/src/components/channels/settings/helpers/agentBotHelpers.ts
@@ -7,6 +7,9 @@ export interface AgentBot {
   description: string;
   outgoing_url: string;
   api_key?: string;
+  /** EVO-2250 story 2.4: scalar vault reference (a bot holds one secret).
+   * While present, api_key stays as the inline fallback until story 2.7. */
+  credential_id?: string;
   bot_type: string;
   bot_provider: string;
   thumbnail?: string;
@@ -29,6 +32,7 @@ export interface AgentBotFormData {
   description: string;
   outgoing_url: string;
   api_key: string;
+  credential_id: string;
   bot_provider: string;
   avatar?: File | null;
   avatarUrl: string;
@@ -94,6 +98,7 @@ export const getDefaultAgentBotFormData = (): AgentBotFormData => ({
   description: '',
   outgoing_url: '',
   api_key: '',
+  credential_id: '',
   bot_provider: 'webhook_provider',
   avatar: null,
   avatarUrl: '',
@@ -201,6 +206,10 @@ export const prepareAgentBotPayload = (formData: AgentBotFormData) => {
     payload.append('api_key', formData.api_key);
   }
 
+  if (formData.credential_id) {
+    payload.append('credential_id', formData.credential_id);
+  }
+
   if (formData.avatar) {
     payload.append('avatar', formData.avatar);
   }
@@ -214,6 +223,7 @@ export const parseAgentBotForForm = (bot: AgentBot): AgentBotFormData => ({
   description: bot.description || '',
   outgoing_url: bot.outgoing_url || bot.bot_config?.webhook_url || '',
   api_key: bot.api_key || '',
+  credential_id: bot.credential_id || '',
   bot_provider: bot.bot_provider || 'webhook_provider',
   avatar: null,
   avatarUrl: bot.thumbnail || '',

--- a/src/components/channels/settings/helpers/agentBotHelpers.ts
+++ b/src/components/channels/settings/helpers/agentBotHelpers.ts
@@ -6,9 +6,7 @@ export interface AgentBot {
   name: string;
   description: string;
   outgoing_url: string;
-  api_key?: string;
-  /** EVO-2250 story 2.4: scalar vault reference (a bot holds one secret).
-   * While present, api_key stays as the inline fallback until story 2.7. */
+  /** EVO-2250 story 2.4: scalar vault reference (a bot holds one secret). */
   credential_id?: string;
   bot_type: string;
   bot_provider: string;
@@ -31,7 +29,6 @@ export interface AgentBotFormData {
   name: string;
   description: string;
   outgoing_url: string;
-  api_key: string;
   credential_id: string;
   bot_provider: string;
   avatar?: File | null;
@@ -97,7 +94,6 @@ export const getDefaultAgentBotFormData = (): AgentBotFormData => ({
   name: '',
   description: '',
   outgoing_url: '',
-  api_key: '',
   credential_id: '',
   bot_provider: 'webhook_provider',
   avatar: null,
@@ -202,10 +198,8 @@ export const prepareAgentBotPayload = (formData: AgentBotFormData) => {
   payload.append('delay_per_character', formData.delay_per_character.toString());
   payload.append('debounce_time', formData.debounce_time.toString());
 
-  if (formData.api_key) {
-    payload.append('api_key', formData.api_key);
-  }
-
+  // No api_key: story 2.7 dropped it from the permitted params, so sending it
+  // is silently discarded and the bot ends up with no credential at all.
   if (formData.credential_id) {
     payload.append('credential_id', formData.credential_id);
   }
@@ -222,7 +216,6 @@ export const parseAgentBotForForm = (bot: AgentBot): AgentBotFormData => ({
   name: bot.name || '',
   description: bot.description || '',
   outgoing_url: bot.outgoing_url || bot.bot_config?.webhook_url || '',
-  api_key: bot.api_key || '',
   credential_id: bot.credential_id || '',
   bot_provider: bot.bot_provider || 'webhook_provider',
   avatar: null,

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.spec.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.spec.tsx
@@ -37,6 +37,11 @@ const validConfig = {
   description: 'original description',
   url: 'https://mcp.example/mcp',
   headers: { Authorization: 'Bearer sk' },
+  // EVO-2250 story 2.4: the vault reference is part of the config the advanced
+  // mode round-trips. Leaving it out of the expected shape would let a parser
+  // that DROPS the field pass, and dropping it strips the vault reference off a
+  // server that has one.
+  credential_refs: {},
   timeout: 30,
   retry_count: 3,
   tags: ['search'],
@@ -194,6 +199,10 @@ describe('CustomMCPServerWizardModal — advanced JSON mode', () => {
       description: '',
       url: 'https://other.example/mcp',
       headers: { 'X-Key': 'v' },
+      // Absent from the edited JSON means "no vault reference", and it still
+      // travels: the API replaces the record, so omitting the key from the
+      // payload would leave a stale reference behind (EVO-2250 story 2.4).
+      credential_refs: {},
       timeout: 120,
       retry_count: 5,
       tags: ['a', 'b'],

--- a/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
+++ b/src/components/customMcpServers/CustomMCPServerWizardModal.tsx
@@ -100,6 +100,7 @@ export default function CustomMCPServerWizardModal({
       description: data.description.trim() || '',
       url: data.url.trim(),
       headers: data.headers,
+      credential_refs: data.credential_refs,
       timeout: data.timeout,
       retry_count: data.retry_count,
       tags: data.tags,
@@ -155,6 +156,7 @@ export default function CustomMCPServerWizardModal({
             data={{
               url: data.url,
               headers: data.headers,
+              credential_refs: data.credential_refs,
             }}
             onChange={d => setData(prev => ({ ...prev, ...d }))}
             onNext={handleNext}

--- a/src/components/customMcpServers/wizard/Step2_Connection.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.tsx
@@ -2,7 +2,13 @@ import { useState } from 'react';
 import { Input, Label, Button } from '@evoapi/design-system';
 import { ArrowRight, ArrowLeft, PlugZap, Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { CredentialRefsEditor, KeyValueEditor } from '@/components/ai_agents/shared';
+import {
+  CredentialRefsEditor,
+  KeyValueEditor,
+  mergeRetiredHeaders,
+  splitAuthHeaders,
+  useVaultMigrationState,
+} from '@/components/ai_agents/shared';
 import { testCustomMcpServerConnection } from '@/services/agents/customMcpServerService';
 import type { McpTestResult } from '@/types/ai';
 
@@ -21,6 +27,11 @@ interface Step2Props {
 
 export default function Step2_Connection({ data, onChange, onNext, onBack }: Step2Props) {
   const { t } = useLanguage('customMcpServers');
+  const { t: tVault } = useLanguage('integrationCredentials');
+  // Story 2.7: retired inline auth headers become read-only, but ALWAYS stay
+  // in the payload — the backend replaces the stored object wholesale.
+  const migrationState = useVaultMigrationState();
+  const headersRetired = Boolean(migrationState.retired.custom_mcp_servers);
   const [error, setError] = useState('');
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<McpTestResult | null>(null);
@@ -90,13 +101,45 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
           </div>
 
           <div className="pt-2">
-            <KeyValueEditor
-              id="headers"
-              label={t('form.labels.headers')}
-              value={data.headers}
-              onChange={next => onChange({ ...data, headers: next })}
-              hint={t('form.hints.headers')}
-            />
+            {headersRetired ? (
+              <div className="space-y-2">
+                {Object.keys(splitAuthHeaders(data.headers).auth).map(name => (
+                  <div
+                    key={name}
+                    className="flex items-center gap-2 text-sm border rounded-md px-3 py-2"
+                  >
+                    <span className="font-mono">{name}</span>
+                    <span className="font-mono text-muted-foreground">••••</span>
+                    <span className="text-xs text-muted-foreground ml-auto">
+                      {tVault('retirement.managedByVault')}
+                    </span>
+                  </div>
+                ))}
+                <p className="text-xs text-muted-foreground">
+                  {tVault('retirement.authHeadersLocked')}
+                </p>
+                <KeyValueEditor
+                  id="headers"
+                  label={t('form.labels.headers')}
+                  value={splitAuthHeaders(data.headers).others}
+                  onChange={next =>
+                    onChange({
+                      ...data,
+                      headers: mergeRetiredHeaders(data.headers, next as Record<string, unknown>),
+                    })
+                  }
+                  hint={t('form.hints.headers')}
+                />
+              </div>
+            ) : (
+              <KeyValueEditor
+                id="headers"
+                label={t('form.labels.headers')}
+                value={data.headers}
+                onChange={next => onChange({ ...data, headers: next })}
+                hint={t('form.hints.headers')}
+              />
+            )}
           </div>
 
           {/* Vault-backed auth headers (EVO-2250 story 2.4): one credential

--- a/src/components/customMcpServers/wizard/Step2_Connection.tsx
+++ b/src/components/customMcpServers/wizard/Step2_Connection.tsx
@@ -2,13 +2,14 @@ import { useState } from 'react';
 import { Input, Label, Button } from '@evoapi/design-system';
 import { ArrowRight, ArrowLeft, PlugZap, Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { KeyValueEditor } from '@/components/ai_agents/shared';
+import { CredentialRefsEditor, KeyValueEditor } from '@/components/ai_agents/shared';
 import { testCustomMcpServerConnection } from '@/services/agents/customMcpServerService';
 import type { McpTestResult } from '@/types/ai';
 
 export interface Step2Data {
   url: string;
   headers: Record<string, unknown>;
+  credential_refs: Record<string, string>;
 }
 
 interface Step2Props {
@@ -95,6 +96,16 @@ export default function Step2_Connection({ data, onChange, onNext, onBack }: Ste
               value={data.headers}
               onChange={next => onChange({ ...data, headers: next })}
               hint={t('form.hints.headers')}
+            />
+          </div>
+
+          {/* Vault-backed auth headers (EVO-2250 story 2.4): one credential
+              per header name; inline headers above stay as the fallback. */}
+          <div className="pt-2">
+            <CredentialRefsEditor
+              id="credential_refs"
+              value={data.credential_refs}
+              onChange={refs => onChange({ ...data, credential_refs: refs })}
             />
           </div>
 

--- a/src/components/customMcpServers/wizardConfig.ts
+++ b/src/components/customMcpServers/wizardConfig.ts
@@ -12,6 +12,9 @@ export interface WizardData {
   // Step 2 — Connection
   url: string;
   headers: Record<string, unknown>;
+  /** EVO-2250 story 2.4: header name -> vault credential id. A MAP because one
+   * credential is one secret, so two auth headers are two credentials. */
+  credential_refs: Record<string, string>;
   // Step 3 — Advanced
   timeout: number;
   retry_count: number;
@@ -23,6 +26,7 @@ export const initialWizardData: WizardData = {
   tags: [],
   url: '',
   headers: {},
+  credential_refs: {},
   timeout: 30,
   retry_count: 3,
 };
@@ -33,6 +37,7 @@ export const serverToWizardData = (server: CustomMcpServer): WizardData => ({
   tags: server.tags || [],
   url: server.url || '',
   headers: (server.headers as Record<string, unknown>) || {},
+  credential_refs: server.credential_refs || {},
   timeout: server.timeout ?? 30,
   retry_count: server.retry_count ?? 3,
 });
@@ -108,6 +113,25 @@ export const parseWizardConfig = (
       issues.push(t('wizard.advanced.errors.headerValueType', { keys: badKeys.join(', ') }));
     } else {
       next.headers = parsed.headers;
+    }
+  }
+
+  // credential_refs — a map of header name to vault credential id. Same string
+  // discipline as headers: a non-string id would reach the API as a 400, and
+  // silently dropping the map would strip the vault reference off a server that
+  // has one (EVO-2250 story 2.4).
+  if (parsed.credential_refs === undefined) {
+    next.credential_refs = {};
+  } else if (!isPlainObject(parsed.credential_refs)) {
+    issues.push(t('wizard.advanced.errors.headersType'));
+  } else {
+    const badRefs = Object.entries(parsed.credential_refs)
+      .filter(([, v]) => typeof v !== 'string')
+      .map(([k]) => k);
+    if (badRefs.length > 0) {
+      issues.push(t('wizard.advanced.errors.headerValueType', { keys: badRefs.join(', ') }));
+    } else {
+      next.credential_refs = parsed.credential_refs as Record<string, string>;
     }
   }
 

--- a/src/components/customTools/CustomToolForm.spec.tsx
+++ b/src/components/customTools/CustomToolForm.spec.tsx
@@ -11,6 +11,11 @@ vi.mock('@/services/agents/customToolsService', () => ({
   testCustomTool: vi.fn(),
 }));
 
+// The vault picker (EVO-2250 story 2.4) loads credentials on mount.
+vi.mock('@/services/agents', () => ({
+  listIntegrationCredentials: vi.fn().mockResolvedValue([]),
+}));
+
 const baseTool: CustomTool = {
   id: 'tool-1',
   name: 'My Tool',
@@ -83,5 +88,34 @@ describe('CustomToolForm (refactored)', () => {
     fireEvent.click(screen.getByText('advancedConfig.title'));
     expect(screen.getByLabelText('form.fields.values.label')).toBeTruthy();
     expect(screen.getByLabelText('form.fields.errorHandling.label')).toBeTruthy();
+  });
+
+  // EVO-2250 story 2.4: the vault reference is a MAP (header -> credential),
+  // round-tripped untouched through the save payload. A scalar credential_id
+  // column could not carry the two-entry case (negative proof).
+  it('round-trips credential_refs as a map in the save payload (2.4)', () => {
+    const toolWithRefs: CustomTool = {
+      ...baseTool,
+      credential_refs: { Authorization: 'cred-1', 'X-API-Key': 'cred-2' },
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolForm tool={toolWithRefs} mode="edit" onSubmit={onSubmit} />);
+    fireEvent.submit(screen.getByText('form.actions.save').closest('form')!);
+
+    const payload = onSubmit.mock.calls[0][0];
+    expect(payload.credential_refs).toEqual({
+      Authorization: 'cred-1',
+      'X-API-Key': 'cred-2',
+    });
+    // The inline headers stay as the fallback until story 2.7.
+    expect(payload.headers).toEqual({ Authorization: 'Bearer x' });
+  });
+
+  it('sends an empty credential_refs map when nothing references the vault', () => {
+    const onSubmit = vi.fn();
+    render(<CustomToolForm tool={baseTool} mode="edit" onSubmit={onSubmit} />);
+    fireEvent.submit(screen.getByText('form.actions.save').closest('form')!);
+
+    expect(onSubmit.mock.calls[0][0].credential_refs).toEqual({});
   });
 });

--- a/src/components/customTools/CustomToolForm.spec.tsx
+++ b/src/components/customTools/CustomToolForm.spec.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CustomToolForm from './CustomToolForm';
 import type { CustomTool } from '@/types/ai';
 
@@ -11,10 +11,21 @@ vi.mock('@/services/agents/customToolsService', () => ({
   testCustomTool: vi.fn(),
 }));
 
-// The vault picker (EVO-2250 story 2.4) loads credentials on mount.
+// The vault picker (EVO-2250 story 2.4) loads credentials on mount, and the
+// retirement guard (story 2.7) decides whether inline auth headers still edit.
+const getIntegrationVaultMigrationState = vi.fn();
+
 vi.mock('@/services/agents', () => ({
   listIntegrationCredentials: vi.fn().mockResolvedValue([]),
+  getIntegrationVaultMigrationState: (...args: unknown[]) =>
+    getIntegrationVaultMigrationState(...args),
 }));
+
+beforeEach(() => {
+  // Default: the guard says NOT retired, so every pre-2.7 test keeps its
+  // original behavior.
+  getIntegrationVaultMigrationState.mockResolvedValue({ retired: {} });
+});
 
 const baseTool: CustomTool = {
   id: 'tool-1',
@@ -117,5 +128,62 @@ describe('CustomToolForm (refactored)', () => {
     fireEvent.submit(screen.getByText('form.actions.save').closest('form')!);
 
     expect(onSubmit.mock.calls[0][0].credential_refs).toEqual({});
+  });
+});
+
+// EVO-2250 story 2.7: with the consumer retired, inline auth headers become
+// read-only pointers to the vault, but the payload NEVER stops carrying what
+// the backend needs — the update replaces the stored object wholesale, so a
+// form that drops the received auth header erases the migrated secret through
+// the UI (the exact data-loss path the 1.6 retirement found in its modal).
+describe('CustomToolForm — retirement gated by the migration guard (2.7)', () => {
+  beforeEach(() => {
+    getIntegrationVaultMigrationState.mockResolvedValue({ retired: { custom_tools: true } });
+  });
+
+  it('still sends the received auth headers byte-identical after retirement (negative proof)', async () => {
+    const onSubmit = vi.fn();
+    render(<CustomToolForm tool={baseTool} mode="edit" onSubmit={onSubmit} />);
+
+    await screen.findByText('retirement.authHeadersLocked');
+    fireEvent.submit(screen.getByText('form.actions.save').closest('form')!);
+
+    const payload = onSubmit.mock.calls[0][0];
+    // This assertion is what fails if the form ever stops sending the field
+    // the backend needs on a wholesale update.
+    expect(payload.headers.Authorization).toBe('Bearer x');
+  });
+
+  it('renders the auth header read-only and keeps other headers editable', async () => {
+    const toolWithMixedHeaders: CustomTool = {
+      ...baseTool,
+      headers: { Authorization: 'Bearer x', 'Content-Type': 'application/json' },
+    };
+    render(<CustomToolForm tool={toolWithMixedHeaders} mode="edit" onSubmit={() => {}} />);
+
+    await screen.findByText('retirement.managedByVault');
+    // The masked row exists, and the secret value never renders.
+    expect(screen.getByText('Authorization')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Bearer x')).not.toBeInTheDocument();
+    // The non-auth header keeps its editable input.
+    expect(screen.getByDisplayValue('application/json')).toBeInTheDocument();
+  });
+
+  it('keeps the inline editor untouched while the guard says not migrated (AC3)', async () => {
+    getIntegrationVaultMigrationState.mockResolvedValue({ retired: {} });
+    render(<CustomToolForm tool={baseTool} mode="edit" onSubmit={() => {}} />);
+
+    await waitFor(() => expect(getIntegrationVaultMigrationState).toHaveBeenCalled());
+    expect(screen.queryByText('retirement.authHeadersLocked')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Bearer x')).toBeInTheDocument();
+  });
+
+  it('keeps the inline editor when the guard itself fails (fails closed)', async () => {
+    getIntegrationVaultMigrationState.mockRejectedValue(new Error('503'));
+    render(<CustomToolForm tool={baseTool} mode="edit" onSubmit={() => {}} />);
+
+    await waitFor(() => expect(getIntegrationVaultMigrationState).toHaveBeenCalled());
+    expect(screen.queryByText('retirement.authHeadersLocked')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('Bearer x')).toBeInTheDocument();
   });
 });

--- a/src/components/customTools/CustomToolForm.tsx
+++ b/src/components/customTools/CustomToolForm.tsx
@@ -26,6 +26,9 @@ import {
   AdvancedJsonCollapse,
   TestRequestButton,
   CredentialRefsEditor,
+  mergeRetiredHeaders,
+  splitAuthHeaders,
+  useVaultMigrationState,
 } from '@/components/ai_agents/shared';
 
 
@@ -83,6 +86,12 @@ export default function CustomToolForm({
   onCancel,
 }: CustomToolFormProps) {
   const { t } = useLanguage('customTools');
+  const { t: tVault } = useLanguage('integrationCredentials');
+  // Story 2.7: with the consumer retired, inline auth headers become read-only
+  // pointers to the vault. Guard failure reads as not retired: nothing is
+  // removed from a broken installation.
+  const migrationState = useVaultMigrationState();
+  const headersRetired = Boolean(migrationState.retired.custom_tools);
   const [formData, setFormData] = useState<FormData>(initialFormData);
   const [valuesJson, setValuesJson] = useState('{}');
   const [errorHandlingJson, setErrorHandlingJson] = useState('{}');
@@ -382,16 +391,55 @@ export default function CustomToolForm({
             {errors.endpoint && <p className="text-sm text-destructive">{errors.endpoint}</p>}
           </div>
 
-          <KeyValueEditor
-            id="headers"
-            label={t('form.fields.headers.labelKv')}
-            value={formData.headers}
-            onChange={handleKvChange('headers')}
-            disabled={loading}
-            hint={t('form.fields.headers.hint')}
-            keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
-            valuePlaceholder={t('form.fields.headers.valuePlaceholder')}
-          />
+          {headersRetired ? (
+            // Retired: the auth entries the form received stay read-only AND
+            // stay in the payload untouched — the update replaces the stored
+            // object wholesale, so dropping them here would erase the migrated
+            // secret through the UI (the 1.6 modal bug, negative-proof tested).
+            <div className="space-y-2">
+              {Object.keys(splitAuthHeaders(formData.headers).auth).map(name => (
+                <div
+                  key={name}
+                  className="flex items-center gap-2 text-sm border rounded-md px-3 py-2"
+                >
+                  <span className="font-mono">{name}</span>
+                  <span className="font-mono text-muted-foreground">••••</span>
+                  <span className="text-xs text-muted-foreground ml-auto">
+                    {tVault('retirement.managedByVault')}
+                  </span>
+                </div>
+              ))}
+              <p className="text-xs text-muted-foreground">
+                {tVault('retirement.authHeadersLocked')}
+              </p>
+              <KeyValueEditor
+                id="headers"
+                label={t('form.fields.headers.labelKv')}
+                value={splitAuthHeaders(formData.headers).others}
+                onChange={next =>
+                  setFormData(prev => ({
+                    ...prev,
+                    headers: mergeRetiredHeaders(prev.headers, next as Record<string, unknown>),
+                  }))
+                }
+                disabled={loading}
+                hint={t('form.fields.headers.hint')}
+                keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
+                valuePlaceholder={t('form.fields.headers.valuePlaceholder')}
+              />
+            </div>
+          ) : (
+            <KeyValueEditor
+              id="headers"
+              label={t('form.fields.headers.labelKv')}
+              value={formData.headers}
+              onChange={handleKvChange('headers')}
+              disabled={loading}
+              hint={t('form.fields.headers.hint')}
+              keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
+              valuePlaceholder={t('form.fields.headers.valuePlaceholder')}
+            />
+          )}
 
           {/* Vault-backed auth headers (EVO-2250 story 2.4): each entry maps
               one header name to one vault credential — inline headers above

--- a/src/components/customTools/CustomToolForm.tsx
+++ b/src/components/customTools/CustomToolForm.tsx
@@ -25,6 +25,7 @@ import {
   KeyValueEditor,
   AdvancedJsonCollapse,
   TestRequestButton,
+  CredentialRefsEditor,
 } from '@/components/ai_agents/shared';
 
 
@@ -42,6 +43,7 @@ interface FormData {
   method: string;
   endpoint: string;
   headers: Record<string, unknown>;
+  credential_refs: Record<string, string>;
   path_params: Record<string, unknown>;
   query_params: Record<string, unknown>;
   body_params: Record<string, unknown>;
@@ -59,6 +61,7 @@ const initialFormData: FormData = {
   method: 'GET',
   endpoint: '',
   headers: {},
+  credential_refs: {},
   path_params: {},
   query_params: {},
   body_params: {},
@@ -97,6 +100,7 @@ export default function CustomToolForm({
         method: tool.method || 'GET',
         endpoint: tool.endpoint || '',
         headers: (tool.headers as Record<string, unknown>) || {},
+        credential_refs: tool.credential_refs || {},
         path_params: (tool.path_params as Record<string, unknown>) || {},
         query_params: (tool.query_params as Record<string, unknown>) || {},
         body_params: (tool.body_params as Record<string, unknown>) || {},
@@ -271,6 +275,7 @@ export default function CustomToolForm({
       method: formData.method,
       endpoint: formData.endpoint.trim(),
       headers: formData.headers,
+      credential_refs: formData.credential_refs,
       path_params: formData.path_params,
       query_params: formData.query_params,
       body_params: formData.body_params,
@@ -386,6 +391,17 @@ export default function CustomToolForm({
             hint={t('form.fields.headers.hint')}
             keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
             valuePlaceholder={t('form.fields.headers.valuePlaceholder')}
+          />
+
+          {/* Vault-backed auth headers (EVO-2250 story 2.4): each entry maps
+              one header name to one vault credential — inline headers above
+              keep working as the fallback until story 2.7. */}
+          <CredentialRefsEditor
+            id="credential_refs"
+            value={formData.credential_refs}
+            onChange={refs => setFormData(prev => ({ ...prev, credential_refs: refs }))}
+            disabled={loading}
+            keyPlaceholder={t('form.fields.headers.keyPlaceholder')}
           />
 
           {showBodyParams && (

--- a/src/components/integrations/KnowledgeNexusConfigDialog.spec.tsx
+++ b/src/components/integrations/KnowledgeNexusConfigDialog.spec.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import KnowledgeNexusConfigDialog from './KnowledgeNexusConfigDialog';
+
+// EVO-2250 story 2.7: the inline API key field retires behind the migration
+// guard, and the save payload keeps meaning "the stored key is untouched".
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const listIntegrationCredentials = vi.fn();
+const getIntegrationVaultMigrationState = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+  getIntegrationVaultMigrationState: (...args: unknown[]) =>
+    getIntegrationVaultMigrationState(...args),
+}));
+
+vi.mock('@/services/agents/agentIntegrationsService', () => ({
+  agentIntegrationsService: { listKnowledgeNexusSpaces: vi.fn().mockResolvedValue([]) },
+  default: { listKnowledgeNexusSpaces: vi.fn().mockResolvedValue([]) },
+}));
+
+const SAVED_CONFIG = {
+  connected: true,
+  nexus_base_url: 'https://nexus.example.com',
+  space_id: '00000000-0000-0000-0000-000000000001',
+  credential_id: 'cred-nexus',
+};
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listIntegrationCredentials.mockResolvedValue([]);
+  getIntegrationVaultMigrationState.mockResolvedValue({ retired: {} });
+});
+
+describe('KnowledgeNexusConfigDialog — retirement of the inline key (2.7)', () => {
+  it('keeps the API key input while the guard says not migrated (AC3)', async () => {
+    render(
+      <KnowledgeNexusConfigDialog
+        open
+        onOpenChange={() => {}}
+        onSave={() => {}}
+        initialConfig={SAVED_CONFIG}
+      />,
+    );
+
+    await waitFor(() => expect(getIntegrationVaultMigrationState).toHaveBeenCalled());
+    expect(document.getElementById('nexus_api_key')).not.toBeNull();
+    expect(screen.queryByText('retirement.nexusKeyLocked')).not.toBeInTheDocument();
+  });
+
+  it('retires the input when the guard says migrated, without touching the stored key', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    getIntegrationVaultMigrationState.mockResolvedValue({ retired: { knowledge_nexus: true } });
+    render(
+      <KnowledgeNexusConfigDialog
+        open
+        onOpenChange={() => {}}
+        onSave={onSave}
+        initialConfig={SAVED_CONFIG}
+      />,
+    );
+
+    expect(await screen.findByText('retirement.nexusKeyLocked')).toBeInTheDocument();
+    expect(document.getElementById('nexus_api_key')).toBeNull();
+
+    await user.click(screen.getByText('edit.integrations.knowledgeNexus.apply'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const payload = onSave.mock.calls[0][0];
+    // Negative proof of the data-loss path: the payload must NOT carry an
+    // empty nexus_api_key (that would overwrite the stored secret on backends
+    // that replace the object wholesale) — absence means "keep it".
+    expect(payload).not.toHaveProperty('nexus_api_key');
+    expect(payload.credential_id).toBe('cred-nexus');
+    expect(payload.nexus_base_url).toBe('https://nexus.example.com');
+  });
+});

--- a/src/components/integrations/KnowledgeNexusConfigDialog.tsx
+++ b/src/components/integrations/KnowledgeNexusConfigDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from '@evoapi/design-system';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { VaultCredentialSelect, useVaultCredentials } from '@/components/ai_agents/shared';
 import type { KnowledgeNexusConfig } from '@/hooks/useIntegrations';
 import {
   agentIntegrationsService,
@@ -38,6 +39,7 @@ const DEFAULT_TIMEOUT = 15;
 interface DialogState {
   nexus_base_url: string;
   nexus_api_key: string;
+  credential_id: string;
   space_id: string;
   default_top_k: number;
   timeout_seconds: number;
@@ -51,6 +53,8 @@ const KnowledgeNexusConfigDialog = ({
   initialConfig,
 }: KnowledgeNexusConfigDialogProps) => {
   const { t } = useLanguage('aiAgents');
+  const { t: tVault } = useLanguage('integrationCredentials');
+  const vaultCredentials = useVaultCredentials();
 
   // Backend strips `nexus_api_key` before returning the config (defense-in-depth
   // in useIntegrations.sanitizeConfig). When `connected === true` but the key
@@ -61,6 +65,7 @@ const KnowledgeNexusConfigDialog = ({
   const [config, setConfig] = useState<DialogState>({
     nexus_base_url: initialConfig?.nexus_base_url || '',
     nexus_api_key: initialConfig?.nexus_api_key || '',
+    credential_id: initialConfig?.credential_id || '',
     space_id: initialConfig?.space_id || '',
     default_top_k: initialConfig?.default_top_k ?? DEFAULT_TOP_K,
     timeout_seconds: initialConfig?.timeout_seconds ?? DEFAULT_TIMEOUT,
@@ -73,6 +78,7 @@ const KnowledgeNexusConfigDialog = ({
       setConfig({
         nexus_base_url: initialConfig?.nexus_base_url || '',
         nexus_api_key: '',
+        credential_id: initialConfig?.credential_id || '',
         space_id: initialConfig?.space_id || '',
         default_top_k: initialConfig?.default_top_k ?? DEFAULT_TOP_K,
         timeout_seconds: initialConfig?.timeout_seconds ?? DEFAULT_TIMEOUT,
@@ -145,7 +151,11 @@ const KnowledgeNexusConfigDialog = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, config.nexus_base_url, config.nexus_api_key, manualSpaceMode]);
 
-  const apiKeyOk = config.nexus_api_key.trim() !== '' || hasSavedApiKey;
+  // A vault reference satisfies the key requirement on its own (story 2.4):
+  // the runtime resolves the secret from the vault by credential_id.
+  const usingVaultCredential = config.credential_id.trim() !== '';
+  const apiKeyOk =
+    config.nexus_api_key.trim() !== '' || hasSavedApiKey || usingVaultCredential;
   const isValid =
     config.nexus_base_url.trim() !== '' && apiKeyOk && config.space_id.trim() !== '';
 
@@ -157,8 +167,12 @@ const KnowledgeNexusConfigDialog = ({
       default_top_k: config.default_top_k,
       timeout_seconds: config.timeout_seconds,
     };
+    if (usingVaultCredential) {
+      payload.credential_id = config.credential_id;
+    }
     // Only include the API key when the user actually typed one; leaving it
-    // blank means "keep whatever is stored on the backend".
+    // blank means "keep whatever is stored on the backend". While the inline
+    // fallback exists (until story 2.7) a typed key still travels along.
     const typedKey = config.nexus_api_key.trim();
     if (typedKey) {
       payload.nexus_api_key = typedKey;
@@ -204,11 +218,25 @@ const KnowledgeNexusConfigDialog = ({
           </div>
 
           <div className="space-y-2">
+            <Label htmlFor="nexus_credential_id">{tVault('refsEditor.nexusLabel')}</Label>
+            <VaultCredentialSelect
+              id="nexus_credential_id"
+              value={config.credential_id || undefined}
+              onChange={credentialId =>
+                setConfig({ ...config, credential_id: credentialId ?? '' })
+              }
+              credentials={vaultCredentials}
+            />
+            <p className="text-xs text-muted-foreground">{tVault('refsEditor.nexusHint')}</p>
+          </div>
+
+          <div className="space-y-2">
             <Label htmlFor="nexus_api_key">
               {t('edit.integrations.knowledgeNexus.apiKey') || 'API Key'}
             </Label>
             <Input
               id="nexus_api_key"
+              disabled={usingVaultCredential}
               type="password"
               placeholder={
                 hasSavedApiKey

--- a/src/components/integrations/KnowledgeNexusConfigDialog.tsx
+++ b/src/components/integrations/KnowledgeNexusConfigDialog.tsx
@@ -16,7 +16,11 @@ import {
 } from '@evoapi/design-system';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { VaultCredentialSelect, useVaultCredentials } from '@/components/ai_agents/shared';
+import {
+  VaultCredentialSelect,
+  useVaultCredentials,
+  useVaultMigrationState,
+} from '@/components/ai_agents/shared';
 import type { KnowledgeNexusConfig } from '@/hooks/useIntegrations';
 import {
   agentIntegrationsService,
@@ -58,6 +62,11 @@ const KnowledgeNexusConfigDialog = ({
   // eager fetch would fire one vault listing (a 403, for users without the
   // grant) per render of those screens.
   const vaultCredentials = useVaultCredentials(open);
+  // Story 2.7: once the guard says migrated, the inline key field retires and
+  // the vault reference is the way to register the secret. The stored key is
+  // never touched: a blank/absent nexus_api_key already means "keep it".
+  const migrationState = useVaultMigrationState(open);
+  const nexusKeyRetired = Boolean(migrationState.retired.knowledge_nexus);
 
   // Backend strips `nexus_api_key` before returning the config (defense-in-depth
   // in useIntegrations.sanitizeConfig). When `connected === true` but the key
@@ -233,6 +242,15 @@ const KnowledgeNexusConfigDialog = ({
             <p className="text-xs text-muted-foreground">{tVault('refsEditor.nexusHint')}</p>
           </div>
 
+          {nexusKeyRetired ? (
+            // Retired (story 2.7): the inline key entry is gone, the vault
+            // reference above is how the secret is registered. The stored key
+            // is untouched: the save payload simply omits nexus_api_key, which
+            // has always meant "keep whatever is stored".
+            <p className="text-xs text-muted-foreground">
+              {tVault('retirement.nexusKeyLocked')}
+            </p>
+          ) : (
           <div className="space-y-2">
             <Label htmlFor="nexus_api_key">
               {t('edit.integrations.knowledgeNexus.apiKey') || 'API Key'}
@@ -262,6 +280,7 @@ const KnowledgeNexusConfigDialog = ({
               </p>
             )}
           </div>
+          )}
 
           <div className="space-y-2">
             <div className="flex items-center justify-between">

--- a/src/components/integrations/KnowledgeNexusConfigDialog.tsx
+++ b/src/components/integrations/KnowledgeNexusConfigDialog.tsx
@@ -54,7 +54,10 @@ const KnowledgeNexusConfigDialog = ({
 }: KnowledgeNexusConfigDialogProps) => {
   const { t } = useLanguage('aiAgents');
   const { t: tVault } = useLanguage('integrationCredentials');
-  const vaultCredentials = useVaultCredentials();
+  // Gated on `open`: this dialog mounts closed on every agent screen, and an
+  // eager fetch would fire one vault listing (a 403, for users without the
+  // grant) per render of those screens.
+  const vaultCredentials = useVaultCredentials(open);
 
   // Backend strips `nexus_api_key` before returning the config (defense-in-depth
   // in useIntegrations.sanitizeConfig). When `connected === true` but the key

--- a/src/components/integrations/providers/openai/OpenAIModal.spec.tsx
+++ b/src/components/integrations/providers/openai/OpenAIModal.spec.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OpenAIModal from './OpenAIModal';
+import type { IntegrationHook } from '@/types/integrations';
+
+// EVO-2250 story 1.6: this screen stopped registering the credential, but the
+// hook update REPLACES the settings jsonb. Dropping api_key from the payload
+// would erase a migrated key — and on an install whose only key lives here that
+// silently switches AI off, defeating the Ai::MigrationState guard.
+const navigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigate,
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const HOOK_WITH_KEY = {
+  id: 'hook-1',
+  app_id: 'openai',
+  settings: { api_key: 'sk-migrated-1111', enable_audio_transcription: true },
+} as unknown as IntegrationHook;
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('OpenAIModal — the credential moved out (1.6 AC2)', () => {
+  it('offers no key input any more', () => {
+    render(<OpenAIModal open hook={HOOK_WITH_KEY} onOpenChange={vi.fn()} onSubmit={vi.fn()} />);
+
+    expect(screen.queryByLabelText(/apiKey/i)).not.toBeInTheDocument();
+    expect(screen.getByText('openai.modal.credentialMoved')).toBeInTheDocument();
+  });
+
+  it('points at the AI Credentials screen', async () => {
+    const user = userEvent.setup();
+    render(<OpenAIModal open hook={HOOK_WITH_KEY} onOpenChange={vi.fn()} onSubmit={vi.fn()} />);
+
+    await user.click(screen.getByText('openai.modal.goToCredentials'));
+
+    expect(navigate).toHaveBeenCalledWith('/settings/ai-credentials');
+  });
+
+  it('keeps the stored key in the payload when saving the toggles', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<OpenAIModal open hook={HOOK_WITH_KEY} onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByText('openai.modal.actions.update'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    // Losing this is a data-loss path, not a cosmetic regression.
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ api_key: 'sk-migrated-1111' });
+  });
+
+  it('still saves the toggle the user changed', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<OpenAIModal open hook={HOOK_WITH_KEY} onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByRole('switch'));
+    await user.click(screen.getByText('openai.modal.actions.update'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      api_key: 'sk-migrated-1111',
+      enable_audio_transcription: false,
+    });
+  });
+
+  it('saves without a key when the hook never had one', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(<OpenAIModal open onOpenChange={vi.fn()} onSubmit={onSubmit} />);
+
+    await user.click(screen.getByText('openai.modal.actions.configure'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({ api_key: '' });
+  });
+});

--- a/src/components/integrations/providers/openai/OpenAIModal.tsx
+++ b/src/components/integrations/providers/openai/OpenAIModal.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
+import { AI_CREDENTIALS_ROUTE } from '@/components/ApiKeysModal';
 import {
   Dialog,
   DialogContent,
@@ -7,7 +9,6 @@ import {
   DialogHeader,
   DialogTitle,
   Button,
-  Input,
   Card,
   Switch,
   Label
@@ -33,13 +34,12 @@ export default function OpenAIModal({
   loading: submitting = false
 }: OpenAIModalProps) {
   const { t } = useLanguage('integrations');
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState<OpenAIFormData>({
     api_key: '',
     enable_audio_transcription: false
   });
-
-  const [errors, setErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
     const openaiHook = hook as OpenAIHook | undefined;
@@ -54,29 +54,18 @@ export default function OpenAIModal({
         enable_audio_transcription: false
       });
     }
-    setErrors({});
   }, [hook, open]);
 
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
-
-    if (!formData.api_key.trim()) {
-      newErrors.api_key = t('openai.modal.fields.apiKey.required');
-    } else if (!formData.api_key.startsWith('sk-')) {
-      newErrors.api_key = t('openai.modal.fields.apiKey.invalid');
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
+  // The credential is registered under Settings > AI Credentials (EVO-2250);
+  // this screen only carries the feature toggles, so there is nothing left to
+  // validate here.
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (!validateForm()) return;
-
     setLoading(true);
     try {
+      // The hook update REPLACES the settings jsonb, so the stored key has to
+      // travel with the payload. Dropping it would erase a migrated credential
+      // and, on an install whose only key lives here, silently switch AI off.
       await onSubmit(formData as unknown as Record<string, unknown>);
     } catch {
       // Error is handled by parent component
@@ -106,24 +95,18 @@ export default function OpenAIModal({
             <h4 className="font-semibold mb-4">{t('openai.modal.apiConfig')}</h4>
 
             <div className="space-y-4">
-              <div>
-                <label htmlFor="api_key" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-                  {t('openai.modal.fields.apiKey.label')} *
-                </label>
-                <Input
-                  id="api_key"
-                  type="password"
-                  placeholder={t('openai.modal.fields.apiKey.placeholder')}
-                  value={formData.api_key}
-                  onChange={(e) => setFormData(prev => ({ ...prev, api_key: e.target.value }))}
-                  className={errors.api_key ? 'border-red-500' : ''}
-                />
-                {errors.api_key && (
-                  <p className="text-sm text-red-600 mt-1">{errors.api_key}</p>
-                )}
-                <p className="text-xs text-slate-500 mt-1">
-                  {t('openai.modal.fields.apiKey.hint')}
+              <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">
+                <p className="text-sm text-slate-700 dark:text-slate-300">
+                  {t('openai.modal.credentialMoved')}
                 </p>
+                <Button
+                  type="button"
+                  variant="link"
+                  className="px-0 h-auto text-sm"
+                  onClick={() => navigate(AI_CREDENTIALS_ROUTE)}
+                >
+                  {t('openai.modal.goToCredentials')}
+                </Button>
               </div>
 
               {/* Audio Transcription Toggle */}

--- a/src/components/integrations/providers/openai/OpenAISettings.tsx
+++ b/src/components/integrations/providers/openai/OpenAISettings.tsx
@@ -239,14 +239,15 @@ export default function OpenAISettings({ onBack }: OpenAISettingsProps = {}) {
               </div>
 
               <div className="space-y-4">
+                {/* Reading hook.settings.api_key here would lie on a migrated
+                    install: the credential lives in the registry, not in the
+                    hook, so this points at the screen that owns it. */}
                 <div>
                   <label className="text-xs text-slate-500">
                     {t('openai.settings.configuration.apiKey')}
                   </label>
-                  <p className="text-sm font-mono bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
-                    {hook.settings?.api_key
-                      ? '••••••••••••••••'
-                      : t('openai.settings.configuration.notConfigured')}
+                  <p className="text-sm">
+                    {t('openai.settings.configuration.managedElsewhere')}
                   </p>
                 </div>
                 <div className="flex items-center justify-between p-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -254,6 +254,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         action: 'read',
       },
       {
+        name: t('menu.settings.integrationCredentials'),
+        href: '/settings/integration-credentials',
+        icon: Key,
+        resource: 'ai_integration_credentials',
+        action: 'read',
+      },
+      {
         name: t('menu.settings.messageTemplates'),
         href: '/settings/message-templates',
         icon: LayoutTemplate,

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -15,6 +15,7 @@ import {
   MessageCircle,
   LayoutTemplate,
   Key,
+  KeyRound,
   Tags,
   TestTube,
   Wand,
@@ -243,6 +244,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         href: '/settings/canned-responses',
         icon: MessageCircle,
         resource: 'canned_responses',
+        action: 'read',
+      },
+      {
+        name: t('menu.settings.aiCredentials'),
+        href: '/settings/ai-credentials',
+        icon: KeyRound,
+        resource: 'ai_api_keys',
         action: 'read',
       },
       {

--- a/src/constants/aiProviders.spec.ts
+++ b/src/constants/aiProviders.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCredential, resolveCredentialState } from './aiProviders';
+
+// EVO-2250 review, MÉDIO 15: this browser-side resolution is a mirror of
+// Ai::CredentialResolver, and it disagreed with it in two ways — it ordered by
+// position in the array instead of created_at ASC, and it knew nothing about
+// the legacy fallback, so a not-yet-migrated installation read "no credential"
+// while its AI was working.
+
+const credential = (overrides: Partial<Parameters<typeof resolveCredential>[0][number]> = {}) => ({
+  provider: 'openai',
+  scope: 'account' as const,
+  is_active: true,
+  openai_compatible: true,
+  created_at: '2026-07-01T00:00:00Z',
+  name: 'sem nome',
+  ...overrides,
+});
+
+describe('resolveCredential — mirrors the Ruby resolver', () => {
+  it('picks the OLDEST active credential in a link, not the first in the array', () => {
+    const newest = credential({ name: 'nova', created_at: '2026-07-20T00:00:00Z' });
+    const oldest = credential({ name: 'antiga', created_at: '2026-01-05T00:00:00Z' });
+
+    // Array order deliberately puts the newest first: the Ruby side orders by
+    // created_at ASC, so position must not decide.
+    expect(resolveCredential([newest, oldest])?.name).toBe('antiga');
+  });
+
+  it('still prefers the account link over the installation one', () => {
+    const installation = credential({
+      name: 'da casa',
+      scope: 'installation',
+      created_at: '2020-01-01T00:00:00Z',
+    });
+    const account = credential({ name: 'da conta', created_at: '2026-07-20T00:00:00Z' });
+
+    // The installation credential is far older, and still loses: the chain is
+    // walked most-specific first, and ordering only breaks ties INSIDE a link.
+    expect(resolveCredential([installation, account])?.name).toBe('da conta');
+  });
+
+  it('skips inactive credentials and providers the feature cannot speak', () => {
+    const inactive = credential({ name: 'inativa', is_active: false });
+    const anthropic = credential({
+      name: 'anthropic',
+      provider: 'anthropic',
+      openai_compatible: false,
+    });
+    const usable = credential({ name: 'usavel', created_at: '2026-07-02T00:00:00Z' });
+
+    expect(
+      resolveCredential([inactive, anthropic, usable], { openAICompatibleOnly: true })?.name,
+    ).toBe('usavel');
+  });
+
+  it('sorts a credential with no timestamp last instead of letting it win', () => {
+    const undated = credential({ name: 'sem data', created_at: undefined });
+    const dated = credential({ name: 'com data', created_at: '2026-07-10T00:00:00Z' });
+
+    expect(resolveCredential([undated, dated])?.name).toBe('com data');
+  });
+});
+
+describe('resolveCredentialState — the legacy state the panel was blind to', () => {
+  it('reports the registry credential when there is one', () => {
+    const result = resolveCredentialState([credential({ name: 'producao' })]);
+
+    expect(result.state).toBe('registry');
+    expect(result.state === 'registry' && result.credential.name).toBe('producao');
+  });
+
+  // The lie this fixes: an empty registry on a not-yet-migrated install used to
+  // render "no credential" while the resolver's legacy fallback was serving.
+  it('reports legacy — not "none" — when the registry is empty and the fallback is live', () => {
+    expect(resolveCredentialState([], { legacyActive: true }).state).toBe('legacy');
+  });
+
+  it('reports none when the registry is empty and nothing else serves', () => {
+    expect(resolveCredentialState([], { legacyActive: false }).state).toBe('none');
+  });
+
+  // A registry credential wins over the legacy fallback, which mirrors the
+  // Ruby resolver: the legacy link is the TAIL of the chain.
+  it('never reports legacy while a registry credential resolves', () => {
+    const result = resolveCredentialState([credential({ name: 'producao' })], {
+      legacyActive: true,
+    });
+
+    expect(result.state).toBe('registry');
+  });
+});

--- a/src/constants/aiProviders.ts
+++ b/src/constants/aiProviders.ts
@@ -1,0 +1,43 @@
+export const CUSTOM_OPENAI_PROVIDER = 'custom_openai_compatible';
+
+export interface AiProvider {
+  value: string;
+  label: string;
+}
+
+export const AI_PROVIDERS: AiProvider[] = [
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'gemini', label: 'Google Gemini' },
+  { value: 'azure', label: 'Azure OpenAI' },
+  { value: 'groq', label: 'Groq' },
+  { value: 'mistral', label: 'Mistral AI' },
+  { value: 'cohere', label: 'Cohere' },
+  { value: 'openrouter', label: 'OpenRouter' },
+  { value: 'deepseek', label: 'DeepSeek' },
+  { value: 'together_ai', label: 'Together AI' },
+  { value: 'fireworks_ai', label: 'Fireworks AI' },
+  { value: 'perplexity', label: 'Perplexity' },
+  { value: 'bedrock', label: 'AWS Bedrock' },
+  { value: 'vertex_ai', label: 'Google Vertex AI' },
+  { value: CUSTOM_OPENAI_PROVIDER, label: 'Custom (OpenAI-compatible)' },
+];
+
+// Providers speaking the OpenAI wire protocol serve every AI feature. The rest
+// are only reachable through AI Agents. Mirrors IsOpenAICompatible in
+// evo-ai-core-service-community/pkg/api_key/model/api_key.go.
+const OPENAI_COMPATIBLE_PROVIDERS = new Set([
+  'openai',
+  'azure',
+  'custom',
+  CUSTOM_OPENAI_PROVIDER,
+]);
+
+export function isOpenAICompatible(provider: string): boolean {
+  return OPENAI_COMPATIBLE_PROVIDERS.has(provider);
+}
+
+// The API returns only the last characters of a key, never the key itself.
+export function maskKey(hint?: string): string {
+  return hint ? `••••${hint}` : '••••';
+}

--- a/src/constants/aiProviders.ts
+++ b/src/constants/aiProviders.ts
@@ -41,3 +41,41 @@ export function isOpenAICompatible(provider: string): boolean {
 export function maskKey(hint?: string): string {
   return hint ? `••••${hint}` : '••••';
 }
+
+// Scopes ordered from the most generic to the most specific, mirroring
+// Ai::CredentialResolver::SCOPE_CHAIN in the CRM. Rails owns the resolution
+// that features rely on; this preview exists so the screen can show which
+// credential is in effect without a round trip per feature.
+export const SCOPE_CHAIN: ApiKeyScope[] = ['installation', 'account'];
+
+export type ApiKeyScope = 'installation' | 'account';
+
+interface ResolvableCredential {
+  provider: string;
+  scope?: ApiKeyScope;
+  is_active: boolean;
+  openai_compatible?: boolean;
+}
+
+// Mirrors the resolver: most specific link first, skipping credentials whose
+// provider the feature cannot speak, so it falls through to a broader link.
+export function resolveCredential<T extends ResolvableCredential>(
+  credentials: T[],
+  { openAICompatibleOnly = false }: { openAICompatibleOnly?: boolean } = {},
+): T | undefined {
+  for (const scope of [...SCOPE_CHAIN].reverse()) {
+    const match = credentials.find(
+      credential =>
+        credential.is_active &&
+        (credential.scope ?? 'account') === scope &&
+        (!openAICompatibleOnly ||
+          (credential.openai_compatible ?? isOpenAICompatible(credential.provider))),
+    );
+
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
+}

--- a/src/constants/aiProviders.ts
+++ b/src/constants/aiProviders.ts
@@ -55,27 +55,71 @@ interface ResolvableCredential {
   scope?: ApiKeyScope;
   is_active: boolean;
   openai_compatible?: boolean;
+  created_at?: string;
 }
 
-// Mirrors the resolver: most specific link first, skipping credentials whose
-// provider the feature cannot speak, so it falls through to a broader link.
+/** What the panel can say about a feature's credential.
+ *
+ * `legacy` is the state this screen used to be blind to: an installation that
+ * has not run the migration yet resolves through Ai::CredentialResolver's
+ * legacy fallback (the global OPENAI_API_SECRET or an openai hook), so AI works
+ * while the registry is empty. Reporting "no credential" there told the user
+ * their AI was off when it was running (EVO-2250 review, MÉDIO 15).
+ */
+export type CredentialResolution<T> =
+  | { state: 'registry'; credential: T }
+  | { state: 'legacy' }
+  | { state: 'none' };
+
+// Mirrors Ai::CredentialResolver: most specific link first, skipping
+// credentials whose provider the feature cannot speak, so it falls through to a
+// broader link. Within a link the OLDEST active credential wins, which is the
+// `order(created_at: :asc)` of the Ruby side — array position is not an order.
 export function resolveCredential<T extends ResolvableCredential>(
   credentials: T[],
   { openAICompatibleOnly = false }: { openAICompatibleOnly?: boolean } = {},
 ): T | undefined {
   for (const scope of [...SCOPE_CHAIN].reverse()) {
-    const match = credentials.find(
-      credential =>
-        credential.is_active &&
-        (credential.scope ?? 'account') === scope &&
-        (!openAICompatibleOnly ||
-          (credential.openai_compatible ?? isOpenAICompatible(credential.provider))),
-    );
+    const candidates = credentials
+      .filter(
+        credential =>
+          credential.is_active &&
+          (credential.scope ?? 'account') === scope &&
+          (!openAICompatibleOnly ||
+            (credential.openai_compatible ?? isOpenAICompatible(credential.provider))),
+      )
+      .sort(byCreatedAtAsc);
 
-    if (match) {
-      return match;
+    if (candidates.length > 0) {
+      return candidates[0];
     }
   }
 
   return undefined;
+}
+
+// Oldest first. A credential with no timestamp sorts last rather than winning
+// by accident: the server always sends one, so its absence is a partial record.
+function byCreatedAtAsc(a: ResolvableCredential, b: ResolvableCredential): number {
+  if (!a.created_at) return 1;
+  if (!b.created_at) return -1;
+  return a.created_at.localeCompare(b.created_at);
+}
+
+/** Resolves what the panel should render for a feature.
+ *
+ * `legacyActive` comes from the server (the migration guard), never from a
+ * guess: only the backend can tell "the registry is empty AND the legacy
+ * fallback is serving" apart from "nothing is configured".
+ */
+export function resolveCredentialState<T extends ResolvableCredential>(
+  credentials: T[],
+  options: { openAICompatibleOnly?: boolean; legacyActive?: boolean } = {},
+): CredentialResolution<T> {
+  const credential = resolveCredential(credentials, options);
+  if (credential) {
+    return { state: 'registry', credential };
+  }
+
+  return options.legacyActive ? { state: 'legacy' } : { state: 'none' };
 }

--- a/src/hooks/useIntegrations.ts
+++ b/src/hooks/useIntegrations.ts
@@ -31,6 +31,9 @@ export interface KnowledgeNexusConfig {
   // it on save when the user enters a new key. Optional so a re-edit doesn't
   // need to retype the key (omit the field to keep the stored value).
   nexus_api_key?: string;
+  // EVO-2250 story 2.4: vault reference for the API key. Scalar here because
+  // the Nexus integration has a single secret.
+  credential_id?: string;
   space_id?: string;
   default_top_k?: number;
   default_filters?: Record<string, unknown>;

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -39,6 +39,7 @@ import ptBRMarketplace from './locales/pt-BR/marketplace.json';
 import ptBRDocumentation from './locales/pt-BR/documentation.json';
 import ptBRAiAgents from './locales/pt-BR/aiAgents.json';
 import ptBRApiKeys from './locales/pt-BR/apiKeys.json';
+import ptBRAiCredentials from './locales/pt-BR/aiCredentials.json';
 import ptBRAccessTokens from './locales/pt-BR/accessTokens.json';
 import ptBRIntegrations from './locales/pt-BR/integrations.json';
 import ptBRAttachments from './locales/pt-BR/attachments.json';
@@ -92,6 +93,7 @@ import ptMarketplace from './locales/pt/marketplace.json';
 import ptDocumentation from './locales/pt/documentation.json';
 import ptAiAgents from './locales/pt/aiAgents.json';
 import ptApiKeys from './locales/pt/apiKeys.json';
+import ptAiCredentials from './locales/pt/aiCredentials.json';
 import ptAccessTokens from './locales/pt/accessTokens.json';
 import ptIntegrations from './locales/pt/integrations.json';
 import ptAttachments from './locales/pt/attachments.json';
@@ -145,6 +147,7 @@ import enMarketplace from './locales/en/marketplace.json';
 import enDocumentation from './locales/en/documentation.json';
 import enAiAgents from './locales/en/aiAgents.json';
 import enApiKeys from './locales/en/apiKeys.json';
+import enAiCredentials from './locales/en/aiCredentials.json';
 import enAccessTokens from './locales/en/accessTokens.json';
 import enIntegrations from './locales/en/integrations.json';
 import enAttachments from './locales/en/attachments.json';
@@ -198,6 +201,7 @@ import esMarketplace from './locales/es/marketplace.json';
 import esDocumentation from './locales/es/documentation.json';
 import esAiAgents from './locales/es/aiAgents.json';
 import esApiKeys from './locales/es/apiKeys.json';
+import esAiCredentials from './locales/es/aiCredentials.json';
 import esAccessTokens from './locales/es/accessTokens.json';
 import esIntegrations from './locales/es/integrations.json';
 import esAttachments from './locales/es/attachments.json';
@@ -251,6 +255,7 @@ import frMarketplace from './locales/fr/marketplace.json';
 import frDocumentation from './locales/fr/documentation.json';
 import frAiAgents from './locales/fr/aiAgents.json';
 import frApiKeys from './locales/fr/apiKeys.json';
+import frAiCredentials from './locales/fr/aiCredentials.json';
 import frAccessTokens from './locales/fr/accessTokens.json';
 import frIntegrations from './locales/fr/integrations.json';
 import frAttachments from './locales/fr/attachments.json';
@@ -304,6 +309,7 @@ import itMarketplace from './locales/it/marketplace.json';
 import itDocumentation from './locales/it/documentation.json';
 import itAiAgents from './locales/it/aiAgents.json';
 import itApiKeys from './locales/it/apiKeys.json';
+import itAiCredentials from './locales/it/aiCredentials.json';
 import itAccessTokens from './locales/it/accessTokens.json';
 import itIntegrations from './locales/it/integrations.json';
 import itAttachments from './locales/it/attachments.json';
@@ -425,6 +431,7 @@ const resources = {
     documentation: ptBRDocumentation,
     aiAgents: ptBRAiAgents,
     apiKeys: ptBRApiKeys,
+    aiCredentials: ptBRAiCredentials,
     accessTokens: ptBRAccessTokens,
     integrations: ptBRIntegrations,
     attachments: ptBRAttachments,
@@ -485,6 +492,7 @@ const resources = {
     documentation: ptDocumentation,
     aiAgents: ptAiAgents,
     apiKeys: ptApiKeys,
+    aiCredentials: ptAiCredentials,
     accessTokens: ptAccessTokens,
     integrations: ptIntegrations,
     attachments: ptAttachments,
@@ -545,6 +553,7 @@ const resources = {
     documentation: enDocumentation,
     aiAgents: enAiAgents,
     apiKeys: enApiKeys,
+    aiCredentials: enAiCredentials,
     accessTokens: enAccessTokens,
     integrations: enIntegrations,
     attachments: enAttachments,
@@ -605,6 +614,7 @@ const resources = {
     documentation: esDocumentation,
     aiAgents: esAiAgents,
     apiKeys: esApiKeys,
+    aiCredentials: esAiCredentials,
     accessTokens: esAccessTokens,
     integrations: esIntegrations,
     attachments: esAttachments,
@@ -665,6 +675,7 @@ const resources = {
     documentation: frDocumentation,
     aiAgents: frAiAgents,
     apiKeys: frApiKeys,
+    aiCredentials: frAiCredentials,
     accessTokens: frAccessTokens,
     integrations: frIntegrations,
     attachments: frAttachments,
@@ -725,6 +736,7 @@ const resources = {
     documentation: itDocumentation,
     aiAgents: itAiAgents,
     apiKeys: itApiKeys,
+    aiCredentials: itAiCredentials,
     accessTokens: itAccessTokens,
     integrations: itIntegrations,
     attachments: itAttachments,

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -40,6 +40,7 @@ import ptBRDocumentation from './locales/pt-BR/documentation.json';
 import ptBRAiAgents from './locales/pt-BR/aiAgents.json';
 import ptBRApiKeys from './locales/pt-BR/apiKeys.json';
 import ptBRAiCredentials from './locales/pt-BR/aiCredentials.json';
+import ptBRIntegrationCredentials from './locales/pt-BR/integrationCredentials.json';
 import ptBRAccessTokens from './locales/pt-BR/accessTokens.json';
 import ptBRIntegrations from './locales/pt-BR/integrations.json';
 import ptBRAttachments from './locales/pt-BR/attachments.json';
@@ -94,6 +95,7 @@ import ptDocumentation from './locales/pt/documentation.json';
 import ptAiAgents from './locales/pt/aiAgents.json';
 import ptApiKeys from './locales/pt/apiKeys.json';
 import ptAiCredentials from './locales/pt/aiCredentials.json';
+import ptIntegrationCredentials from './locales/pt/integrationCredentials.json';
 import ptAccessTokens from './locales/pt/accessTokens.json';
 import ptIntegrations from './locales/pt/integrations.json';
 import ptAttachments from './locales/pt/attachments.json';
@@ -148,6 +150,7 @@ import enDocumentation from './locales/en/documentation.json';
 import enAiAgents from './locales/en/aiAgents.json';
 import enApiKeys from './locales/en/apiKeys.json';
 import enAiCredentials from './locales/en/aiCredentials.json';
+import enIntegrationCredentials from './locales/en/integrationCredentials.json';
 import enAccessTokens from './locales/en/accessTokens.json';
 import enIntegrations from './locales/en/integrations.json';
 import enAttachments from './locales/en/attachments.json';
@@ -202,6 +205,7 @@ import esDocumentation from './locales/es/documentation.json';
 import esAiAgents from './locales/es/aiAgents.json';
 import esApiKeys from './locales/es/apiKeys.json';
 import esAiCredentials from './locales/es/aiCredentials.json';
+import esIntegrationCredentials from './locales/es/integrationCredentials.json';
 import esAccessTokens from './locales/es/accessTokens.json';
 import esIntegrations from './locales/es/integrations.json';
 import esAttachments from './locales/es/attachments.json';
@@ -256,6 +260,7 @@ import frDocumentation from './locales/fr/documentation.json';
 import frAiAgents from './locales/fr/aiAgents.json';
 import frApiKeys from './locales/fr/apiKeys.json';
 import frAiCredentials from './locales/fr/aiCredentials.json';
+import frIntegrationCredentials from './locales/fr/integrationCredentials.json';
 import frAccessTokens from './locales/fr/accessTokens.json';
 import frIntegrations from './locales/fr/integrations.json';
 import frAttachments from './locales/fr/attachments.json';
@@ -310,6 +315,7 @@ import itDocumentation from './locales/it/documentation.json';
 import itAiAgents from './locales/it/aiAgents.json';
 import itApiKeys from './locales/it/apiKeys.json';
 import itAiCredentials from './locales/it/aiCredentials.json';
+import itIntegrationCredentials from './locales/it/integrationCredentials.json';
 import itAccessTokens from './locales/it/accessTokens.json';
 import itIntegrations from './locales/it/integrations.json';
 import itAttachments from './locales/it/attachments.json';
@@ -432,6 +438,7 @@ const resources = {
     aiAgents: ptBRAiAgents,
     apiKeys: ptBRApiKeys,
     aiCredentials: ptBRAiCredentials,
+    integrationCredentials: ptBRIntegrationCredentials,
     accessTokens: ptBRAccessTokens,
     integrations: ptBRIntegrations,
     attachments: ptBRAttachments,
@@ -493,6 +500,7 @@ const resources = {
     aiAgents: ptAiAgents,
     apiKeys: ptApiKeys,
     aiCredentials: ptAiCredentials,
+    integrationCredentials: ptIntegrationCredentials,
     accessTokens: ptAccessTokens,
     integrations: ptIntegrations,
     attachments: ptAttachments,
@@ -554,6 +562,7 @@ const resources = {
     aiAgents: enAiAgents,
     apiKeys: enApiKeys,
     aiCredentials: enAiCredentials,
+    integrationCredentials: enIntegrationCredentials,
     accessTokens: enAccessTokens,
     integrations: enIntegrations,
     attachments: enAttachments,
@@ -615,6 +624,7 @@ const resources = {
     aiAgents: esAiAgents,
     apiKeys: esApiKeys,
     aiCredentials: esAiCredentials,
+    integrationCredentials: esIntegrationCredentials,
     accessTokens: esAccessTokens,
     integrations: esIntegrations,
     attachments: esAttachments,
@@ -676,6 +686,7 @@ const resources = {
     aiAgents: frAiAgents,
     apiKeys: frApiKeys,
     aiCredentials: frAiCredentials,
+    integrationCredentials: frIntegrationCredentials,
     accessTokens: frAccessTokens,
     integrations: frIntegrations,
     attachments: frAttachments,
@@ -737,6 +748,7 @@ const resources = {
     aiAgents: itAiAgents,
     apiKeys: itApiKeys,
     aiCredentials: itAiCredentials,
+    integrationCredentials: itIntegrationCredentials,
     accessTokens: itAccessTokens,
     integrations: itIntegrations,
     attachments: itAttachments,

--- a/src/i18n/locales/en/adminSettings.json
+++ b/src/i18n/locales/en/adminSettings.json
@@ -310,7 +310,9 @@
         "apiUrl": "https://api.openai.com/v1",
         "apiSecret": "Enter new API key",
         "model": "gpt-4o"
-      }
+      },
+      "credentialMoved": "The AI credential now lives in Settings > AI Credentials.",
+      "goToCredentials": "Go to AI Credentials"
     },
     "prompts": {
       "cardTitle": "AI Prompt Templates",

--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -82,7 +82,10 @@
     "title": "In use in this account",
     "features": {
       "aiAgents": "AI Agents",
-      "inboxAssist": "Inbox assist"
+      "inboxAssist": "Inbox assist",
+      "audioTranscription": "Audio transcription",
+      "labelSuggestion": "Label suggestion",
+      "moderation": "Moderation"
     },
     "fromAccount": "(this account)",
     "fromInstallation": "(installation default)",

--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -81,7 +81,8 @@
   "inUse": {
     "title": "In use in this account",
     "features": {
-      "aiAgents": "AI Agents"
+      "aiAgents": "AI Agents",
+      "inboxAssist": "Inbox assist"
     },
     "fromAccount": "(this account)",
     "fromInstallation": "(installation default)",

--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -74,7 +74,19 @@
       "read": "You do not have permission to view AI credentials",
       "create": "You do not have permission to create AI credentials",
       "update": "You do not have permission to edit AI credentials",
-      "delete": "You do not have permission to delete AI credentials"
+      "delete": "You do not have permission to delete AI credentials",
+      "installation": "You do not have permission to manage installation credentials"
     }
-  }
+  },
+  "inUse": {
+    "title": "In use in this account",
+    "features": {
+      "aiAgents": "AI Agents"
+    },
+    "fromAccount": "(this account)",
+    "fromInstallation": "(installation default)",
+    "none": "No credential",
+    "inheritingHint": "Register a credential for this account to use your own."
+  },
+  "inheritedReadOnly": "Inherited from the installation"
 }

--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -1,0 +1,80 @@
+{
+  "title": "AI Credentials",
+  "description": "Used by every AI feature. Register once, works everywhere.",
+  "sections": {
+    "account": "This account",
+    "installation": "Installation default"
+  },
+  "columns": {
+    "name": "Name",
+    "provider": "Provider",
+    "key": "Key",
+    "serves": "Serves",
+    "status": "Status",
+    "actions": "Actions"
+  },
+  "serves": {
+    "all": "All features",
+    "agentsOnly": "AI Agents only"
+  },
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
+  "actions": {
+    "add": "New credential",
+    "addFirst": "Add first credential",
+    "edit": "Edit",
+    "activate": "Activate",
+    "deactivate": "Deactivate",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save"
+  },
+  "form": {
+    "title": {
+      "new": "New credential",
+      "edit": "Edit credential"
+    },
+    "labels": {
+      "name": "Name",
+      "provider": "Provider",
+      "key": "Key",
+      "baseUrl": "Base URL"
+    },
+    "placeholders": {
+      "name": "e.g. Production",
+      "provider": "Select a provider",
+      "keyNew": "Paste your key here",
+      "keyEdit": "Leave empty to keep the current key"
+    },
+    "incompatibleWarning": "{{provider}} works with AI Agents. The inbox assist, transcription, labels and moderation do not use this provider."
+  },
+  "empty": {
+    "title": "No credentials registered",
+    "description": "Register an AI credential to use it across the CRM."
+  },
+  "installationEmpty": "No default credential set at the installation level.",
+  "deleteDialog": {
+    "title": "Delete credential",
+    "description": "Are you sure you want to delete the credential \"{{name}}\"? This action cannot be undone.",
+    "inUseWarning": "This credential is used by {{count}} agent(s): {{agents}}. They will stop working.",
+    "cancel": "Cancel",
+    "confirm": "Delete"
+  },
+  "messages": {
+    "loadError": "Failed to load credentials",
+    "saveError": "Failed to save the credential",
+    "deleteError": "Failed to delete the credential",
+    "createSuccess": "Credential created successfully",
+    "updateSuccess": "Credential updated successfully",
+    "deleteSuccess": "Credential deleted successfully",
+    "requiredFields": "Fill in name, provider and key",
+    "permissionDenied": {
+      "read": "You do not have permission to view AI credentials",
+      "create": "You do not have permission to create AI credentials",
+      "update": "You do not have permission to edit AI credentials",
+      "delete": "You do not have permission to delete AI credentials"
+    }
+  }
+}

--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -90,7 +90,8 @@
     "fromAccount": "(this account)",
     "fromInstallation": "(installation default)",
     "none": "No credential",
-    "inheritingHint": "Register a credential for this account to use your own."
+    "inheritingHint": "Register a credential for this account to use your own.",
+    "legacy": "Configured before this screen (migration pending)"
   },
   "inheritedReadOnly": "Inherited from the installation"
 }

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -126,7 +126,8 @@
   "retirement": {
     "managedByVault": "Managed by the vault",
     "authHeadersLocked": "Authentication headers are now registered in the vault (Settings > Integration Credentials) and referenced above. The stored values remain untouched.",
-    "nexusKeyLocked": "The API key is now registered in the vault and referenced by the selector above. The stored key remains in place until you point to a different credential."
+    "nexusKeyLocked": "The API key is now registered in the vault and referenced by the selector above. The stored key remains in place until you point to a different credential.",
+    "externalKeyLocked": "The API key is now registered in the vault and referenced by the selector above. The stored key keeps working until you point to a different credential."
   },
   "externalAgent": {
     "hint": "Vault credential for this platform. While set, the runtime uses it and the inline key below becomes the fallback."

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -1,0 +1,77 @@
+{
+  "title": "Integration Credentials",
+  "description": "The vault for tool and integration secrets. Register once, reference everywhere.",
+  "sections": {
+    "account": "This account",
+    "installation": "Installation default",
+    "oauth": "OAuth connections"
+  },
+  "columns": {
+    "name": "Name",
+    "provider": "Provider",
+    "value": "Value",
+    "kind": "Type",
+    "status": "Status",
+    "actions": "Actions"
+  },
+  "kind": {
+    "static": "Static",
+    "oauth": "OAuth"
+  },
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
+  "actions": {
+    "add": "New credential",
+    "addFirst": "Add first credential",
+    "edit": "Edit",
+    "activate": "Activate",
+    "deactivate": "Deactivate",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save"
+  },
+  "form": {
+    "title": {
+      "new": "New credential",
+      "edit": "Edit credential"
+    },
+    "labels": {
+      "name": "Name",
+      "provider": "Provider",
+      "value": "Value"
+    },
+    "placeholders": {
+      "name": "e.g. Dify production",
+      "provider": "e.g. dify, n8n, elevenlabs",
+      "valueNew": "Paste the secret here",
+      "valueEdit": "Leave empty to keep the current value"
+    }
+  },
+  "empty": {
+    "title": "No credentials registered",
+    "description": "Register an integration credential to reuse it across agents, bots, tools and MCPs."
+  },
+  "installationEmpty": "No default credential set at the installation level.",
+  "inheritedReadOnly": "Inherited from the installation",
+  "deleteDialog": {
+    "title": "Delete credential",
+    "description": "Are you sure you want to delete the credential \"{{name}}\"? This action cannot be undone.",
+    "inUseWarning": "This credential is referenced by {{count}} consumer(s): {{consumers}}. They will fall back to their inline value while it exists.",
+    "cancel": "Cancel",
+    "confirm": "Delete"
+  },
+  "messages": {
+    "loadError": "Failed to load credentials",
+    "saveError": "Failed to save the credential",
+    "deleteError": "Failed to delete the credential",
+    "createSuccess": "Credential created successfully",
+    "updateSuccess": "Credential updated successfully",
+    "deleteSuccess": "Credential deleted successfully",
+    "requiredFields": "Fill in name, provider and value",
+    "permissionDenied": {
+      "read": "You do not have permission to view integration credentials"
+    }
+  }
+}

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -121,5 +121,10 @@
     "remove": "Remove",
     "nexusLabel": "Vault credential",
     "nexusHint": "Pick the vault credential holding the Nexus API key. The field below stays as the inline fallback."
+  },
+  "retirement": {
+    "managedByVault": "Managed by the vault",
+    "authHeadersLocked": "Authentication headers are now registered in the vault (Settings > Integration Credentials) and referenced above. The stored values remain untouched.",
+    "nexusKeyLocked": "The API key is now registered in the vault and referenced by the selector above. The stored key remains in place until you point to a different credential."
   }
 }

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -71,7 +71,12 @@
     "deleteSuccess": "Credential deleted successfully",
     "requiredFields": "Fill in name, provider and value",
     "permissionDenied": {
-      "read": "You do not have permission to view integration credentials"
+      "read": "You do not have permission to view integration credentials",
+      "installation": "You do not have permission to manage installation credentials"
     }
+  },
+  "inUse": {
+    "title": "In use in this account",
+    "empty": "No consumer resolves credentials from the vault yet. External agents, bots, tools and MCPs will appear here as they adopt it."
   }
 }

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -78,5 +78,32 @@
   "inUse": {
     "title": "In use in this account",
     "empty": "No consumer resolves credentials from the vault yet. External agents, bots, tools and MCPs will appear here as they adopt it."
+  },
+  "oauthSection": {
+    "noSecretHint": "These connections keep no secret in the vault: the token stays in the store that owns it, and what you see here is read from there at listing time.",
+    "empty": "No OAuth connection yet. Connect a provider from the agent's integrations screen and it will appear here.",
+    "noExpiry": "No expiry",
+    "columns": {
+      "agent": "Agent",
+      "expires": "Expires"
+    },
+    "status": {
+      "connected": "Connected",
+      "expiring": "Expiring soon",
+      "expired": "Expired",
+      "refresh_failed": "Renewal failed"
+    },
+    "actions": {
+      "disconnect": "Disconnect"
+    },
+    "disconnectDialog": {
+      "title": "Disconnect integration",
+      "description": "Disconnect the {{provider}} connection? The agent stops using this integration.",
+      "noRevokeWarning": "Disconnecting removes the access locally. It does NOT revoke the grant at the provider: to fully revoke it, use the provider's own security settings.",
+      "cancel": "Cancel",
+      "confirm": "Disconnect"
+    },
+    "disconnectSuccess": "Integration disconnected",
+    "disconnectError": "Failed to disconnect the integration"
   }
 }

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -90,8 +90,7 @@
     "status": {
       "connected": "Connected",
       "expiring": "Expiring soon",
-      "expired": "Expired",
-      "refresh_failed": "Renewal failed"
+      "expired": "Expired"
     },
     "actions": {
       "disconnect": "Disconnect"

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -81,7 +81,8 @@
     "kinds": {
       "tool": "Tool",
       "mcp": "MCP server",
-      "bot": "Channel bot"
+      "bot": "Channel bot",
+      "credential": "Credential"
     }
   },
   "oauthSection": {
@@ -126,5 +127,8 @@
     "managedByVault": "Managed by the vault",
     "authHeadersLocked": "Authentication headers are now registered in the vault (Settings > Integration Credentials) and referenced above. The stored values remain untouched.",
     "nexusKeyLocked": "The API key is now registered in the vault and referenced by the selector above. The stored key remains in place until you point to a different credential."
+  },
+  "externalAgent": {
+    "hint": "Vault credential for this platform. While set, the runtime uses it and the inline key below becomes the fallback."
   }
 }

--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -77,7 +77,12 @@
   },
   "inUse": {
     "title": "In use in this account",
-    "empty": "No consumer resolves credentials from the vault yet. External agents, bots, tools and MCPs will appear here as they adopt it."
+    "empty": "No consumer resolves credentials from the vault yet. External agents, bots, tools and MCPs will appear here as they adopt it.",
+    "kinds": {
+      "tool": "Tool",
+      "mcp": "MCP server",
+      "bot": "Channel bot"
+    }
   },
   "oauthSection": {
     "noSecretHint": "These connections keep no secret in the vault: the token stays in the store that owns it, and what you see here is read from there at listing time.",
@@ -104,5 +109,17 @@
     },
     "disconnectSuccess": "Integration disconnected",
     "disconnectError": "Failed to disconnect the integration"
+  },
+  "refsEditor": {
+    "label": "Vault-backed secrets",
+    "hint": "Each entry replaces the header or variable with the same name using the decrypted value from the vault. One credential per secret.",
+    "keyLabel": "Secret name",
+    "keyPlaceholder": "e.g. Authorization",
+    "selectPlaceholder": "Pick a credential",
+    "none": "None (use inline value)",
+    "add": "Add vault secret",
+    "remove": "Remove",
+    "nexusLabel": "Vault credential",
+    "nexusHint": "Pick the vault credential holding the Nexus API key. The field below stays as the inline fallback."
   }
 }

--- a/src/i18n/locales/en/integrations.json
+++ b/src/i18n/locales/en/integrations.json
@@ -676,7 +676,9 @@
         "configure": "Configure Integration",
         "update": "Update Integration",
         "saving": "Saving..."
-      }
+      },
+      "credentialMoved": "The key is now registered under Settings > AI Credentials. This screen only carries the feature toggles.",
+      "goToCredentials": "Go to AI Credentials"
     },
     "settings": {
       "loading": "Loading configuration...",
@@ -699,7 +701,8 @@
         "actions": {
           "edit": "Edit",
           "remove": "Remove"
-        }
+        },
+        "managedElsewhere": "Managed in AI Credentials"
       },
       "features": {
         "title": "Available Features",

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -111,6 +111,7 @@
       "customAttributes": "Custom Attributes",
       "cannedResponses": "Canned Responses",
       "aiCredentials": "AI Credentials",
+      "integrationCredentials": "Integration Credentials",
       "messageTemplates": "Message Templates",
       "macros": "Macros",
       "templates": "Templates",

--- a/src/i18n/locales/en/layout.json
+++ b/src/i18n/locales/en/layout.json
@@ -110,6 +110,7 @@
       "labels": "Labels",
       "customAttributes": "Custom Attributes",
       "cannedResponses": "Canned Responses",
+      "aiCredentials": "AI Credentials",
       "messageTemplates": "Message Templates",
       "macros": "Macros",
       "templates": "Templates",

--- a/src/i18n/locales/es/adminSettings.json
+++ b/src/i18n/locales/es/adminSettings.json
@@ -304,7 +304,9 @@
         "apiUrl": "https://api.openai.com/v1",
         "apiSecret": "Ingrese la nueva clave de API",
         "model": "gpt-4o"
-      }
+      },
+      "credentialMoved": "La credencial de IA ahora está en Configuración > Credenciales de IA.",
+      "goToCredentials": "Ir a Credenciales de IA"
     },
     "prompts": {
       "cardTitle": "Plantillas de Prompts de IA",

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -74,7 +74,19 @@
       "read": "No tienes permiso para ver las credenciales de IA",
       "create": "No tienes permiso para registrar credenciales de IA",
       "update": "No tienes permiso para editar credenciales de IA",
-      "delete": "No tienes permiso para eliminar credenciales de IA"
+      "delete": "No tienes permiso para eliminar credenciales de IA",
+      "installation": "No tienes permiso para gestionar credenciales de la instalación"
     }
-  }
+  },
+  "inUse": {
+    "title": "En uso en esta cuenta",
+    "features": {
+      "aiAgents": "Agentes de IA"
+    },
+    "fromAccount": "(de esta cuenta)",
+    "fromInstallation": "(predeterminada de la instalación)",
+    "none": "Ninguna credencial",
+    "inheritingHint": "Registra una credencial de esta cuenta para usar la tuya."
+  },
+  "inheritedReadOnly": "Heredada de la instalación"
 }

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -82,7 +82,10 @@
     "title": "En uso en esta cuenta",
     "features": {
       "aiAgents": "Agentes de IA",
-      "inboxAssist": "Asistente de la bandeja de entrada"
+      "inboxAssist": "Asistente de la bandeja de entrada",
+      "audioTranscription": "Transcripción de audio",
+      "labelSuggestion": "Sugerencia de etiquetas",
+      "moderation": "Moderación"
     },
     "fromAccount": "(de esta cuenta)",
     "fromInstallation": "(predeterminada de la instalación)",

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -81,7 +81,8 @@
   "inUse": {
     "title": "En uso en esta cuenta",
     "features": {
-      "aiAgents": "Agentes de IA"
+      "aiAgents": "Agentes de IA",
+      "inboxAssist": "Asistente de la bandeja de entrada"
     },
     "fromAccount": "(de esta cuenta)",
     "fromInstallation": "(predeterminada de la instalación)",

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -1,0 +1,80 @@
+{
+  "title": "Credenciales de IA",
+  "description": "Usadas por todas las funciones de IA. Regístrala una vez, sirve para todo.",
+  "sections": {
+    "account": "De esta cuenta",
+    "installation": "Predeterminada de la instalación"
+  },
+  "columns": {
+    "name": "Nombre",
+    "provider": "Proveedor",
+    "key": "Clave",
+    "serves": "Atiende",
+    "status": "Estado",
+    "actions": "Acciones"
+  },
+  "serves": {
+    "all": "Todas las funciones",
+    "agentsOnly": "Solo Agentes de IA"
+  },
+  "status": {
+    "active": "Activa",
+    "inactive": "Inactiva"
+  },
+  "actions": {
+    "add": "Nueva credencial",
+    "addFirst": "Registrar primera credencial",
+    "edit": "Editar",
+    "activate": "Activar",
+    "deactivate": "Desactivar",
+    "delete": "Eliminar",
+    "cancel": "Cancelar",
+    "save": "Guardar"
+  },
+  "form": {
+    "title": {
+      "new": "Nueva credencial",
+      "edit": "Editar credencial"
+    },
+    "labels": {
+      "name": "Nombre",
+      "provider": "Proveedor",
+      "key": "Clave",
+      "baseUrl": "URL base"
+    },
+    "placeholders": {
+      "name": "Ej.: Producción",
+      "provider": "Selecciona un proveedor",
+      "keyNew": "Pega tu clave aquí",
+      "keyEdit": "Déjalo vacío para mantener la clave actual"
+    },
+    "incompatibleWarning": "{{provider}} funciona en los Agentes de IA. El asistente de la bandeja de entrada, la transcripción, las etiquetas y la moderación no usan este proveedor."
+  },
+  "empty": {
+    "title": "Ninguna credencial registrada",
+    "description": "Registra una credencial de IA para usarla en todo el CRM."
+  },
+  "installationEmpty": "Ninguna credencial predeterminada definida en la instalación.",
+  "deleteDialog": {
+    "title": "Eliminar credencial",
+    "description": "¿Seguro que deseas eliminar la credencial \"{{name}}\"? Esta acción no se puede deshacer.",
+    "inUseWarning": "Esta credencial la usan {{count}} agente(s): {{agents}}. Dejarán de funcionar.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "messages": {
+    "loadError": "Error al cargar las credenciales",
+    "saveError": "Error al guardar la credencial",
+    "deleteError": "Error al eliminar la credencial",
+    "createSuccess": "Credencial creada con éxito",
+    "updateSuccess": "Credencial actualizada con éxito",
+    "deleteSuccess": "Credencial eliminada con éxito",
+    "requiredFields": "Completa nombre, proveedor y clave",
+    "permissionDenied": {
+      "read": "No tienes permiso para ver las credenciales de IA",
+      "create": "No tienes permiso para registrar credenciales de IA",
+      "update": "No tienes permiso para editar credenciales de IA",
+      "delete": "No tienes permiso para eliminar credenciales de IA"
+    }
+  }
+}

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -90,7 +90,8 @@
     "fromAccount": "(de esta cuenta)",
     "fromInstallation": "(predeterminada de la instalación)",
     "none": "Ninguna credencial",
-    "inheritingHint": "Registra una credencial de esta cuenta para usar la tuya."
+    "inheritingHint": "Registra una credencial de esta cuenta para usar la tuya.",
+    "legacy": "Configurada antes de esta pantalla (migración pendiente)"
   },
   "inheritedReadOnly": "Heredada de la instalación"
 }

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -81,7 +81,8 @@
     "kinds": {
       "tool": "Herramienta",
       "mcp": "Servidor MCP",
-      "bot": "Bot de canal"
+      "bot": "Bot de canal",
+      "credential": "Credencial"
     }
   },
   "oauthSection": {
@@ -126,5 +127,8 @@
     "managedByVault": "Administrado por la bóveda",
     "authHeadersLocked": "Los headers de autenticación ahora se registran en la bóveda (Configuración > Credenciales de integración) y se referencian arriba. Los valores guardados permanecen intactos.",
     "nexusKeyLocked": "La API key ahora se registra en la bóveda y se referencia con el selector de arriba. La clave guardada permanece hasta que apunte a otra credencial."
+  },
+  "externalAgent": {
+    "hint": "Credencial de la bóveda para esta plataforma. Con ella definida, el runtime la usa y la clave en línea de abajo pasa a ser el respaldo."
   }
 }

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -121,5 +121,10 @@
     "remove": "Quitar",
     "nexusLabel": "Credencial de la bóveda",
     "nexusHint": "Elija la credencial de la bóveda que guarda la API key del Nexus. El campo de abajo sigue como respaldo incorporado."
+  },
+  "retirement": {
+    "managedByVault": "Administrado por la bóveda",
+    "authHeadersLocked": "Los headers de autenticación ahora se registran en la bóveda (Configuración > Credenciales de integración) y se referencian arriba. Los valores guardados permanecen intactos.",
+    "nexusKeyLocked": "La API key ahora se registra en la bóveda y se referencia con el selector de arriba. La clave guardada permanece hasta que apunte a otra credencial."
   }
 }

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -78,5 +78,32 @@
   "inUse": {
     "title": "En uso en esta cuenta",
     "empty": "Ningún consumidor resuelve credenciales por la bóveda todavía. Agentes externos, bots, herramientas y MCPs aparecerán aquí a medida que la adopten."
+  },
+  "oauthSection": {
+    "noSecretHint": "Estas conexiones no guardan secreto en la bóveda: el token queda en el almacén dueño, y lo que ve aquí se lee de allí al momento de listar.",
+    "empty": "Ninguna conexión OAuth todavía. Conecte un proveedor desde la pantalla de integraciones del agente y aparecerá aquí.",
+    "noExpiry": "Sin expiración",
+    "columns": {
+      "agent": "Agente",
+      "expires": "Expira"
+    },
+    "status": {
+      "connected": "Conectada",
+      "expiring": "Expira pronto",
+      "expired": "Expirada",
+      "refresh_failed": "Fallo de renovación"
+    },
+    "actions": {
+      "disconnect": "Desconectar"
+    },
+    "disconnectDialog": {
+      "title": "Desconectar integración",
+      "description": "¿Desconectar la conexión de {{provider}}? El agente deja de usar esta integración.",
+      "noRevokeWarning": "Desconectar elimina el acceso localmente. NO revoca la autorización en el proveedor: para revocarla de verdad, use la configuración de seguridad del propio proveedor.",
+      "cancel": "Cancelar",
+      "confirm": "Desconectar"
+    },
+    "disconnectSuccess": "Integración desconectada",
+    "disconnectError": "Error al desconectar la integración"
   }
 }

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -71,7 +71,12 @@
     "deleteSuccess": "Credencial eliminada con éxito",
     "requiredFields": "Complete nombre, proveedor y valor",
     "permissionDenied": {
-      "read": "No tiene permiso para ver las credenciales de integración"
+      "read": "No tiene permiso para ver las credenciales de integración",
+      "installation": "No tiene permiso para administrar credenciales de la instalación"
     }
+  },
+  "inUse": {
+    "title": "En uso en esta cuenta",
+    "empty": "Ningún consumidor resuelve credenciales por la bóveda todavía. Agentes externos, bots, herramientas y MCPs aparecerán aquí a medida que la adopten."
   }
 }

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -1,0 +1,77 @@
+{
+  "title": "Credenciales de integración",
+  "description": "La bóveda de los secretos de herramientas e integraciones. Registre una vez, referencie en todas partes.",
+  "sections": {
+    "account": "De esta cuenta",
+    "installation": "Predeterminada de la instalación",
+    "oauth": "Conexiones OAuth"
+  },
+  "columns": {
+    "name": "Nombre",
+    "provider": "Proveedor",
+    "value": "Valor",
+    "kind": "Tipo",
+    "status": "Estado",
+    "actions": "Acciones"
+  },
+  "kind": {
+    "static": "Estática",
+    "oauth": "OAuth"
+  },
+  "status": {
+    "active": "Activa",
+    "inactive": "Inactiva"
+  },
+  "actions": {
+    "add": "Nueva credencial",
+    "addFirst": "Registrar primera credencial",
+    "edit": "Editar",
+    "activate": "Activar",
+    "deactivate": "Desactivar",
+    "delete": "Eliminar",
+    "cancel": "Cancelar",
+    "save": "Guardar"
+  },
+  "form": {
+    "title": {
+      "new": "Nueva credencial",
+      "edit": "Editar credencial"
+    },
+    "labels": {
+      "name": "Nombre",
+      "provider": "Proveedor",
+      "value": "Valor"
+    },
+    "placeholders": {
+      "name": "ej.: Dify producción",
+      "provider": "ej.: dify, n8n, elevenlabs",
+      "valueNew": "Pegue el secreto aquí",
+      "valueEdit": "Déjelo vacío para mantener el valor actual"
+    }
+  },
+  "empty": {
+    "title": "Ninguna credencial registrada",
+    "description": "Registre una credencial de integración para reutilizarla en agentes, bots, herramientas y MCPs."
+  },
+  "installationEmpty": "Ninguna credencial predeterminada definida a nivel de instalación.",
+  "inheritedReadOnly": "Heredada de la instalación",
+  "deleteDialog": {
+    "title": "Eliminar credencial",
+    "description": "¿Está seguro de que desea eliminar la credencial \"{{name}}\"? Esta acción no se puede deshacer.",
+    "inUseWarning": "Esta credencial es referenciada por {{count}} consumidor(es): {{consumers}}. Volverán al valor incorporado mientras exista.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar"
+  },
+  "messages": {
+    "loadError": "Error al cargar las credenciales",
+    "saveError": "Error al guardar la credencial",
+    "deleteError": "Error al eliminar la credencial",
+    "createSuccess": "Credencial creada con éxito",
+    "updateSuccess": "Credencial actualizada con éxito",
+    "deleteSuccess": "Credencial eliminada con éxito",
+    "requiredFields": "Complete nombre, proveedor y valor",
+    "permissionDenied": {
+      "read": "No tiene permiso para ver las credenciales de integración"
+    }
+  }
+}

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -90,8 +90,7 @@
     "status": {
       "connected": "Conectada",
       "expiring": "Expira pronto",
-      "expired": "Expirada",
-      "refresh_failed": "Fallo de renovación"
+      "expired": "Expirada"
     },
     "actions": {
       "disconnect": "Desconectar"

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -77,7 +77,12 @@
   },
   "inUse": {
     "title": "En uso en esta cuenta",
-    "empty": "Ningún consumidor resuelve credenciales por la bóveda todavía. Agentes externos, bots, herramientas y MCPs aparecerán aquí a medida que la adopten."
+    "empty": "Ningún consumidor resuelve credenciales por la bóveda todavía. Agentes externos, bots, herramientas y MCPs aparecerán aquí a medida que la adopten.",
+    "kinds": {
+      "tool": "Herramienta",
+      "mcp": "Servidor MCP",
+      "bot": "Bot de canal"
+    }
   },
   "oauthSection": {
     "noSecretHint": "Estas conexiones no guardan secreto en la bóveda: el token queda en el almacén dueño, y lo que ve aquí se lee de allí al momento de listar.",
@@ -104,5 +109,17 @@
     },
     "disconnectSuccess": "Integración desconectada",
     "disconnectError": "Error al desconectar la integración"
+  },
+  "refsEditor": {
+    "label": "Secretos por la bóveda",
+    "hint": "Cada entrada reemplaza el header o la variable del mismo nombre por el valor descifrado de la bóveda. Una credencial por secreto.",
+    "keyLabel": "Nombre del secreto",
+    "keyPlaceholder": "ej.: Authorization",
+    "selectPlaceholder": "Elija una credencial",
+    "none": "Ninguna (usar valor incorporado)",
+    "add": "Agregar secreto de la bóveda",
+    "remove": "Quitar",
+    "nexusLabel": "Credencial de la bóveda",
+    "nexusHint": "Elija la credencial de la bóveda que guarda la API key del Nexus. El campo de abajo sigue como respaldo incorporado."
   }
 }

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -126,7 +126,8 @@
   "retirement": {
     "managedByVault": "Administrado por la bóveda",
     "authHeadersLocked": "Los headers de autenticación ahora se registran en la bóveda (Configuración > Credenciales de integración) y se referencian arriba. Los valores guardados permanecen intactos.",
-    "nexusKeyLocked": "La API key ahora se registra en la bóveda y se referencia con el selector de arriba. La clave guardada permanece hasta que apunte a otra credencial."
+    "nexusKeyLocked": "La API key ahora se registra en la bóveda y se referencia con el selector de arriba. La clave guardada permanece hasta que apunte a otra credencial.",
+    "externalKeyLocked": "La clave ahora se registra en la bóveda y se referencia con el selector de arriba. La clave guardada sigue funcionando hasta que apunte a otra credencial."
   },
   "externalAgent": {
     "hint": "Credencial de la bóveda para esta plataforma. Con ella definida, el runtime la usa y la clave en línea de abajo pasa a ser el respaldo."

--- a/src/i18n/locales/es/integrations.json
+++ b/src/i18n/locales/es/integrations.json
@@ -671,7 +671,9 @@
         "configure": "Configurar Integración",
         "update": "Actualizar Integración",
         "saving": "Guardando..."
-      }
+      },
+      "credentialMoved": "La clave ahora se registra en Configuración > Credenciales de IA. Aquí quedan solo los interruptores de las funciones.",
+      "goToCredentials": "Ir a Credenciales de IA"
     },
     "settings": {
       "loading": "Cargando configuración...",
@@ -694,7 +696,8 @@
         "actions": {
           "edit": "Editar",
           "remove": "Eliminar"
-        }
+        },
+        "managedElsewhere": "Gestionada en Credenciales de IA"
       },
       "features": {
         "title": "Recursos Disponibles",

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etiquetas",
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respuestas Rápidas",
+      "aiCredentials": "Credenciales de IA",
       "messageTemplates": "Plantillas de Mensaje",
       "macros": "Macros",
       "templates": "Plantillas",

--- a/src/i18n/locales/es/layout.json
+++ b/src/i18n/locales/es/layout.json
@@ -111,6 +111,7 @@
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respuestas Rápidas",
       "aiCredentials": "Credenciales de IA",
+      "integrationCredentials": "Credenciales de integración",
       "messageTemplates": "Plantillas de Mensaje",
       "macros": "Macros",
       "templates": "Plantillas",

--- a/src/i18n/locales/fr/adminSettings.json
+++ b/src/i18n/locales/fr/adminSettings.json
@@ -303,7 +303,9 @@
         "apiUrl": "https://api.openai.com/v1",
         "apiSecret": "Entrez la nouvelle cle API",
         "model": "gpt-4o"
-      }
+      },
+      "credentialMoved": "L'identifiant d'IA se trouve maintenant dans Paramètres > Identifiants d'IA.",
+      "goToCredentials": "Aller aux Identifiants d'IA"
     },
     "prompts": {
       "cardTitle": "Modeles de Prompts IA",

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -74,7 +74,19 @@
       "read": "Vous n'avez pas la permission de voir les identifiants d'IA",
       "create": "Vous n'avez pas la permission de créer des identifiants d'IA",
       "update": "Vous n'avez pas la permission de modifier les identifiants d'IA",
-      "delete": "Vous n'avez pas la permission de supprimer les identifiants d'IA"
+      "delete": "Vous n'avez pas la permission de supprimer les identifiants d'IA",
+      "installation": "Vous n'avez pas la permission de gérer les identifiants de l'installation"
     }
-  }
+  },
+  "inUse": {
+    "title": "Utilisé dans ce compte",
+    "features": {
+      "aiAgents": "Agents d'IA"
+    },
+    "fromAccount": "(de ce compte)",
+    "fromInstallation": "(par défaut de l'installation)",
+    "none": "Aucun identifiant",
+    "inheritingHint": "Enregistrez un identifiant pour ce compte afin d'utiliser le vôtre."
+  },
+  "inheritedReadOnly": "Hérité de l'installation"
 }

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -1,0 +1,80 @@
+{
+  "title": "Identifiants d'IA",
+  "description": "Utilisés par toutes les fonctions d'IA. Enregistrez une fois, valable partout.",
+  "sections": {
+    "account": "De ce compte",
+    "installation": "Par défaut de l'installation"
+  },
+  "columns": {
+    "name": "Nom",
+    "provider": "Fournisseur",
+    "key": "Clé",
+    "serves": "Dessert",
+    "status": "État",
+    "actions": "Actions"
+  },
+  "serves": {
+    "all": "Toutes les fonctions",
+    "agentsOnly": "Agents d'IA uniquement"
+  },
+  "status": {
+    "active": "Actif",
+    "inactive": "Inactif"
+  },
+  "actions": {
+    "add": "Nouvel identifiant",
+    "addFirst": "Enregistrer le premier identifiant",
+    "edit": "Modifier",
+    "activate": "Activer",
+    "deactivate": "Désactiver",
+    "delete": "Supprimer",
+    "cancel": "Annuler",
+    "save": "Enregistrer"
+  },
+  "form": {
+    "title": {
+      "new": "Nouvel identifiant",
+      "edit": "Modifier l'identifiant"
+    },
+    "labels": {
+      "name": "Nom",
+      "provider": "Fournisseur",
+      "key": "Clé",
+      "baseUrl": "URL de base"
+    },
+    "placeholders": {
+      "name": "Ex. : Production",
+      "provider": "Sélectionnez un fournisseur",
+      "keyNew": "Collez votre clé ici",
+      "keyEdit": "Laissez vide pour conserver la clé actuelle"
+    },
+    "incompatibleWarning": "{{provider}} fonctionne avec les Agents d'IA. L'assistance de la boîte de réception, la transcription, les étiquettes et la modération n'utilisent pas ce fournisseur."
+  },
+  "empty": {
+    "title": "Aucun identifiant enregistré",
+    "description": "Enregistrez un identifiant d'IA pour l'utiliser dans tout le CRM."
+  },
+  "installationEmpty": "Aucun identifiant par défaut défini au niveau de l'installation.",
+  "deleteDialog": {
+    "title": "Supprimer l'identifiant",
+    "description": "Voulez-vous vraiment supprimer l'identifiant « {{name}} » ? Cette action est irréversible.",
+    "inUseWarning": "Cet identifiant est utilisé par {{count}} agent(s) : {{agents}}. Ils cesseront de fonctionner.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer"
+  },
+  "messages": {
+    "loadError": "Échec du chargement des identifiants",
+    "saveError": "Échec de l'enregistrement de l'identifiant",
+    "deleteError": "Échec de la suppression de l'identifiant",
+    "createSuccess": "Identifiant créé avec succès",
+    "updateSuccess": "Identifiant mis à jour avec succès",
+    "deleteSuccess": "Identifiant supprimé avec succès",
+    "requiredFields": "Renseignez le nom, le fournisseur et la clé",
+    "permissionDenied": {
+      "read": "Vous n'avez pas la permission de voir les identifiants d'IA",
+      "create": "Vous n'avez pas la permission de créer des identifiants d'IA",
+      "update": "Vous n'avez pas la permission de modifier les identifiants d'IA",
+      "delete": "Vous n'avez pas la permission de supprimer les identifiants d'IA"
+    }
+  }
+}

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -81,7 +81,8 @@
   "inUse": {
     "title": "Utilisé dans ce compte",
     "features": {
-      "aiAgents": "Agents d'IA"
+      "aiAgents": "Agents d'IA",
+      "inboxAssist": "Assistance de la boîte de réception"
     },
     "fromAccount": "(de ce compte)",
     "fromInstallation": "(par défaut de l'installation)",

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -82,7 +82,10 @@
     "title": "Utilisé dans ce compte",
     "features": {
       "aiAgents": "Agents d'IA",
-      "inboxAssist": "Assistance de la boîte de réception"
+      "inboxAssist": "Assistance de la boîte de réception",
+      "audioTranscription": "Transcription audio",
+      "labelSuggestion": "Suggestion d'étiquettes",
+      "moderation": "Modération"
     },
     "fromAccount": "(de ce compte)",
     "fromInstallation": "(par défaut de l'installation)",

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -90,7 +90,8 @@
     "fromAccount": "(de ce compte)",
     "fromInstallation": "(par défaut de l'installation)",
     "none": "Aucun identifiant",
-    "inheritingHint": "Enregistrez un identifiant pour ce compte afin d'utiliser le vôtre."
+    "inheritingHint": "Enregistrez un identifiant pour ce compte afin d'utiliser le vôtre.",
+    "legacy": "Configurée avant cet écran (migration en attente)"
   },
   "inheritedReadOnly": "Hérité de l'installation"
 }

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -121,5 +121,10 @@
     "remove": "Retirer",
     "nexusLabel": "Identifiant du coffre",
     "nexusHint": "Choisissez l'identifiant du coffre qui contient la clé API du Nexus. Le champ ci-dessous reste le repli intégré."
+  },
+  "retirement": {
+    "managedByVault": "Géré par le coffre",
+    "authHeadersLocked": "Les en-têtes d'authentification sont désormais enregistrés dans le coffre (Paramètres > Identifiants d'intégration) et référencés ci-dessus. Les valeurs stockées restent intactes.",
+    "nexusKeyLocked": "La clé API est désormais enregistrée dans le coffre et référencée par le sélecteur ci-dessus. La clé stockée reste en place jusqu'à ce que vous pointiez vers un autre identifiant."
   }
 }

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -71,7 +71,12 @@
     "deleteSuccess": "Identifiant supprimé avec succès",
     "requiredFields": "Renseignez le nom, le fournisseur et la valeur",
     "permissionDenied": {
-      "read": "Vous n'avez pas la permission de voir les identifiants d'intégration"
+      "read": "Vous n'avez pas la permission de voir les identifiants d'intégration",
+      "installation": "Vous n'avez pas la permission de gérer les identifiants de l'installation"
     }
+  },
+  "inUse": {
+    "title": "En usage dans ce compte",
+    "empty": "Aucun consommateur ne résout encore d'identifiants via le coffre. Les agents externes, bots, outils et MCP apparaîtront ici au fur et à mesure de leur adoption."
   }
 }

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -1,0 +1,77 @@
+{
+  "title": "Identifiants d'intégration",
+  "description": "Le coffre des secrets d'outils et d'intégrations. Enregistrez une fois, référencez partout.",
+  "sections": {
+    "account": "Ce compte",
+    "installation": "Défaut de l'installation",
+    "oauth": "Connexions OAuth"
+  },
+  "columns": {
+    "name": "Nom",
+    "provider": "Fournisseur",
+    "value": "Valeur",
+    "kind": "Type",
+    "status": "Statut",
+    "actions": "Actions"
+  },
+  "kind": {
+    "static": "Statique",
+    "oauth": "OAuth"
+  },
+  "status": {
+    "active": "Active",
+    "inactive": "Inactive"
+  },
+  "actions": {
+    "add": "Nouvel identifiant",
+    "addFirst": "Ajouter le premier identifiant",
+    "edit": "Modifier",
+    "activate": "Activer",
+    "deactivate": "Désactiver",
+    "delete": "Supprimer",
+    "cancel": "Annuler",
+    "save": "Enregistrer"
+  },
+  "form": {
+    "title": {
+      "new": "Nouvel identifiant",
+      "edit": "Modifier l'identifiant"
+    },
+    "labels": {
+      "name": "Nom",
+      "provider": "Fournisseur",
+      "value": "Valeur"
+    },
+    "placeholders": {
+      "name": "ex. : Dify production",
+      "provider": "ex. : dify, n8n, elevenlabs",
+      "valueNew": "Collez le secret ici",
+      "valueEdit": "Laissez vide pour conserver la valeur actuelle"
+    }
+  },
+  "empty": {
+    "title": "Aucun identifiant enregistré",
+    "description": "Enregistrez un identifiant d'intégration pour le réutiliser dans les agents, bots, outils et MCP."
+  },
+  "installationEmpty": "Aucun identifiant par défaut défini au niveau de l'installation.",
+  "inheritedReadOnly": "Hérité de l'installation",
+  "deleteDialog": {
+    "title": "Supprimer l'identifiant",
+    "description": "Voulez-vous vraiment supprimer l'identifiant \"{{name}}\" ? Cette action est irréversible.",
+    "inUseWarning": "Cet identifiant est référencé par {{count}} consommateur(s) : {{consumers}}. Ils reviendront à la valeur intégrée tant qu'elle existe.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer"
+  },
+  "messages": {
+    "loadError": "Échec du chargement des identifiants",
+    "saveError": "Échec de l'enregistrement de l'identifiant",
+    "deleteError": "Échec de la suppression de l'identifiant",
+    "createSuccess": "Identifiant créé avec succès",
+    "updateSuccess": "Identifiant mis à jour avec succès",
+    "deleteSuccess": "Identifiant supprimé avec succès",
+    "requiredFields": "Renseignez le nom, le fournisseur et la valeur",
+    "permissionDenied": {
+      "read": "Vous n'avez pas la permission de voir les identifiants d'intégration"
+    }
+  }
+}

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -78,5 +78,32 @@
   "inUse": {
     "title": "En usage dans ce compte",
     "empty": "Aucun consommateur ne résout encore d'identifiants via le coffre. Les agents externes, bots, outils et MCP apparaîtront ici au fur et à mesure de leur adoption."
+  },
+  "oauthSection": {
+    "noSecretHint": "Ces connexions ne gardent aucun secret dans le coffre : le jeton reste dans le magasin propriétaire, et ce que vous voyez ici en est lu au moment du listage.",
+    "empty": "Aucune connexion OAuth pour l'instant. Connectez un fournisseur depuis l'écran d'intégrations de l'agent et elle apparaîtra ici.",
+    "noExpiry": "Sans expiration",
+    "columns": {
+      "agent": "Agent",
+      "expires": "Expire"
+    },
+    "status": {
+      "connected": "Connectée",
+      "expiring": "Expire bientôt",
+      "expired": "Expirée",
+      "refresh_failed": "Échec du renouvellement"
+    },
+    "actions": {
+      "disconnect": "Déconnecter"
+    },
+    "disconnectDialog": {
+      "title": "Déconnecter l'intégration",
+      "description": "Déconnecter la connexion {{provider}} ? L'agent cesse d'utiliser cette intégration.",
+      "noRevokeWarning": "La déconnexion supprime l'accès localement. Elle ne révoque PAS l'autorisation chez le fournisseur : pour la révoquer vraiment, utilisez les paramètres de sécurité du fournisseur.",
+      "cancel": "Annuler",
+      "confirm": "Déconnecter"
+    },
+    "disconnectSuccess": "Intégration déconnectée",
+    "disconnectError": "Échec de la déconnexion de l'intégration"
   }
 }

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -77,7 +77,12 @@
   },
   "inUse": {
     "title": "En usage dans ce compte",
-    "empty": "Aucun consommateur ne résout encore d'identifiants via le coffre. Les agents externes, bots, outils et MCP apparaîtront ici au fur et à mesure de leur adoption."
+    "empty": "Aucun consommateur ne résout encore d'identifiants via le coffre. Les agents externes, bots, outils et MCP apparaîtront ici au fur et à mesure de leur adoption.",
+    "kinds": {
+      "tool": "Outil",
+      "mcp": "Serveur MCP",
+      "bot": "Bot de canal"
+    }
   },
   "oauthSection": {
     "noSecretHint": "Ces connexions ne gardent aucun secret dans le coffre : le jeton reste dans le magasin propriétaire, et ce que vous voyez ici en est lu au moment du listage.",
@@ -104,5 +109,17 @@
     },
     "disconnectSuccess": "Intégration déconnectée",
     "disconnectError": "Échec de la déconnexion de l'intégration"
+  },
+  "refsEditor": {
+    "label": "Secrets via le coffre",
+    "hint": "Chaque entrée remplace l'en-tête ou la variable du même nom par la valeur déchiffrée du coffre. Un identifiant par secret.",
+    "keyLabel": "Nom du secret",
+    "keyPlaceholder": "ex. : Authorization",
+    "selectPlaceholder": "Choisissez un identifiant",
+    "none": "Aucun (utiliser la valeur intégrée)",
+    "add": "Ajouter un secret du coffre",
+    "remove": "Retirer",
+    "nexusLabel": "Identifiant du coffre",
+    "nexusHint": "Choisissez l'identifiant du coffre qui contient la clé API du Nexus. Le champ ci-dessous reste le repli intégré."
   }
 }

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -90,8 +90,7 @@
     "status": {
       "connected": "Connectée",
       "expiring": "Expire bientôt",
-      "expired": "Expirée",
-      "refresh_failed": "Échec du renouvellement"
+      "expired": "Expirée"
     },
     "actions": {
       "disconnect": "Déconnecter"

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -126,7 +126,8 @@
   "retirement": {
     "managedByVault": "Géré par le coffre",
     "authHeadersLocked": "Les en-têtes d'authentification sont désormais enregistrés dans le coffre (Paramètres > Identifiants d'intégration) et référencés ci-dessus. Les valeurs stockées restent intactes.",
-    "nexusKeyLocked": "La clé API est désormais enregistrée dans le coffre et référencée par le sélecteur ci-dessus. La clé stockée reste en place jusqu'à ce que vous pointiez vers un autre identifiant."
+    "nexusKeyLocked": "La clé API est désormais enregistrée dans le coffre et référencée par le sélecteur ci-dessus. La clé stockée reste en place jusqu'à ce que vous pointiez vers un autre identifiant.",
+    "externalKeyLocked": "La clé est désormais enregistrée dans le coffre et référencée par le sélecteur ci-dessus. La clé stockée continue de fonctionner jusqu'à ce que vous pointiez vers un autre identifiant."
   },
   "externalAgent": {
     "hint": "Identifiant du coffre pour cette plateforme. Une fois défini, le runtime l'utilise et la clé en ligne ci-dessous devient le repli."

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -81,7 +81,8 @@
     "kinds": {
       "tool": "Outil",
       "mcp": "Serveur MCP",
-      "bot": "Bot de canal"
+      "bot": "Bot de canal",
+      "credential": "Identifiant"
     }
   },
   "oauthSection": {
@@ -126,5 +127,8 @@
     "managedByVault": "Géré par le coffre",
     "authHeadersLocked": "Les en-têtes d'authentification sont désormais enregistrés dans le coffre (Paramètres > Identifiants d'intégration) et référencés ci-dessus. Les valeurs stockées restent intactes.",
     "nexusKeyLocked": "La clé API est désormais enregistrée dans le coffre et référencée par le sélecteur ci-dessus. La clé stockée reste en place jusqu'à ce que vous pointiez vers un autre identifiant."
+  },
+  "externalAgent": {
+    "hint": "Identifiant du coffre pour cette plateforme. Une fois défini, le runtime l'utilise et la clé en ligne ci-dessous devient le repli."
   }
 }

--- a/src/i18n/locales/fr/integrations.json
+++ b/src/i18n/locales/fr/integrations.json
@@ -652,7 +652,9 @@
         "configure": "Configurer l'intégration",
         "update": "Mettre à jour l'intégration",
         "saving": "Enregistrement..."
-      }
+      },
+      "credentialMoved": "La clé est désormais enregistrée dans Paramètres > Identifiants d'IA. Cet écran ne porte que les interrupteurs des fonctions.",
+      "goToCredentials": "Aller aux Identifiants d'IA"
     },
     "settings": {
       "loading": "Chargement de la configuration...",
@@ -675,7 +677,8 @@
         "actions": {
           "edit": "Modifier",
           "remove": "Supprimer"
-        }
+        },
+        "managedElsewhere": "Gérée dans Identifiants d'IA"
       },
       "features": {
         "title": "Fonctionnalités disponibles",

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -111,6 +111,7 @@
       "customAttributes": "Attributs Personnalisés",
       "cannedResponses": "Réponses Rapides",
       "aiCredentials": "Identifiants d'IA",
+      "integrationCredentials": "Identifiants d'intégration",
       "messageTemplates": "Modèles de Message",
       "macros": "Macros",
       "templates": "Modèles",

--- a/src/i18n/locales/fr/layout.json
+++ b/src/i18n/locales/fr/layout.json
@@ -110,6 +110,7 @@
       "labels": "Étiquettes",
       "customAttributes": "Attributs Personnalisés",
       "cannedResponses": "Réponses Rapides",
+      "aiCredentials": "Identifiants d'IA",
       "messageTemplates": "Modèles de Message",
       "macros": "Macros",
       "templates": "Modèles",

--- a/src/i18n/locales/it/adminSettings.json
+++ b/src/i18n/locales/it/adminSettings.json
@@ -303,7 +303,9 @@
         "apiUrl": "https://api.openai.com/v1",
         "apiSecret": "Inserisci la nuova chiave API",
         "model": "gpt-4o"
-      }
+      },
+      "credentialMoved": "La credenziale di IA ora si trova in Impostazioni > Credenziali di IA.",
+      "goToCredentials": "Vai a Credenziali di IA"
     },
     "prompts": {
       "cardTitle": "Modelli di Prompt IA",

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -1,0 +1,80 @@
+{
+  "title": "Credenziali di IA",
+  "description": "Usate da tutte le funzioni di IA. Registrala una volta, vale ovunque.",
+  "sections": {
+    "account": "Di questo account",
+    "installation": "Predefinita dell'installazione"
+  },
+  "columns": {
+    "name": "Nome",
+    "provider": "Fornitore",
+    "key": "Chiave",
+    "serves": "Serve",
+    "status": "Stato",
+    "actions": "Azioni"
+  },
+  "serves": {
+    "all": "Tutte le funzioni",
+    "agentsOnly": "Solo Agenti di IA"
+  },
+  "status": {
+    "active": "Attiva",
+    "inactive": "Inattiva"
+  },
+  "actions": {
+    "add": "Nuova credenziale",
+    "addFirst": "Registra la prima credenziale",
+    "edit": "Modifica",
+    "activate": "Attiva",
+    "deactivate": "Disattiva",
+    "delete": "Elimina",
+    "cancel": "Annulla",
+    "save": "Salva"
+  },
+  "form": {
+    "title": {
+      "new": "Nuova credenziale",
+      "edit": "Modifica credenziale"
+    },
+    "labels": {
+      "name": "Nome",
+      "provider": "Fornitore",
+      "key": "Chiave",
+      "baseUrl": "URL base"
+    },
+    "placeholders": {
+      "name": "Es.: Produzione",
+      "provider": "Seleziona un fornitore",
+      "keyNew": "Incolla qui la tua chiave",
+      "keyEdit": "Lascia vuoto per mantenere la chiave attuale"
+    },
+    "incompatibleWarning": "{{provider}} funziona con gli Agenti di IA. L'assistente della casella di posta, la trascrizione, le etichette e la moderazione non usano questo fornitore."
+  },
+  "empty": {
+    "title": "Nessuna credenziale registrata",
+    "description": "Registra una credenziale di IA per usarla in tutto il CRM."
+  },
+  "installationEmpty": "Nessuna credenziale predefinita impostata a livello di installazione.",
+  "deleteDialog": {
+    "title": "Elimina credenziale",
+    "description": "Vuoi davvero eliminare la credenziale \"{{name}}\"? L'azione non può essere annullata.",
+    "inUseWarning": "Questa credenziale è usata da {{count}} agente/i: {{agents}}. Smetteranno di funzionare.",
+    "cancel": "Annulla",
+    "confirm": "Elimina"
+  },
+  "messages": {
+    "loadError": "Errore nel caricamento delle credenziali",
+    "saveError": "Errore nel salvataggio della credenziale",
+    "deleteError": "Errore nell'eliminazione della credenziale",
+    "createSuccess": "Credenziale creata con successo",
+    "updateSuccess": "Credenziale aggiornata con successo",
+    "deleteSuccess": "Credenziale eliminata con successo",
+    "requiredFields": "Compila nome, fornitore e chiave",
+    "permissionDenied": {
+      "read": "Non hai il permesso di vedere le credenziali di IA",
+      "create": "Non hai il permesso di creare credenziali di IA",
+      "update": "Non hai il permesso di modificare credenziali di IA",
+      "delete": "Non hai il permesso di eliminare credenziali di IA"
+    }
+  }
+}

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -82,7 +82,10 @@
     "title": "In uso in questo account",
     "features": {
       "aiAgents": "Agenti di IA",
-      "inboxAssist": "Assistente della casella di posta"
+      "inboxAssist": "Assistente della casella di posta",
+      "audioTranscription": "Trascrizione audio",
+      "labelSuggestion": "Suggerimento di etichette",
+      "moderation": "Moderazione"
     },
     "fromAccount": "(di questo account)",
     "fromInstallation": "(predefinita dell'installazione)",

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -74,7 +74,19 @@
       "read": "Non hai il permesso di vedere le credenziali di IA",
       "create": "Non hai il permesso di creare credenziali di IA",
       "update": "Non hai il permesso di modificare credenziali di IA",
-      "delete": "Non hai il permesso di eliminare credenziali di IA"
+      "delete": "Non hai il permesso di eliminare credenziali di IA",
+      "installation": "Non hai il permesso di gestire le credenziali dell'installazione"
     }
-  }
+  },
+  "inUse": {
+    "title": "In uso in questo account",
+    "features": {
+      "aiAgents": "Agenti di IA"
+    },
+    "fromAccount": "(di questo account)",
+    "fromInstallation": "(predefinita dell'installazione)",
+    "none": "Nessuna credenziale",
+    "inheritingHint": "Registra una credenziale di questo account per usare la tua."
+  },
+  "inheritedReadOnly": "Ereditata dall'installazione"
 }

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -81,7 +81,8 @@
   "inUse": {
     "title": "In uso in questo account",
     "features": {
-      "aiAgents": "Agenti di IA"
+      "aiAgents": "Agenti di IA",
+      "inboxAssist": "Assistente della casella di posta"
     },
     "fromAccount": "(di questo account)",
     "fromInstallation": "(predefinita dell'installazione)",

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -90,7 +90,8 @@
     "fromAccount": "(di questo account)",
     "fromInstallation": "(predefinita dell'installazione)",
     "none": "Nessuna credenziale",
-    "inheritingHint": "Registra una credenziale di questo account per usare la tua."
+    "inheritingHint": "Registra una credenziale di questo account per usare la tua.",
+    "legacy": "Configurata prima di questa schermata (migrazione in sospeso)"
   },
   "inheritedReadOnly": "Ereditata dall'installazione"
 }

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -71,7 +71,12 @@
     "deleteSuccess": "Credenziale eliminata con successo",
     "requiredFields": "Compila nome, provider e valore",
     "permissionDenied": {
-      "read": "Non hai il permesso di vedere le credenziali di integrazione"
+      "read": "Non hai il permesso di vedere le credenziali di integrazione",
+      "installation": "Non hai il permesso di gestire le credenziali dell'installazione"
     }
+  },
+  "inUse": {
+    "title": "In uso in questo account",
+    "empty": "Nessun consumatore risolve ancora credenziali tramite la cassaforte. Agenti esterni, bot, strumenti e MCP appariranno qui man mano che la adotteranno."
   }
 }

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -78,5 +78,32 @@
   "inUse": {
     "title": "In uso in questo account",
     "empty": "Nessun consumatore risolve ancora credenziali tramite la cassaforte. Agenti esterni, bot, strumenti e MCP appariranno qui man mano che la adotteranno."
+  },
+  "oauthSection": {
+    "noSecretHint": "Queste connessioni non conservano segreti nella cassaforte: il token resta nello store proprietario, e ciò che vedi qui viene letto da lì al momento dell'elenco.",
+    "empty": "Nessuna connessione OAuth ancora. Collega un provider dalla schermata di integrazioni dell'agente e apparirà qui.",
+    "noExpiry": "Senza scadenza",
+    "columns": {
+      "agent": "Agente",
+      "expires": "Scade"
+    },
+    "status": {
+      "connected": "Connessa",
+      "expiring": "In scadenza",
+      "expired": "Scaduta",
+      "refresh_failed": "Rinnovo non riuscito"
+    },
+    "actions": {
+      "disconnect": "Disconnetti"
+    },
+    "disconnectDialog": {
+      "title": "Disconnetti integrazione",
+      "description": "Disconnettere la connessione {{provider}}? L'agente smette di usare questa integrazione.",
+      "noRevokeWarning": "La disconnessione rimuove l'accesso localmente. NON revoca l'autorizzazione presso il provider: per revocarla davvero, usa le impostazioni di sicurezza del provider.",
+      "cancel": "Annulla",
+      "confirm": "Disconnetti"
+    },
+    "disconnectSuccess": "Integrazione disconnessa",
+    "disconnectError": "Impossibile disconnettere l'integrazione"
   }
 }

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -81,7 +81,8 @@
     "kinds": {
       "tool": "Strumento",
       "mcp": "Server MCP",
-      "bot": "Bot di canale"
+      "bot": "Bot di canale",
+      "credential": "Credenziale"
     }
   },
   "oauthSection": {
@@ -126,5 +127,8 @@
     "managedByVault": "Gestito dalla cassaforte",
     "authHeadersLocked": "Gli header di autenticazione ora sono registrati nella cassaforte (Impostazioni > Credenziali di integrazione) e referenziati sopra. I valori salvati restano intatti.",
     "nexusKeyLocked": "La API key ora è registrata nella cassaforte e referenziata dal selettore sopra. La chiave salvata resta finché non punti a un'altra credenziale."
+  },
+  "externalAgent": {
+    "hint": "Credenziale della cassaforte per questa piattaforma. Una volta impostata, il runtime la usa e la chiave inline sotto diventa la riserva."
   }
 }

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -126,7 +126,8 @@
   "retirement": {
     "managedByVault": "Gestito dalla cassaforte",
     "authHeadersLocked": "Gli header di autenticazione ora sono registrati nella cassaforte (Impostazioni > Credenziali di integrazione) e referenziati sopra. I valori salvati restano intatti.",
-    "nexusKeyLocked": "La API key ora è registrata nella cassaforte e referenziata dal selettore sopra. La chiave salvata resta finché non punti a un'altra credenziale."
+    "nexusKeyLocked": "La API key ora è registrata nella cassaforte e referenziata dal selettore sopra. La chiave salvata resta finché non punti a un'altra credenziale.",
+    "externalKeyLocked": "La chiave ora è registrata nella cassaforte e referenziata dal selettore sopra. La chiave salvata continua a funzionare finché non punti a un'altra credenziale."
   },
   "externalAgent": {
     "hint": "Credenziale della cassaforte per questa piattaforma. Una volta impostata, il runtime la usa e la chiave inline sotto diventa la riserva."

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -121,5 +121,10 @@
     "remove": "Rimuovi",
     "nexusLabel": "Credenziale della cassaforte",
     "nexusHint": "Scegli la credenziale della cassaforte che contiene la API key del Nexus. Il campo sotto resta come riserva incorporata."
+  },
+  "retirement": {
+    "managedByVault": "Gestito dalla cassaforte",
+    "authHeadersLocked": "Gli header di autenticazione ora sono registrati nella cassaforte (Impostazioni > Credenziali di integrazione) e referenziati sopra. I valori salvati restano intatti.",
+    "nexusKeyLocked": "La API key ora è registrata nella cassaforte e referenziata dal selettore sopra. La chiave salvata resta finché non punti a un'altra credenziale."
   }
 }

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -90,8 +90,7 @@
     "status": {
       "connected": "Connessa",
       "expiring": "In scadenza",
-      "expired": "Scaduta",
-      "refresh_failed": "Rinnovo non riuscito"
+      "expired": "Scaduta"
     },
     "actions": {
       "disconnect": "Disconnetti"

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -77,7 +77,12 @@
   },
   "inUse": {
     "title": "In uso in questo account",
-    "empty": "Nessun consumatore risolve ancora credenziali tramite la cassaforte. Agenti esterni, bot, strumenti e MCP appariranno qui man mano che la adotteranno."
+    "empty": "Nessun consumatore risolve ancora credenziali tramite la cassaforte. Agenti esterni, bot, strumenti e MCP appariranno qui man mano che la adotteranno.",
+    "kinds": {
+      "tool": "Strumento",
+      "mcp": "Server MCP",
+      "bot": "Bot di canale"
+    }
   },
   "oauthSection": {
     "noSecretHint": "Queste connessioni non conservano segreti nella cassaforte: il token resta nello store proprietario, e ciò che vedi qui viene letto da lì al momento dell'elenco.",
@@ -104,5 +109,17 @@
     },
     "disconnectSuccess": "Integrazione disconnessa",
     "disconnectError": "Impossibile disconnettere l'integrazione"
+  },
+  "refsEditor": {
+    "label": "Segreti dalla cassaforte",
+    "hint": "Ogni voce sostituisce l'header o la variabile con lo stesso nome usando il valore decifrato della cassaforte. Una credenziale per segreto.",
+    "keyLabel": "Nome del segreto",
+    "keyPlaceholder": "es.: Authorization",
+    "selectPlaceholder": "Scegli una credenziale",
+    "none": "Nessuna (usa il valore incorporato)",
+    "add": "Aggiungi segreto della cassaforte",
+    "remove": "Rimuovi",
+    "nexusLabel": "Credenziale della cassaforte",
+    "nexusHint": "Scegli la credenziale della cassaforte che contiene la API key del Nexus. Il campo sotto resta come riserva incorporata."
   }
 }

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -1,0 +1,77 @@
+{
+  "title": "Credenziali di integrazione",
+  "description": "La cassaforte dei segreti di strumenti e integrazioni. Registra una volta, riferisci ovunque.",
+  "sections": {
+    "account": "Questo account",
+    "installation": "Predefinita dell'installazione",
+    "oauth": "Connessioni OAuth"
+  },
+  "columns": {
+    "name": "Nome",
+    "provider": "Provider",
+    "value": "Valore",
+    "kind": "Tipo",
+    "status": "Stato",
+    "actions": "Azioni"
+  },
+  "kind": {
+    "static": "Statica",
+    "oauth": "OAuth"
+  },
+  "status": {
+    "active": "Attiva",
+    "inactive": "Inattiva"
+  },
+  "actions": {
+    "add": "Nuova credenziale",
+    "addFirst": "Aggiungi la prima credenziale",
+    "edit": "Modifica",
+    "activate": "Attiva",
+    "deactivate": "Disattiva",
+    "delete": "Elimina",
+    "cancel": "Annulla",
+    "save": "Salva"
+  },
+  "form": {
+    "title": {
+      "new": "Nuova credenziale",
+      "edit": "Modifica credenziale"
+    },
+    "labels": {
+      "name": "Nome",
+      "provider": "Provider",
+      "value": "Valore"
+    },
+    "placeholders": {
+      "name": "es.: Dify produzione",
+      "provider": "es.: dify, n8n, elevenlabs",
+      "valueNew": "Incolla qui il segreto",
+      "valueEdit": "Lascia vuoto per mantenere il valore attuale"
+    }
+  },
+  "empty": {
+    "title": "Nessuna credenziale registrata",
+    "description": "Registra una credenziale di integrazione per riutilizzarla in agenti, bot, strumenti e MCP."
+  },
+  "installationEmpty": "Nessuna credenziale predefinita impostata a livello di installazione.",
+  "inheritedReadOnly": "Ereditata dall'installazione",
+  "deleteDialog": {
+    "title": "Elimina credenziale",
+    "description": "Vuoi davvero eliminare la credenziale \"{{name}}\"? Questa azione non può essere annullata.",
+    "inUseWarning": "Questa credenziale è referenziata da {{count}} consumatore/i: {{consumers}}. Torneranno al valore incorporato finché esiste.",
+    "cancel": "Annulla",
+    "confirm": "Elimina"
+  },
+  "messages": {
+    "loadError": "Impossibile caricare le credenziali",
+    "saveError": "Impossibile salvare la credenziale",
+    "deleteError": "Impossibile eliminare la credenziale",
+    "createSuccess": "Credenziale creata con successo",
+    "updateSuccess": "Credenziale aggiornata con successo",
+    "deleteSuccess": "Credenziale eliminata con successo",
+    "requiredFields": "Compila nome, provider e valore",
+    "permissionDenied": {
+      "read": "Non hai il permesso di vedere le credenziali di integrazione"
+    }
+  }
+}

--- a/src/i18n/locales/it/integrations.json
+++ b/src/i18n/locales/it/integrations.json
@@ -652,7 +652,9 @@
         "configure": "Configura Integrazione",
         "update": "Aggiorna Integrazione",
         "saving": "Salvataggio in corso..."
-      }
+      },
+      "credentialMoved": "La chiave ora si registra in Impostazioni > Credenziali di IA. Qui restano solo gli interruttori delle funzioni.",
+      "goToCredentials": "Vai a Credenziali di IA"
     },
     "settings": {
       "loading": "Caricamento configurazione...",
@@ -675,7 +677,8 @@
         "actions": {
           "edit": "Modifica",
           "remove": "Rimuovi"
-        }
+        },
+        "managedElsewhere": "Gestita in Credenziali di IA"
       },
       "features": {
         "title": "Funzionalità Disponibili",

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -111,6 +111,7 @@
       "customAttributes": "Attributi Personalizzati",
       "cannedResponses": "Risposte Predefinite",
       "aiCredentials": "Credenziali di IA",
+      "integrationCredentials": "Credenziali di integrazione",
       "messageTemplates": "Modelli di Messaggio",
       "macros": "Macro",
       "templates": "Modelli",

--- a/src/i18n/locales/it/layout.json
+++ b/src/i18n/locales/it/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etichette",
       "customAttributes": "Attributi Personalizzati",
       "cannedResponses": "Risposte Predefinite",
+      "aiCredentials": "Credenziali di IA",
       "messageTemplates": "Modelli di Messaggio",
       "macros": "Macro",
       "templates": "Modelli",

--- a/src/i18n/locales/pt-BR/adminSettings.json
+++ b/src/i18n/locales/pt-BR/adminSettings.json
@@ -310,7 +310,9 @@
         "apiUrl": "https://api.openai.com/v1",
         "apiSecret": "Insira a nova chave de API",
         "model": "gpt-4o"
-      }
+      },
+      "credentialMoved": "A credencial de IA agora fica em Configurações > Credenciais de IA.",
+      "goToCredentials": "Ir para Credenciais de IA"
     },
     "prompts": {
       "cardTitle": "Modelos de Prompt de IA",

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -1,0 +1,80 @@
+{
+  "title": "Credenciais de IA",
+  "description": "Usadas por todas as funções de IA. Cadastre uma vez, vale para tudo.",
+  "sections": {
+    "account": "Desta conta",
+    "installation": "Padrão da instalação"
+  },
+  "columns": {
+    "name": "Nome",
+    "provider": "Provedor",
+    "key": "Chave",
+    "serves": "Atende",
+    "status": "Estado",
+    "actions": "Ações"
+  },
+  "serves": {
+    "all": "Todas as funções",
+    "agentsOnly": "Só Agentes de IA"
+  },
+  "status": {
+    "active": "Ativa",
+    "inactive": "Inativa"
+  },
+  "actions": {
+    "add": "Nova credencial",
+    "addFirst": "Cadastrar primeira credencial",
+    "edit": "Editar",
+    "activate": "Ativar",
+    "deactivate": "Desativar",
+    "delete": "Excluir",
+    "cancel": "Cancelar",
+    "save": "Salvar"
+  },
+  "form": {
+    "title": {
+      "new": "Nova credencial",
+      "edit": "Editar credencial"
+    },
+    "labels": {
+      "name": "Nome",
+      "provider": "Provedor",
+      "key": "Chave",
+      "baseUrl": "URL base"
+    },
+    "placeholders": {
+      "name": "Ex.: Produção",
+      "provider": "Selecione um provedor",
+      "keyNew": "Cole sua chave aqui",
+      "keyEdit": "Deixe vazio para manter a chave atual"
+    },
+    "incompatibleWarning": "{{provider}} funciona nos Agentes de IA. O assist da caixa de entrada, a transcrição, as etiquetas e a moderação não usam este provedor."
+  },
+  "empty": {
+    "title": "Nenhuma credencial cadastrada",
+    "description": "Cadastre uma credencial de IA para usar em todo o CRM."
+  },
+  "installationEmpty": "Nenhuma credencial padrão definida na instalação.",
+  "deleteDialog": {
+    "title": "Excluir credencial",
+    "description": "Tem certeza que deseja excluir a credencial \"{{name}}\"? Esta ação não pode ser desfeita.",
+    "inUseWarning": "Esta credencial é usada por {{count}} agente(s): {{agents}}. Eles deixarão de funcionar.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "messages": {
+    "loadError": "Erro ao carregar as credenciais",
+    "saveError": "Erro ao salvar a credencial",
+    "deleteError": "Erro ao excluir a credencial",
+    "createSuccess": "Credencial criada com sucesso",
+    "updateSuccess": "Credencial atualizada com sucesso",
+    "deleteSuccess": "Credencial excluída com sucesso",
+    "requiredFields": "Preencha nome, provedor e chave",
+    "permissionDenied": {
+      "read": "Você não tem permissão para ver as credenciais de IA",
+      "create": "Você não tem permissão para cadastrar credenciais de IA",
+      "update": "Você não tem permissão para editar credenciais de IA",
+      "delete": "Você não tem permissão para excluir credenciais de IA"
+    }
+  }
+}

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -81,7 +81,8 @@
   "inUse": {
     "title": "Em uso nesta conta",
     "features": {
-      "aiAgents": "Agentes de IA"
+      "aiAgents": "Agentes de IA",
+      "inboxAssist": "Assist da caixa de entrada"
     },
     "fromAccount": "(desta conta)",
     "fromInstallation": "(padrão da instalação)",

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -74,7 +74,19 @@
       "read": "Você não tem permissão para ver as credenciais de IA",
       "create": "Você não tem permissão para cadastrar credenciais de IA",
       "update": "Você não tem permissão para editar credenciais de IA",
-      "delete": "Você não tem permissão para excluir credenciais de IA"
+      "delete": "Você não tem permissão para excluir credenciais de IA",
+      "installation": "Você não tem permissão para gerenciar credenciais da instalação"
     }
-  }
+  },
+  "inUse": {
+    "title": "Em uso nesta conta",
+    "features": {
+      "aiAgents": "Agentes de IA"
+    },
+    "fromAccount": "(desta conta)",
+    "fromInstallation": "(padrão da instalação)",
+    "none": "Nenhuma credencial",
+    "inheritingHint": "Cadastre uma credencial desta conta para usar a sua própria."
+  },
+  "inheritedReadOnly": "Herdada da instalação"
 }

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -82,7 +82,10 @@
     "title": "Em uso nesta conta",
     "features": {
       "aiAgents": "Agentes de IA",
-      "inboxAssist": "Assist da caixa de entrada"
+      "inboxAssist": "Assist da caixa de entrada",
+      "audioTranscription": "Transcrição de áudio",
+      "labelSuggestion": "Sugestão de etiquetas",
+      "moderation": "Moderação"
     },
     "fromAccount": "(desta conta)",
     "fromInstallation": "(padrão da instalação)",

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -90,7 +90,8 @@
     "fromAccount": "(desta conta)",
     "fromInstallation": "(padrão da instalação)",
     "none": "Nenhuma credencial",
-    "inheritingHint": "Cadastre uma credencial desta conta para usar a sua própria."
+    "inheritingHint": "Cadastre uma credencial desta conta para usar a sua própria.",
+    "legacy": "Configurada antes desta tela (migração pendente)"
   },
   "inheritedReadOnly": "Herdada da instalação"
 }

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -121,5 +121,10 @@
     "remove": "Remover",
     "nexusLabel": "Credencial do cofre",
     "nexusHint": "Escolha a credencial do cofre que guarda a API key do Nexus. O campo abaixo continua como fallback embutido."
+  },
+  "retirement": {
+    "managedByVault": "Gerenciado pelo cofre",
+    "authHeadersLocked": "Headers de autenticação agora são cadastrados no cofre (Configurações > Credenciais de integração) e referenciados acima. Os valores guardados permanecem intocados.",
+    "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial."
   }
 }

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -71,7 +71,12 @@
     "deleteSuccess": "Credencial excluída com sucesso",
     "requiredFields": "Preencha nome, provedor e valor",
     "permissionDenied": {
-      "read": "Você não tem permissão para ver as credenciais de integração"
+      "read": "Você não tem permissão para ver as credenciais de integração",
+      "installation": "Você não tem permissão para gerenciar credenciais da instalação"
     }
+  },
+  "inUse": {
+    "title": "Em uso nesta conta",
+    "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem."
   }
 }

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -126,7 +126,8 @@
   "retirement": {
     "managedByVault": "Gerenciado pelo cofre",
     "authHeadersLocked": "Headers de autenticação agora são cadastrados no cofre (Configurações > Credenciais de integração) e referenciados acima. Os valores guardados permanecem intocados.",
-    "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial."
+    "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial.",
+    "externalKeyLocked": "A chave agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada continua funcionando até você apontar para outra credencial."
   },
   "externalAgent": {
     "hint": "Credencial do cofre para esta plataforma. Com ela definida, o runtime a usa e a chave inline abaixo vira o fallback."

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -77,7 +77,12 @@
   },
   "inUse": {
     "title": "Em uso nesta conta",
-    "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem."
+    "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem.",
+    "kinds": {
+      "tool": "Ferramenta",
+      "mcp": "Servidor MCP",
+      "bot": "Bot de canal"
+    }
   },
   "oauthSection": {
     "noSecretHint": "Estas conexões não guardam segredo no cofre: o token fica no store dono, e o que você vê aqui é lido de lá no momento da listagem.",
@@ -104,5 +109,17 @@
     },
     "disconnectSuccess": "Integração desconectada",
     "disconnectError": "Falha ao desconectar a integração"
+  },
+  "refsEditor": {
+    "label": "Segredos pelo cofre",
+    "hint": "Cada entrada substitui o header ou a variável de mesmo nome pelo valor decifrado do cofre. Uma credencial por segredo.",
+    "keyLabel": "Nome do segredo",
+    "keyPlaceholder": "ex.: Authorization",
+    "selectPlaceholder": "Escolha uma credencial",
+    "none": "Nenhuma (usar valor embutido)",
+    "add": "Adicionar segredo do cofre",
+    "remove": "Remover",
+    "nexusLabel": "Credencial do cofre",
+    "nexusHint": "Escolha a credencial do cofre que guarda a API key do Nexus. O campo abaixo continua como fallback embutido."
   }
 }

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -81,7 +81,8 @@
     "kinds": {
       "tool": "Ferramenta",
       "mcp": "Servidor MCP",
-      "bot": "Bot de canal"
+      "bot": "Bot de canal",
+      "credential": "Credencial"
     }
   },
   "oauthSection": {
@@ -126,5 +127,8 @@
     "managedByVault": "Gerenciado pelo cofre",
     "authHeadersLocked": "Headers de autenticação agora são cadastrados no cofre (Configurações > Credenciais de integração) e referenciados acima. Os valores guardados permanecem intocados.",
     "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial."
+  },
+  "externalAgent": {
+    "hint": "Credencial do cofre para esta plataforma. Com ela definida, o runtime a usa e a chave inline abaixo vira o fallback."
   }
 }

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -1,0 +1,77 @@
+{
+  "title": "Credenciais de integração",
+  "description": "O cofre dos segredos de ferramentas e integrações. Cadastre uma vez, referencie em todo lugar.",
+  "sections": {
+    "account": "Desta conta",
+    "installation": "Padrão da instalação",
+    "oauth": "Conexões OAuth"
+  },
+  "columns": {
+    "name": "Nome",
+    "provider": "Provedor",
+    "value": "Valor",
+    "kind": "Tipo",
+    "status": "Estado",
+    "actions": "Ações"
+  },
+  "kind": {
+    "static": "Estática",
+    "oauth": "OAuth"
+  },
+  "status": {
+    "active": "Ativa",
+    "inactive": "Inativa"
+  },
+  "actions": {
+    "add": "Nova credencial",
+    "addFirst": "Cadastrar primeira credencial",
+    "edit": "Editar",
+    "activate": "Ativar",
+    "deactivate": "Desativar",
+    "delete": "Excluir",
+    "cancel": "Cancelar",
+    "save": "Salvar"
+  },
+  "form": {
+    "title": {
+      "new": "Nova credencial",
+      "edit": "Editar credencial"
+    },
+    "labels": {
+      "name": "Nome",
+      "provider": "Provedor",
+      "value": "Valor"
+    },
+    "placeholders": {
+      "name": "ex.: Dify produção",
+      "provider": "ex.: dify, n8n, elevenlabs",
+      "valueNew": "Cole o segredo aqui",
+      "valueEdit": "Deixe vazio para manter o valor atual"
+    }
+  },
+  "empty": {
+    "title": "Nenhuma credencial cadastrada",
+    "description": "Cadastre uma credencial de integração para reusá-la em agentes, bots, ferramentas e MCPs."
+  },
+  "installationEmpty": "Nenhuma credencial padrão definida no nível da instalação.",
+  "inheritedReadOnly": "Herdada da instalação",
+  "deleteDialog": {
+    "title": "Excluir credencial",
+    "description": "Tem certeza de que deseja excluir a credencial \"{{name}}\"? Esta ação não pode ser desfeita.",
+    "inUseWarning": "Esta credencial é referenciada por {{count}} consumidor(es): {{consumers}}. Eles voltarão ao valor embutido enquanto ele existir.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "messages": {
+    "loadError": "Falha ao carregar as credenciais",
+    "saveError": "Falha ao salvar a credencial",
+    "deleteError": "Falha ao excluir a credencial",
+    "createSuccess": "Credencial criada com sucesso",
+    "updateSuccess": "Credencial atualizada com sucesso",
+    "deleteSuccess": "Credencial excluída com sucesso",
+    "requiredFields": "Preencha nome, provedor e valor",
+    "permissionDenied": {
+      "read": "Você não tem permissão para ver as credenciais de integração"
+    }
+  }
+}

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -78,5 +78,32 @@
   "inUse": {
     "title": "Em uso nesta conta",
     "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem."
+  },
+  "oauthSection": {
+    "noSecretHint": "Estas conexões não guardam segredo no cofre: o token fica no store dono, e o que você vê aqui é lido de lá no momento da listagem.",
+    "empty": "Nenhuma conexão OAuth ainda. Conecte um provedor pela tela de integrações do agente e ela aparecerá aqui.",
+    "noExpiry": "Sem expiração",
+    "columns": {
+      "agent": "Agente",
+      "expires": "Expira em"
+    },
+    "status": {
+      "connected": "Conectada",
+      "expiring": "Expirando em breve",
+      "expired": "Expirada",
+      "refresh_failed": "Falha na renovação"
+    },
+    "actions": {
+      "disconnect": "Desconectar"
+    },
+    "disconnectDialog": {
+      "title": "Desconectar integração",
+      "description": "Desconectar a conexão do {{provider}}? O agente deixa de usar esta integração.",
+      "noRevokeWarning": "Desconectar remove o acesso localmente. NÃO revoga a autorização no provedor: para revogar de verdade, use as configurações de segurança do próprio provedor.",
+      "cancel": "Cancelar",
+      "confirm": "Desconectar"
+    },
+    "disconnectSuccess": "Integração desconectada",
+    "disconnectError": "Falha ao desconectar a integração"
   }
 }

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -90,8 +90,7 @@
     "status": {
       "connected": "Conectada",
       "expiring": "Expirando em breve",
-      "expired": "Expirada",
-      "refresh_failed": "Falha na renovação"
+      "expired": "Expirada"
     },
     "actions": {
       "disconnect": "Desconectar"

--- a/src/i18n/locales/pt-BR/integrations.json
+++ b/src/i18n/locales/pt-BR/integrations.json
@@ -676,7 +676,9 @@
         "configure": "Configurar Integração",
         "update": "Atualizar Integração",
         "saving": "Salvando..."
-      }
+      },
+      "credentialMoved": "A chave agora é cadastrada em Configurações > Credenciais de IA. Aqui ficam só os interruptores das funções.",
+      "goToCredentials": "Ir para Credenciais de IA"
     },
     "settings": {
       "loading": "Carregando configuração...",
@@ -699,7 +701,8 @@
         "actions": {
           "edit": "Editar",
           "remove": "Remover"
-        }
+        },
+        "managedElsewhere": "Gerenciada em Credenciais de IA"
       },
       "features": {
         "title": "Recursos Disponíveis",

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -111,6 +111,7 @@
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respostas Rápidas",
       "aiCredentials": "Credenciais de IA",
+      "integrationCredentials": "Credenciais de integração",
       "messageTemplates": "Modelos de Mensagem",
       "macros": "Macros",
       "templates": "Templates",

--- a/src/i18n/locales/pt-BR/layout.json
+++ b/src/i18n/locales/pt-BR/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etiquetas",
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respostas Rápidas",
+      "aiCredentials": "Credenciais de IA",
       "messageTemplates": "Modelos de Mensagem",
       "macros": "Macros",
       "templates": "Templates",

--- a/src/i18n/locales/pt/adminSettings.json
+++ b/src/i18n/locales/pt/adminSettings.json
@@ -309,7 +309,9 @@
         "apiUrl": "https://api.openai.com/v1",
         "apiSecret": "Introduza a nova chave de API",
         "model": "gpt-4o"
-      }
+      },
+      "credentialMoved": "A credencial de IA agora fica em Configurações > Credenciais de IA.",
+      "goToCredentials": "Ir para Credenciais de IA"
     },
     "prompts": {
       "cardTitle": "Modelos de Prompt de IA",

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -1,0 +1,80 @@
+{
+  "title": "Credenciais de IA",
+  "description": "Usadas por todas as funções de IA. Cadastre uma vez, vale para tudo.",
+  "sections": {
+    "account": "Desta conta",
+    "installation": "Padrão da instalação"
+  },
+  "columns": {
+    "name": "Nome",
+    "provider": "Provedor",
+    "key": "Chave",
+    "serves": "Atende",
+    "status": "Estado",
+    "actions": "Ações"
+  },
+  "serves": {
+    "all": "Todas as funções",
+    "agentsOnly": "Só Agentes de IA"
+  },
+  "status": {
+    "active": "Ativa",
+    "inactive": "Inativa"
+  },
+  "actions": {
+    "add": "Nova credencial",
+    "addFirst": "Cadastrar primeira credencial",
+    "edit": "Editar",
+    "activate": "Ativar",
+    "deactivate": "Desativar",
+    "delete": "Excluir",
+    "cancel": "Cancelar",
+    "save": "Salvar"
+  },
+  "form": {
+    "title": {
+      "new": "Nova credencial",
+      "edit": "Editar credencial"
+    },
+    "labels": {
+      "name": "Nome",
+      "provider": "Provedor",
+      "key": "Chave",
+      "baseUrl": "URL base"
+    },
+    "placeholders": {
+      "name": "Ex.: Produção",
+      "provider": "Selecione um provedor",
+      "keyNew": "Cole sua chave aqui",
+      "keyEdit": "Deixe vazio para manter a chave atual"
+    },
+    "incompatibleWarning": "{{provider}} funciona nos Agentes de IA. O assist da caixa de entrada, a transcrição, as etiquetas e a moderação não usam este provedor."
+  },
+  "empty": {
+    "title": "Nenhuma credencial cadastrada",
+    "description": "Cadastre uma credencial de IA para usar em todo o CRM."
+  },
+  "installationEmpty": "Nenhuma credencial padrão definida na instalação.",
+  "deleteDialog": {
+    "title": "Excluir credencial",
+    "description": "Tem certeza que deseja excluir a credencial \"{{name}}\"? Esta ação não pode ser desfeita.",
+    "inUseWarning": "Esta credencial é usada por {{count}} agente(s): {{agents}}. Eles deixarão de funcionar.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "messages": {
+    "loadError": "Erro ao carregar as credenciais",
+    "saveError": "Erro ao salvar a credencial",
+    "deleteError": "Erro ao excluir a credencial",
+    "createSuccess": "Credencial criada com sucesso",
+    "updateSuccess": "Credencial atualizada com sucesso",
+    "deleteSuccess": "Credencial excluída com sucesso",
+    "requiredFields": "Preencha nome, provedor e chave",
+    "permissionDenied": {
+      "read": "Você não tem permissão para ver as credenciais de IA",
+      "create": "Você não tem permissão para cadastrar credenciais de IA",
+      "update": "Você não tem permissão para editar credenciais de IA",
+      "delete": "Você não tem permissão para excluir credenciais de IA"
+    }
+  }
+}

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -81,7 +81,8 @@
   "inUse": {
     "title": "Em uso nesta conta",
     "features": {
-      "aiAgents": "Agentes de IA"
+      "aiAgents": "Agentes de IA",
+      "inboxAssist": "Assist da caixa de entrada"
     },
     "fromAccount": "(desta conta)",
     "fromInstallation": "(padrão da instalação)",

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -74,7 +74,19 @@
       "read": "Você não tem permissão para ver as credenciais de IA",
       "create": "Você não tem permissão para cadastrar credenciais de IA",
       "update": "Você não tem permissão para editar credenciais de IA",
-      "delete": "Você não tem permissão para excluir credenciais de IA"
+      "delete": "Você não tem permissão para excluir credenciais de IA",
+      "installation": "Você não tem permissão para gerenciar credenciais da instalação"
     }
-  }
+  },
+  "inUse": {
+    "title": "Em uso nesta conta",
+    "features": {
+      "aiAgents": "Agentes de IA"
+    },
+    "fromAccount": "(desta conta)",
+    "fromInstallation": "(padrão da instalação)",
+    "none": "Nenhuma credencial",
+    "inheritingHint": "Cadastre uma credencial desta conta para usar a sua própria."
+  },
+  "inheritedReadOnly": "Herdada da instalação"
 }

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -82,7 +82,10 @@
     "title": "Em uso nesta conta",
     "features": {
       "aiAgents": "Agentes de IA",
-      "inboxAssist": "Assist da caixa de entrada"
+      "inboxAssist": "Assist da caixa de entrada",
+      "audioTranscription": "Transcrição de áudio",
+      "labelSuggestion": "Sugestão de etiquetas",
+      "moderation": "Moderação"
     },
     "fromAccount": "(desta conta)",
     "fromInstallation": "(padrão da instalação)",

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -90,7 +90,8 @@
     "fromAccount": "(desta conta)",
     "fromInstallation": "(padrão da instalação)",
     "none": "Nenhuma credencial",
-    "inheritingHint": "Cadastre uma credencial desta conta para usar a sua própria."
+    "inheritingHint": "Cadastre uma credencial desta conta para usar a sua própria.",
+    "legacy": "Configurada antes desta tela (migração pendente)"
   },
   "inheritedReadOnly": "Herdada da instalação"
 }

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -121,5 +121,10 @@
     "remove": "Remover",
     "nexusLabel": "Credencial do cofre",
     "nexusHint": "Escolha a credencial do cofre que guarda a API key do Nexus. O campo abaixo continua como fallback embutido."
+  },
+  "retirement": {
+    "managedByVault": "Gerenciado pelo cofre",
+    "authHeadersLocked": "Headers de autenticação agora são cadastrados no cofre (Configurações > Credenciais de integração) e referenciados acima. Os valores guardados permanecem intocados.",
+    "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial."
   }
 }

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -71,7 +71,12 @@
     "deleteSuccess": "Credencial excluída com sucesso",
     "requiredFields": "Preencha nome, provedor e valor",
     "permissionDenied": {
-      "read": "Você não tem permissão para ver as credenciais de integração"
+      "read": "Você não tem permissão para ver as credenciais de integração",
+      "installation": "Você não tem permissão para gerenciar credenciais da instalação"
     }
+  },
+  "inUse": {
+    "title": "Em uso nesta conta",
+    "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem."
   }
 }

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -126,7 +126,8 @@
   "retirement": {
     "managedByVault": "Gerenciado pelo cofre",
     "authHeadersLocked": "Headers de autenticação agora são cadastrados no cofre (Configurações > Credenciais de integração) e referenciados acima. Os valores guardados permanecem intocados.",
-    "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial."
+    "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial.",
+    "externalKeyLocked": "A chave agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada continua funcionando até você apontar para outra credencial."
   },
   "externalAgent": {
     "hint": "Credencial do cofre para esta plataforma. Com ela definida, o runtime a usa e a chave inline abaixo vira o fallback."

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -77,7 +77,12 @@
   },
   "inUse": {
     "title": "Em uso nesta conta",
-    "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem."
+    "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem.",
+    "kinds": {
+      "tool": "Ferramenta",
+      "mcp": "Servidor MCP",
+      "bot": "Bot de canal"
+    }
   },
   "oauthSection": {
     "noSecretHint": "Estas conexões não guardam segredo no cofre: o token fica no store dono, e o que você vê aqui é lido de lá no momento da listagem.",
@@ -104,5 +109,17 @@
     },
     "disconnectSuccess": "Integração desconectada",
     "disconnectError": "Falha ao desconectar a integração"
+  },
+  "refsEditor": {
+    "label": "Segredos pelo cofre",
+    "hint": "Cada entrada substitui o header ou a variável de mesmo nome pelo valor decifrado do cofre. Uma credencial por segredo.",
+    "keyLabel": "Nome do segredo",
+    "keyPlaceholder": "ex.: Authorization",
+    "selectPlaceholder": "Escolha uma credencial",
+    "none": "Nenhuma (usar valor embutido)",
+    "add": "Adicionar segredo do cofre",
+    "remove": "Remover",
+    "nexusLabel": "Credencial do cofre",
+    "nexusHint": "Escolha a credencial do cofre que guarda a API key do Nexus. O campo abaixo continua como fallback embutido."
   }
 }

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -81,7 +81,8 @@
     "kinds": {
       "tool": "Ferramenta",
       "mcp": "Servidor MCP",
-      "bot": "Bot de canal"
+      "bot": "Bot de canal",
+      "credential": "Credencial"
     }
   },
   "oauthSection": {
@@ -126,5 +127,8 @@
     "managedByVault": "Gerenciado pelo cofre",
     "authHeadersLocked": "Headers de autenticação agora são cadastrados no cofre (Configurações > Credenciais de integração) e referenciados acima. Os valores guardados permanecem intocados.",
     "nexusKeyLocked": "A API key agora é cadastrada no cofre e referenciada pelo seletor acima. A chave guardada permanece até você apontar para outra credencial."
+  },
+  "externalAgent": {
+    "hint": "Credencial do cofre para esta plataforma. Com ela definida, o runtime a usa e a chave inline abaixo vira o fallback."
   }
 }

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -1,0 +1,77 @@
+{
+  "title": "Credenciais de integração",
+  "description": "O cofre dos segredos de ferramentas e integrações. Cadastre uma vez, referencie em todo lugar.",
+  "sections": {
+    "account": "Desta conta",
+    "installation": "Padrão da instalação",
+    "oauth": "Conexões OAuth"
+  },
+  "columns": {
+    "name": "Nome",
+    "provider": "Provedor",
+    "value": "Valor",
+    "kind": "Tipo",
+    "status": "Estado",
+    "actions": "Ações"
+  },
+  "kind": {
+    "static": "Estática",
+    "oauth": "OAuth"
+  },
+  "status": {
+    "active": "Ativa",
+    "inactive": "Inativa"
+  },
+  "actions": {
+    "add": "Nova credencial",
+    "addFirst": "Cadastrar primeira credencial",
+    "edit": "Editar",
+    "activate": "Ativar",
+    "deactivate": "Desativar",
+    "delete": "Excluir",
+    "cancel": "Cancelar",
+    "save": "Salvar"
+  },
+  "form": {
+    "title": {
+      "new": "Nova credencial",
+      "edit": "Editar credencial"
+    },
+    "labels": {
+      "name": "Nome",
+      "provider": "Provedor",
+      "value": "Valor"
+    },
+    "placeholders": {
+      "name": "ex.: Dify produção",
+      "provider": "ex.: dify, n8n, elevenlabs",
+      "valueNew": "Cole o segredo aqui",
+      "valueEdit": "Deixe vazio para manter o valor atual"
+    }
+  },
+  "empty": {
+    "title": "Nenhuma credencial cadastrada",
+    "description": "Cadastre uma credencial de integração para reusá-la em agentes, bots, ferramentas e MCPs."
+  },
+  "installationEmpty": "Nenhuma credencial padrão definida no nível da instalação.",
+  "inheritedReadOnly": "Herdada da instalação",
+  "deleteDialog": {
+    "title": "Excluir credencial",
+    "description": "Tem certeza de que deseja excluir a credencial \"{{name}}\"? Esta ação não pode ser desfeita.",
+    "inUseWarning": "Esta credencial é referenciada por {{count}} consumidor(es): {{consumers}}. Eles voltarão ao valor embutido enquanto ele existir.",
+    "cancel": "Cancelar",
+    "confirm": "Excluir"
+  },
+  "messages": {
+    "loadError": "Falha ao carregar as credenciais",
+    "saveError": "Falha ao salvar a credencial",
+    "deleteError": "Falha ao excluir a credencial",
+    "createSuccess": "Credencial criada com sucesso",
+    "updateSuccess": "Credencial atualizada com sucesso",
+    "deleteSuccess": "Credencial excluída com sucesso",
+    "requiredFields": "Preencha nome, provedor e valor",
+    "permissionDenied": {
+      "read": "Você não tem permissão para ver as credenciais de integração"
+    }
+  }
+}

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -78,5 +78,32 @@
   "inUse": {
     "title": "Em uso nesta conta",
     "empty": "Nenhum consumidor resolve credenciais pelo cofre ainda. Agentes externos, bots, ferramentas e MCPs aparecerão aqui conforme o adotarem."
+  },
+  "oauthSection": {
+    "noSecretHint": "Estas conexões não guardam segredo no cofre: o token fica no store dono, e o que você vê aqui é lido de lá no momento da listagem.",
+    "empty": "Nenhuma conexão OAuth ainda. Conecte um provedor pela tela de integrações do agente e ela aparecerá aqui.",
+    "noExpiry": "Sem expiração",
+    "columns": {
+      "agent": "Agente",
+      "expires": "Expira em"
+    },
+    "status": {
+      "connected": "Conectada",
+      "expiring": "Expirando em breve",
+      "expired": "Expirada",
+      "refresh_failed": "Falha na renovação"
+    },
+    "actions": {
+      "disconnect": "Desconectar"
+    },
+    "disconnectDialog": {
+      "title": "Desconectar integração",
+      "description": "Desconectar a conexão do {{provider}}? O agente deixa de usar esta integração.",
+      "noRevokeWarning": "Desconectar remove o acesso localmente. NÃO revoga a autorização no provedor: para revogar de verdade, use as configurações de segurança do próprio provedor.",
+      "cancel": "Cancelar",
+      "confirm": "Desconectar"
+    },
+    "disconnectSuccess": "Integração desconectada",
+    "disconnectError": "Falha ao desconectar a integração"
   }
 }

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -90,8 +90,7 @@
     "status": {
       "connected": "Conectada",
       "expiring": "Expirando em breve",
-      "expired": "Expirada",
-      "refresh_failed": "Falha na renovação"
+      "expired": "Expirada"
     },
     "actions": {
       "disconnect": "Desconectar"

--- a/src/i18n/locales/pt/integrations.json
+++ b/src/i18n/locales/pt/integrations.json
@@ -663,7 +663,9 @@
         "configure": "Configurar Integração",
         "update": "Atualizar Integração",
         "saving": "Salvando..."
-      }
+      },
+      "credentialMoved": "A chave agora é cadastrada em Configurações > Credenciais de IA. Aqui ficam só os interruptores das funções.",
+      "goToCredentials": "Ir para Credenciais de IA"
     },
     "settings": {
       "loading": "Carregando configuração...",
@@ -686,7 +688,8 @@
         "actions": {
           "edit": "Editar",
           "remove": "Remover"
-        }
+        },
+        "managedElsewhere": "Gerenciada em Credenciais de IA"
       },
       "features": {
         "title": "Recursos Disponíveis",

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -111,6 +111,7 @@
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respostas Rápidas",
       "aiCredentials": "Credenciais de IA",
+      "integrationCredentials": "Credenciais de integração",
       "messageTemplates": "Modelos de Mensagem",
       "macros": "Macros",
       "templates": "Templates",

--- a/src/i18n/locales/pt/layout.json
+++ b/src/i18n/locales/pt/layout.json
@@ -110,6 +110,7 @@
       "labels": "Etiquetas",
       "customAttributes": "Atributos Personalizados",
       "cannedResponses": "Respostas Rápidas",
+      "aiCredentials": "Credenciais de IA",
       "messageTemplates": "Modelos de Mensagem",
       "macros": "Macros",
       "templates": "Templates",

--- a/src/pages/Admin/Settings/OpenAIConfig.spec.tsx
+++ b/src/pages/Admin/Settings/OpenAIConfig.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import OpenAIConfig from './OpenAIConfig';
 
 // Radix UI Switch uses ResizeObserver internally
@@ -59,7 +60,7 @@ const EMPTY_CONFIG: Record<string, unknown> = {
 async function renderAndWait(mockData: Record<string, unknown> = EMPTY_CONFIG) {
   mockGetConfig.mockImplementation(() => Promise.resolve(mockData));
   await act(async () => {
-    render(<OpenAIConfig />);
+    render(<OpenAIConfig />, { wrapper: MemoryRouter });
   });
 }
 
@@ -70,7 +71,7 @@ describe('OpenAIConfig', () => {
 
   it('renders loading spinner before data loads', () => {
     mockGetConfig.mockReturnValue(new Promise(() => {}));
-    const { container } = render(<OpenAIConfig />);
+    const { container } = render(<OpenAIConfig />, { wrapper: MemoryRouter });
     expect(container.querySelector('.animate-spin')).toBeInTheDocument();
   });
 
@@ -92,8 +93,10 @@ describe('OpenAIConfig', () => {
 
     expect(screen.getByText('openai.connection.cardTitle')).toBeInTheDocument();
     expect(screen.getByLabelText('openai.connection.fields.apiUrl')).toBeInTheDocument();
-    expect(screen.getByLabelText('openai.connection.fields.apiSecret')).toBeInTheDocument();
     expect(screen.getByLabelText('openai.connection.fields.model')).toBeInTheDocument();
+    // EVO-2250: the credential moved to Settings > AI Credentials.
+    expect(screen.queryByLabelText('openai.connection.fields.apiSecret')).not.toBeInTheDocument();
+    expect(screen.getByText('openai.connection.credentialMoved')).toBeInTheDocument();
   });
 
   it('renders audio transcription toggle', async () => {
@@ -119,25 +122,8 @@ describe('OpenAIConfig', () => {
     }
 
     const textareas = screen.getAllByRole('textbox');
-    // 3 connection inputs (apiUrl, apiSecret, model) + 9 prompt textareas = 12
-    // But apiSecret is type="password" so not counted as textbox
-    // So: 2 inputs + 9 textareas = 11 textboxes
+    // 2 connection inputs (apiUrl, model) + 9 prompt textareas.
     expect(textareas.length).toBeGreaterThanOrEqual(9);
-  });
-
-  it('shows secret configured status for masked secret', async () => {
-    await renderAndWait({
-      ...EMPTY_CONFIG,
-      OPENAI_API_SECRET: '••••masked',
-    });
-
-    expect(screen.getByText('openai.secretConfigured')).toBeInTheDocument();
-  });
-
-  it('shows secret not configured when secret is empty', async () => {
-    await renderAndWait();
-
-    expect(screen.getByText('openai.secretNotConfigured')).toBeInTheDocument();
   });
 
   it('calls saveConfig with openai on form submit', async () => {
@@ -164,24 +150,17 @@ describe('OpenAIConfig', () => {
     });
   });
 
-  it('sends null for unmodified secret on save', async () => {
-    await renderAndWait({
-      ...EMPTY_CONFIG,
-      OPENAI_API_SECRET: '••••masked',
-    });
-    mockSaveConfig.mockResolvedValue({
-      ...EMPTY_CONFIG,
-      OPENAI_API_SECRET: '••••masked',
-    });
+  it('never sends the retired credential field on save (EVO-2250)', async () => {
+    await renderAndWait();
+    mockSaveConfig.mockResolvedValue(EMPTY_CONFIG);
 
     await act(async () => {
       fireEvent.click(screen.getByText('openai.save'));
     });
 
     await waitFor(() => {
-      expect(mockSaveConfig).toHaveBeenCalledWith('openai', expect.objectContaining({
-        OPENAI_API_SECRET: null,
-      }));
+      const [, payload] = mockSaveConfig.mock.calls[0];
+      expect(payload).not.toHaveProperty('OPENAI_API_SECRET');
     });
   });
 });

--- a/src/pages/Admin/Settings/OpenAIConfig.tsx
+++ b/src/pages/Admin/Settings/OpenAIConfig.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useForm, Controller } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -14,8 +15,9 @@ import {
   Textarea,
 } from '@evoapi/design-system';
 import { toast } from 'sonner';
-import { Loader2, Lock, LockOpen, X } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { AI_CREDENTIALS_ROUTE } from '@/components/ApiKeysModal';
 import { adminConfigService } from '@/services/admin/adminConfigService';
 import { extractError } from '@/utils/apiHelpers';
 import type { AdminConfigData } from '@/types/admin/adminConfig';
@@ -25,8 +27,7 @@ import type { AdminConfigData } from '@/types/admin/adminConfig';
 function createOpenAISchema(_t: (key: string) => string) {
   return z.object({
     OPENAI_API_URL: z.string().optional(),
-    OPENAI_API_SECRET: z.string().optional().nullable(),
-    OPENAI_MODEL: z.string().optional(),
+      OPENAI_MODEL: z.string().optional(),
     OPENAI_ENABLE_AUDIO_TRANSCRIPTION: z.union([z.boolean(), z.string()]).optional(),
     OPENAI_PROMPT_REPLY: z.string().optional(),
     OPENAI_PROMPT_SUMMARY: z.string().optional(),
@@ -44,7 +45,6 @@ type OpenAIFormData = z.infer<ReturnType<typeof createOpenAISchema>>;
 
 const DEFAULTS: OpenAIFormData = {
   OPENAI_API_URL: '',
-  OPENAI_API_SECRET: null,
   OPENAI_MODEL: '',
   OPENAI_ENABLE_AUDIO_TRANSCRIPTION: false,
   OPENAI_PROMPT_REPLY: '',
@@ -58,7 +58,9 @@ const DEFAULTS: OpenAIFormData = {
   OPENAI_PROMPT_SIMPLIFY: '',
 };
 
-const SECRET_FIELDS = ['OPENAI_API_SECRET'];
+// The AI credential moved to Settings > AI Credentials (EVO-2250). With no
+// secret left on this screen, the masking machinery it required went with it —
+// URL, model, toggle and the nine prompts are plain config.
 
 const PROMPT_FIELDS = [
   'OPENAI_PROMPT_REPLY',
@@ -72,10 +74,6 @@ const PROMPT_FIELDS = [
   'OPENAI_PROMPT_SIMPLIFY',
 ] as const;
 
-function isSecretMasked(value: unknown): boolean {
-  return typeof value === 'string' && value.includes('••••');
-}
-
 function toBool(value: unknown): boolean {
   if (typeof value === 'boolean') return value;
   if (typeof value === 'string') return value === 'true';
@@ -85,21 +83,16 @@ function toBool(value: unknown): boolean {
 function buildFormValues(data: Record<string, unknown>): OpenAIFormData {
   const formValues: Record<string, unknown> = { ...DEFAULTS };
   for (const [key, value] of Object.entries(data)) {
-    if (SECRET_FIELDS.includes(key)) {
-      formValues[key] = isSecretMasked(value) ? '' : (value ?? '');
-    } else {
-      formValues[key] = value ?? formValues[key] ?? '';
-    }
+    formValues[key] = value ?? formValues[key] ?? '';
   }
   return formValues as OpenAIFormData;
 }
 
 export default function OpenAIConfig() {
   const { t } = useLanguage('adminSettings');
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [secretModified, setSecretModified] = useState<Record<string, boolean>>({});
-  const [secretConfigured, setSecretConfigured] = useState<Record<string, boolean>>({});
 
   const openaiSchema = useMemo(() => createOpenAISchema(t), [t]);
 
@@ -107,7 +100,6 @@ export default function OpenAIConfig() {
     register,
     handleSubmit,
     reset,
-    setValue,
     control,
     formState: { errors },
   } = useForm<OpenAIFormData>({
@@ -115,20 +107,10 @@ export default function OpenAIConfig() {
     defaultValues: DEFAULTS,
   });
 
-  const updateSecretStatus = (data: Record<string, unknown>) => {
-    const configured: Record<string, boolean> = {};
-    for (const key of SECRET_FIELDS) {
-      configured[key] = isSecretMasked(data[key]);
-    }
-    setSecretConfigured(configured);
-    setSecretModified({});
-  };
-
   const loadConfig = useCallback(async () => {
     setLoading(true);
     try {
       const data = await adminConfigService.getConfig('openai');
-      updateSecretStatus(data);
       reset(buildFormValues(data));
     } catch (error) {
       toast.error(t('openai.messages.loadError'));
@@ -144,21 +126,9 @@ export default function OpenAIConfig() {
   const onSubmit = async (formData: OpenAIFormData) => {
     setSaving(true);
     try {
-      const payload: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(formData)) {
-        if (SECRET_FIELDS.includes(key)) {
-          if (!secretModified[key] || value === '') {
-            payload[key] = null;
-          } else {
-            payload[key] = value;
-          }
-        } else {
-          payload[key] = value;
-        }
-      }
+      const payload: Record<string, unknown> = { ...formData };
 
       const data = await adminConfigService.saveConfig('openai', payload as AdminConfigData);
-      updateSecretStatus(data);
       reset(buildFormValues(data));
 
       toast.success(t('openai.messages.saveSuccess'));
@@ -172,57 +142,6 @@ export default function OpenAIConfig() {
     }
   };
 
-  const handleSecretChange = (fieldName: string, value: string) => {
-    setSecretModified((prev) => ({ ...prev, [fieldName]: value.length > 0 }));
-  };
-
-  const handleClearSecret = (fieldName: string) => {
-    setValue(fieldName as keyof OpenAIFormData, '');
-    setSecretModified((prev) => ({ ...prev, [fieldName]: true }));
-  };
-
-  const renderSecretField = (fieldName: string, label: string, placeholder: string) => (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <Label htmlFor={fieldName}>{label}</Label>
-        {!secretModified[fieldName] && (
-          secretConfigured[fieldName] ? (
-            <span className="inline-flex items-center gap-1 text-xs text-green-600">
-              <Lock className="h-3 w-3" />
-              {t('openai.secretConfigured')}
-            </span>
-          ) : (
-            <span className="inline-flex items-center gap-1 text-xs text-sidebar-foreground/50">
-              <LockOpen className="h-3 w-3" />
-              {t('openai.secretNotConfigured')}
-            </span>
-          )
-        )}
-      </div>
-      <div className="relative">
-        <Input
-          id={fieldName}
-          type="password"
-          autoComplete="off"
-          placeholder={placeholder}
-          {...register(fieldName as keyof OpenAIFormData, {
-            onChange: (e: React.ChangeEvent<HTMLInputElement>) => handleSecretChange(fieldName, e.target.value),
-          })}
-        />
-        {secretConfigured[fieldName] && !secretModified[fieldName] && (
-          <button
-            type="button"
-            onClick={() => handleClearSecret(fieldName)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-sidebar-accent text-sidebar-foreground/50 hover:text-sidebar-foreground"
-            title={t('openai.clearSecret')}
-            aria-label={t('openai.clearSecret')}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        )}
-      </div>
-    </div>
-  );
 
   if (loading) {
     return (
@@ -258,7 +177,17 @@ export default function OpenAIConfig() {
               )}
             </div>
 
-            {renderSecretField('OPENAI_API_SECRET', t('openai.connection.fields.apiSecret'), t('openai.connection.placeholders.apiSecret'))}
+            <div className="rounded-lg border p-3 space-y-1">
+              <p className="text-sm">{t('openai.connection.credentialMoved')}</p>
+              <Button
+                type="button"
+                variant="link"
+                className="px-0 h-auto text-sm"
+                onClick={() => navigate(AI_CREDENTIALS_ROUTE)}
+              >
+                {t('openai.connection.goToCredentials')}
+              </Button>
+            </div>
 
             <div className="space-y-2">
               <Label htmlFor="OPENAI_MODEL">{t('openai.connection.fields.model')}</Label>

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -374,14 +374,27 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
     await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
   });
 
-  it('lists only features already wired to the resolver (1.3/1.4 add theirs)', async () => {
+  it('lists only features already wired to the resolver (1.4 adds the rest)', async () => {
     listApiKeys.mockResolvedValue([OPENAI_KEY]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
     expect(panel).toHaveTextContent('inUse.features.aiAgents');
-    expect(panel).not.toHaveTextContent('inUse.features.inboxAssist');
+    expect(panel).toHaveTextContent('inUse.features.inboxAssist');
     expect(panel).not.toHaveTextContent('inUse.features.audioTranscription');
+  });
+
+  // 1.3 AC8 + FR18: the assist cannot speak Anthropic, so it shows the
+  // installation default while AI Agents keep the account credential.
+  it('shows the assist falling back when the account credential is incompatible', async () => {
+    const anthropicActive = { ...ANTHROPIC_KEY, is_active: true };
+    listApiKeys.mockResolvedValue([INSTALLATION_KEY, anthropicActive]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Testes'));
+    expect(panel).toHaveTextContent('Chave da casa');
+    expect(panel).toHaveTextContent('inUse.fromInstallation');
   });
 });
 

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -374,14 +374,28 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
     await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
   });
 
-  it('lists only features already wired to the resolver (1.4 adds the rest)', async () => {
+  it('lists the five AI features of the CRM (1.4 completes the panel)', async () => {
     listApiKeys.mockResolvedValue([OPENAI_KEY]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
-    expect(panel).toHaveTextContent('inUse.features.aiAgents');
-    expect(panel).toHaveTextContent('inUse.features.inboxAssist');
-    expect(panel).not.toHaveTextContent('inUse.features.audioTranscription');
+    ['aiAgents', 'inboxAssist', 'audioTranscription', 'labelSuggestion', 'moderation'].forEach(
+      feature => expect(panel).toHaveTextContent(`inUse.features.${feature}`),
+    );
+  });
+
+  // 1.4 AC7: an Anthropic account credential serves Agents but none of the four
+  // OpenAI-shaped features, which fall through to the installation default.
+  it('splits agents from the OpenAI-only features when providers differ', async () => {
+    const anthropicActive = { ...ANTHROPIC_KEY, is_active: true };
+    listApiKeys.mockResolvedValue([INSTALLATION_KEY, anthropicActive]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Testes'));
+    // The house key covers transcription, labels and moderation.
+    expect(panel).toHaveTextContent('Chave da casa');
+    expect(panel).toHaveTextContent('inUse.fromInstallation');
   });
 
   // 1.3 AC8 + FR18: the assist cannot speak Anthropic, so it shows the

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -45,6 +45,7 @@ const OPENAI_KEY: ApiKey = {
   provider: 'openai',
   key_hint: '4f2a',
   openai_compatible: true,
+  scope: 'account',
   is_active: true,
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
@@ -56,9 +57,22 @@ const ANTHROPIC_KEY: ApiKey = {
   provider: 'anthropic',
   key_hint: '91bc',
   openai_compatible: false,
+  scope: 'account',
   is_active: false,
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
+};
+
+const INSTALLATION_KEY: ApiKey = {
+  id: 'key-installation',
+  name: 'Chave da casa',
+  provider: 'openai',
+  key_hint: 'aa11',
+  openai_compatible: true,
+  scope: 'installation',
+  is_active: true,
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
 };
 
 const ALL_PERMISSIONS = [
@@ -67,6 +81,10 @@ const ALL_PERMISSIONS = [
   'ai_api_keys.update',
   'ai_api_keys.delete',
 ];
+
+// Since story 1.2 the credential name also appears in the "in use" panel, so
+// table assertions resolve the row instead of the bare text.
+const findAccountRow = () => screen.findByRole('cell', { name: 'Producao' });
 
 beforeAll(() => {
   globalThis.ResizeObserver = class {
@@ -87,7 +105,7 @@ describe('AiCredentials — listing (AC1, AC7)', () => {
   it('renders each credential with a masked key, never the key itself', async () => {
     render(<AiCredentials />);
 
-    expect(await screen.findByText('Producao')).toBeInTheDocument();
+    expect(await findAccountRow()).toBeInTheDocument();
     expect(screen.getByText(maskKey('4f2a'))).toBeInTheDocument();
     expect(screen.getByText(maskKey('91bc'))).toBeInTheDocument();
     // The registry is the only source consulted.
@@ -97,7 +115,7 @@ describe('AiCredentials — listing (AC1, AC7)', () => {
   it('says which features each provider serves', async () => {
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     expect(screen.getByText('serves.all')).toBeInTheDocument();
     expect(screen.getByText('serves.agentsOnly')).toBeInTheDocument();
   });
@@ -105,7 +123,7 @@ describe('AiCredentials — listing (AC1, AC7)', () => {
   it('shows the active/inactive state per credential', async () => {
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     expect(screen.getByText('status.active')).toBeInTheDocument();
     expect(screen.getByText('status.inactive')).toBeInTheDocument();
   });
@@ -124,7 +142,7 @@ describe('AiCredentials — permission gates (AC8)', () => {
     granted = ['ai_api_keys.read'];
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
   });
 
@@ -132,7 +150,7 @@ describe('AiCredentials — permission gates (AC8)', () => {
     granted = ['ai_api_keys.read'];
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     expect(screen.queryByLabelText('actions.edit')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('actions.delete')).not.toBeInTheDocument();
   });
@@ -140,7 +158,7 @@ describe('AiCredentials — permission gates (AC8)', () => {
   it('shows edit and delete when granted (positive control)', async () => {
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     expect(screen.getAllByLabelText('actions.edit').length).toBeGreaterThan(0);
     expect(screen.getAllByLabelText('actions.delete').length).toBeGreaterThan(0);
   });
@@ -152,7 +170,7 @@ describe('AiCredentials — editing without resending the key (AC3)', () => {
     updateApiKey.mockResolvedValue(OPENAI_KEY);
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     await user.click(screen.getAllByLabelText('actions.edit')[0]);
     await user.click(await screen.findByText('actions.save'));
 
@@ -167,7 +185,7 @@ describe('AiCredentials — editing without resending the key (AC3)', () => {
     updateApiKey.mockResolvedValue(OPENAI_KEY);
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     await user.click(screen.getAllByLabelText('actions.edit')[0]);
     await user.type(await screen.findByLabelText('form.labels.key'), 'sk-rotated-0001');
     await user.click(screen.getByText('actions.save'));
@@ -183,7 +201,7 @@ describe('AiCredentials — incompatible provider warning (AC7)', () => {
     const user = userEvent.setup();
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     // The Anthropic credential is incompatible; editing it surfaces the notice.
     await user.click(screen.getAllByLabelText('actions.edit')[1]);
 
@@ -196,7 +214,7 @@ describe('AiCredentials — incompatible provider warning (AC7)', () => {
     const user = userEvent.setup();
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     await user.click(screen.getAllByLabelText('actions.edit')[0]);
 
     await screen.findByLabelText('form.labels.key');
@@ -215,7 +233,7 @@ describe('AiCredentials — delete warns about agents in use (AC5)', () => {
     });
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     await user.click(screen.getAllByLabelText('actions.delete')[0]);
 
     expect(await screen.findByRole('alert')).toHaveTextContent('deleteDialog.inUseWarning');
@@ -228,11 +246,142 @@ describe('AiCredentials — delete warns about agents in use (AC5)', () => {
     deleteApiKey.mockResolvedValue({ message: 'ok' });
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     await user.click(screen.getAllByLabelText('actions.delete')[0]);
     await user.click(await screen.findByText('deleteDialog.confirm'));
 
     await waitFor(() => expect(deleteApiKey).toHaveBeenCalledWith('key-openai'));
+  });
+});
+
+// EVO-2250 story 1.2: the installation link of the chain.
+describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
+  const findInstallationRow = () => screen.findByRole('cell', { name: 'Chave da casa' });
+
+  beforeEach(() => {
+    listApiKeys.mockResolvedValue([OPENAI_KEY, INSTALLATION_KEY]);
+  });
+
+  it('splits credentials into the account and installation sections', async () => {
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    expect(await findInstallationRow()).toBeInTheDocument();
+    // A single listing call feeds both sections.
+    expect(listApiKeys).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets an installation admin add a credential at that level', async () => {
+    const user = userEvent.setup();
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    createApiKey.mockResolvedValue(INSTALLATION_KEY);
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    // The section header carries its own add button.
+    const addButtons = screen.getAllByText('actions.add');
+    await user.click(addButtons[addButtons.length - 1]);
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da casa');
+    await user.type(screen.getByLabelText('form.labels.key'), 'sk-house-0002');
+    await user.click(screen.getByText('actions.save'));
+
+    // Provider is still required, so nothing is sent — the scope plumbing is
+    // asserted by the payload test below.
+    await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+  });
+
+  it('renders installation credentials read-only without installation_configs.manage (AC2)', async () => {
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    expect(screen.getByText('inheritedReadOnly')).toBeInTheDocument();
+    // Exactly one edit control: the account row's. The installation row has none.
+    expect(screen.getAllByLabelText('actions.edit')).toHaveLength(1);
+    expect(screen.getAllByLabelText('actions.delete')).toHaveLength(1);
+  });
+
+  it('exposes write controls on the installation row when granted (positive control)', async () => {
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    expect(screen.queryByText('inheritedReadOnly')).not.toBeInTheDocument();
+    expect(screen.getAllByLabelText('actions.edit')).toHaveLength(2);
+  });
+
+  it('sends the scope when updating an installation credential', async () => {
+    const user = userEvent.setup();
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    updateApiKey.mockResolvedValue(INSTALLATION_KEY);
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    await user.click(screen.getAllByLabelText('actions.edit')[1]);
+    await user.click(await screen.findByText('actions.save'));
+
+    await waitFor(() => expect(updateApiKey).toHaveBeenCalled());
+    const [id, payload] = updateApiKey.mock.calls[0];
+    expect(id).toBe('key-installation');
+    expect(payload.scope).toBe('installation');
+  });
+
+  it('shows the empty hint when the installation has no default', async () => {
+    listApiKeys.mockResolvedValue([OPENAI_KEY]);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    expect(screen.getByText('installationEmpty')).toBeInTheDocument();
+  });
+});
+
+// The panel answers "which credential is in effect right now" (1.2 AC9).
+describe('AiCredentials — in-use panel (1.2 AC9)', () => {
+  it('shows the account credential winning over the installation default', async () => {
+    listApiKeys.mockResolvedValue([INSTALLATION_KEY, OPENAI_KEY]);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    const panel = screen.getByLabelText('inUse.title');
+    expect(panel).toHaveTextContent('inUse.features.aiAgents');
+    expect(panel).toHaveTextContent('Producao');
+    expect(panel).toHaveTextContent('inUse.fromAccount');
+  });
+
+  it('falls back to the installation default when the account has none', async () => {
+    listApiKeys.mockResolvedValue([INSTALLATION_KEY]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Chave da casa'));
+    expect(panel).toHaveTextContent('inUse.fromInstallation');
+    expect(panel).toHaveTextContent('inUse.inheritingHint');
+  });
+
+  it('ignores an inactive account credential and inherits the default', async () => {
+    listApiKeys.mockResolvedValue([INSTALLATION_KEY, ANTHROPIC_KEY]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Chave da casa'));
+  });
+
+  it('reports no credential when nothing is configured', async () => {
+    listApiKeys.mockResolvedValue([]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+  });
+
+  it('lists only features already wired to the resolver (1.3/1.4 add theirs)', async () => {
+    listApiKeys.mockResolvedValue([OPENAI_KEY]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    expect(panel).toHaveTextContent('inUse.features.aiAgents');
+    expect(panel).not.toHaveTextContent('inUse.features.inboxAssist');
+    expect(panel).not.toHaveTextContent('inUse.features.audioTranscription');
   });
 });
 
@@ -242,7 +391,7 @@ describe('AiCredentials — creating (AC2)', () => {
     createApiKey.mockResolvedValue(OPENAI_KEY);
     render(<AiCredentials />);
 
-    await screen.findByText('Producao');
+    await findAccountRow();
     await user.click(screen.getByText('actions.add'));
 
     await user.type(await screen.findByLabelText('form.labels.name'), 'Nova');

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AiCredentials from './AiCredentials';
+import { maskKey } from '@/constants/aiProviders';
+import type { ApiKey } from '@/types/agents';
+
+// EVO-2250 story 1.1: the page reads the evo_core_api_keys registry only, never
+// returns the key to the browser, and gates every action on ai_api_keys.*.
+let granted: string[] = [];
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => granted.includes(`${resource}.${action}`),
+    isReady: true,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const listApiKeys = vi.fn();
+const createApiKey = vi.fn();
+const updateApiKey = vi.fn();
+const deleteApiKey = vi.fn();
+const listAgents = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  listApiKeys: (...args: unknown[]) => listApiKeys(...args),
+  createApiKey: (...args: unknown[]) => createApiKey(...args),
+  updateApiKey: (...args: unknown[]) => updateApiKey(...args),
+  deleteApiKey: (...args: unknown[]) => deleteApiKey(...args),
+  listAgents: (...args: unknown[]) => listAgents(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const OPENAI_KEY: ApiKey = {
+  id: 'key-openai',
+  name: 'Producao',
+  provider: 'openai',
+  key_hint: '4f2a',
+  openai_compatible: true,
+  is_active: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const ANTHROPIC_KEY: ApiKey = {
+  id: 'key-anthropic',
+  name: 'Testes',
+  provider: 'anthropic',
+  key_hint: '91bc',
+  openai_compatible: false,
+  is_active: false,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const ALL_PERMISSIONS = [
+  'ai_api_keys.read',
+  'ai_api_keys.create',
+  'ai_api_keys.update',
+  'ai_api_keys.delete',
+];
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  granted = [...ALL_PERMISSIONS];
+  listApiKeys.mockResolvedValue([OPENAI_KEY, ANTHROPIC_KEY]);
+  listAgents.mockResolvedValue({ data: [] });
+});
+
+describe('AiCredentials — listing (AC1, AC7)', () => {
+  it('renders each credential with a masked key, never the key itself', async () => {
+    render(<AiCredentials />);
+
+    expect(await screen.findByText('Producao')).toBeInTheDocument();
+    expect(screen.getByText(maskKey('4f2a'))).toBeInTheDocument();
+    expect(screen.getByText(maskKey('91bc'))).toBeInTheDocument();
+    // The registry is the only source consulted.
+    expect(listApiKeys).toHaveBeenCalledTimes(1);
+  });
+
+  it('says which features each provider serves', async () => {
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    expect(screen.getByText('serves.all')).toBeInTheDocument();
+    expect(screen.getByText('serves.agentsOnly')).toBeInTheDocument();
+  });
+
+  it('shows the active/inactive state per credential', async () => {
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    expect(screen.getByText('status.active')).toBeInTheDocument();
+    expect(screen.getByText('status.inactive')).toBeInTheDocument();
+  });
+});
+
+describe('AiCredentials — permission gates (AC8)', () => {
+  it('refuses to render the list without ai_api_keys.read', async () => {
+    granted = [];
+    render(<AiCredentials />);
+
+    expect(await screen.findByText('messages.permissionDenied.read')).toBeInTheDocument();
+    expect(listApiKeys).not.toHaveBeenCalled();
+  });
+
+  it('hides the create action without ai_api_keys.create', async () => {
+    granted = ['ai_api_keys.read'];
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
+  });
+
+  it('hides edit and delete without the matching grants', async () => {
+    granted = ['ai_api_keys.read'];
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    expect(screen.queryByLabelText('actions.edit')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('actions.delete')).not.toBeInTheDocument();
+  });
+
+  it('shows edit and delete when granted (positive control)', async () => {
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    expect(screen.getAllByLabelText('actions.edit').length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('actions.delete').length).toBeGreaterThan(0);
+  });
+});
+
+describe('AiCredentials — editing without resending the key (AC3)', () => {
+  it('omits key_value when the field is left empty', async () => {
+    const user = userEvent.setup();
+    updateApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await user.click(await screen.findByText('actions.save'));
+
+    await waitFor(() => expect(updateApiKey).toHaveBeenCalled());
+    const [, payload] = updateApiKey.mock.calls[0];
+    expect(payload).not.toHaveProperty('key_value');
+    expect(payload.name).toBe('Producao');
+  });
+
+  it('sends key_value when a new key is typed', async () => {
+    const user = userEvent.setup();
+    updateApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await user.type(await screen.findByLabelText('form.labels.key'), 'sk-rotated-0001');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(updateApiKey).toHaveBeenCalled());
+    const [, payload] = updateApiKey.mock.calls[0];
+    expect(payload.key_value).toBe('sk-rotated-0001');
+  });
+});
+
+describe('AiCredentials — incompatible provider warning (AC7)', () => {
+  it('warns without blocking when the provider is not OpenAI-compatible', async () => {
+    const user = userEvent.setup();
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    // The Anthropic credential is incompatible; editing it surfaces the notice.
+    await user.click(screen.getAllByLabelText('actions.edit')[1]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('form.incompatibleWarning');
+    // Saving stays available — the warning informs, it does not block.
+    expect(screen.getByText('actions.save')).toBeEnabled();
+  });
+
+  it('does not warn for an OpenAI-compatible provider', async () => {
+    const user = userEvent.setup();
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+
+    await screen.findByLabelText('form.labels.key');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('AiCredentials — delete warns about agents in use (AC5)', () => {
+  it('lists the agents using the credential before confirming', async () => {
+    const user = userEvent.setup();
+    listAgents.mockResolvedValue({
+      data: [
+        { id: 'a1', name: 'Atendente', api_key_id: 'key-openai' },
+        { id: 'a2', name: 'Outro', api_key_id: 'key-anthropic' },
+      ],
+    });
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('deleteDialog.inUseWarning');
+    // Nothing is deleted until the user confirms.
+    expect(deleteApiKey).not.toHaveBeenCalled();
+  });
+
+  it('deletes only after confirmation', async () => {
+    const user = userEvent.setup();
+    deleteApiKey.mockResolvedValue({ message: 'ok' });
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+    await user.click(await screen.findByText('deleteDialog.confirm'));
+
+    await waitFor(() => expect(deleteApiKey).toHaveBeenCalledWith('key-openai'));
+  });
+});
+
+describe('AiCredentials — creating (AC2)', () => {
+  it('sends name, provider and key to the registry', async () => {
+    const user = userEvent.setup();
+    createApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await screen.findByText('Producao');
+    await user.click(screen.getByText('actions.add'));
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova');
+    await user.type(screen.getByLabelText('form.labels.key'), 'sk-nova-0001');
+    await user.click(screen.getByText('actions.save'));
+
+    // Provider is required, so an untouched select must block the save.
+    await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+  });
+});

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -366,12 +366,16 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
     await waitFor(() => expect(panel).toHaveTextContent('Chave da casa'));
   });
 
-  it('reports no credential when nothing is configured', async () => {
+  // This used to assert `inUse.none` for an empty registry. That was the lie
+  // MÉDIO 15 names: an installation that has not migrated resolves through the
+  // resolver's legacy fallback, so AI is running while the registry is empty.
+  // "No credential" told the user their working AI was off.
+  it('reports the legacy fallback, not "none", when the registry is empty', async () => {
     listApiKeys.mockResolvedValue([]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
-    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
   });
 
   it('lists the five AI features of the CRM (1.4 completes the panel)', async () => {
@@ -427,5 +431,97 @@ describe('AiCredentials — creating (AC2)', () => {
 
     // Provider is required, so an untouched select must block the save.
     await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+  });
+});
+
+// EVO-2250 review, ALTO 7: the screen has always sent base_url, but the field
+// did not exist in the backend and the value was silently discarded. Now that
+// the column exists (core migration 000022), these lock the round trip.
+describe('AiCredentials — base_url round trip (ALTO 7)', () => {
+  it('sends the typed endpoint on create', async () => {
+    const user = userEvent.setup();
+    createApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.add'));
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Gateway');
+    await user.type(screen.getByLabelText('form.labels.key'), 'sk-gw-0001');
+    // The base URL input only renders for the custom OpenAI-compatible
+    // provider, which is exactly the case that needs an endpoint.
+    expect(screen.queryByLabelText('form.labels.baseUrl')).not.toBeInTheDocument();
+  });
+
+  it('renders the stored endpoint when editing a credential that has one', async () => {
+    const user = userEvent.setup();
+    listApiKeys.mockResolvedValue([
+      { ...OPENAI_KEY, provider: 'custom_openai_compatible', base_url: 'https://gw.example.com/v1' },
+    ]);
+    render(<AiCredentials />);
+
+    await screen.findByRole('cell', { name: 'Producao' });
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+
+    expect(await screen.findByLabelText('form.labels.baseUrl')).toHaveValue(
+      'https://gw.example.com/v1',
+    );
+  });
+
+  it('carries base_url in the update payload (negative proof of the discard)', async () => {
+    const user = userEvent.setup();
+    updateApiKey.mockResolvedValue(OPENAI_KEY);
+    listApiKeys.mockResolvedValue([
+      { ...OPENAI_KEY, provider: 'custom_openai_compatible', base_url: 'https://gw.example.com/v1' },
+    ]);
+    render(<AiCredentials />);
+
+    await screen.findByRole('cell', { name: 'Producao' });
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await screen.findByLabelText('form.labels.baseUrl');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(updateApiKey).toHaveBeenCalled());
+    const [, payload] = updateApiKey.mock.calls[0];
+    // This fails if the endpoint ever stops travelling: the backend replaces
+    // what it receives, so a dropped base_url is a lost endpoint.
+    expect(payload.base_url).toBe('https://gw.example.com/v1');
+  });
+});
+
+// EVO-2250 review, MÉDIO 15 and BAIXO 19.
+describe('AiCredentials — panel honesty and full agent count', () => {
+  it('says "configured before this screen" instead of "no credential" on a non-migrated install', async () => {
+    listApiKeys.mockResolvedValue([]);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    // The registry is empty but the resolver's legacy fallback still serves:
+    // claiming "no credential" told the user their working AI was off.
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
+    expect(panel).not.toHaveTextContent('inUse.none');
+  });
+
+  it('counts agents beyond the first page before confirming a delete', async () => {
+    const user = userEvent.setup();
+    const firstPage = Array.from({ length: 100 }, (_, i) => ({
+      id: `a${i}`,
+      name: `Agente ${i}`,
+      api_key_id: 'outra-chave',
+    }));
+    listAgents.mockImplementation((page?: number) =>
+      Promise.resolve({
+        data: page === 1 ? firstPage : [{ id: 'a100', name: 'Agente tardio', api_key_id: 'key-openai' }],
+      }),
+    );
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+
+    // The only agent using this credential sits on page 2: stopping at the
+    // first page told the user nothing would break.
+    expect(await screen.findByRole('alert')).toHaveTextContent('deleteDialog.inUseWarning');
+    expect(listAgents).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -1,0 +1,476 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { toast } from 'sonner';
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { AlertTriangle, Edit, Key, Loader2, Plus, Trash2 } from 'lucide-react';
+import EmptyState from '@/components/base/EmptyState';
+import {
+  AI_PROVIDERS,
+  CUSTOM_OPENAI_PROVIDER,
+  isOpenAICompatible,
+  maskKey,
+} from '@/constants/aiProviders';
+import { createApiKey, deleteApiKey, listApiKeys, listAgents, updateApiKey } from '@/services/agents';
+import type { ApiKey, ApiKeyCreate, ApiKeyUpdate } from '@/types/agents';
+
+interface CredentialDraft {
+  id?: string;
+  name: string;
+  provider: string;
+  key_value: string;
+  base_url: string;
+}
+
+const EMPTY_DRAFT: CredentialDraft = {
+  name: '',
+  provider: '',
+  key_value: '',
+  base_url: '',
+};
+
+export default function AiCredentials() {
+  const { t } = useLanguage('aiCredentials');
+  const { can, isReady: permissionsReady } = usePermissions();
+
+  const [credentials, setCredentials] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [formOpen, setFormOpen] = useState(false);
+  const [draft, setDraft] = useState<CredentialDraft>(EMPTY_DRAFT);
+  const [credentialToDelete, setCredentialToDelete] = useState<ApiKey | null>(null);
+  const [agentsUsingCredential, setAgentsUsingCredential] = useState<string[]>([]);
+
+  const canRead = can('ai_api_keys', 'read');
+  const canCreate = can('ai_api_keys', 'create');
+  const canUpdate = can('ai_api_keys', 'update');
+  const canDelete = can('ai_api_keys', 'delete');
+
+  const isEditing = Boolean(draft.id);
+
+  const loadCredentials = useCallback(async () => {
+    if (!canRead) {
+      toast.error(t('messages.permissionDenied.read'));
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setCredentials(await listApiKeys());
+    } catch (error) {
+      console.error('Error loading AI credentials:', error);
+      toast.error(t('messages.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [canRead, t]);
+
+  useEffect(() => {
+    if (!permissionsReady) {
+      return;
+    }
+
+    loadCredentials();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [permissionsReady]);
+
+  const providerLabel = useCallback(
+    (value: string) => AI_PROVIDERS.find(provider => provider.value === value)?.label ?? value,
+    [],
+  );
+
+  // The backend derives openai_compatible; fall back to the local table so the
+  // column still renders against an older core-service.
+  const servesAllFeatures = useCallback(
+    (credential: ApiKey) => credential.openai_compatible ?? isOpenAICompatible(credential.provider),
+    [],
+  );
+
+  const draftIsIncompatible = useMemo(
+    () => Boolean(draft.provider) && !isOpenAICompatible(draft.provider),
+    [draft.provider],
+  );
+
+  const openCreateForm = () => {
+    setDraft(EMPTY_DRAFT);
+    setFormOpen(true);
+  };
+
+  const openEditForm = (credential: ApiKey) => {
+    setDraft({
+      id: credential.id,
+      name: credential.name,
+      provider: credential.provider,
+      key_value: '',
+      base_url: credential.base_url ?? '',
+    });
+    setFormOpen(true);
+  };
+
+  const handleSave = async () => {
+    const needsKey = !isEditing;
+    if (!draft.name.trim() || !draft.provider || (needsKey && !draft.key_value.trim())) {
+      toast.error(t('messages.requiredFields'));
+      return;
+    }
+
+    try {
+      setSaving(true);
+
+      if (draft.id) {
+        const payload: ApiKeyUpdate = {
+          name: draft.name,
+          provider: draft.provider,
+          base_url: draft.base_url || undefined,
+        };
+        // An empty field keeps the stored key: never send a blank key_value.
+        if (draft.key_value.trim()) {
+          payload.key_value = draft.key_value;
+        }
+
+        await updateApiKey(draft.id, payload);
+        toast.success(t('messages.updateSuccess'));
+      } else {
+        const payload: ApiKeyCreate = {
+          name: draft.name,
+          provider: draft.provider,
+          key_value: draft.key_value,
+          base_url: draft.base_url || undefined,
+        };
+
+        await createApiKey(payload);
+        toast.success(t('messages.createSuccess'));
+      }
+
+      setFormOpen(false);
+      setDraft(EMPTY_DRAFT);
+      loadCredentials();
+    } catch (error) {
+      console.error('Error saving AI credential:', error);
+      toast.error(t('messages.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleActive = async (credential: ApiKey) => {
+    try {
+      setSaving(true);
+      await updateApiKey(credential.id, {
+        name: credential.name,
+        provider: credential.provider,
+        is_active: !credential.is_active,
+      });
+      toast.success(t('messages.updateSuccess'));
+      loadCredentials();
+    } catch (error) {
+      console.error('Error toggling AI credential:', error);
+      toast.error(t('messages.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const openDeleteDialog = async (credential: ApiKey) => {
+    setCredentialToDelete(credential);
+    setAgentsUsingCredential([]);
+
+    try {
+      const response = await listAgents();
+      const agents = Array.isArray(response) ? response : (response?.data ?? []);
+      setAgentsUsingCredential(
+        agents.filter(agent => agent.api_key_id === credential.id).map(agent => agent.name),
+      );
+    } catch (error) {
+      // Listing agents is advisory: a failure must not block the deletion flow.
+      console.error('Error checking agents using the credential:', error);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!credentialToDelete) {
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await deleteApiKey(credentialToDelete.id);
+      toast.success(t('messages.deleteSuccess'));
+      setCredentialToDelete(null);
+      loadCredentials();
+    } catch (error) {
+      console.error('Error deleting AI credential:', error);
+      toast.error(t('messages.deleteError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (permissionsReady && !canRead) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon={Key}
+          title={t('title')}
+          description={t('messages.permissionDenied.read')}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{t('title')}</h1>
+          <p className="text-muted-foreground">{t('description')}</p>
+        </div>
+        {canCreate && (
+          <Button onClick={openCreateForm}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t('actions.add')}
+          </Button>
+        )}
+      </div>
+
+      <section aria-label={t('sections.account')} className="space-y-3">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          {t('sections.account')}
+        </h2>
+
+        {loading ? (
+          <div className="flex items-center justify-center h-40">
+            <Loader2 className="h-8 w-8 animate-spin" />
+          </div>
+        ) : credentials.length === 0 ? (
+          <EmptyState
+            icon={Key}
+            title={t('empty.title')}
+            description={t('empty.description')}
+            action={
+              canCreate ? { label: t('actions.addFirst'), onClick: openCreateForm } : undefined
+            }
+          />
+        ) : (
+          <div className="overflow-x-auto border rounded-lg">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left p-3">{t('columns.name')}</th>
+                  <th className="text-left p-3">{t('columns.provider')}</th>
+                  <th className="text-left p-3">{t('columns.key')}</th>
+                  <th className="text-left p-3">{t('columns.serves')}</th>
+                  <th className="text-left p-3">{t('columns.status')}</th>
+                  <th className="text-right p-3">{t('columns.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {credentials.map(credential => (
+                  <tr key={credential.id} className="border-t">
+                    <td className="p-3 font-medium">{credential.name}</td>
+                    <td className="p-3">
+                      <Badge variant="outline">{providerLabel(credential.provider)}</Badge>
+                    </td>
+                    <td className="p-3 font-mono">{maskKey(credential.key_hint)}</td>
+                    <td className="p-3">
+                      {servesAllFeatures(credential) ? t('serves.all') : t('serves.agentsOnly')}
+                    </td>
+                    <td className="p-3">
+                      <Badge variant={credential.is_active ? 'default' : 'secondary'}>
+                        {credential.is_active ? t('status.active') : t('status.inactive')}
+                      </Badge>
+                    </td>
+                    <td className="p-3">
+                      <div className="flex justify-end gap-2">
+                        {canUpdate && (
+                          <>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              aria-label={t('actions.edit')}
+                              onClick={() => openEditForm(credential)}
+                            >
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              disabled={saving}
+                              onClick={() => handleToggleActive(credential)}
+                            >
+                              {credential.is_active ? t('actions.deactivate') : t('actions.activate')}
+                            </Button>
+                          </>
+                        )}
+                        {canDelete && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={t('actions.delete')}
+                            onClick={() => openDeleteDialog(credential)}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Filled by story 1.2 — the markup lands here so the table is not rebuilt. */}
+      <section aria-label={t('sections.installation')} className="space-y-3">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          {t('sections.installation')}
+        </h2>
+        <p className="text-sm text-muted-foreground border border-dashed rounded-lg p-4">
+          {t('installationEmpty')}
+        </p>
+      </section>
+
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {isEditing ? t('form.title.edit') : t('form.title.new')}
+            </DialogTitle>
+            <DialogDescription>{t('description')}</DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="credential-name">{t('form.labels.name')}</Label>
+              <Input
+                id="credential-name"
+                value={draft.name}
+                placeholder={t('form.placeholders.name')}
+                onChange={event => setDraft({ ...draft, name: event.target.value })}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="credential-provider">{t('form.labels.provider')}</Label>
+              <Select
+                value={draft.provider}
+                onValueChange={value =>
+                  setDraft({
+                    ...draft,
+                    provider: value,
+                    ...(value !== CUSTOM_OPENAI_PROVIDER ? { base_url: '' } : {}),
+                  })
+                }
+              >
+                <SelectTrigger id="credential-provider">
+                  <SelectValue placeholder={t('form.placeholders.provider')} />
+                </SelectTrigger>
+                <SelectContent>
+                  {AI_PROVIDERS.map(provider => (
+                    <SelectItem key={provider.value} value={provider.value}>
+                      {provider.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {draft.provider === CUSTOM_OPENAI_PROVIDER && (
+              <div className="grid gap-2">
+                <Label htmlFor="credential-base-url">{t('form.labels.baseUrl')}</Label>
+                <Input
+                  id="credential-base-url"
+                  value={draft.base_url}
+                  placeholder="https://api.example.com/v1"
+                  onChange={event => setDraft({ ...draft, base_url: event.target.value })}
+                />
+              </div>
+            )}
+
+            <div className="grid gap-2">
+              <Label htmlFor="credential-key">{t('form.labels.key')}</Label>
+              <Input
+                id="credential-key"
+                type="password"
+                value={draft.key_value}
+                placeholder={
+                  isEditing ? t('form.placeholders.keyEdit') : t('form.placeholders.keyNew')
+                }
+                onChange={event => setDraft({ ...draft, key_value: event.target.value })}
+              />
+            </div>
+
+            {draftIsIncompatible && (
+              <p role="alert" className="flex gap-2 text-sm text-amber-600">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                {t('form.incompatibleWarning', { provider: providerLabel(draft.provider) })}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setFormOpen(false)}>
+              {t('actions.cancel')}
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('actions.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(credentialToDelete)}
+        onOpenChange={open => !open && setCredentialToDelete(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('deleteDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('deleteDialog.description', { name: credentialToDelete?.name })}
+            </DialogDescription>
+          </DialogHeader>
+
+          {agentsUsingCredential.length > 0 && (
+            <p role="alert" className="flex gap-2 text-sm text-amber-600">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              {t('deleteDialog.inUseWarning', {
+                count: agentsUsingCredential.length,
+                agents: agentsUsingCredential.join(', '),
+              })}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCredentialToDelete(null)}>
+              {t('deleteDialog.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteConfirm} disabled={saving}>
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('deleteDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -26,9 +26,10 @@ import {
   CUSTOM_OPENAI_PROVIDER,
   isOpenAICompatible,
   maskKey,
+  resolveCredential,
 } from '@/constants/aiProviders';
 import { createApiKey, deleteApiKey, listApiKeys, listAgents, updateApiKey } from '@/services/agents';
-import type { ApiKey, ApiKeyCreate, ApiKeyUpdate } from '@/types/agents';
+import type { ApiKey, ApiKeyCreate, ApiKeyScope, ApiKeyUpdate } from '@/types/agents';
 
 interface CredentialDraft {
   id?: string;
@@ -36,6 +37,7 @@ interface CredentialDraft {
   provider: string;
   key_value: string;
   base_url: string;
+  scope: ApiKeyScope;
 }
 
 const EMPTY_DRAFT: CredentialDraft = {
@@ -43,6 +45,7 @@ const EMPTY_DRAFT: CredentialDraft = {
   provider: '',
   key_value: '',
   base_url: '',
+  scope: 'account',
 };
 
 export default function AiCredentials() {
@@ -61,8 +64,33 @@ export default function AiCredentials() {
   const canCreate = can('ai_api_keys', 'create');
   const canUpdate = can('ai_api_keys', 'update');
   const canDelete = can('ai_api_keys', 'delete');
+  // Writing at the installation level is a separate privilege: an account admin
+  // sees the inherited default but cannot change it.
+  const canManageInstallation = can('installation_configs', 'manage');
 
   const isEditing = Boolean(draft.id);
+
+  const accountCredentials = useMemo(
+    () => credentials.filter(credential => (credential.scope ?? 'account') === 'account'),
+    [credentials],
+  );
+
+  const installationCredentials = useMemo(
+    () => credentials.filter(credential => credential.scope === 'installation'),
+    [credentials],
+  );
+
+  // Only features already wired to the resolver appear here. Story 1.3 adds the
+  // inbox assist and 1.4 the remaining three.
+  const featuresInUse = useMemo(
+    () => [
+      {
+        key: 'aiAgents',
+        credential: resolveCredential(credentials),
+      },
+    ],
+    [credentials],
+  );
 
   const loadCredentials = useCallback(async () => {
     if (!canRead) {
@@ -107,8 +135,8 @@ export default function AiCredentials() {
     [draft.provider],
   );
 
-  const openCreateForm = () => {
-    setDraft(EMPTY_DRAFT);
+  const openCreateForm = (scope: ApiKeyScope = 'account') => {
+    setDraft({ ...EMPTY_DRAFT, scope });
     setFormOpen(true);
   };
 
@@ -119,14 +147,25 @@ export default function AiCredentials() {
       provider: credential.provider,
       key_value: '',
       base_url: credential.base_url ?? '',
+      scope: credential.scope ?? 'account',
     });
     setFormOpen(true);
   };
+
+  // Editing an installation credential needs the installation privilege;
+  // account credentials only need ai_api_keys.update.
+  const canWriteScope = (scope: ApiKeyScope) =>
+    scope === 'installation' ? canManageInstallation : canUpdate;
 
   const handleSave = async () => {
     const needsKey = !isEditing;
     if (!draft.name.trim() || !draft.provider || (needsKey && !draft.key_value.trim())) {
       toast.error(t('messages.requiredFields'));
+      return;
+    }
+
+    if (!canWriteScope(draft.scope)) {
+      toast.error(t('messages.permissionDenied.installation'));
       return;
     }
 
@@ -138,6 +177,7 @@ export default function AiCredentials() {
           name: draft.name,
           provider: draft.provider,
           base_url: draft.base_url || undefined,
+          scope: draft.scope,
         };
         // An empty field keeps the stored key: never send a blank key_value.
         if (draft.key_value.trim()) {
@@ -152,6 +192,7 @@ export default function AiCredentials() {
           provider: draft.provider,
           key_value: draft.key_value,
           base_url: draft.base_url || undefined,
+          scope: draft.scope,
         };
 
         await createApiKey(payload);
@@ -234,6 +275,86 @@ export default function AiCredentials() {
     );
   }
 
+  const renderCredentialsTable = (rows: ApiKey[], scope: ApiKeyScope) => {
+    const writable = canWriteScope(scope);
+
+    return (
+      <div className="overflow-x-auto border rounded-lg">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left p-3">{t('columns.name')}</th>
+              <th className="text-left p-3">{t('columns.provider')}</th>
+              <th className="text-left p-3">{t('columns.key')}</th>
+              <th className="text-left p-3">{t('columns.serves')}</th>
+              <th className="text-left p-3">{t('columns.status')}</th>
+              <th className="text-right p-3">{t('columns.actions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(credential => (
+              <tr key={credential.id} className="border-t">
+                <td className="p-3 font-medium">{credential.name}</td>
+                <td className="p-3">
+                  <Badge variant="outline">{providerLabel(credential.provider)}</Badge>
+                </td>
+                <td className="p-3 font-mono">{maskKey(credential.key_hint)}</td>
+                <td className="p-3">
+                  {servesAllFeatures(credential) ? t('serves.all') : t('serves.agentsOnly')}
+                </td>
+                <td className="p-3">
+                  <Badge variant={credential.is_active ? 'default' : 'secondary'}>
+                    {credential.is_active ? t('status.active') : t('status.inactive')}
+                  </Badge>
+                </td>
+                <td className="p-3">
+                  <div className="flex justify-end gap-2">
+                    {writable ? (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={t('actions.edit')}
+                          onClick={() => openEditForm(credential)}
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={saving}
+                          onClick={() => handleToggleActive(credential)}
+                        >
+                          {credential.is_active ? t('actions.deactivate') : t('actions.activate')}
+                        </Button>
+                      </>
+                    ) : (
+                      scope === 'installation' && (
+                        <span className="text-xs text-muted-foreground">
+                          {t('inheritedReadOnly')}
+                        </span>
+                      )
+                    )}
+                    {canDelete && writable && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label={t('actions.delete')}
+                        onClick={() => openDeleteDialog(credential)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
   return (
     <div className="p-6 space-y-6">
       <div className="flex items-start justify-between gap-4">
@@ -242,12 +363,43 @@ export default function AiCredentials() {
           <p className="text-muted-foreground">{t('description')}</p>
         </div>
         {canCreate && (
-          <Button onClick={openCreateForm}>
+          <Button onClick={() => openCreateForm('account')}>
             <Plus className="mr-2 h-4 w-4" />
             {t('actions.add')}
           </Button>
         )}
       </div>
+
+      {/* Answers "which credential is in effect right now". Story 1.3 adds the
+          inbox assist row and 1.4 the remaining three. */}
+      <section
+        aria-label={t('inUse.title')}
+        className="border rounded-lg p-4 space-y-2"
+      >
+        <h2 className="text-sm font-medium">{t('inUse.title')}</h2>
+
+        {featuresInUse.map(feature => (
+          <div key={feature.key} className="flex items-baseline gap-2 text-sm">
+            <span className="text-muted-foreground">{t(`inUse.features.${feature.key}`)}</span>
+            {feature.credential ? (
+              <>
+                <span className="font-medium">{feature.credential.name}</span>
+                <span className="text-xs text-muted-foreground">
+                  {(feature.credential.scope ?? 'account') === 'installation'
+                    ? t('inUse.fromInstallation')
+                    : t('inUse.fromAccount')}
+                </span>
+              </>
+            ) : (
+              <span className="text-muted-foreground">{t('inUse.none')}</span>
+            )}
+          </div>
+        ))}
+
+        {accountCredentials.length === 0 && installationCredentials.length > 0 && (
+          <p className="text-xs text-muted-foreground">{t('inUse.inheritingHint')}</p>
+        )}
+      </section>
 
       <section aria-label={t('sections.account')} className="space-y-3">
         <h2 className="text-sm font-medium uppercase text-muted-foreground">
@@ -258,94 +410,42 @@ export default function AiCredentials() {
           <div className="flex items-center justify-center h-40">
             <Loader2 className="h-8 w-8 animate-spin" />
           </div>
-        ) : credentials.length === 0 ? (
+        ) : accountCredentials.length === 0 ? (
           <EmptyState
             icon={Key}
             title={t('empty.title')}
             description={t('empty.description')}
             action={
-              canCreate ? { label: t('actions.addFirst'), onClick: openCreateForm } : undefined
+              canCreate
+                ? { label: t('actions.addFirst'), onClick: () => openCreateForm('account') }
+                : undefined
             }
           />
         ) : (
-          <div className="overflow-x-auto border rounded-lg">
-            <table className="w-full text-sm">
-              <thead className="bg-muted/50">
-                <tr>
-                  <th className="text-left p-3">{t('columns.name')}</th>
-                  <th className="text-left p-3">{t('columns.provider')}</th>
-                  <th className="text-left p-3">{t('columns.key')}</th>
-                  <th className="text-left p-3">{t('columns.serves')}</th>
-                  <th className="text-left p-3">{t('columns.status')}</th>
-                  <th className="text-right p-3">{t('columns.actions')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {credentials.map(credential => (
-                  <tr key={credential.id} className="border-t">
-                    <td className="p-3 font-medium">{credential.name}</td>
-                    <td className="p-3">
-                      <Badge variant="outline">{providerLabel(credential.provider)}</Badge>
-                    </td>
-                    <td className="p-3 font-mono">{maskKey(credential.key_hint)}</td>
-                    <td className="p-3">
-                      {servesAllFeatures(credential) ? t('serves.all') : t('serves.agentsOnly')}
-                    </td>
-                    <td className="p-3">
-                      <Badge variant={credential.is_active ? 'default' : 'secondary'}>
-                        {credential.is_active ? t('status.active') : t('status.inactive')}
-                      </Badge>
-                    </td>
-                    <td className="p-3">
-                      <div className="flex justify-end gap-2">
-                        {canUpdate && (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              aria-label={t('actions.edit')}
-                              onClick={() => openEditForm(credential)}
-                            >
-                              <Edit className="h-4 w-4" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              disabled={saving}
-                              onClick={() => handleToggleActive(credential)}
-                            >
-                              {credential.is_active ? t('actions.deactivate') : t('actions.activate')}
-                            </Button>
-                          </>
-                        )}
-                        {canDelete && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            aria-label={t('actions.delete')}
-                            onClick={() => openDeleteDialog(credential)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </Button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          renderCredentialsTable(accountCredentials, 'account')
         )}
       </section>
 
-      {/* Filled by story 1.2 — the markup lands here so the table is not rebuilt. */}
       <section aria-label={t('sections.installation')} className="space-y-3">
-        <h2 className="text-sm font-medium uppercase text-muted-foreground">
-          {t('sections.installation')}
-        </h2>
-        <p className="text-sm text-muted-foreground border border-dashed rounded-lg p-4">
-          {t('installationEmpty')}
-        </p>
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-sm font-medium uppercase text-muted-foreground">
+            {t('sections.installation')}
+          </h2>
+          {canManageInstallation && (
+            <Button variant="outline" size="sm" onClick={() => openCreateForm('installation')}>
+              <Plus className="mr-2 h-4 w-4" />
+              {t('actions.add')}
+            </Button>
+          )}
+        </div>
+
+        {loading ? null : installationCredentials.length === 0 ? (
+          <p className="text-sm text-muted-foreground border border-dashed rounded-lg p-4">
+            {t('installationEmpty')}
+          </p>
+        ) : (
+          renderCredentialsTable(installationCredentials, 'installation')
+        )}
       </section>
 
       <Dialog open={formOpen} onOpenChange={setFormOpen}>

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -80,13 +80,18 @@ export default function AiCredentials() {
     [credentials],
   );
 
-  // Only features already wired to the resolver appear here. Story 1.3 adds the
-  // inbox assist and 1.4 the remaining three.
+  // Only features already wired to the resolver appear here. Story 1.4 adds the
+  // remaining three. The assist only speaks the OpenAI protocol, so it resolves
+  // with the same compatibility filter the backend applies.
   const featuresInUse = useMemo(
     () => [
       {
         key: 'aiAgents',
         credential: resolveCredential(credentials),
+      },
+      {
+        key: 'inboxAssist',
+        credential: resolveCredential(credentials, { openAICompatibleOnly: true }),
       },
     ],
     [credentials],

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -80,22 +80,20 @@ export default function AiCredentials() {
     [credentials],
   );
 
-  // Only features already wired to the resolver appear here. Story 1.4 adds the
-  // remaining three. The assist only speaks the OpenAI protocol, so it resolves
-  // with the same compatibility filter the backend applies.
-  const featuresInUse = useMemo(
-    () => [
-      {
-        key: 'aiAgents',
-        credential: resolveCredential(credentials),
-      },
-      {
-        key: 'inboxAssist',
-        credential: resolveCredential(credentials, { openAICompatibleOnly: true }),
-      },
-    ],
-    [credentials],
-  );
+  // Every AI feature of the CRM, mirroring Ai::ConsumerCompatibility. Agents
+  // reach any provider; the other four build OpenAI-shaped requests, so they
+  // resolve with the same compatibility filter the backend applies.
+  const featuresInUse = useMemo(() => {
+    const openAIOnly = resolveCredential(credentials, { openAICompatibleOnly: true });
+
+    return [
+      { key: 'aiAgents', credential: resolveCredential(credentials) },
+      { key: 'inboxAssist', credential: openAIOnly },
+      { key: 'audioTranscription', credential: openAIOnly },
+      { key: 'labelSuggestion', credential: openAIOnly },
+      { key: 'moderation', credential: openAIOnly },
+    ];
+  }, [credentials]);
 
   const loadCredentials = useCallback(async () => {
     if (!canRead) {

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -26,7 +26,7 @@ import {
   CUSTOM_OPENAI_PROVIDER,
   isOpenAICompatible,
   maskKey,
-  resolveCredential,
+  resolveCredentialState,
 } from '@/constants/aiProviders';
 import { createApiKey, deleteApiKey, listApiKeys, listAgents, updateApiKey } from '@/services/agents';
 import type { ApiKey, ApiKeyCreate, ApiKeyScope, ApiKeyUpdate } from '@/types/agents';
@@ -83,17 +83,30 @@ export default function AiCredentials() {
   // Every AI feature of the CRM, mirroring Ai::ConsumerCompatibility. Agents
   // reach any provider; the other four build OpenAI-shaped requests, so they
   // resolve with the same compatibility filter the backend applies.
+  // An installation that has not migrated resolves through the resolver's
+  // legacy fallback, so AI works while the registry is empty. The signal comes
+  // from the server (a credential imported by the 1.5 task marks a migrated
+  // install); with the registry empty and no such mark, the panel says
+  // "legacy" instead of the flat lie "no credential" (review, MÉDIO 15).
+  const legacyActive = useMemo(
+    () => credentials.length === 0,
+    [credentials],
+  );
+
   const featuresInUse = useMemo(() => {
-    const openAIOnly = resolveCredential(credentials, { openAICompatibleOnly: true });
+    const openAIOnly = resolveCredentialState(credentials, {
+      openAICompatibleOnly: true,
+      legacyActive,
+    });
 
     return [
-      { key: 'aiAgents', credential: resolveCredential(credentials) },
-      { key: 'inboxAssist', credential: openAIOnly },
-      { key: 'audioTranscription', credential: openAIOnly },
-      { key: 'labelSuggestion', credential: openAIOnly },
-      { key: 'moderation', credential: openAIOnly },
+      { key: 'aiAgents', resolution: resolveCredentialState(credentials, { legacyActive }) },
+      { key: 'inboxAssist', resolution: openAIOnly },
+      { key: 'audioTranscription', resolution: openAIOnly },
+      { key: 'labelSuggestion', resolution: openAIOnly },
+      { key: 'moderation', resolution: openAIOnly },
     ];
-  }, [credentials]);
+  }, [credentials, legacyActive]);
 
   const loadCredentials = useCallback(async () => {
     if (!canRead) {
@@ -231,13 +244,36 @@ export default function AiCredentials() {
     }
   };
 
+  // Walks the agent listing to the end. Bounded so a paging bug on the server
+  // cannot spin here forever; the bound is far above any real agent count.
+  const listAllAgents = async () => {
+    const PAGE_SIZE = 100;
+    const MAX_PAGES = 50;
+    const collected: { api_key_id?: string; name: string }[] = [];
+
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const response = await listAgents(page, PAGE_SIZE);
+      const batch = Array.isArray(response) ? response : (response?.data ?? []);
+      collected.push(...batch);
+
+      if (batch.length < PAGE_SIZE) {
+        break;
+      }
+    }
+
+    return collected;
+  };
+
   const openDeleteDialog = async (credential: ApiKey) => {
     setCredentialToDelete(credential);
     setAgentsUsingCredential([]);
 
     try {
-      const response = await listAgents();
-      const agents = Array.isArray(response) ? response : (response?.data ?? []);
+      // Every page, not just the first: the warning exists to say what breaks,
+      // and an agent past the default page size used to go uncounted, so the
+      // user confirmed a delete believing nothing used the credential
+      // (EVO-2250 review, BAIXO 19).
+      const agents = await listAllAgents();
       setAgentsUsingCredential(
         agents.filter(agent => agent.api_key_id === credential.id).map(agent => agent.name),
       );
@@ -384,15 +420,17 @@ export default function AiCredentials() {
         {featuresInUse.map(feature => (
           <div key={feature.key} className="flex items-baseline gap-2 text-sm">
             <span className="text-muted-foreground">{t(`inUse.features.${feature.key}`)}</span>
-            {feature.credential ? (
+            {feature.resolution.state === 'registry' ? (
               <>
-                <span className="font-medium">{feature.credential.name}</span>
+                <span className="font-medium">{feature.resolution.credential.name}</span>
                 <span className="text-xs text-muted-foreground">
-                  {(feature.credential.scope ?? 'account') === 'installation'
+                  {(feature.resolution.credential.scope ?? 'account') === 'installation'
                     ? t('inUse.fromInstallation')
                     : t('inUse.fromAccount')}
                 </span>
               </>
+            ) : feature.resolution.state === 'legacy' ? (
+              <span className="text-muted-foreground">{t('inUse.legacy')}</span>
             ) : (
               <span className="text-muted-foreground">{t('inUse.none')}</span>
             )}

--- a/src/pages/Customer/Settings/AiCredentials/index.ts
+++ b/src/pages/Customer/Settings/AiCredentials/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AiCredentials';

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -26,12 +26,23 @@ const listIntegrationCredentials = vi.fn();
 const createIntegrationCredential = vi.fn();
 const updateIntegrationCredential = vi.fn();
 const deleteIntegrationCredential = vi.fn();
+const listCustomTools = vi.fn();
+const listCustomMcpServers = vi.fn();
+const listAgentBots = vi.fn();
 
 vi.mock('@/services/agents', () => ({
   listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
   createIntegrationCredential: (...args: unknown[]) => createIntegrationCredential(...args),
   updateIntegrationCredential: (...args: unknown[]) => updateIntegrationCredential(...args),
   deleteIntegrationCredential: (...args: unknown[]) => deleteIntegrationCredential(...args),
+  listCustomTools: (...args: unknown[]) => listCustomTools(...args),
+  listCustomMcpServers: (...args: unknown[]) => listCustomMcpServers(...args),
+}));
+
+vi.mock('@/services/channels/agentBotsService', () => ({
+  default: {
+    getAll: (...args: unknown[]) => listAgentBots(...args),
+  },
 }));
 
 const deleteIntegration = vi.fn();
@@ -132,6 +143,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   granted = [...ALL_PERMISSIONS];
   listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, ELEVENLABS_CREDENTIAL]);
+  listCustomTools.mockResolvedValue([]);
+  listCustomMcpServers.mockResolvedValue([]);
+  listAgentBots.mockResolvedValue([]);
 });
 
 describe('IntegrationCredentials — listing (AC1, AC3)', () => {
@@ -418,15 +432,56 @@ describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
   });
 });
 
-// The panel answers "which credential is in effect" and is born empty: the
-// consumers plug in with stories 2.3/2.4 (2.2 AC9).
-describe('IntegrationCredentials — in-use panel (2.2 AC9)', () => {
+// The panel answers "which credential is in effect". Born empty in 2.2; the
+// 2.4 consumers (tools, MCPs, bots) fill it from their own listings.
+describe('IntegrationCredentials — in-use panel (2.2 AC9, 2.4 AC10)', () => {
   it('renders the panel above the lists with the empty explanation', async () => {
     render(<IntegrationCredentials />);
 
     await findAccountRow();
     const panel = screen.getByLabelText('inUse.title');
     expect(panel).toHaveTextContent('inUse.empty');
+  });
+
+  it('lists tools, MCPs and bots that reference the vault, with the credential name (2.4 AC10)', async () => {
+    listCustomTools.mockResolvedValue([
+      {
+        id: 'tool-1',
+        name: 'CRM lookup',
+        credential_refs: { Authorization: 'cred-dify' },
+      },
+      { id: 'tool-2', name: 'Sem cofre', credential_refs: {} },
+    ]);
+    listCustomMcpServers.mockResolvedValue([
+      { id: 'mcp-1', name: 'Notion MCP', credential_refs: { 'X-API-Key': 'cred-elevenlabs' } },
+    ]);
+    listAgentBots.mockResolvedValue([
+      { id: 'bot-1', name: 'Bot vendas', credential_id: 'cred-dify' },
+      { id: 'bot-2', name: 'Bot webhook' },
+    ]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('CRM lookup'));
+    // The reference resolves to the credential NAME, not the raw id.
+    expect(panel).toHaveTextContent('Dify producao');
+    expect(panel).toHaveTextContent('Notion MCP');
+    expect(panel).toHaveTextContent('ElevenLabs');
+    expect(panel).toHaveTextContent('Bot vendas');
+    // Consumers without a vault reference stay out (negative proof: a panel
+    // listing every consumer would drag webhook bots and plain tools in).
+    expect(panel).not.toHaveTextContent('Sem cofre');
+    expect(panel).not.toHaveTextContent('Bot webhook');
+    expect(panel).not.toHaveTextContent('inUse.empty');
+  });
+
+  it('keeps the vault page alive when a consumer listing fails (advisory)', async () => {
+    listCustomTools.mockRejectedValue(new Error('403'));
+    render(<IntegrationCredentials />);
+
+    expect(await findAccountRow()).toBeInTheDocument();
+    expect(screen.getByLabelText('inUse.title')).toHaveTextContent('inUse.empty');
   });
 });
 

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import IntegrationCredentials from './IntegrationCredentials';
+import { parseOwnerTimestamp } from './ownerTimestamp';
 import { maskKey } from '@/constants/aiProviders';
 import type { IntegrationCredential } from '@/types/agents';
 
@@ -482,6 +483,60 @@ describe('IntegrationCredentials — in-use panel (2.2 AC9, 2.4 AC10)', () => {
 
     expect(await findAccountRow()).toBeInTheDocument();
     expect(screen.getByLabelText('inUse.title')).toHaveTextContent('inUse.empty');
+  });
+
+  // AC10 complete: the backend aggregates the consumers of each credential
+  // into referenced_by, covering external agents too — which the client-side
+  // join never could (per-agent fetches).
+  it('prefers the server-side referenced_by and skips the client-side join (negative proof)', async () => {
+    listIntegrationCredentials.mockResolvedValue([
+      { ...DIFY_CREDENTIAL, referenced_by: ['Agente Dify', 'Tool CRM lookup'] },
+      { ...ELEVENLABS_CREDENTIAL, referenced_by: [] },
+    ]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Agente Dify, Tool CRM lookup'));
+    expect(panel).toHaveTextContent('Dify producao');
+    // A credential nobody references stays out of the panel.
+    expect(panel).not.toHaveTextContent('ElevenLabs');
+    // With the server answering, the client-side join must stay OFF: double
+    // sourcing would duplicate rows and reintroduce the per-consumer fetches.
+    expect(listCustomTools).not.toHaveBeenCalled();
+    expect(listCustomMcpServers).not.toHaveBeenCalled();
+    expect(listAgentBots).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the client-side join when no row carries referenced_by (older backend)', async () => {
+    listCustomTools.mockResolvedValue([
+      { id: 'tool-1', name: 'CRM lookup', credential_refs: { Authorization: 'cred-dify' } },
+    ]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('CRM lookup'));
+    expect(listCustomTools).toHaveBeenCalled();
+  });
+});
+
+// The owner store writes naive UTC timestamps; parsing them as local time
+// shifts the expiry by the viewer's offset.
+describe('parseOwnerTimestamp — naive timestamps are UTC', () => {
+  it('reads a naive timestamp as UTC, identical to its zoned form', () => {
+    expect(parseOwnerTimestamp('2026-08-15T00:00:00').getTime()).toBe(
+      new Date('2026-08-15T00:00:00Z').getTime(),
+    );
+  });
+
+  it('passes zoned values through untouched', () => {
+    expect(parseOwnerTimestamp('2026-08-15T00:00:00Z').getTime()).toBe(
+      new Date('2026-08-15T00:00:00Z').getTime(),
+    );
+    expect(parseOwnerTimestamp('2026-08-15T03:00:00-03:00').getTime()).toBe(
+      new Date('2026-08-15T06:00:00Z').getTime(),
+    );
   });
 });
 

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import IntegrationCredentials from './IntegrationCredentials';
+import { maskKey } from '@/constants/aiProviders';
+import type { IntegrationCredential } from '@/types/agents';
+
+// EVO-2250 story 2.1: the vault page reads the new registry only, never
+// returns the value to the browser, gates every action on
+// ai_integration_credentials.* and only creates `static` credentials.
+let granted: string[] = [];
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => granted.includes(`${resource}.${action}`),
+    isReady: true,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const listIntegrationCredentials = vi.fn();
+const createIntegrationCredential = vi.fn();
+const updateIntegrationCredential = vi.fn();
+const deleteIntegrationCredential = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+  createIntegrationCredential: (...args: unknown[]) => createIntegrationCredential(...args),
+  updateIntegrationCredential: (...args: unknown[]) => updateIntegrationCredential(...args),
+  deleteIntegrationCredential: (...args: unknown[]) => deleteIntegrationCredential(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const DIFY_CREDENTIAL: IntegrationCredential = {
+  id: 'cred-dify',
+  name: 'Dify producao',
+  provider: 'dify',
+  kind: 'static',
+  value_hint: '4f2a',
+  value_format: 'scalar',
+  scope: 'account',
+  is_active: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const ELEVENLABS_CREDENTIAL: IntegrationCredential = {
+  id: 'cred-elevenlabs',
+  name: 'ElevenLabs',
+  provider: 'elevenlabs',
+  kind: 'static',
+  value_hint: '91bc',
+  value_format: 'scalar',
+  scope: 'account',
+  is_active: false,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const INSTALLATION_CREDENTIAL: IntegrationCredential = {
+  id: 'cred-installation',
+  name: 'n8n da casa',
+  provider: 'n8n',
+  kind: 'static',
+  value_hint: 'aa11',
+  value_format: 'composite',
+  scope: 'installation',
+  is_active: true,
+  created_at: '2026-06-01T00:00:00Z',
+  updated_at: '2026-06-01T00:00:00Z',
+};
+
+const OAUTH_CREDENTIAL: IntegrationCredential = {
+  id: 'cred-oauth-github',
+  name: 'GitHub',
+  provider: 'github',
+  kind: 'oauth',
+  scope: 'account',
+  owner_store: 'agent_integration',
+  owner_ref: 'integration-1',
+  is_active: true,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const ALL_PERMISSIONS = [
+  'ai_integration_credentials.read',
+  'ai_integration_credentials.create',
+  'ai_integration_credentials.update',
+  'ai_integration_credentials.delete',
+];
+
+const findAccountRow = () => screen.findByRole('cell', { name: 'Dify producao' });
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  granted = [...ALL_PERMISSIONS];
+  listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, ELEVENLABS_CREDENTIAL]);
+});
+
+describe('IntegrationCredentials — listing (AC1, AC3)', () => {
+  it('renders each credential with a masked hint, never the value itself', async () => {
+    render(<IntegrationCredentials />);
+
+    expect(await findAccountRow()).toBeInTheDocument();
+    expect(screen.getByText(maskKey('4f2a'))).toBeInTheDocument();
+    expect(screen.getByText(maskKey('91bc'))).toBeInTheDocument();
+    // The new registry is the only source consulted.
+    expect(listIntegrationCredentials).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows provider, kind and state per credential', async () => {
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(screen.getByText('dify')).toBeInTheDocument();
+    expect(screen.getAllByText('kind.static').length).toBe(2);
+    expect(screen.getByText('status.active')).toBeInTheDocument();
+    expect(screen.getByText('status.inactive')).toBeInTheDocument();
+  });
+});
+
+describe('IntegrationCredentials — permission gates (AC7)', () => {
+  it('refuses to render the list without ai_integration_credentials.read', async () => {
+    granted = [];
+    render(<IntegrationCredentials />);
+
+    expect(await screen.findByText('messages.permissionDenied.read')).toBeInTheDocument();
+    expect(listIntegrationCredentials).not.toHaveBeenCalled();
+  });
+
+  it('hides the create action without ai_integration_credentials.create', async () => {
+    granted = ['ai_integration_credentials.read'];
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
+  });
+
+  it('hides edit and delete without the matching grants', async () => {
+    granted = ['ai_integration_credentials.read'];
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(screen.queryByLabelText('actions.edit')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('actions.delete')).not.toBeInTheDocument();
+  });
+
+  it('shows edit and delete when granted (positive control)', async () => {
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(screen.getAllByLabelText('actions.edit').length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText('actions.delete').length).toBeGreaterThan(0);
+  });
+});
+
+describe('IntegrationCredentials — creating only static (AC2, AC4)', () => {
+  it('sends kind static and never offers an oauth choice', async () => {
+    const user = userEvent.setup();
+    createIntegrationCredential.mockResolvedValue(DIFY_CREDENTIAL);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.add'));
+
+    // The form has no kind selector at all: oauth is opened by story 2.5.
+    expect(screen.queryByText('kind.oauth')).not.toBeInTheDocument();
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova');
+    await user.type(screen.getByLabelText('form.labels.provider'), 'dify');
+    await user.type(screen.getByLabelText('form.labels.value'), 'app-secret-0001');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createIntegrationCredential).toHaveBeenCalled());
+    const [payload] = createIntegrationCredential.mock.calls[0];
+    expect(payload.kind).toBe('static');
+    expect(payload.value).toBe('app-secret-0001');
+  });
+
+  it('blocks the save when name, provider or value is missing', async () => {
+    const user = userEvent.setup();
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.add'));
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Sem valor');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createIntegrationCredential).not.toHaveBeenCalled());
+  });
+});
+
+describe('IntegrationCredentials — editing without resending the value (AC3)', () => {
+  it('omits value when the field is left empty', async () => {
+    const user = userEvent.setup();
+    updateIntegrationCredential.mockResolvedValue(DIFY_CREDENTIAL);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await user.click(await screen.findByText('actions.save'));
+
+    await waitFor(() => expect(updateIntegrationCredential).toHaveBeenCalled());
+    const [, payload] = updateIntegrationCredential.mock.calls[0];
+    expect(payload).not.toHaveProperty('value');
+    expect(payload.name).toBe('Dify producao');
+  });
+
+  it('sends the value when a new one is typed', async () => {
+    const user = userEvent.setup();
+    updateIntegrationCredential.mockResolvedValue(DIFY_CREDENTIAL);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await user.type(await screen.findByLabelText('form.labels.value'), 'rotated-0001');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(updateIntegrationCredential).toHaveBeenCalled());
+    const [, payload] = updateIntegrationCredential.mock.calls[0];
+    expect(payload.value).toBe('rotated-0001');
+  });
+});
+
+describe('IntegrationCredentials — oauth rows stay out of the static tables (AC4)', () => {
+  it('keeps an oauth credential off the account and installation sections', async () => {
+    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, OAUTH_CREDENTIAL]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    // The oauth reference is not a static credential: it belongs to the
+    // connections section, hidden until story 2.5.
+    expect(screen.queryByRole('cell', { name: 'GitHub' })).not.toBeInTheDocument();
+  });
+});
+
+describe('IntegrationCredentials — installation section (AC1, story 2.2 slot)', () => {
+  it('renders installation credentials read-only', async () => {
+    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, INSTALLATION_CREDENTIAL]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(await screen.findByRole('cell', { name: 'n8n da casa' })).toBeInTheDocument();
+    expect(screen.getByText('inheritedReadOnly')).toBeInTheDocument();
+    // Exactly one edit control: the account row's.
+    expect(screen.getAllByLabelText('actions.edit')).toHaveLength(1);
+  });
+
+  it('shows the empty hint when the installation has nothing', async () => {
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(screen.getByText('installationEmpty')).toBeInTheDocument();
+  });
+});
+
+describe('IntegrationCredentials — deleting (AC6)', () => {
+  it('warns about consumers referencing the credential before confirming', async () => {
+    const user = userEvent.setup();
+    listIntegrationCredentials.mockResolvedValue([
+      { ...DIFY_CREDENTIAL, referenced_by: ['Agente Dify', 'Bot vendas'] },
+    ]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('deleteDialog.inUseWarning');
+    expect(deleteIntegrationCredential).not.toHaveBeenCalled();
+  });
+
+  it('deletes only after confirmation', async () => {
+    const user = userEvent.setup();
+    deleteIntegrationCredential.mockResolvedValue({ message: 'ok' });
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+    await user.click(await screen.findByText('deleteDialog.confirm'));
+
+    await waitFor(() => expect(deleteIntegrationCredential).toHaveBeenCalledWith('cred-dify'));
+  });
+});

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import IntegrationCredentials from './IntegrationCredentials';
 import { maskKey } from '@/constants/aiProviders';
@@ -32,6 +32,14 @@ vi.mock('@/services/agents', () => ({
   createIntegrationCredential: (...args: unknown[]) => createIntegrationCredential(...args),
   updateIntegrationCredential: (...args: unknown[]) => updateIntegrationCredential(...args),
   deleteIntegrationCredential: (...args: unknown[]) => deleteIntegrationCredential(...args),
+}));
+
+const deleteIntegration = vi.fn();
+
+vi.mock('@/services/agents/agentIntegrationsService', () => ({
+  default: {
+    deleteIntegration: (...args: unknown[]) => deleteIntegration(...args),
+  },
 }));
 
 vi.mock('sonner', () => ({
@@ -85,9 +93,22 @@ const OAUTH_CREDENTIAL: IntegrationCredential = {
   scope: 'account',
   owner_store: 'agent_integration',
   owner_ref: 'integration-1',
+  connection_status: 'connected',
+  connection_expires_at: '2026-08-15T00:00:00Z',
+  agent_id: 'agent-1',
+  agent_name: 'Atendente',
   is_active: true,
   created_at: '2026-07-01T00:00:00Z',
   updated_at: '2026-07-01T00:00:00Z',
+};
+
+const OAUTH_EXPIRED: IntegrationCredential = {
+  ...OAUTH_CREDENTIAL,
+  id: 'cred-oauth-stripe',
+  provider: 'stripe',
+  agent_id: 'agent-2',
+  agent_name: 'Cobrança',
+  connection_status: 'expired',
 };
 
 const ALL_PERMISSIONS = [
@@ -238,15 +259,92 @@ describe('IntegrationCredentials — editing without resending the value (AC3)',
   });
 });
 
-describe('IntegrationCredentials — oauth rows stay out of the static tables (AC4)', () => {
-  it('keeps an oauth credential off the account and installation sections', async () => {
-    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, OAUTH_CREDENTIAL]);
+// EVO-2250 story 2.5 (front): OAuth connections render by reference. Status
+// and expiry come straight from the listing response; there is no secret in
+// the vault for these rows and therefore no value to see or edit.
+describe('IntegrationCredentials — OAuth connections section (2.5 AC1, AC2, AC7)', () => {
+  const oauthSection = () => screen.getByLabelText('sections.oauth');
+
+  beforeEach(() => {
+    granted = [...ALL_PERMISSIONS, 'ai_agents.update'];
+    listIntegrationCredentials.mockResolvedValue([
+      DIFY_CREDENTIAL,
+      OAUTH_CREDENTIAL,
+      OAUTH_EXPIRED,
+    ]);
+  });
+
+  it('keeps oauth rows out of the static tables and inside the connections section', async () => {
     render(<IntegrationCredentials />);
 
     await findAccountRow();
-    // The oauth reference is not a static credential: it belongs to the
-    // connections section, hidden until story 2.5.
-    expect(screen.queryByRole('cell', { name: 'GitHub' })).not.toBeInTheDocument();
+    const section = oauthSection();
+    expect(within(section).getByText('github')).toBeInTheDocument();
+    expect(within(section).getByText('Atendente')).toBeInTheDocument();
+    // The static (account) table never lists the oauth reference.
+    const accountSection = screen.getByLabelText('sections.account');
+    expect(within(accountSection).queryByText('github')).not.toBeInTheDocument();
+  });
+
+  it('renders the state exactly as the response reports it, per row (AC7)', async () => {
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const section = oauthSection();
+    expect(within(section).getByText('oauthSection.status.connected')).toBeInTheDocument();
+    expect(within(section).getByText('oauthSection.status.expired')).toBeInTheDocument();
+    expect(within(section).getByText('oauthSection.noSecretHint')).toBeInTheDocument();
+  });
+
+  it('never offers value editing or a masked value on an oauth row (negative proof, AC2)', async () => {
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const section = oauthSection();
+    // A row rendered through the static table would expose these controls:
+    // this test fails if oauth rows ever share that rendering path.
+    expect(within(section).queryByLabelText('actions.edit')).not.toBeInTheDocument();
+    expect(within(section).queryByLabelText('actions.delete')).not.toBeInTheDocument();
+    expect(within(section).queryByText(maskKey('4f2a'))).not.toBeInTheDocument();
+    // And the page-wide edit controls count only the static account row.
+    expect(screen.getAllByLabelText('actions.edit')).toHaveLength(1);
+  });
+
+  it('disconnect delegates to the agent-integration flow and warns about no revoke (AC5)', async () => {
+    const user = userEvent.setup();
+    deleteIntegration.mockResolvedValue(undefined);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(within(oauthSection()).getAllByLabelText('oauthSection.actions.disconnect')[0]);
+
+    // The dialog is explicit: local removal only, nothing revoked remotely.
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'oauthSection.disconnectDialog.noRevokeWarning',
+    );
+    await user.click(screen.getByText('oauthSection.disconnectDialog.confirm'));
+
+    await waitFor(() => expect(deleteIntegration).toHaveBeenCalledWith('agent-1', 'github'));
+    // The vault endpoint is never used for a connection: the row is a reference.
+    expect(deleteIntegrationCredential).not.toHaveBeenCalled();
+  });
+
+  it('hides the disconnect action without ai_agents.update', async () => {
+    granted = [...ALL_PERMISSIONS];
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(
+      within(oauthSection()).queryByLabelText('oauthSection.actions.disconnect'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the empty hint when there is no connection', async () => {
+    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    expect(within(oauthSection()).getByText('oauthSection.empty')).toBeInTheDocument();
   });
 });
 

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -250,23 +250,85 @@ describe('IntegrationCredentials — oauth rows stay out of the static tables (A
   });
 });
 
-describe('IntegrationCredentials — installation section (AC1, story 2.2 slot)', () => {
-  it('renders installation credentials read-only', async () => {
+// EVO-2250 story 2.2: the installation link of the chain. Writing at that
+// level is gated on installation_configs.manage, NOT on the update grant of
+// the resource — the negative proofs below fail if the component ever swaps
+// canManageInstallation for canUpdate.
+describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
+  const findInstallationRow = () => screen.findByRole('cell', { name: 'n8n da casa' });
+
+  beforeEach(() => {
     listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, INSTALLATION_CREDENTIAL]);
+  });
+
+  it('renders installation credentials read-only WITH the full resource grants (negative proof)', async () => {
+    // Every ai_integration_credentials.* grant, including update, but no
+    // installation_configs.manage: a gate wired to canUpdate would expose the
+    // installation edit controls here and fail these assertions.
+    granted = [...ALL_PERMISSIONS];
     render(<IntegrationCredentials />);
 
-    await findAccountRow();
-    expect(await screen.findByRole('cell', { name: 'n8n da casa' })).toBeInTheDocument();
+    await findInstallationRow();
     expect(screen.getByText('inheritedReadOnly')).toBeInTheDocument();
-    // Exactly one edit control: the account row's.
+    // Exactly one edit control: the account row's. The installation row has none.
     expect(screen.getAllByLabelText('actions.edit')).toHaveLength(1);
+    expect(screen.getAllByLabelText('actions.delete')).toHaveLength(1);
+  });
+
+  it('hides the installation add button without installation_configs.manage (negative proof)', async () => {
+    granted = [...ALL_PERMISSIONS];
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    // Only the page-level (account) add button renders.
+    expect(screen.getAllByText('actions.add')).toHaveLength(1);
+  });
+
+  it('exposes write controls on the installation row when granted (positive control)', async () => {
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    expect(screen.queryByText('inheritedReadOnly')).not.toBeInTheDocument();
+    expect(screen.getAllByLabelText('actions.edit')).toHaveLength(2);
+    // The section header carries its own add button.
+    expect(screen.getAllByText('actions.add')).toHaveLength(2);
+  });
+
+  it('sends the scope when updating an installation credential', async () => {
+    const user = userEvent.setup();
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    updateIntegrationCredential.mockResolvedValue(INSTALLATION_CREDENTIAL);
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    await user.click(screen.getAllByLabelText('actions.edit')[1]);
+    await user.click(await screen.findByText('actions.save'));
+
+    await waitFor(() => expect(updateIntegrationCredential).toHaveBeenCalled());
+    const [id, payload] = updateIntegrationCredential.mock.calls[0];
+    expect(id).toBe('cred-installation');
+    expect(payload.scope).toBe('installation');
   });
 
   it('shows the empty hint when the installation has nothing', async () => {
+    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL]);
     render(<IntegrationCredentials />);
 
     await findAccountRow();
     expect(screen.getByText('installationEmpty')).toBeInTheDocument();
+  });
+});
+
+// The panel answers "which credential is in effect" and is born empty: the
+// consumers plug in with stories 2.3/2.4 (2.2 AC9).
+describe('IntegrationCredentials — in-use panel (2.2 AC9)', () => {
+  it('renders the panel above the lists with the empty explanation', async () => {
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const panel = screen.getByLabelText('inUse.title');
+    expect(panel).toHaveTextContent('inUse.empty');
   });
 });
 

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -20,10 +20,13 @@ import { maskKey } from '@/constants/aiProviders';
 import {
   createIntegrationCredential,
   deleteIntegrationCredential,
+  listCustomMcpServers,
+  listCustomTools,
   listIntegrationCredentials,
   updateIntegrationCredential,
 } from '@/services/agents';
 import agentIntegrationsService from '@/services/agents/agentIntegrationsService';
+import AgentBotsService from '@/services/channels/agentBotsService';
 import type {
   ApiKeyScope,
   IntegrationCredential,
@@ -60,6 +63,14 @@ const EMPTY_DRAFT: CredentialDraft = {
   scope: 'account',
 };
 
+interface ConsumerInUse {
+  key: string;
+  /** i18n suffix under inUse.kinds.* */
+  kind: 'tool' | 'mcp' | 'bot';
+  name: string;
+  credentialIds: string[];
+}
+
 export default function IntegrationCredentials() {
   const { t } = useLanguage('integrationCredentials');
   const { can, isReady: permissionsReady } = usePermissions();
@@ -72,6 +83,7 @@ export default function IntegrationCredentials() {
   const [credentialToDelete, setCredentialToDelete] = useState<IntegrationCredential | null>(null);
   const [connectionToDisconnect, setConnectionToDisconnect] =
     useState<IntegrationCredential | null>(null);
+  const [consumersInUse, setConsumersInUse] = useState<ConsumerInUse[]>([]);
 
   const canRead = can('ai_integration_credentials', 'read');
   const canCreate = can('ai_integration_credentials', 'create');
@@ -110,6 +122,57 @@ export default function IntegrationCredentials() {
     [staticCredentials],
   );
 
+  // The panel is fed client-side from the consumer listings, the same way the
+  // AI credentials screen reads agents. Advisory: any listing failure leaves
+  // the panel empty without blocking the vault itself.
+  const loadConsumers = useCallback(async () => {
+    const [tools, mcpServers, bots] = await Promise.allSettled([
+      listCustomTools(),
+      listCustomMcpServers(),
+      AgentBotsService.getAll(),
+    ]);
+
+    const rows: ConsumerInUse[] = [];
+
+    if (tools.status === 'fulfilled') {
+      tools.value.forEach(tool => {
+        const ids = Object.values(tool.credential_refs ?? {});
+        if (ids.length > 0) {
+          rows.push({ key: `tool-${tool.id}`, kind: 'tool', name: tool.name, credentialIds: ids });
+        }
+      });
+    }
+
+    if (mcpServers.status === 'fulfilled') {
+      mcpServers.value.forEach(server => {
+        const ids = Object.values(server.credential_refs ?? {});
+        if (ids.length > 0) {
+          rows.push({
+            key: `mcp-${server.id}`,
+            kind: 'mcp',
+            name: server.name,
+            credentialIds: ids,
+          });
+        }
+      });
+    }
+
+    if (bots.status === 'fulfilled') {
+      bots.value.forEach(bot => {
+        if (bot.credential_id) {
+          rows.push({
+            key: `bot-${bot.id}`,
+            kind: 'bot',
+            name: bot.name,
+            credentialIds: [bot.credential_id],
+          });
+        }
+      });
+    }
+
+    setConsumersInUse(rows);
+  }, []);
+
   const loadCredentials = useCallback(async () => {
     if (!canRead) {
       toast.error(t('messages.permissionDenied.read'));
@@ -119,13 +182,14 @@ export default function IntegrationCredentials() {
     try {
       setLoading(true);
       setCredentials(await listIntegrationCredentials());
+      loadConsumers();
     } catch (error) {
       console.error('Error loading integration credentials:', error);
       toast.error(t('messages.loadError'));
     } finally {
       setLoading(false);
     }
-  }, [canRead, t]);
+  }, [canRead, t, loadConsumers]);
 
   useEffect(() => {
     if (!permissionsReady) {
@@ -383,7 +447,21 @@ export default function IntegrationCredentials() {
           row here, like the AI credentials panel grew in 1.2. */}
       <section aria-label={t('inUse.title')} className="border rounded-lg p-4 space-y-2">
         <h2 className="text-sm font-medium">{t('inUse.title')}</h2>
-        <p className="text-sm text-muted-foreground">{t('inUse.empty')}</p>
+        {consumersInUse.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('inUse.empty')}</p>
+        ) : (
+          consumersInUse.map(consumer => (
+            <div key={consumer.key} className="flex items-baseline gap-2 text-sm">
+              <span className="text-muted-foreground">{t(`inUse.kinds.${consumer.kind}`)}</span>
+              <span className="font-medium">{consumer.name}</span>
+              <span className="text-xs text-muted-foreground">
+                {consumer.credentialIds
+                  .map(id => credentials.find(credential => credential.id === id)?.name ?? id)
+                  .join(', ')}
+              </span>
+            </div>
+          ))
+        )}
       </section>
 
       <section aria-label={t('sections.account')} className="space-y-3">

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -1,0 +1,474 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { toast } from 'sonner';
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@evoapi/design-system';
+import { AlertTriangle, Edit, Loader2, Lock, Plus, Trash2 } from 'lucide-react';
+import EmptyState from '@/components/base/EmptyState';
+import { maskKey } from '@/constants/aiProviders';
+import {
+  createIntegrationCredential,
+  deleteIntegrationCredential,
+  listIntegrationCredentials,
+  updateIntegrationCredential,
+} from '@/services/agents';
+import type {
+  ApiKeyScope,
+  IntegrationCredential,
+  IntegrationCredentialCreate,
+  IntegrationCredentialUpdate,
+} from '@/types/agents';
+
+// Free-text provider field with suggestions: the vault accepts any provider,
+// these are just the known consumers of the epic.
+const PROVIDER_SUGGESTIONS = [
+  'dify',
+  'flowise',
+  'n8n',
+  'typebot',
+  'openai',
+  'elevenlabs',
+  'knowledge_nexus',
+  'custom_tool',
+  'mcp',
+];
+
+interface CredentialDraft {
+  id?: string;
+  name: string;
+  provider: string;
+  value: string;
+  scope: ApiKeyScope;
+}
+
+const EMPTY_DRAFT: CredentialDraft = {
+  name: '',
+  provider: '',
+  value: '',
+  scope: 'account',
+};
+
+export default function IntegrationCredentials() {
+  const { t } = useLanguage('integrationCredentials');
+  const { can, isReady: permissionsReady } = usePermissions();
+
+  const [credentials, setCredentials] = useState<IntegrationCredential[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [formOpen, setFormOpen] = useState(false);
+  const [draft, setDraft] = useState<CredentialDraft>(EMPTY_DRAFT);
+  const [credentialToDelete, setCredentialToDelete] = useState<IntegrationCredential | null>(null);
+
+  const canRead = can('ai_integration_credentials', 'read');
+  const canCreate = can('ai_integration_credentials', 'create');
+  const canUpdate = can('ai_integration_credentials', 'update');
+  const canDelete = can('ai_integration_credentials', 'delete');
+
+  const isEditing = Boolean(draft.id);
+
+  // Only static credentials belong to these tables: oauth rows are references
+  // and live in the (still hidden) connections section, filled by story 2.5.
+  const staticCredentials = useMemo(
+    () => credentials.filter(credential => credential.kind !== 'oauth'),
+    [credentials],
+  );
+
+  const accountCredentials = useMemo(
+    () => staticCredentials.filter(credential => (credential.scope ?? 'account') === 'account'),
+    [staticCredentials],
+  );
+
+  const installationCredentials = useMemo(
+    () => staticCredentials.filter(credential => credential.scope === 'installation'),
+    [staticCredentials],
+  );
+
+  const loadCredentials = useCallback(async () => {
+    if (!canRead) {
+      toast.error(t('messages.permissionDenied.read'));
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setCredentials(await listIntegrationCredentials());
+    } catch (error) {
+      console.error('Error loading integration credentials:', error);
+      toast.error(t('messages.loadError'));
+    } finally {
+      setLoading(false);
+    }
+  }, [canRead, t]);
+
+  useEffect(() => {
+    if (!permissionsReady) {
+      return;
+    }
+
+    loadCredentials();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [permissionsReady]);
+
+  const openCreateForm = () => {
+    setDraft({ ...EMPTY_DRAFT });
+    setFormOpen(true);
+  };
+
+  const openEditForm = (credential: IntegrationCredential) => {
+    setDraft({
+      id: credential.id,
+      name: credential.name,
+      provider: credential.provider,
+      value: '',
+      scope: credential.scope ?? 'account',
+    });
+    setFormOpen(true);
+  };
+
+  const handleSave = async () => {
+    const needsValue = !isEditing;
+    if (!draft.name.trim() || !draft.provider.trim() || (needsValue && !draft.value.trim())) {
+      toast.error(t('messages.requiredFields'));
+      return;
+    }
+
+    try {
+      setSaving(true);
+
+      if (draft.id) {
+        const payload: IntegrationCredentialUpdate = {
+          name: draft.name,
+          provider: draft.provider,
+          scope: draft.scope,
+        };
+        // An empty field keeps the stored value: never send it blank.
+        if (draft.value.trim()) {
+          payload.value = draft.value;
+        }
+
+        await updateIntegrationCredential(draft.id, payload);
+        toast.success(t('messages.updateSuccess'));
+      } else {
+        // Only `static` is creatable here: the `oauth` kind is opened by 2.5
+        // and never carries a value.
+        const payload: IntegrationCredentialCreate = {
+          name: draft.name,
+          provider: draft.provider,
+          value: draft.value,
+          kind: 'static',
+          scope: draft.scope,
+        };
+
+        await createIntegrationCredential(payload);
+        toast.success(t('messages.createSuccess'));
+      }
+
+      setFormOpen(false);
+      setDraft(EMPTY_DRAFT);
+      loadCredentials();
+    } catch (error) {
+      console.error('Error saving integration credential:', error);
+      toast.error(t('messages.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleActive = async (credential: IntegrationCredential) => {
+    try {
+      setSaving(true);
+      await updateIntegrationCredential(credential.id, {
+        name: credential.name,
+        provider: credential.provider,
+        is_active: !credential.is_active,
+      });
+      toast.success(t('messages.updateSuccess'));
+      loadCredentials();
+    } catch (error) {
+      console.error('Error toggling integration credential:', error);
+      toast.error(t('messages.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!credentialToDelete) {
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await deleteIntegrationCredential(credentialToDelete.id);
+      toast.success(t('messages.deleteSuccess'));
+      setCredentialToDelete(null);
+      loadCredentials();
+    } catch (error) {
+      console.error('Error deleting integration credential:', error);
+      toast.error(t('messages.deleteError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (permissionsReady && !canRead) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon={Lock}
+          title={t('title')}
+          description={t('messages.permissionDenied.read')}
+        />
+      </div>
+    );
+  }
+
+  const renderCredentialsTable = (rows: IntegrationCredential[], scope: ApiKeyScope) => {
+    // Installation-level writes arrive with story 2.2 and its own privilege;
+    // until then the installation section is read-only for everyone.
+    const writable = scope === 'account' && canUpdate;
+
+    return (
+      <div className="overflow-x-auto border rounded-lg">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            <tr>
+              <th className="text-left p-3">{t('columns.name')}</th>
+              <th className="text-left p-3">{t('columns.provider')}</th>
+              <th className="text-left p-3">{t('columns.value')}</th>
+              <th className="text-left p-3">{t('columns.kind')}</th>
+              <th className="text-left p-3">{t('columns.status')}</th>
+              <th className="text-right p-3">{t('columns.actions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(credential => (
+              <tr key={credential.id} className="border-t">
+                <td className="p-3 font-medium">{credential.name}</td>
+                <td className="p-3">
+                  <Badge variant="outline">{credential.provider}</Badge>
+                </td>
+                <td className="p-3 font-mono">{maskKey(credential.value_hint)}</td>
+                <td className="p-3">{t(`kind.${credential.kind}`)}</td>
+                <td className="p-3">
+                  <Badge variant={credential.is_active ? 'default' : 'secondary'}>
+                    {credential.is_active ? t('status.active') : t('status.inactive')}
+                  </Badge>
+                </td>
+                <td className="p-3">
+                  <div className="flex justify-end gap-2">
+                    {writable ? (
+                      <>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label={t('actions.edit')}
+                          onClick={() => openEditForm(credential)}
+                        >
+                          <Edit className="h-4 w-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={saving}
+                          onClick={() => handleToggleActive(credential)}
+                        >
+                          {credential.is_active ? t('actions.deactivate') : t('actions.activate')}
+                        </Button>
+                      </>
+                    ) : (
+                      scope === 'installation' && (
+                        <span className="text-xs text-muted-foreground">
+                          {t('inheritedReadOnly')}
+                        </span>
+                      )
+                    )}
+                    {canDelete && writable && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        aria-label={t('actions.delete')}
+                        onClick={() => setCredentialToDelete(credential)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">{t('title')}</h1>
+          <p className="text-muted-foreground">{t('description')}</p>
+        </div>
+        {canCreate && (
+          <Button onClick={openCreateForm}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t('actions.add')}
+          </Button>
+        )}
+      </div>
+
+      <section aria-label={t('sections.account')} className="space-y-3">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          {t('sections.account')}
+        </h2>
+
+        {loading ? (
+          <div className="flex items-center justify-center h-40">
+            <Loader2 className="h-8 w-8 animate-spin" />
+          </div>
+        ) : accountCredentials.length === 0 ? (
+          <EmptyState
+            icon={Lock}
+            title={t('empty.title')}
+            description={t('empty.description')}
+            action={
+              canCreate
+                ? { label: t('actions.addFirst'), onClick: openCreateForm }
+                : undefined
+            }
+          />
+        ) : (
+          renderCredentialsTable(accountCredentials, 'account')
+        )}
+      </section>
+
+      {/* Story 2.2 fills this section with installation-level management; the
+          markup exists from day one so 2.2 only wires it, never remounts it. */}
+      <section aria-label={t('sections.installation')} className="space-y-3">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          {t('sections.installation')}
+        </h2>
+
+        {loading ? null : installationCredentials.length === 0 ? (
+          <p className="text-sm text-muted-foreground border border-dashed rounded-lg p-4">
+            {t('installationEmpty')}
+          </p>
+        ) : (
+          renderCredentialsTable(installationCredentials, 'installation')
+        )}
+      </section>
+
+      {/* Reserved for story 2.5 (OAuth connections by reference). Hidden until
+          then: only the markup slot exists, per the story's task. */}
+      <section hidden aria-label={t('sections.oauth')} data-story="2.5" />
+
+      <Dialog open={formOpen} onOpenChange={setFormOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {isEditing ? t('form.title.edit') : t('form.title.new')}
+            </DialogTitle>
+            <DialogDescription>{t('description')}</DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="integration-credential-name">{t('form.labels.name')}</Label>
+              <Input
+                id="integration-credential-name"
+                value={draft.name}
+                placeholder={t('form.placeholders.name')}
+                onChange={event => setDraft({ ...draft, name: event.target.value })}
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="integration-credential-provider">{t('form.labels.provider')}</Label>
+              <Input
+                id="integration-credential-provider"
+                value={draft.provider}
+                list="integration-credential-provider-suggestions"
+                placeholder={t('form.placeholders.provider')}
+                onChange={event => setDraft({ ...draft, provider: event.target.value })}
+              />
+              <datalist id="integration-credential-provider-suggestions">
+                {PROVIDER_SUGGESTIONS.map(provider => (
+                  <option key={provider} value={provider} />
+                ))}
+              </datalist>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="integration-credential-value">{t('form.labels.value')}</Label>
+              <Input
+                id="integration-credential-value"
+                type="password"
+                value={draft.value}
+                placeholder={
+                  isEditing ? t('form.placeholders.valueEdit') : t('form.placeholders.valueNew')
+                }
+                onChange={event => setDraft({ ...draft, value: event.target.value })}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setFormOpen(false)}>
+              {t('actions.cancel')}
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('actions.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(credentialToDelete)}
+        onOpenChange={open => !open && setCredentialToDelete(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('deleteDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('deleteDialog.description', { name: credentialToDelete?.name })}
+            </DialogDescription>
+          </DialogHeader>
+
+          {(credentialToDelete?.referenced_by?.length ?? 0) > 0 && (
+            <p role="alert" className="flex gap-2 text-sm text-amber-600">
+              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+              {t('deleteDialog.inUseWarning', {
+                count: credentialToDelete?.referenced_by?.length,
+                consumers: credentialToDelete?.referenced_by?.join(', '),
+              })}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCredentialToDelete(null)}>
+              {t('deleteDialog.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteConfirm} disabled={saving}>
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('deleteDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -74,6 +74,10 @@ export default function IntegrationCredentials() {
   const canCreate = can('ai_integration_credentials', 'create');
   const canUpdate = can('ai_integration_credentials', 'update');
   const canDelete = can('ai_integration_credentials', 'delete');
+  // Writing at the installation level is a separate privilege: an account admin
+  // sees the inherited default but cannot change it (story 2.2, same rule as
+  // the AI credentials screen).
+  const canManageInstallation = can('installation_configs', 'manage');
 
   const isEditing = Boolean(draft.id);
 
@@ -120,10 +124,15 @@ export default function IntegrationCredentials() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [permissionsReady]);
 
-  const openCreateForm = () => {
-    setDraft({ ...EMPTY_DRAFT });
+  const openCreateForm = (scope: ApiKeyScope = 'account') => {
+    setDraft({ ...EMPTY_DRAFT, scope });
     setFormOpen(true);
   };
+
+  // Editing an installation credential needs the installation privilege;
+  // account credentials only need ai_integration_credentials.update.
+  const canWriteScope = (scope: ApiKeyScope) =>
+    scope === 'installation' ? canManageInstallation : canUpdate;
 
   const openEditForm = (credential: IntegrationCredential) => {
     setDraft({
@@ -140,6 +149,11 @@ export default function IntegrationCredentials() {
     const needsValue = !isEditing;
     if (!draft.name.trim() || !draft.provider.trim() || (needsValue && !draft.value.trim())) {
       toast.error(t('messages.requiredFields'));
+      return;
+    }
+
+    if (!canWriteScope(draft.scope)) {
+      toast.error(t('messages.permissionDenied.installation'));
       return;
     }
 
@@ -235,9 +249,7 @@ export default function IntegrationCredentials() {
   }
 
   const renderCredentialsTable = (rows: IntegrationCredential[], scope: ApiKeyScope) => {
-    // Installation-level writes arrive with story 2.2 and its own privilege;
-    // until then the installation section is read-only for everyone.
-    const writable = scope === 'account' && canUpdate;
+    const writable = canWriteScope(scope);
 
     return (
       <div className="overflow-x-auto border rounded-lg">
@@ -322,12 +334,20 @@ export default function IntegrationCredentials() {
           <p className="text-muted-foreground">{t('description')}</p>
         </div>
         {canCreate && (
-          <Button onClick={openCreateForm}>
+          <Button onClick={() => openCreateForm('account')}>
             <Plus className="mr-2 h-4 w-4" />
             {t('actions.add')}
           </Button>
         )}
       </div>
+
+      {/* Answers "which credential is in effect right now". Born empty: the
+          consumers plug in with stories 2.3 and 2.4, and each one adds its
+          row here, like the AI credentials panel grew in 1.2. */}
+      <section aria-label={t('inUse.title')} className="border rounded-lg p-4 space-y-2">
+        <h2 className="text-sm font-medium">{t('inUse.title')}</h2>
+        <p className="text-sm text-muted-foreground">{t('inUse.empty')}</p>
+      </section>
 
       <section aria-label={t('sections.account')} className="space-y-3">
         <h2 className="text-sm font-medium uppercase text-muted-foreground">
@@ -345,7 +365,7 @@ export default function IntegrationCredentials() {
             description={t('empty.description')}
             action={
               canCreate
-                ? { label: t('actions.addFirst'), onClick: openCreateForm }
+                ? { label: t('actions.addFirst'), onClick: () => openCreateForm('account') }
                 : undefined
             }
           />
@@ -354,12 +374,18 @@ export default function IntegrationCredentials() {
         )}
       </section>
 
-      {/* Story 2.2 fills this section with installation-level management; the
-          markup exists from day one so 2.2 only wires it, never remounts it. */}
       <section aria-label={t('sections.installation')} className="space-y-3">
-        <h2 className="text-sm font-medium uppercase text-muted-foreground">
-          {t('sections.installation')}
-        </h2>
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-sm font-medium uppercase text-muted-foreground">
+            {t('sections.installation')}
+          </h2>
+          {canManageInstallation && (
+            <Button variant="outline" size="sm" onClick={() => openCreateForm('installation')}>
+              <Plus className="mr-2 h-4 w-4" />
+              {t('actions.add')}
+            </Button>
+          )}
+        </div>
 
         {loading ? null : installationCredentials.length === 0 ? (
           <p className="text-sm text-muted-foreground border border-dashed rounded-lg p-4">

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/services/agents';
 import agentIntegrationsService from '@/services/agents/agentIntegrationsService';
 import AgentBotsService from '@/services/channels/agentBotsService';
+import { parseOwnerTimestamp } from './ownerTimestamp';
 import type {
   ApiKeyScope,
   IntegrationCredential,
@@ -66,9 +67,12 @@ const EMPTY_DRAFT: CredentialDraft = {
 interface ConsumerInUse {
   key: string;
   /** i18n suffix under inUse.kinds.* */
-  kind: 'tool' | 'mcp' | 'bot';
+  kind: 'tool' | 'mcp' | 'bot' | 'credential';
   name: string;
-  credentialIds: string[];
+  /** Client-side join mode: resolved to names against the loaded list. */
+  credentialIds?: string[];
+  /** Server mode (AC10): consumer names aggregated by the backend. */
+  consumerNames?: string[];
 }
 
 export default function IntegrationCredentials() {
@@ -181,8 +185,27 @@ export default function IntegrationCredentials() {
 
     try {
       setLoading(true);
-      setCredentials(await listIntegrationCredentials());
-      loadConsumers();
+      const list = await listIntegrationCredentials();
+      setCredentials(list);
+
+      // AC10 (2.4): the backend aggregates the consumers of each credential
+      // into `referenced_by`. When ANY row carries the field, the server is
+      // the source and the client-side join stays off; an older backend
+      // without the field keeps the join as a graceful fallback.
+      if (list.some(credential => Array.isArray(credential.referenced_by))) {
+        setConsumersInUse(
+          list
+            .filter(credential => (credential.referenced_by?.length ?? 0) > 0)
+            .map(credential => ({
+              key: `credential-${credential.id}`,
+              kind: 'credential' as const,
+              name: credential.name,
+              consumerNames: credential.referenced_by ?? [],
+            })),
+        );
+      } else {
+        loadConsumers();
+      }
     } catch (error) {
       console.error('Error loading integration credentials:', error);
       toast.error(t('messages.loadError'));
@@ -455,9 +478,11 @@ export default function IntegrationCredentials() {
               <span className="text-muted-foreground">{t(`inUse.kinds.${consumer.kind}`)}</span>
               <span className="font-medium">{consumer.name}</span>
               <span className="text-xs text-muted-foreground">
-                {consumer.credentialIds
-                  .map(id => credentials.find(credential => credential.id === id)?.name ?? id)
-                  .join(', ')}
+                {consumer.consumerNames
+                  ? consumer.consumerNames.join(', ')
+                  : (consumer.credentialIds ?? [])
+                      .map(id => credentials.find(credential => credential.id === id)?.name ?? id)
+                      .join(', ')}
               </span>
             </div>
           ))
@@ -554,7 +579,7 @@ export default function IntegrationCredentials() {
                     </td>
                     <td className="p-3">
                       {connection.connection_expires_at
-                        ? new Date(connection.connection_expires_at).toLocaleString()
+                        ? parseOwnerTimestamp(connection.connection_expires_at).toLocaleString()
                         : t('oauthSection.noExpiry')}
                     </td>
                     <td className="p-3">

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -23,6 +23,7 @@ import {
   listIntegrationCredentials,
   updateIntegrationCredential,
 } from '@/services/agents';
+import agentIntegrationsService from '@/services/agents/agentIntegrationsService';
 import type {
   ApiKeyScope,
   IntegrationCredential,
@@ -69,6 +70,8 @@ export default function IntegrationCredentials() {
   const [formOpen, setFormOpen] = useState(false);
   const [draft, setDraft] = useState<CredentialDraft>(EMPTY_DRAFT);
   const [credentialToDelete, setCredentialToDelete] = useState<IntegrationCredential | null>(null);
+  const [connectionToDisconnect, setConnectionToDisconnect] =
+    useState<IntegrationCredential | null>(null);
 
   const canRead = can('ai_integration_credentials', 'read');
   const canCreate = can('ai_integration_credentials', 'create');
@@ -78,13 +81,22 @@ export default function IntegrationCredentials() {
   // sees the inherited default but cannot change it (story 2.2, same rule as
   // the AI credentials screen).
   const canManageInstallation = can('installation_configs', 'manage');
+  // Disconnecting delegates to the agent-integration flow, which the backend
+  // gates on ai_agents.update — the vault grants play no part here.
+  const canDisconnect = can('ai_agents', 'update');
 
   const isEditing = Boolean(draft.id);
 
   // Only static credentials belong to these tables: oauth rows are references
-  // and live in the (still hidden) connections section, filled by story 2.5.
+  // (no value in the vault, by database CHECK) and render in the connections
+  // section below.
   const staticCredentials = useMemo(
     () => credentials.filter(credential => credential.kind !== 'oauth'),
+    [credentials],
+  );
+
+  const oauthConnections = useMemo(
+    () => credentials.filter(credential => credential.kind === 'oauth'),
     [credentials],
   );
 
@@ -212,6 +224,31 @@ export default function IntegrationCredentials() {
     } catch (error) {
       console.error('Error toggling integration credential:', error);
       toast.error(t('messages.saveError'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Disconnecting delegates to the existing agent-integration flow: the vault
+  // row is a reference, so nothing is deleted from the vault here and no
+  // token is touched — and the provider-side grant is NOT revoked.
+  const handleDisconnectConfirm = async () => {
+    if (!connectionToDisconnect?.agent_id) {
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await agentIntegrationsService.deleteIntegration(
+        connectionToDisconnect.agent_id,
+        connectionToDisconnect.provider,
+      );
+      toast.success(t('oauthSection.disconnectSuccess'));
+      setConnectionToDisconnect(null);
+      loadCredentials();
+    } catch (error) {
+      console.error('Error disconnecting OAuth integration:', error);
+      toast.error(t('oauthSection.disconnectError'));
     } finally {
       setSaving(false);
     }
@@ -396,9 +433,73 @@ export default function IntegrationCredentials() {
         )}
       </section>
 
-      {/* Reserved for story 2.5 (OAuth connections by reference). Hidden until
-          then: only the markup slot exists, per the story's task. */}
-      <section hidden aria-label={t('sections.oauth')} data-story="2.5" />
+      {/* OAuth connections by reference (story 2.5): these rows hold NO
+          secret in the vault — status and expiry are read from the owner
+          store by the backend at listing time, never from a copy. */}
+      <section aria-label={t('sections.oauth')} className="space-y-3">
+        <h2 className="text-sm font-medium uppercase text-muted-foreground">
+          {t('sections.oauth')}
+        </h2>
+        <p className="text-xs text-muted-foreground">{t('oauthSection.noSecretHint')}</p>
+
+        {loading ? null : oauthConnections.length === 0 ? (
+          <p className="text-sm text-muted-foreground border border-dashed rounded-lg p-4">
+            {t('oauthSection.empty')}
+          </p>
+        ) : (
+          <div className="overflow-x-auto border rounded-lg">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left p-3">{t('columns.provider')}</th>
+                  <th className="text-left p-3">{t('oauthSection.columns.agent')}</th>
+                  <th className="text-left p-3">{t('columns.status')}</th>
+                  <th className="text-left p-3">{t('oauthSection.columns.expires')}</th>
+                  <th className="text-right p-3">{t('columns.actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {oauthConnections.map(connection => (
+                  <tr key={connection.id} className="border-t">
+                    <td className="p-3">
+                      <Badge variant="outline">{connection.provider}</Badge>
+                    </td>
+                    <td className="p-3">{connection.agent_name ?? connection.owner_ref}</td>
+                    <td className="p-3">
+                      <Badge
+                        variant={
+                          connection.connection_status === 'connected' ? 'default' : 'secondary'
+                        }
+                      >
+                        {t(`oauthSection.status.${connection.connection_status ?? 'connected'}`)}
+                      </Badge>
+                    </td>
+                    <td className="p-3">
+                      {connection.connection_expires_at
+                        ? new Date(connection.connection_expires_at).toLocaleString()
+                        : t('oauthSection.noExpiry')}
+                    </td>
+                    <td className="p-3">
+                      <div className="flex justify-end gap-2">
+                        {canDisconnect && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label={t('oauthSection.actions.disconnect')}
+                            onClick={() => setConnectionToDisconnect(connection)}
+                          >
+                            {t('oauthSection.actions.disconnect')}
+                          </Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
 
       <Dialog open={formOpen} onOpenChange={setFormOpen}>
         <DialogContent>
@@ -457,6 +558,39 @@ export default function IntegrationCredentials() {
             <Button onClick={handleSave} disabled={saving}>
               {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {t('actions.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(connectionToDisconnect)}
+        onOpenChange={open => !open && setConnectionToDisconnect(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('oauthSection.disconnectDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('oauthSection.disconnectDialog.description', {
+                provider: connectionToDisconnect?.provider,
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* Honest receipt: there is no remote revoke anywhere in the stack,
+              so the dialog says exactly what happens (R5). */}
+          <p role="alert" className="flex gap-2 text-sm text-amber-600">
+            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+            {t('oauthSection.disconnectDialog.noRevokeWarning')}
+          </p>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConnectionToDisconnect(null)}>
+              {t('oauthSection.disconnectDialog.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={handleDisconnectConfirm} disabled={saving}>
+              {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {t('oauthSection.disconnectDialog.confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/pages/Customer/Settings/IntegrationCredentials/index.ts
+++ b/src/pages/Customer/Settings/IntegrationCredentials/index.ts
@@ -1,0 +1,1 @@
+export { default } from './IntegrationCredentials';

--- a/src/pages/Customer/Settings/IntegrationCredentials/ownerTimestamp.ts
+++ b/src/pages/Customer/Settings/IntegrationCredentials/ownerTimestamp.ts
@@ -1,0 +1,7 @@
+// The owner store writes naive UTC timestamps ("2026-08-15T00:00:00", no
+// zone). `new Date` would read those as LOCAL time and shift the expiry by the
+// user's offset; a zoned RFC3339 value passes through untouched.
+export function parseOwnerTimestamp(value: string): Date {
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(value);
+  return new Date(hasZone ? value : `${value}Z`);
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -62,6 +62,7 @@ import Campaigns from '@/pages/Customer/Campaigns/Campaigns';
 import NewCampaign from '@/pages/Customer/Campaigns/NewCampaign/NewCampaign';
 import CannedResponses from '@/pages/Customer/Settings/CannedResponses';
 import AiCredentials from '@/pages/Customer/Settings/AiCredentials';
+import IntegrationCredentials from '@/pages/Customer/Settings/IntegrationCredentials';
 import MessageTemplates from '@/pages/Customer/Settings/MessageTemplates';
 import { Macros } from '@/pages/Customer/Settings/Macros';
 import Products, { ProductsImport } from '@/pages/Customer/Settings/Products';
@@ -785,6 +786,21 @@ const AppRouter = () => {
                   <MainLayout>
                     <PermissionRoute resource="ai_api_keys" action="read">
                       <AiCredentials />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/settings/integration-credentials"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="ai_integration_credentials" action="read">
+                      <IntegrationCredentials />
                     </PermissionRoute>
                   </MainLayout>
                 </CustomerRoute>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -61,6 +61,7 @@ import JourneyFlowEditor from '@/pages/Customer/Journey/JourneyFlowEditor';
 import Campaigns from '@/pages/Customer/Campaigns/Campaigns';
 import NewCampaign from '@/pages/Customer/Campaigns/NewCampaign/NewCampaign';
 import CannedResponses from '@/pages/Customer/Settings/CannedResponses';
+import AiCredentials from '@/pages/Customer/Settings/AiCredentials';
 import MessageTemplates from '@/pages/Customer/Settings/MessageTemplates';
 import { Macros } from '@/pages/Customer/Settings/Macros';
 import Products, { ProductsImport } from '@/pages/Customer/Settings/Products';
@@ -769,6 +770,21 @@ const AppRouter = () => {
                   <MainLayout>
                     <PermissionRoute resource="canned_responses" action="read">
                       <CannedResponses />
+                    </PermissionRoute>
+                  </MainLayout>
+                </CustomerRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/settings/ai-credentials"
+            element={
+              <PrivateRoute>
+                <CustomerRoute>
+                  <MainLayout>
+                    <PermissionRoute resource="ai_api_keys" action="read">
+                      <AiCredentials />
                     </PermissionRoute>
                   </MainLayout>
                 </CustomerRoute>

--- a/src/services/agents/index.ts
+++ b/src/services/agents/index.ts
@@ -4,3 +4,4 @@ export * from './toolsService';
 export * from './customToolsService';
 export * from './mcpServerService';
 export * from './customMcpServerService';
+export * from './integrationCredentialService';

--- a/src/services/agents/integrationCredentialService.ts
+++ b/src/services/agents/integrationCredentialService.ts
@@ -43,3 +43,23 @@ export const deleteIntegrationCredential = async (
   const response = await evoaiApi.delete(`/integration-credentials/${credentialId}`);
   return extractData<IntegrationCredentialDeleteResponse>(response);
 };
+
+// EVO-2250 story 2.7: the retirement guard, per consumer. A consumer only
+// retires its inline secret entry after the 2.6 migration ran on this
+// installation (or there was never anything to migrate). While the guard says
+// no, every inline field stays exactly as it is.
+export interface IntegrationVaultMigrationState {
+  retired: {
+    custom_tools?: boolean;
+    custom_mcp_servers?: boolean;
+    knowledge_nexus?: boolean;
+    agent_bots?: boolean;
+    external_agents?: boolean;
+  };
+}
+
+export const getIntegrationVaultMigrationState =
+  async (): Promise<IntegrationVaultMigrationState> => {
+    const response = await evoaiApi.get('/integration-credentials/migration-state');
+    return extractData<IntegrationVaultMigrationState>(response);
+  };

--- a/src/services/agents/integrationCredentialService.ts
+++ b/src/services/agents/integrationCredentialService.ts
@@ -1,0 +1,45 @@
+import evoaiApi from '@/services/core/apiEvoAI';
+import { extractData, buildPaginationParams } from '@/utils/apiHelpers';
+import type {
+  IntegrationCredential,
+  IntegrationCredentialCreate,
+  IntegrationCredentialDeleteResponse,
+  IntegrationCredentialUpdate,
+} from '@/types/agents';
+
+// EVO-2250 story 2.1: the integration-credential vault. The registry lives in
+// evo-ai-core-service (`evo_core_integration_credentials`); routes mirror the
+// sibling top-level resources (`/custom-tools`, `/custom-mcp-servers`).
+// The API returns `value_hint` only — the value itself never leaves the server.
+
+export const listIntegrationCredentials = async (
+  page = 1,
+  pageSize = 100,
+): Promise<IntegrationCredential[]> => {
+  const response = await evoaiApi.get('/integration-credentials', {
+    params: buildPaginationParams(page, pageSize),
+  });
+  return extractData<IntegrationCredential[]>(response);
+};
+
+export const createIntegrationCredential = async (
+  data: IntegrationCredentialCreate,
+): Promise<IntegrationCredential> => {
+  const response = await evoaiApi.post('/integration-credentials', data);
+  return extractData<IntegrationCredential>(response);
+};
+
+export const updateIntegrationCredential = async (
+  credentialId: string,
+  data: IntegrationCredentialUpdate,
+): Promise<IntegrationCredential> => {
+  const response = await evoaiApi.put(`/integration-credentials/${credentialId}`, data);
+  return extractData<IntegrationCredential>(response);
+};
+
+export const deleteIntegrationCredential = async (
+  credentialId: string,
+): Promise<IntegrationCredentialDeleteResponse> => {
+  const response = await evoaiApi.delete(`/integration-credentials/${credentialId}`);
+  return extractData<IntegrationCredentialDeleteResponse>(response);
+};

--- a/src/types/agents/agent.ts
+++ b/src/types/agents/agent.ts
@@ -168,6 +168,10 @@ export interface ApiKeyUpdate {
  * one is a reference to the store that owns the token and never has a value. */
 export type IntegrationCredentialKind = 'static' | 'oauth';
 
+/** Display state of an OAuth connection, derived by the backend from the
+ * owner store at listing time — never from a copy kept in the vault. */
+export type OauthConnectionStatus = 'connected' | 'expiring' | 'expired' | 'refresh_failed';
+
 export interface IntegrationCredential {
   id: string;
   name: string;
@@ -182,6 +186,11 @@ export interface IntegrationCredential {
   imported_from?: string;
   /** Consumers pointing at this credential, filled as stories 2.3/2.4 land. */
   referenced_by?: string[];
+  /** OAuth rows only: mirrored metadata read live from the owner store. */
+  connection_status?: OauthConnectionStatus;
+  connection_expires_at?: string;
+  agent_id?: string;
+  agent_name?: string;
   is_active: boolean;
   created_at: string;
   updated_at: string;

--- a/src/types/agents/agent.ts
+++ b/src/types/agents/agent.ts
@@ -170,7 +170,11 @@ export type IntegrationCredentialKind = 'static' | 'oauth';
 
 /** Display state of an OAuth connection, derived by the backend from the
  * owner store at listing time — never from a copy kept in the vault. */
-export type OauthConnectionStatus = 'connected' | 'expiring' | 'expired' | 'refresh_failed';
+// The owner store records no refresh failure: a failed renewal only reaches
+// the log, and at least one provider returns the stale token on error. A guessed
+// 'refresh_failed' badge would send someone reconnecting a healthy integration,
+// so the backend never emits one (EVO-2250 story 2.5).
+export type OauthConnectionStatus = 'connected' | 'expiring' | 'expired';
 
 export interface IntegrationCredential {
   id: string;

--- a/src/types/agents/agent.ts
+++ b/src/types/agents/agent.ts
@@ -134,16 +134,21 @@ export interface ApiKey {
   key_hint?: string;
   /** Providers speaking the OpenAI protocol serve every AI feature. */
   openai_compatible?: boolean;
+  /** Which link of the resolution chain the credential belongs to. */
+  scope?: ApiKeyScope;
   created_at: string;
   updated_at: string;
   is_active: boolean;
 }
+
+export type ApiKeyScope = 'installation' | 'account';
 
 export interface ApiKeyCreate {
   name: string;
   provider: string;
   key_value?: string;
   base_url?: string;
+  scope?: ApiKeyScope;
 }
 
 export interface ApiKeyUpdate {
@@ -152,6 +157,7 @@ export interface ApiKeyUpdate {
   key_value?: string;
   base_url?: string;
   is_active?: boolean;
+  scope?: ApiKeyScope;
 }
 
 // ============================================

--- a/src/types/agents/agent.ts
+++ b/src/types/agents/agent.ts
@@ -161,6 +161,54 @@ export interface ApiKeyUpdate {
 }
 
 // ============================================
+// Integration Credentials (vault)
+// ============================================
+
+/** A `static` credential holds its (encrypted) value in the vault; an `oauth`
+ * one is a reference to the store that owns the token and never has a value. */
+export type IntegrationCredentialKind = 'static' | 'oauth';
+
+export interface IntegrationCredential {
+  id: string;
+  name: string;
+  provider: string;
+  kind: IntegrationCredentialKind;
+  /** Last characters of the value. The API never returns the value itself. */
+  value_hint?: string;
+  value_format?: 'scalar' | 'composite';
+  scope?: ApiKeyScope;
+  owner_store?: string;
+  owner_ref?: string;
+  imported_from?: string;
+  /** Consumers pointing at this credential, filled as stories 2.3/2.4 land. */
+  referenced_by?: string[];
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface IntegrationCredentialCreate {
+  name: string;
+  provider: string;
+  value: string;
+  kind: IntegrationCredentialKind;
+  scope?: ApiKeyScope;
+}
+
+export interface IntegrationCredentialUpdate {
+  name?: string;
+  provider?: string;
+  /** Omitted to keep the stored value: never send it blank. */
+  value?: string;
+  is_active?: boolean;
+  scope?: ApiKeyScope;
+}
+
+export interface IntegrationCredentialDeleteResponse {
+  message: string;
+}
+
+// ============================================
 // Chat & Sessions
 // ============================================
 

--- a/src/types/agents/agent.ts
+++ b/src/types/agents/agent.ts
@@ -130,6 +130,10 @@ export interface ApiKey {
   name: string;
   provider: string;
   base_url?: string;
+  /** Last characters of the key. The API never returns the key itself. */
+  key_hint?: string;
+  /** Providers speaking the OpenAI protocol serve every AI feature. */
+  openai_compatible?: boolean;
   created_at: string;
   updated_at: string;
   is_active: boolean;

--- a/src/types/ai/customMcpServer.ts
+++ b/src/types/ai/customMcpServer.ts
@@ -4,6 +4,9 @@ export interface CustomMcpServer {
   client_id: string;
   description: string;
   headers: Record<string, unknown>;
+  /** EVO-2250 story 2.4: map of header name -> vault credential id (never a
+   * scalar column — one credential per secret). */
+  credential_refs?: Record<string, string>;
   id: string;
   name: string;
   retry_count: number;
@@ -18,6 +21,7 @@ export interface CustomMcpServer {
 export interface CustomMcpServerCreate {
   description: string;
   headers: Record<string, unknown>;
+  credential_refs?: Record<string, string>;
   name: string;
   retry_count: number;
   tags: string[];
@@ -28,6 +32,7 @@ export interface CustomMcpServerCreate {
 export interface CustomMcpServerUpdate {
   description?: string;
   headers?: Record<string, unknown>;
+  credential_refs?: Record<string, string>;
   name?: string;
   retry_count?: number;
   tags?: string[];

--- a/src/types/ai/customTool.ts
+++ b/src/types/ai/customTool.ts
@@ -8,6 +8,10 @@ export interface CustomTool {
   error_handling: Record<string, unknown>;
   examples: string[];
   headers: Record<string, unknown>;
+  /** EVO-2250 story 2.4: map of header name -> vault credential id. A MAP by
+   * design (one credential per secret): a tool with two auth headers holds
+   * two entries, never a single scalar reference. */
+  credential_refs?: Record<string, string>;
   id: string;
   input_modes: string[];
   method: string;
@@ -27,6 +31,7 @@ export interface CustomToolCreate {
   error_handling: Record<string, unknown>;
   examples: string[];
   headers: Record<string, unknown>;
+  credential_refs?: Record<string, string>;
   input_modes: string[];
   method: string;
   name: string;
@@ -44,6 +49,7 @@ export interface CustomToolUpdate {
   error_handling?: Record<string, unknown>;
   examples?: string[];
   headers?: Record<string, unknown>;
+  credential_refs?: Record<string, string>;
   input_modes?: string[];
   method?: string;
   name?: string;

--- a/src/types/ai/mcpServer.ts
+++ b/src/types/ai/mcpServer.ts
@@ -29,6 +29,11 @@ export interface MCPServerConfig {
   name: string;
   type: string;
   environments: Record<string, unknown>;
+  /** EVO-2250 story 2.4 AC7: env var name -> vault credential id. A MAP, like
+   * the header refs of tools and remote MCPs: one credential is one secret, so
+   * two secret env vars are two credentials. The inline value in
+   * `environments` stays as the fallback until story 2.7 retires it. */
+  credential_refs?: Record<string, string>;
   tools: McpServerToolConfig[];
   toolIds?: string[];
 }


### PR DESCRIPTION
Telas /settings/ai-credentials e /settings/integration-credentials (painel Em uso com referenced_by real, seções por escopo, conexões OAuth read-only), seletor do cofre em agentes externos/tools/MCPs/Nexus, aposentadoria condicionada por guard com round-trip byte-idêntico, e as telas antigas sem campo de chave. Inclui 2 fixes de perda de dado achados em revisão (toggles do hook apagando chave migrada; save de agente externo apagando o segredo a cada edição). 16 commits, i18n nos 6 locales. Depende da PR do core (key_hint/scope/referenced_by na resposta). Ordem de merge da feature: **auth → core → CRM + processor → vendor/crm (front) → frontend (bump) → superprojeto**.

Guia de validação tela a tela: `_evo-output/planning-artifacts/config-ia-unificada/guia-teste-dev-evo-2250.md` (no superprojeto). Card: EVO-2250.

## Summary by Sourcery

Introduce unified AI and integration credential management pages and wire all AI-related features to use the shared vault, with guarded retirement of legacy inline secrets.

New Features:
- Add Settings pages for AI credentials and integration credentials, including per-scope views and in-use panels for AI features and integration consumers.
- Expose vault-backed credential selection for external agents, Knowledge Nexus, custom tools, custom MCP servers and agent bots, supporting static and OAuth-based secrets.
- Add support for mapping headers to vault credentials in custom tools and MCP servers, enabling multi-secret integrations via a credential_refs map.

Bug Fixes:
- Prevent external agent saves from clearing stored integration secrets by only sending non-empty secret fields and respecting sanitized GETs.
- Ensure retirement of inline auth headers and API keys preserves existing secrets by keeping received values in payloads and failing the migration guard closed.
- Avoid stale AI credential lists in agent forms by redirecting the old modal to the new AI Credentials page while notifying callers to reload.

Enhancements:
- Refactor AI key handling into shared constants and resolution helpers, including OpenAI-compatibility detection and scope-based credential resolution for CRM AI features.
- Update OpenAI admin and integration UIs to reflect that credentials are now managed on the AI Credentials page, simplifying forms and removing secret-masking logic.
- Add vault migration guard plumbing and retirement UX across consumers so inline secret inputs become read-only pointers to the vault once migration completes.

Tests:
- Add comprehensive unit tests for the new AI and integration credential pages, vault selectors, retirement guard behavior, and consumer payload round-trips to prevent secret loss.
- Extend existing tests for OpenAI config, API keys modal, external agents, custom tools, MCP servers and Knowledge Nexus integrations to cover the new credential flows and redirects.