### PR TITLE
fix(agents): exclusão em massa real na barra de seleção de agentes de IA

### DIFF
--- a/src/i18n/locales/en/agents.json
+++ b/src/i18n/locales/en/agents.json
@@ -161,7 +161,17 @@
     "deleting": "Deleting...",
     "success": "AI agent \"{{name}}\" deleted successfully!"
   },
-  "bulkDelete": "Bulk Delete",
+  "bulkDeleteDialog": {
+    "title": "Delete AI Agents",
+    "description_one": "Are you sure you want to delete {{count}} AI agent? This action cannot be undone.",
+    "description_other": "Are you sure you want to delete {{count}} AI agents? This action cannot be undone.",
+    "cancel": "Cancel",
+    "confirm": "Delete",
+    "deleting": "Deleting...",
+    "success_one": "{{count}} AI agent deleted successfully!",
+    "success_other": "{{count}} AI agents deleted successfully!",
+    "partialError": "{{failed}} of {{total}} AI agents could not be deleted"
+  },
   "testA2A": "Test A2A",
   "moveToFolder": "Move to folder",
   "exportJSON": "Export JSON",

--- a/src/i18n/locales/es/agents.json
+++ b/src/i18n/locales/es/agents.json
@@ -161,7 +161,17 @@
     "deleting": "Eliminando...",
     "success": "¡Agente de IA \"{{name}}\" eliminado con éxito!"
   },
-  "bulkDelete": "Funcionalidad de eliminación masiva en desarrollo",
+  "bulkDeleteDialog": {
+    "title": "Eliminar Agentes de IA",
+    "description_one": "¿Estás seguro de que deseas eliminar {{count}} agente de IA? Esta acción no se puede deshacer.",
+    "description_other": "¿Estás seguro de que deseas eliminar {{count}} agentes de IA? Esta acción no se puede deshacer.",
+    "cancel": "Cancelar",
+    "confirm": "Eliminar",
+    "deleting": "Eliminando...",
+    "success_one": "¡{{count}} agente de IA eliminado con éxito!",
+    "success_other": "¡{{count}} agentes de IA eliminados con éxito!",
+    "partialError": "{{failed}} de {{total}} agentes de IA no se pudieron eliminar"
+  },
   "testA2A": "Funcionalidad de prueba A2A en desarrollo",
   "moveToFolder": "Funcionalidad de mover a carpeta en desarrollo",
   "exportJSON": "Funcionalidad de exportar JSON en desarrollo",

--- a/src/i18n/locales/fr/agents.json
+++ b/src/i18n/locales/fr/agents.json
@@ -161,7 +161,17 @@
     "deleting": "Suppression...",
     "success": "Agent IA \"{{name}}\" supprimé avec succès !"
   },
-  "bulkDelete": "Fonctionnalité de suppression en masse en développement",
+  "bulkDeleteDialog": {
+    "title": "Supprimer les Agents IA",
+    "description_one": "Êtes-vous sûr de vouloir supprimer {{count}} agent IA ? Cette action ne peut pas être annulée.",
+    "description_other": "Êtes-vous sûr de vouloir supprimer {{count}} agents IA ? Cette action ne peut pas être annulée.",
+    "cancel": "Annuler",
+    "confirm": "Supprimer",
+    "deleting": "Suppression...",
+    "success_one": "{{count}} agent IA supprimé avec succès !",
+    "success_other": "{{count}} agents IA supprimés avec succès !",
+    "partialError": "{{failed}} sur {{total}} agents IA n'ont pas pu être supprimés"
+  },
   "testA2A": "Fonctionnalité de test A2A en développement",
   "moveToFolder": "Fonctionnalité de déplacement vers un dossier en développement",
   "exportJSON": "Fonctionnalité d'exportation JSON en développement",

--- a/src/i18n/locales/it/agents.json
+++ b/src/i18n/locales/it/agents.json
@@ -161,7 +161,17 @@
     "deleting": "Eliminazione...",
     "success": "Agente IA \"{{name}}\" eliminato con successo!"
   },
-  "bulkDelete": "Funzionalità di eliminazione di massa in sviluppo",
+  "bulkDeleteDialog": {
+    "title": "Elimina Agenti IA",
+    "description_one": "Sei sicuro di voler eliminare {{count}} agente IA? Questa azione non può essere annullata.",
+    "description_other": "Sei sicuro di voler eliminare {{count}} agenti IA? Questa azione non può essere annullata.",
+    "cancel": "Annulla",
+    "confirm": "Elimina",
+    "deleting": "Eliminazione...",
+    "success_one": "{{count}} agente IA eliminato con successo!",
+    "success_other": "{{count}} agenti IA eliminati con successo!",
+    "partialError": "Non è stato possibile eliminare {{failed}} di {{total}} agenti IA"
+  },
   "testA2A": "Funzionalità di test A2A in sviluppo",
   "moveToFolder": "Funzionalità di spostamento in cartella in sviluppo",
   "exportJSON": "Funzionalità di esportazione JSON in sviluppo",

--- a/src/i18n/locales/pt-BR/agents.json
+++ b/src/i18n/locales/pt-BR/agents.json
@@ -161,7 +161,17 @@
     "deleting": "Deletando...",
     "success": "Agente de IA \"{{name}}\" deletado com sucesso!"
   },
-  "bulkDelete": "Funcionalidade de exclusão em massa em desenvolvimento",
+  "bulkDeleteDialog": {
+    "title": "Deletar Agentes de IA",
+    "description_one": "Tem certeza de que deseja deletar {{count}} agente de IA? Esta ação não pode ser desfeita.",
+    "description_other": "Tem certeza de que deseja deletar {{count}} agentes de IA? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Deletar",
+    "deleting": "Deletando...",
+    "success_one": "{{count}} agente de IA deletado com sucesso!",
+    "success_other": "{{count}} agentes de IA deletados com sucesso!",
+    "partialError": "{{failed}} de {{total}} agentes de IA não puderam ser deletados"
+  },
   "testA2A": "Funcionalidade de teste A2A em desenvolvimento",
   "moveToFolder": "Funcionalidade de mover para pasta em desenvolvimento",
   "exportJSON": "Funcionalidade de exportar JSON em desenvolvimento",

--- a/src/i18n/locales/pt/agents.json
+++ b/src/i18n/locales/pt/agents.json
@@ -161,7 +161,17 @@
     "deleting": "Deletando...",
     "success": "Agente de IA \"{{name}}\" deletado com sucesso!"
   },
-  "bulkDelete": "Funcionalidade de exclusão em massa em desenvolvimento",
+  "bulkDeleteDialog": {
+    "title": "Deletar Agentes de IA",
+    "description_one": "Tem certeza de que deseja deletar {{count}} agente de IA? Esta ação não pode ser desfeita.",
+    "description_other": "Tem certeza de que deseja deletar {{count}} agentes de IA? Esta ação não pode ser desfeita.",
+    "cancel": "Cancelar",
+    "confirm": "Deletar",
+    "deleting": "Deletando...",
+    "success_one": "{{count}} agente de IA deletado com sucesso!",
+    "success_other": "{{count}} agentes de IA deletados com sucesso!",
+    "partialError": "{{failed}} de {{total}} agentes de IA não puderam ser deletados"
+  },
   "testA2A": "Funcionalidade de teste A2A em desenvolvimento",
   "moveToFolder": "Funcionalidade de mover para pasta em desenvolvimento",
   "exportJSON": "Funcionalidade de exportar JSON em desenvolvimento",

--- a/src/pages/Customer/Agents/Agents.spec.tsx
+++ b/src/pages/Customer/Agents/Agents.spec.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Agents from './Agents';
+import { Agent } from '@/types/agents';
+
+// The selection-bar "Delete AI Agent" used to be a stub: it fired an informative
+// toast and deleted nothing. These specs pin the real behavior: confirm dialog,
+// one DELETE per selected agent, honest partial-failure reporting and a refetch.
+const agentA = { id: 'a-1', name: 'Support bot', description: '' } as unknown as Agent;
+const agentB = { id: 'a-2', name: 'Sales bot', description: '' } as unknown as Agent;
+
+const getAccessibleAgents = vi.fn();
+const deleteAgent = vi.fn();
+const success = vi.fn();
+const error = vi.fn();
+const can = vi.fn();
+
+vi.mock('@/services/agents', () => ({
+  getAccessibleAgents: (...args: unknown[]) => getAccessibleAgents(...args),
+  deleteAgent: (...args: unknown[]) => deleteAgent(...args),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => success(...args),
+    error: (...args: unknown[]) => error(...args),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    can: (...args: unknown[]) => can(...args),
+    isReady: true,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    // Options-aware echo so assertions can see the interpolated count.
+    t: (key: string, opts?: { count?: number }) =>
+      opts && typeof opts.count === 'number' ? `${key}#${opts.count}` : key,
+    currentLanguage: 'en',
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/agents/list' }),
+}));
+
+vi.mock('@/hooks/useDarkMode', () => ({ useDarkMode: () => undefined }));
+vi.mock('@/tours', () => ({ AgentsTour: () => null }));
+vi.mock('@/components/ApiKeysModal', () => ({ ApiKeysModal: () => null }));
+
+// The page wires selection and bulk actions through these components; the specs
+// only need the wiring, not their markup.
+vi.mock('@/components/agents', () => ({
+  AgentsTable: ({
+    agents,
+    onSelectionChange,
+  }: {
+    agents: Agent[];
+    onSelectionChange: (agents: Agent[]) => void;
+  }) => (
+    <button data-testid="select-all" onClick={() => onSelectionChange(agents)}>
+      select-all
+    </button>
+  ),
+  AgentsHeader: ({
+    selectedCount,
+    onBulkDelete,
+  }: {
+    selectedCount: number;
+    onBulkDelete: () => void;
+  }) => (
+    <div>
+      <span data-testid="selected-count">{selectedCount}</span>
+      <button data-testid="bulk-delete" onClick={onBulkDelete}>
+        bulk-delete
+      </button>
+    </div>
+  ),
+  AgentsPagination: () => null,
+  AgentWizardModal: () => null,
+  AgentsFilterPanel: () => null,
+  AgentsTabsLayout: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+async function selectAllAndOpenBulkDialog() {
+  await userEvent.click(await screen.findByTestId('select-all'));
+  await userEvent.click(screen.getByTestId('bulk-delete'));
+}
+
+describe('Agents bulk delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    can.mockReturnValue(true);
+    getAccessibleAgents.mockResolvedValue({
+      data: [agentA, agentB],
+      meta: { pagination: { page: 1, page_size: 48, total: 2, total_pages: 1 } },
+    });
+    deleteAgent.mockResolvedValue({});
+  });
+
+  it('opens a confirmation dialog naming how many agents are selected', async () => {
+    render(<Agents />);
+
+    await selectAllAndOpenBulkDialog();
+
+    expect(await screen.findByText('bulkDeleteDialog.title')).toBeInTheDocument();
+    expect(screen.getByText('bulkDeleteDialog.description#2')).toBeInTheDocument();
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+
+  it('deletes every selected agent, clears the selection and refetches', async () => {
+    render(<Agents />);
+
+    await selectAllAndOpenBulkDialog();
+    await userEvent.click(await screen.findByText('bulkDeleteDialog.confirm'));
+
+    await waitFor(() => expect(deleteAgent).toHaveBeenCalledTimes(2));
+    expect(deleteAgent).toHaveBeenCalledWith('a-1');
+    expect(deleteAgent).toHaveBeenCalledWith('a-2');
+
+    await waitFor(() => expect(success).toHaveBeenCalledWith('bulkDeleteDialog.success#2'));
+    expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
+    // Initial load + post-delete refetch, preserving the user's page size (not the
+    // 24-per-page default loadAgents falls back to).
+    await waitFor(() => expect(getAccessibleAgents).toHaveBeenCalledTimes(2));
+    expect(getAccessibleAgents).toHaveBeenLastCalledWith(1, 48, expect.anything());
+  });
+
+  it('reports a partial failure instead of claiming success', async () => {
+    deleteAgent.mockImplementation((id: string) =>
+      id === 'a-2' ? Promise.reject(new Error('boom')) : Promise.resolve({}),
+    );
+    render(<Agents />);
+
+    await selectAllAndOpenBulkDialog();
+    await userEvent.click(await screen.findByText('bulkDeleteDialog.confirm'));
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith('bulkDeleteDialog.partialError'));
+    expect(success).not.toHaveBeenCalled();
+    // The refetch reconciles the list with what actually got deleted.
+    await waitFor(() => expect(getAccessibleAgents).toHaveBeenCalledTimes(2));
+  });
+
+  it('denies the action without the delete permission', async () => {
+    can.mockImplementation((_resource: string, action: string) => action !== 'delete');
+    render(<Agents />);
+
+    await selectAllAndOpenBulkDialog();
+
+    expect(error).toHaveBeenCalledWith('permissions.deleteDenied');
+    expect(screen.queryByText('bulkDeleteDialog.title')).not.toBeInTheDocument();
+    expect(deleteAgent).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/Customer/Agents/Agents.spec.tsx
+++ b/src/pages/Customer/Agents/Agents.spec.tsx
@@ -39,9 +39,15 @@ vi.mock('@/contexts/PermissionsContext', () => ({
 
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({
-    // Options-aware echo so assertions can see the interpolated count.
-    t: (key: string, opts?: { count?: number }) =>
-      opts && typeof opts.count === 'number' ? `${key}#${opts.count}` : key,
+    // Options-aware echo. Every interpolated value lands in the echoed string, not just
+    // `count`: a swapped `failed`/`total` has to fail the spec instead of still matching
+    // on the bare key.
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const named = Object.keys(opts ?? {}).sort();
+      return named.length > 0
+        ? `${key}#${named.map(name => `${name}=${String(opts![name])}`).join(',')}`
+        : key;
+    },
     currentLanguage: 'en',
   }),
 }));
@@ -111,7 +117,7 @@ describe('Agents bulk delete', () => {
     await selectAllAndOpenBulkDialog();
 
     expect(await screen.findByText('bulkDeleteDialog.title')).toBeInTheDocument();
-    expect(screen.getByText('bulkDeleteDialog.description#2')).toBeInTheDocument();
+    expect(screen.getByText('bulkDeleteDialog.description#count=2')).toBeInTheDocument();
     expect(deleteAgent).not.toHaveBeenCalled();
   });
 
@@ -125,7 +131,7 @@ describe('Agents bulk delete', () => {
     expect(deleteAgent).toHaveBeenCalledWith('a-1');
     expect(deleteAgent).toHaveBeenCalledWith('a-2');
 
-    await waitFor(() => expect(success).toHaveBeenCalledWith('bulkDeleteDialog.success#2'));
+    await waitFor(() => expect(success).toHaveBeenCalledWith('bulkDeleteDialog.success#count=2'));
     expect(screen.getByTestId('selected-count')).toHaveTextContent('0');
     // Initial load + post-delete refetch, preserving the user's page size (not the
     // 24-per-page default loadAgents falls back to).
@@ -142,10 +148,29 @@ describe('Agents bulk delete', () => {
     await selectAllAndOpenBulkDialog();
     await userEvent.click(await screen.findByText('bulkDeleteDialog.confirm'));
 
-    await waitFor(() => expect(error).toHaveBeenCalledWith('bulkDeleteDialog.partialError'));
+    // The counts are the whole point of the report: 1 of the 2 selected failed.
+    await waitFor(() =>
+      expect(error).toHaveBeenCalledWith('bulkDeleteDialog.partialError#failed=1,total=2'),
+    );
     expect(success).not.toHaveBeenCalled();
     // The refetch reconciles the list with what actually got deleted.
     await waitFor(() => expect(getAccessibleAgents).toHaveBeenCalledTimes(2));
+  });
+
+  it('clamps the refetch to the last page that survives the deletion', async () => {
+    // Page 2 holds the single leftover row of a 21-agent list. Deleting it leaves page 2
+    // with nothing to show, so the refetch has to walk back to page 1.
+    getAccessibleAgents.mockResolvedValue({
+      data: [agentA],
+      meta: { pagination: { page: 2, page_size: 20, total: 21, total_pages: 2 } },
+    });
+    render(<Agents />);
+
+    await selectAllAndOpenBulkDialog();
+    await userEvent.click(await screen.findByText('bulkDeleteDialog.confirm'));
+
+    await waitFor(() => expect(getAccessibleAgents).toHaveBeenCalledTimes(2));
+    expect(getAccessibleAgents).toHaveBeenLastCalledWith(1, 20, expect.anything());
   });
 
   it('denies the action without the delete permission', async () => {

--- a/src/pages/Customer/Agents/Agents.tsx
+++ b/src/pages/Customer/Agents/Agents.tsx
@@ -268,10 +268,19 @@ const Agentes = () => {
     setIsBulkDeleting(true);
     try {
       const results = await Promise.allSettled(selected.map(agent => deleteAgent(agent.id)));
-      const failed = results.filter(result => result.status === 'rejected').length;
+      const rejected = results.filter(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      );
+      const failed = rejected.length;
       const deleted = selected.length - failed;
 
       if (failed > 0) {
+        // The toast only carries a count: without this the reason each delete failed is
+        // lost, and a partial failure leaves nothing to debug.
+        console.error(
+          'Erro ao deletar agentes em massa:',
+          rejected.map(result => result.reason),
+        );
         toast.error(t('bulkDeleteDialog.partialError', { failed, total: selected.length }));
       } else {
         toast.success(t('bulkDeleteDialog.success', { count: deleted }));

--- a/src/pages/Customer/Agents/Agents.tsx
+++ b/src/pages/Customer/Agents/Agents.tsx
@@ -78,6 +78,8 @@ const Agentes = () => {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
   const isWizardOpen = location.pathname === '/agents/new';
 
   const loadAgents = useCallback(
@@ -249,7 +251,44 @@ const Agentes = () => {
   };
 
   const handleBulkDelete = () => {
-    toast.info(t('bulkDelete'));
+    if (!can('ai_agents', 'delete')) {
+      toast.error(t('permissions.deleteDenied'));
+      return;
+    }
+    if (state.selectedAgents.length === 0) {
+      return;
+    }
+    setBulkDeleteDialogOpen(true);
+  };
+
+  const confirmBulkDelete = async () => {
+    const selected = state.selectedAgents;
+    if (selected.length === 0) return;
+
+    setIsBulkDeleting(true);
+    try {
+      const results = await Promise.allSettled(selected.map(agent => deleteAgent(agent.id)));
+      const failed = results.filter(result => result.status === 'rejected').length;
+      const deleted = selected.length - failed;
+
+      if (failed > 0) {
+        toast.error(t('bulkDeleteDialog.partialError', { failed, total: selected.length }));
+      } else {
+        toast.success(t('bulkDeleteDialog.success', { count: deleted }));
+      }
+
+      // Refetch instead of local math: after a partial failure the local list is a guess,
+      // and the current page may no longer exist once rows are gone.
+      const { total, page_size, page } = state.meta.pagination;
+      const remainingPages = Math.max(1, Math.ceil(Math.max(0, total - deleted) / page_size));
+      setState(prev => ({ ...prev, selectedAgents: [] }));
+      setBulkDeleteDialogOpen(false);
+      // per_page must travel along: loadAgents defaults to 24, which would desync the
+      // target page computed from the user's current page size.
+      await loadAgents({ page: Math.min(page, remainingPages), per_page: page_size });
+    } finally {
+      setIsBulkDeleting(false);
+    }
   };
 
   // A facet change is a refetch from page 1: staying on page 5 would ask for a page the
@@ -384,6 +423,34 @@ const Agentes = () => {
             </Button>
             <Button variant="destructive" onClick={confirmDeleteAgent} disabled={isDeleting}>
               {isDeleting ? t('deleteDialog.deleting') : t('deleteDialog.confirm')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={bulkDeleteDialogOpen}
+        onOpenChange={open => {
+          if (!isBulkDeleting) setBulkDeleteDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('bulkDeleteDialog.title')}</DialogTitle>
+            <DialogDescription>
+              {t('bulkDeleteDialog.description', { count: state.selectedAgents.length })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBulkDeleteDialogOpen(false)}
+              disabled={isBulkDeleting}
+            >
+              {t('bulkDeleteDialog.cancel')}
+            </Button>
+            <Button variant="destructive" onClick={confirmBulkDelete} disabled={isBulkDeleting}>
+              {isBulkDeleting ? t('bulkDeleteDialog.deleting') : t('bulkDeleteDialog.confirm')}
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- O botão **Excluir Agente de IA** da barra de seleção era um stub: só disparava um toast informativo (em inglês, "Bulk Delete", facilmente lido como sucesso) e nenhum agente era excluído.
- Agora ele abre um diálogo de confirmação citando a quantidade selecionada, exclui cada agente via `DELETE /agents/:id`, reporta falhas parciais em vez de assumir sucesso, refaz a busca preservando página e page size, e limpa a seleção.
- O handler passa a checar `ai_agents:delete` antes de abrir o diálogo, espelhando a exclusão de linha única (defesa em profundidade — o botão já era gateado e a API já exige a permissão server-side).
- A chave i18n `bulkDelete` (o toast fake) foi removida nos 6 locales e substituída por `bulkDeleteDialog.*` com plurais `_one`/`_other` (padrão do i18next v25).

## Security
- Sem superfície nova: endpoint existente, já protegido server-side por permissão + ownership; o front apenas soma a checagem de UX no handler.
- Sem `dangerouslySetInnerHTML`, sem input livre do usuário.

## Test plan
- `npx vitest run src/pages/Customer/Agents/Agents.spec.tsx` — 4 testes novos: diálogo com contagem, um DELETE por selecionado + refetch preservando page size + seleção limpa, falha parcial reportada sem toast de sucesso, negação sem a permissão.
- `npx vitest run src/i18n/locales/i18n-parity.spec.ts` — paridade de `agents.json` verde (a falha de `products.json` é pré-existente na `develop` e não é tocada aqui).
- `npx tsc -b` e `npx eslint` nos arquivos alterados, limpos.
- Manual: selecionar 2+ agentes → confirmar → agentes somem e a paginação atualiza; selecionar 1 → texto no singular; cancelar → nada excluído.

## Changed Files
- `src/pages/Customer/Agents/Agents.tsx`
- `src/pages/Customer/Agents/Agents.spec.tsx` (novo)
- `src/i18n/locales/{pt,pt-BR,en,es,fr,it}/agents.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement real bulk deletion for AI agents from the selection bar, with confirmation, permission checks, honest feedback, and list refresh.

New Features:
- Add a confirmation dialog for bulk deleting selected AI agents from the agents selection bar.
- Enable actual bulk deletion of selected agents by calling the backend delete endpoint for each selected agent.

Enhancements:
- Report partial failures in bulk deletion with dedicated feedback instead of always assuming success.
- Refetch the agents list after bulk deletion while preserving the current page and page size, and clearing the selection.
- Update i18n keys for bulk deletion across all locales to use structured dialog messages with pluralization support.

Tests:
- Add a dedicated test suite for agents bulk delete behavior, covering dialog display, deletion and refetch, partial failures, and permission denial.