### PR TITLE
fix(frontend): responsive mobile layout for the open chat conversation (EVO-2234)

### DIFF
--- a/src/components/chat/audio/AudioRecorder.spec.tsx
+++ b/src/components/chat/audio/AudioRecorder.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import AudioRecorder from './AudioRecorder';
+
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string, fallback?: string) => fallback ?? key }),
+}));
+
+const recorder = {
+  isRecording: true,
+  duration: 3,
+  audioLevel: 0.4,
+  hasRecording: false,
+  recordingData: null,
+  startRecording: vi.fn(),
+  stopRecording: vi.fn(),
+  deleteRecording: vi.fn(),
+  isSupported: true,
+};
+
+vi.mock('@/hooks/chat/useAudioRecorder', () => ({
+  useAudioRecorder: () => recorder,
+}));
+
+const waveform = () => {
+  const row = screen.getByTitle('Enviar').parentElement!;
+  return row.querySelector<HTMLElement>('.h-8')!;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// jsdom does not lay out or evaluate media queries, so this locks the classes:
+// the bars are flex-shrink-0 (32 * 2px + 31 * 3px = 157px minimum), so without
+// overflow-hidden they spill over the send button on narrow screens (EVO-2234).
+describe('AudioRecorder responsive waveform (EVO-2234)', () => {
+  it('fills the row on mobile and clips the bars instead of letting them spill', () => {
+    render(<AudioRecorder onRecordingComplete={vi.fn()} />);
+
+    const bars = waveform();
+    expect(bars).toHaveClass('flex-1');
+    expect(bars).toHaveClass('min-w-0');
+    expect(bars).toHaveClass('overflow-hidden');
+  });
+
+  it('keeps the fixed right-hugged waveform on desktop', () => {
+    render(<AudioRecorder onRecordingComplete={vi.fn()} />);
+
+    const bars = waveform();
+    expect(bars).toHaveClass('md:flex-none');
+    expect(bars).toHaveClass('md:w-40');
+    expect(bars.parentElement).toHaveClass('md:justify-end');
+  });
+});

--- a/src/components/chat/audio/AudioRecorder.tsx
+++ b/src/components/chat/audio/AudioRecorder.tsx
@@ -123,8 +123,10 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
       </div>
 
       {/* Reactive waveform — fills the row on mobile (EVO-2234); on desktop stays a
-          fixed w-40 hugged to the right with the other controls, WhatsApp-style. */}
-      <div className="flex-1 min-w-0 md:flex-none md:w-40 flex items-center justify-between md:justify-normal gap-[3px] h-8">
+          fixed w-40 hugged to the right with the other controls, WhatsApp-style.
+          overflow-hidden: the bars are flex-shrink-0 (32 * 2px + 31 * 3px = 157px min),
+          so under ~333px of viewport they would spill over the send button. */}
+      <div className="flex-1 min-w-0 md:flex-none md:w-40 flex items-center justify-between md:justify-normal gap-[3px] h-8 overflow-hidden">
         {levels.map((level, i) => (
           <div
             key={i}

--- a/src/components/chat/audio/AudioRecorder.tsx
+++ b/src/components/chat/audio/AudioRecorder.tsx
@@ -104,7 +104,7 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
   }
 
   return (
-    <div className={`flex items-center justify-end gap-3 px-4 py-3 ${className}`}>
+    <div className={`flex items-center gap-3 px-4 py-3 md:justify-end ${className}`}>
       {/* Cancelar (lixeira) */}
       <button
         type="button"
@@ -122,9 +122,9 @@ const AudioRecorder: React.FC<AudioRecorderProps> = ({
         <span className="text-sm font-mono text-foreground tabular-nums">{formatDuration(duration)}</span>
       </div>
 
-      {/* Waveform reativo — largura fixa (não flex-1: tudo fica agrupado à
-          direita, colado nos outros controles, como o WhatsApp) */}
-      <div className="flex-shrink-0 flex items-center gap-[3px] h-8 w-40">
+      {/* Reactive waveform — fills the row on mobile (EVO-2234); on desktop stays a
+          fixed w-40 hugged to the right with the other controls, WhatsApp-style. */}
+      <div className="flex-1 min-w-0 md:flex-none md:w-40 flex items-center justify-between md:justify-normal gap-[3px] h-8">
         {levels.map((level, i) => (
           <div
             key={i}

--- a/src/components/chat/chat-header/ChatHeader.spec.tsx
+++ b/src/components/chat/chat-header/ChatHeader.spec.tsx
@@ -522,3 +522,56 @@ describe('ChatHeader contact panel', () => {
   });
 
 });
+
+// jsdom does not evaluate media queries, so these lock the responsive classes
+// themselves — a className "cleanup" is exactly how EVO-2234 would come back.
+describe('ChatHeader mobile layout (EVO-2234)', () => {
+  beforeEach(() => {
+    vi.mocked(pipelinesService.getPipelines).mockResolvedValue({ data: [] } as never);
+    vi.mocked(pipelinesService.getPipelinesByConversation).mockResolvedValue([]);
+  });
+
+  it('names the mobile back button (the only exit once the close X is desktop-only)', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const back = screen.getByRole('button', { name: 'chatHeader.backToConversations' });
+    expect(back).toHaveClass('md:hidden');
+  });
+
+  it('keeps the close (X) button out of the mobile header', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const close = screen.getByRole('button', { name: 'chatHeader.closeConversation' });
+    expect(close).toHaveClass('hidden');
+    expect(close).toHaveClass('md:inline-flex');
+  });
+
+  it('lets the contact name truncate instead of pushing the actions off-screen', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const name = screen.getByRole('heading', { name: 'Test Contact' });
+    expect(name).toHaveClass('truncate');
+    expect(name).toHaveClass('max-w-full');
+  });
+
+  it('lets the inbox name shrink and truncate instead of overflowing the header', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const inbox = screen.getByText('WhatsApp');
+    // min-w-0 is what actually allows the shrink: a flex item's automatic minimum
+    // size is its content, so truncate alone would never engage.
+    expect(inbox).toHaveClass('min-w-0');
+    expect(inbox).toHaveClass('truncate');
+  });
+
+  it('still states the status as text on mobile, not by color alone', () => {
+    render(<ChatHeader {...defaultProps} />);
+
+    const longPill = screen.getByText('• chatHeader.statusPill.open');
+    expect(longPill).toHaveClass('hidden');
+    expect(longPill).toHaveClass('md:inline');
+
+    const shortStatus = screen.getByText('• open');
+    expect(shortStatus).toHaveClass('md:hidden');
+  });
+});

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -436,7 +436,7 @@ const ChatHeader = ({
   return (
     <div className="relative z-20 flex-shrink-0 p-3 md:p-4 border-b bg-background/95 backdrop-blur-sm">
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 min-w-0">
           {/* Back button for mobile */}
           <Button variant="ghost" size="sm" className="md:hidden" onClick={onBackClick}>
             <ArrowLeft className="h-4 w-4" />
@@ -447,10 +447,10 @@ const ChatHeader = ({
           >
             <ContactAvatar contact={conversation.contact} />
           </div>
-          <div>
-            <div className="flex items-center gap-2 flex-wrap">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap min-w-0">
               <h3
-                className="font-semibold cursor-pointer hover:text-primary transition-colors"
+                className="font-semibold cursor-pointer hover:text-primary transition-colors truncate max-w-full"
                 onClick={onContactSidebarOpen}
               >
                 {conversation.contact?.name || t('chatHeader.contactNoName')}
@@ -479,6 +479,7 @@ const ChatHeader = ({
                 );
                 return (
                   <span
+                    className="hidden md:inline"
                     style={{
                       background: meta.bg,
                       border: `1px solid ${meta.border}`,
@@ -511,12 +512,12 @@ const ChatHeader = ({
           {/* Dropdown de ações da conversa */}
           {renderConversationStatusDropdown()}
 
-          {/* Botão fechar conversa */}
+          {/* Botão fechar conversa — hidden on mobile: the back arrow already leaves the conversation */}
           <Button
             variant="ghost"
             size="sm"
             onClick={onCloseConversation}
-            className="text-muted-foreground hover:text-foreground"
+            className="hidden md:inline-flex text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />
             <span className="sr-only">{t('chatHeader.closeConversation')}</span>

--- a/src/components/chat/chat-header/ChatHeader.tsx
+++ b/src/components/chat/chat-header/ChatHeader.tsx
@@ -437,9 +437,11 @@ const ChatHeader = ({
     <div className="relative z-20 flex-shrink-0 p-3 md:p-4 border-b bg-background/95 backdrop-blur-sm">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3 min-w-0">
-          {/* Back button for mobile */}
+          {/* Back button for mobile — the only way out of the conversation on mobile
+              (the close X is desktop-only), so it needs an accessible name of its own. */}
           <Button variant="ghost" size="sm" className="md:hidden" onClick={onBackClick}>
             <ArrowLeft className="h-4 w-4" />
+            <span className="sr-only">{t('chatHeader.backToConversations')}</span>
           </Button>
           <div
             className="cursor-pointer hover:ring-2 hover:ring-primary/20 transition-all rounded-full"
@@ -466,7 +468,10 @@ const ChatHeader = ({
               )}
             </div>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              {inboxName && <span>{inboxName}</span>}
+              {/* min-w-0: a flex item's automatic minimum size is its content, so without
+                  it a long inbox name overflows the header and runs under the action
+                  buttons on mobile instead of truncating (EVO-2234). */}
+              {inboxName && <span className="min-w-0 truncate">{inboxName}</span>}
               {(() => {
                 const meta = STATUS_META_LIGHT[conversation.status] || STATUS_META_LIGHT.snoozed;
                 // Rótulo LONGO do protótipo ("Atendimento em Aberto" etc.), distinto do
@@ -478,21 +483,29 @@ const ChatHeader = ({
                   STATUS_META[conversation.status]?.label || getStatusLabel(conversation.status, t),
                 );
                 return (
-                  <span
-                    className="hidden md:inline"
-                    style={{
-                      background: meta.bg,
-                      border: `1px solid ${meta.border}`,
-                      color: meta.text,
-                      borderRadius: 9,
-                      padding: '7px 14px',
-                      fontSize: 13,
-                      fontWeight: 600,
-                      lineHeight: 1,
-                    }}
-                  >
-                    • {pillLabel}
-                  </span>
+                  <>
+                    {/* Mobile carries the status as short text: the pill is hidden here and
+                        the ConversationStatusButton labels the NEXT action ("Concluir"), not
+                        the current state — without this the status would be color-only. */}
+                    <span className="md:hidden flex-shrink-0">
+                      • {getStatusLabel(conversation.status, t)}
+                    </span>
+                    <span
+                      className="hidden md:inline"
+                      style={{
+                        background: meta.bg,
+                        border: `1px solid ${meta.border}`,
+                        color: meta.text,
+                        borderRadius: 9,
+                        padding: '7px 14px',
+                        fontSize: 13,
+                        fontWeight: 600,
+                        lineHeight: 1,
+                      }}
+                    >
+                      • {pillLabel}
+                    </span>
+                  </>
                 );
               })()}
             </div>

--- a/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.spec.tsx
@@ -631,3 +631,27 @@ describe('ChatSidebar scroll pagination (EVO-1407)', () => {
     expect(loadMore).not.toHaveBeenCalled();
   });
 });
+
+// jsdom does not evaluate media queries, so this locks the mechanism instead:
+// the resize width must never reach the element as a raw inline width, which is
+// what overrode w-full and left the list desktop-sized on mobile (EVO-2234).
+describe('ChatSidebar responsive width (EVO-2234)', () => {
+  it('keeps the resize width desktop-only, as a CSS var instead of an inline width', () => {
+    render(<ChatSidebar {...defaultProps} width={420} />);
+
+    const root = document.querySelector<HTMLElement>('[data-tour="chat-sidebar"]')!;
+    expect(root.style.width).toBe('');
+    expect(root.style.getPropertyValue('--chat-sidebar-width')).toBe('420px');
+    expect(root.className).toContain('w-full');
+    expect(root.className).toContain('md:w-[var(--chat-sidebar-width)]');
+  });
+
+  it('falls back to the fixed desktop width when no resize width is set', () => {
+    render(<ChatSidebar {...defaultProps} />);
+
+    const root = document.querySelector<HTMLElement>('[data-tour="chat-sidebar"]')!;
+    expect(root.style.width).toBe('');
+    expect(root.className).toContain('w-full');
+    expect(root.className).toContain('md:w-96');
+  });
+});

--- a/src/components/chat/chat-sidebar/ChatSidebar.tsx
+++ b/src/components/chat/chat-sidebar/ChatSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type CSSProperties } from 'react';
 import { Button } from '@evoapi/design-system/button';
 import { Checkbox } from '@evoapi/design-system/checkbox';
 import { Input } from '@evoapi/design-system/input';
@@ -638,9 +638,9 @@ const ChatSidebar = ({
       data-tour="chat-sidebar"
       className={`
         ${mobileView === 'list' ? 'flex' : 'hidden'} md:flex
-        w-full ${width == null ? 'md:w-96' : 'md:shrink-0'} border-r bg-card/50 flex-col h-full
+        w-full ${width == null ? 'md:w-96' : 'md:w-[var(--chat-sidebar-width)] md:shrink-0'} border-r bg-card/50 flex-col h-full
       `}
-      style={width != null ? { width: `${width}px` } : undefined}
+      style={width != null ? ({ '--chat-sidebar-width': `${width}px` } as CSSProperties) : undefined}
     >
       {/* Search and Filter Header */}
       <div className="p-4 border-b space-y-3">

--- a/src/components/chat/rich-text-editor/RichTextEditor.css
+++ b/src/components/chat/rich-text-editor/RichTextEditor.css
@@ -35,6 +35,12 @@
   color: hsl(var(--muted-foreground));
   position: absolute;
   pointer-events: none;
+  /* EVO-2234: keep the placeholder on one line and cut it with an ellipsis
+     instead of letting a long string clip mid-word on narrow (mobile) widths. */
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .prosemirror-editor:focus:empty:before,

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -318,6 +318,7 @@
     },
     "openConversation": "Open Conversation",
     "closeConversation": "Close conversation",
+    "backToConversations": "Back to conversations",
     "phoneNumber": "Phone number",
     "openContactPanel": "Open contact details",
     "closeContactPanel": "Close contact details"

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -313,6 +313,7 @@
     },
     "openConversation": "Abrir Conversación",
     "closeConversation": "Cerrar conversación",
+    "backToConversations": "Volver a las conversaciones",
     "phoneNumber": "Número de teléfono",
     "openContactPanel": "Abrir detalles del contacto",
     "closeContactPanel": "Cerrar detalles del contacto"

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -313,6 +313,7 @@
     },
     "openConversation": "Ouvrir la Conversation",
     "closeConversation": "Fermer la conversation",
+    "backToConversations": "Retour aux conversations",
     "phoneNumber": "Numéro de téléphone",
     "openContactPanel": "Ouvrir les détails du contact",
     "closeContactPanel": "Fermer les détails du contact"

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -313,6 +313,7 @@
     },
     "openConversation": "Apri Conversazione",
     "closeConversation": "Chiudi conversazione",
+    "backToConversations": "Torna alle conversazioni",
     "phoneNumber": "Numero di telefono",
     "openContactPanel": "Apri dettagli contatto",
     "closeContactPanel": "Chiudi dettagli contatto"

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -318,6 +318,7 @@
     },
     "openConversation": "Abrir Conversa",
     "closeConversation": "Fechar conversa",
+    "backToConversations": "Voltar para as conversas",
     "phoneNumber": "Número de telefone",
     "openContactPanel": "Abrir detalhes do contato",
     "closeContactPanel": "Fechar detalhes do contato"

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -313,6 +313,7 @@
     },
     "openConversation": "Abrir Conversa",
     "closeConversation": "Fechar conversa",
+    "backToConversations": "Voltar para as conversas",
     "phoneNumber": "Número de telefone",
     "openContactPanel": "Abrir detalhes do contato",
     "closeContactPanel": "Fechar detalhes do contato"


### PR DESCRIPTION
## Summary

At ≤768px the **open conversation** view was cramped (residue of the EVO-1782 mobile polish). This PR makes it responsive without touching desktop. All changes are generic responsive CSS in the community components (`vendor/crm`) — no shell/URL/panel logic (that is EVO-1846, enterprise).

- **ChatHeader** — de-crowd the header row on mobile: hide the long status pill (status is already conveyed by the `ConversationStatusButton` color) and the redundant close (X) button (the mobile back arrow already leaves the conversation); let the name/phone column shrink and truncate (`min-w-0` + `truncate`).
- **RichTextEditor** — the message-input placeholder is a single-line `data-placeholder`; truncate it with an ellipsis (`max-width:100%; nowrap; overflow:hidden; text-overflow:ellipsis`) instead of clipping mid-word. Width-driven, so it only bites when the text doesn't fit.
- **ChatSidebar** — the conversations list kept its desktop resize width on mobile: a raw inline `style.width` was overriding `w-full`. The px width is now desktop-only via `md:w-[var(--chat-sidebar-width)]`, so `w-full` reigns on mobile. The resize handle was already `hidden md:flex`.
- **AudioRecorder** — the recorder hugged the right corner on all widths; now it fills the row on mobile (`justify-between` + waveform `flex-1`) while keeping the WhatsApp-style right-hugged layout on desktop (`md:justify-end` + `md:w-40`).

## Scope note

This card grew during smoke, on the same axis (mobile layout of the open conversation). The card description carries a dated rescope callout: the conversations list was **not** actually "ok" on mobile (contrary to the original card), and the audio-recorder width was added. Two things stayed out and were filed separately:
- **Dark theme** (chat components with hardcoded colors) → **EVO-2254**.
- **URL panel orchestration** → EVO-1846 (enterprise shell).

## Validation

- `evo-ai-frontend-community`: `pnpm exec tsc -b --noEmit` → exit 0
- `evo-ai-frontend-community`: `pnpm exec eslint` on changed files → clean
- `evo-ai-frontend-community`: `pnpm exec vitest run` ChatHeader + RichTextEditor specs → pass; ChatSidebar spec has 7 **pre-existing** failures (pipeline submenu, baselined on clean develop — unrelated to this change)
- Manual smoke at ≤768px (DevTools mobile): header no overlap, placeholder ellipsis, list full-width, audio full-width — desktop unchanged.

## Linked Issue
- Fixes EVO-2234
- Sibling (filed from this work): EVO-2254 (dark theme)

## Summary by Sourcery

Improve the mobile responsiveness of the open chat conversation view without affecting desktop layouts.

Bug Fixes:
- Ensure the chat conversation header adapts on mobile by truncating long contact names, hiding the status pill, and hiding the redundant close button on small screens.
- Fix the chat sidebar width so the conversation list uses full width on mobile while preserving resizable width on desktop.
- Prevent rich text editor placeholders from clipping mid-word on narrow screens by constraining them to a single truncated line with ellipsis.
- Adjust the audio recorder layout so its controls and waveform fill the row on mobile while keeping the compact right-aligned layout on desktop.