### PR TITLE
fix(contacts): import mostra o motivo real da falha, nao o erro generico (CRM-115)

### DIFF
--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -624,9 +624,14 @@ export default function Contacts() {
       loadContacts();
     } catch (error: unknown) {
       console.error('Error importing contacts:', error);
-      const errorMessage =
-        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
-        t('messages.importError');
+      // `error` is an object in the community envelope and a string in the
+      // self-hosted overlay ({ error: "...", code }); vendor/crm serves both.
+      const data = (error as {
+        response?: { data?: { error?: { message?: string } | string; message?: string } };
+      })?.response?.data;
+      const backendMessage =
+        typeof data?.error === 'string' ? data.error : data?.error?.message;
+      const errorMessage = backendMessage || data?.message || t('messages.importError');
       toast.error(errorMessage);
     } finally {
       setState(prev => ({ ...prev, loading: { ...prev.loading, import: false } }));


### PR DESCRIPTION
Parte de front do [CRM-115](https://plane.evosetup.com/evolution/browse/CRM-115/).

## O problema

Com o teto de contatos passando a valer no import em lote, o backend responde 422 `QUOTA_EXCEEDED` com uma mensagem que traz linhas do arquivo, usados e limite.

O `catch` de `handleImportModalSubmit` lia `response.data.message` — caminho que **não existe** no envelope do community, que é `{ success, error: { code, message }, meta }`. Resultado: todo 422 virava `messages.importError` ("Erro ao importar contatos") e o admin não tinha como saber por que o import foi barrado.

## O que muda

Uma leitura só, em `Contacts.tsx`:

- lê `data.error.message` (envelope do community);
- lê também a forma em string `{ error: "...", code }`, que é o envelope do overlay self-hosted — `vendor/crm` serve os dois produtos;
- qualquer outro erro (rede, 500, HTML) continua caindo no fallback traduzido.

Nenhuma chave de i18n nova, então nada a fazer nos 6 locales.

## Verificação

`npx tsc -p tsconfig.app.json --noEmit` → 0 erros.

## ⚠️ Ordem de merge

**Depende de** `evo-enterprise-licensing-ruby#83`, que produz o 422 novo. Mergeado sozinho este PR não quebra nada — só não tem mensagem nova pra exibir ainda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Display the backend quota and validation error messages returned on contact import failures, falling back to the generic translated error only when no specific message is available.