### PR TITLE
Fix email content color in dark mode

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -417,7 +417,7 @@
   /* Elements with inline color styles will use those, others will use default black */
   /* This ensures HTML email templates maintain their original colors regardless of theme */
   .email-html-content-wrapper *:not([style*="color"]) {
-    color: #000000 !important;
+    color: #ffffff !important;
   }
 
   /* Elements without explicit color should use black, not theme colors */
@@ -426,7 +426,7 @@
   .email-html-content-wrapper span:not([style*="color"]),
   .email-html-content-wrapper td:not([style*="color"]),
   .email-html-content-wrapper th:not([style*="color"]) {
-    color: #000000 !important;
+    color: #ffffff !important;
   }
 }
 


### PR DESCRIPTION
## Descrição

Corrige a legibilidade do conteúdo HTML de e-mails quando o sistema está utilizando o modo escuro.

## Alterações

- Alterada a cor padrão do texto dos conteúdos HTML de e-mail de preto para branco quando não existe uma cor definida no estilo inline.
- Mantém os templates de e-mail legíveis no tema escuro.

## Motivo

Templates de e-mail sem uma definição explícita de cor estavam sendo renderizados com texto preto, dificultando a leitura quando o CRM estava no modo escuro.

Testado localmente.

## Summary by Sourcery

Bug Fixes:
- Ensure email HTML content without inline color styles renders with white text instead of black when viewed in dark mode.