### PR TITLE
fix(channels): mensagem do backend chega na tela quando um canal é recusado

### DIFF
--- a/src/hooks/channels/useChannelSubmission.spec.ts
+++ b/src/hooks/channels/useChannelSubmission.spec.ts
@@ -146,9 +146,6 @@ describe('useChannelSubmission.submitCreate', () => {
     expect(toast.success).toHaveBeenCalledWith('Canal criado com sucesso');
   });
 
-  // A create barred by the plan ceiling comes back as 422 with a ready-to-show
-  // reason; showing `error.message` would print axios's "Request failed with
-  // status code 422" and leave the operator with no idea what to do.
   it('shows the reason the backend gave for refusing the create', async () => {
     createChannelMock.mockRejectedValue({
       response: {

--- a/src/hooks/channels/useChannelSubmission.spec.ts
+++ b/src/hooks/channels/useChannelSubmission.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
+import { toast } from 'sonner';
 import { useChannelSubmission } from './useChannelSubmission';
 import InboxesService from '@/services/channels/inboxesService';
 import EvolutionService from '@/services/channels/evolutionService';
@@ -137,5 +138,42 @@ describe('useChannelSubmission.submitCreate', () => {
       instance_uuid: 'uuid-1',
       instance_token: 'tok-1',
     });
+  });
+
+  it('confirms the creation on screen', async () => {
+    await submit('api', 'api', { name: 'api-inbox', webhook_url: 'https://hook' });
+
+    expect(toast.success).toHaveBeenCalledWith('Canal criado com sucesso');
+  });
+
+  // A create barred by the plan ceiling comes back as 422 with a ready-to-show
+  // reason; showing `error.message` would print axios's "Request failed with
+  // status code 422" and leave the operator with no idea what to do.
+  it('shows the reason the backend gave for refusing the create', async () => {
+    createChannelMock.mockRejectedValue({
+      response: {
+        status: 422,
+        data: {
+          success: false,
+          error: {
+            code: 'QUOTA_EXCEEDED',
+            message: 'Limite do plano excedido (5/5) para channels',
+          },
+        },
+      },
+      message: 'Request failed with status code 422',
+    } as never);
+
+    await submit('api', 'api', { name: 'api-inbox', webhook_url: 'https://hook' });
+
+    expect(toast.error).toHaveBeenCalledWith('Limite do plano excedido (5/5) para channels');
+  });
+
+  it('falls back to its own message when the failure carries no envelope', async () => {
+    createChannelMock.mockRejectedValue(new Error('Network Error') as never);
+
+    await submit('api', 'api', { name: 'api-inbox', webhook_url: 'https://hook' });
+
+    expect(toast.error).toHaveBeenCalledWith('Network Error');
   });
 });

--- a/src/hooks/channels/useChannelSubmission.ts
+++ b/src/hooks/channels/useChannelSubmission.ts
@@ -27,6 +27,7 @@ import NotificameService from '@/services/channels/notificameService';
 import { ChannelType, FormData } from '@/hooks/channels/useChannelForm';
 import { useChannelValidation } from '@/hooks/channels/useChannelValidation';
 import { useAppDataStore } from '@/store/appDataStore';
+import { apiErrorMessage } from '@/utils/apiHelpers';
 
 export const useChannelSubmission = (form?: FormData) => {
   const navigate = useNavigate();
@@ -147,7 +148,7 @@ export const useChannelSubmission = (form?: FormData) => {
           result = { success: true, message: 'Conexão verificada com sucesso' };
           setHealthCheckPassed(true);
         } catch (error) {
-          result = { success: false, error: (error as Error).message };
+          result = { success: false, error: apiErrorMessage(error) || (error as Error).message };
           setHealthCheckPassed(false);
         }
       } else if (selectedProvider.id === 'evolution_go') {
@@ -201,7 +202,7 @@ export const useChannelSubmission = (form?: FormData) => {
           result = { success: true, message: 'Conexão verificada com sucesso' };
           setHealthCheckPassed(true);
         } catch (error) {
-          result = { success: false, error: (error as Error).message };
+          result = { success: false, error: apiErrorMessage(error) || (error as Error).message };
           setHealthCheckPassed(false);
         }
       } else if (selectedProvider.id === 'twilio' && selectedChannel.type === 'whatsapp') {
@@ -216,7 +217,7 @@ export const useChannelSubmission = (form?: FormData) => {
               : undefined,
           });
         } catch (error) {
-          result = { success: false, error: (error as Error).message };
+          result = { success: false, error: apiErrorMessage(error) || (error as Error).message };
         }
       } else if (selectedProvider.id === 'notificame') {
         try {
@@ -226,7 +227,7 @@ export const useChannelSubmission = (form?: FormData) => {
             phone_number: getStr(form, 'phone_number'),
           });
         } catch (error) {
-          result = { success: false, error: (error as Error).message };
+          result = { success: false, error: apiErrorMessage(error) || (error as Error).message };
         }
       }
 
@@ -238,7 +239,9 @@ export const useChannelSubmission = (form?: FormData) => {
         }
       }
     } catch (error) {
-      toast.error((error as Error).message || 'Erro no teste de conexão');
+      toast.error(
+        apiErrorMessage(error) || (error as Error).message || 'Erro no teste de conexão',
+      );
     } finally {
       setIsTesting(false);
     }
@@ -441,7 +444,9 @@ export const useChannelSubmission = (form?: FormData) => {
                   : undefined,
               });
             } catch (error) {
-              throw new Error((error as Error).message || 'Falha na verificação do Twilio');
+              throw new Error(
+                apiErrorMessage(error) || (error as Error).message || 'Falha na verificação do Twilio',
+              );
             }
             payload = {
               name: getStr(form, 'name') || 'WhatsApp Twilio',
@@ -467,7 +472,11 @@ export const useChannelSubmission = (form?: FormData) => {
                 phone_number: getStr(form, 'phone_number'),
               });
             } catch (error) {
-              throw new Error((error as Error).message || 'Falha na verificação do Notificame');
+              throw new Error(
+                apiErrorMessage(error) ||
+                  (error as Error).message ||
+                  'Falha na verificação do Notificame',
+              );
             }
             payload = {
               name: getStr(form, 'name') || 'WhatsApp Notificame',
@@ -711,8 +720,11 @@ export const useChannelSubmission = (form?: FormData) => {
         navigate(`/channels/${createdId}/settings`);
       }
     } catch (e: unknown) {
+      // The backend rejects a create with a ready-to-show reason in the envelope
+      // (plan quota, validation). Reading only `.message` off the rejection would
+      // print axios's "Request failed with status code 422" instead.
       const err = e as Error;
-      toast.error(err?.message || 'Falha ao criar canal');
+      toast.error(apiErrorMessage(e) || err?.message || 'Falha ao criar canal');
     } finally {
       setIsSubmitting(false);
     }

--- a/src/hooks/channels/useChannelSubmission.ts
+++ b/src/hooks/channels/useChannelSubmission.ts
@@ -720,9 +720,6 @@ export const useChannelSubmission = (form?: FormData) => {
         navigate(`/channels/${createdId}/settings`);
       }
     } catch (e: unknown) {
-      // The backend rejects a create with a ready-to-show reason in the envelope
-      // (plan quota, validation). Reading only `.message` off the rejection would
-      // print axios's "Request failed with status code 422" instead.
       const err = e as Error;
       toast.error(apiErrorMessage(e) || err?.message || 'Falha ao criar canal');
     } finally {

--- a/src/hooks/channels/useChannelValidation.spec.ts
+++ b/src/hooks/channels/useChannelValidation.spec.ts
@@ -4,9 +4,6 @@ import { useChannelValidation } from './useChannelValidation';
 
 vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
 
-// Every guard in useChannelValidation toasts before returning false, except one:
-// picking "whatsapp" with no provider selected returned false silently (CRM-114) —
-// the create button did nothing visible.
 describe('validateByChannelAndProvider — whatsapp without a provider', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/hooks/channels/useChannelValidation.spec.ts
+++ b/src/hooks/channels/useChannelValidation.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+import { useChannelValidation } from './useChannelValidation';
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+// Every guard in useChannelValidation toasts before returning false, except one:
+// picking "whatsapp" with no provider selected returned false silently (CRM-114) —
+// the create button did nothing visible.
+describe('validateByChannelAndProvider — whatsapp without a provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('toasts and fails validation instead of exiting silently', () => {
+    const { validateByChannelAndProvider } = useChannelValidation();
+
+    const result = validateByChannelAndProvider('whatsapp', undefined, {});
+
+    expect(result).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith('Selecione um provedor');
+  });
+});

--- a/src/hooks/channels/useChannelValidation.ts
+++ b/src/hooks/channels/useChannelValidation.ts
@@ -190,9 +190,7 @@ export const useChannelValidation = () => {
         return validateWebWidget(form);
 
       case 'whatsapp':
-        // Every other guard in this file toasts before returning false — this was
-        // the one silent exit (CRM-114): pick a provider without filling anything
-        // else and the button did nothing visible.
+        // Every other guard in this file toasts before returning false.
         if (!providerId) {
           toast.error('Selecione um provedor');
           return false;

--- a/src/hooks/channels/useChannelValidation.ts
+++ b/src/hooks/channels/useChannelValidation.ts
@@ -190,7 +190,13 @@ export const useChannelValidation = () => {
         return validateWebWidget(form);
 
       case 'whatsapp':
-        if (!providerId) return false;
+        // Every other guard in this file toasts before returning false — this was
+        // the one silent exit (CRM-114): pick a provider without filling anything
+        // else and the button did nothing visible.
+        if (!providerId) {
+          toast.error('Selecione um provedor');
+          return false;
+        }
 
         switch (providerId) {
           case 'twilio':

--- a/src/utils/apiHelpers.spec.ts
+++ b/src/utils/apiHelpers.spec.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { apiErrorMessage } from './apiHelpers';
 
-// The envelope every controller renders through
-// app/controllers/concerns/api_response_helper.rb#error_response.
+// Mirrors app/controllers/concerns/api_response_helper.rb#error_response.
 function rejection(data: unknown, status = 422) {
   return { response: { status, data }, message: `Request failed with status code ${status}` };
 }
@@ -24,8 +23,6 @@ describe('apiErrorMessage', () => {
     );
   });
 
-  // Without a message from the server there is nothing better to show than the
-  // caller's own localized fallback — "Unprocessable Entity" is not it.
   it('returns undefined when the body carries no message', () => {
     expect(apiErrorMessage(rejection({ whatever: true }))).toBeUndefined();
     expect(apiErrorMessage(rejection(null))).toBeUndefined();
@@ -35,8 +32,6 @@ describe('apiErrorMessage', () => {
     expect(apiErrorMessage(new Error('Network Error'))).toBeUndefined();
   });
 
-  // A catch block can receive anything, and this runs inside error handling —
-  // it must not become the failure it is reporting.
   it.each([null, undefined, 'boom', 42])('returns undefined without throwing for %p', value => {
     expect(apiErrorMessage(value)).toBeUndefined();
   });

--- a/src/utils/apiHelpers.spec.ts
+++ b/src/utils/apiHelpers.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { apiErrorMessage } from './apiHelpers';
+
+// The envelope every controller renders through
+// app/controllers/concerns/api_response_helper.rb#error_response.
+function rejection(data: unknown, status = 422) {
+  return { response: { status, data }, message: `Request failed with status code ${status}` };
+}
+
+describe('apiErrorMessage', () => {
+  it('reads the message the backend authored', () => {
+    const error = rejection({
+      success: false,
+      error: { code: 'QUOTA_EXCEEDED', message: 'Limite do plano excedido (5/5) para channels' },
+    });
+
+    expect(apiErrorMessage(error)).toBe('Limite do plano excedido (5/5) para channels');
+  });
+
+  it('reads the legacy string and bare-message shapes', () => {
+    expect(apiErrorMessage(rejection({ error: 'Canal já existe' }))).toBe('Canal já existe');
+    expect(apiErrorMessage(rejection({ message: 'Nome é obrigatório' }))).toBe(
+      'Nome é obrigatório',
+    );
+  });
+
+  // Without a message from the server there is nothing better to show than the
+  // caller's own localized fallback — "Unprocessable Entity" is not it.
+  it('returns undefined when the body carries no message', () => {
+    expect(apiErrorMessage(rejection({ whatever: true }))).toBeUndefined();
+    expect(apiErrorMessage(rejection(null))).toBeUndefined();
+  });
+
+  it('returns undefined for a rejection with no response at all', () => {
+    expect(apiErrorMessage(new Error('Network Error'))).toBeUndefined();
+  });
+
+  // A catch block can receive anything, and this runs inside error handling —
+  // it must not become the failure it is reporting.
+  it.each([null, undefined, 'boom', 42])('returns undefined without throwing for %p', value => {
+    expect(apiErrorMessage(value)).toBeUndefined();
+  });
+});

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -108,6 +108,30 @@ export function extractError(error: any): ErrorInfo {
 }
 
 /**
+ * Message the backend authored for the user in the error envelope
+ * ({ success: false, error: { code, message } }), or undefined when the response
+ * carries none.
+ *
+ * Returning undefined instead of a message lets each caller keep its own
+ * localized fallback: extractError's last resort is the HTTP status text, and
+ * "Unprocessable Entity" reads worse on screen than "Falha ao criar canal".
+ * Rejections without a response body (a local `throw`, a network failure) are
+ * not this function's business either — the caller still has `error.message`.
+ *
+ * @param error - Value caught from a rejected request (anything at all)
+ * @returns The server-authored message, or undefined
+ */
+export function apiErrorMessage(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+
+  const data = (error as { response?: { data?: unknown } }).response?.data;
+  if (!data || typeof data !== 'object') return undefined;
+
+  const { code, message } = extractError(error);
+  return code.startsWith('HTTP_') ? undefined : message;
+}
+
+/**
  * Extract success message from response
  * @param response - Axios response object
  * @returns Success message or undefined

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -108,17 +108,9 @@ export function extractError(error: any): ErrorInfo {
 }
 
 /**
- * Message the backend authored for the user in the error envelope
- * ({ success: false, error: { code, message } }), or undefined when the response
- * carries none.
- *
- * Returning undefined instead of a message lets each caller keep its own
- * localized fallback: extractError's last resort is the HTTP status text, and
- * "Unprocessable Entity" reads worse on screen than "Falha ao criar canal".
- * Rejections without a response body (a local `throw`, a network failure) are
- * not this function's business either — the caller still has `error.message`.
- *
- * @param error - Value caught from a rejected request (anything at all)
+ * The backend's message from the error envelope, or undefined if it has none —
+ * so each caller keeps its own localized fallback instead of a raw HTTP status text.
+ * @param error - Value caught from a rejected request
  * @returns The server-authored message, or undefined
  */
 export function apiErrorMessage(error: unknown): string | undefined {


### PR DESCRIPTION
Um create barrado pelo teto de canais do plano volta 422 com uma mensagem pronta pro usuário no envelope de erro (`{ error: { code, message } }`), mas `useChannelSubmission` lia só `.message` da rejeição — então o toast dizia "Request failed with status code 422", quando dizia algo.

`apiErrorMessage()` (`apiHelpers.ts`) lê a mensagem que o backend escreveu e devolve `undefined` quando a resposta não traz nenhuma, para cada call site manter o próprio fallback localizado. Aplicado no create e nos paths de verify-connection da mesma tela.

Segundo commit: `useChannelValidation` tinha um único `return false` sem toast (WhatsApp sem provider selecionado) — todos os outros ~25 guards do arquivo avisam antes de sair. Era esse o caso onde "nem toast genérico sai" que o card descreve.

## Summary by Sourcery

Improve channel submission and validation error handling to surface backend-provided messages to operators and avoid silent failures.

Bug Fixes:
- Show backend-authored error messages for channel creation and connection verification failures instead of generic Axios status messages.
- Display a validation error toast when attempting WhatsApp channel creation without a provider selected to avoid silent button failures.

Enhancements:
- Introduce apiErrorMessage helper to extract user-facing error messages from API responses while allowing localized fallbacks.
- Use apiErrorMessage across channel submission flows to standardize how server-side error envelopes are surfaced in toasts.

Tests:
- Add unit tests for apiErrorMessage to cover standard, legacy, and edge-case error envelope formats.
- Extend useChannelSubmission tests to cover success toasts and error toast behavior for quota and network failures.
- Add a test for WhatsApp validation to ensure a toast is shown when no provider is selected.