### PR TITLE
ci: roda as specs de canais do CRM-114 em toda PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
       #     bare-body fallback when the backend skips the response envelope.
       #   - Users (EVO-1947): a list reload keeps carrying the search term and
       #     the chosen sort — dropping either serves a differently ordered page.
+      #   - apiHelpers / useChannelSubmission / useChannelValidation (CRM-114):
+      #     a refused channel create keeps showing the message the backend wrote
+      #     (the plan-quota 422 envelope) instead of the axios status text, and
+      #     no validation guard returns false without saying why.
       # The whole list runs in ~10s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -54,4 +58,7 @@ jobs:
             src/pages/Admin/Roles/RoleDetail.spec.tsx \
             src/pages/Admin/Roles/RolesList.spec.tsx \
             src/services/campaigns/campaignsService.spec.ts \
-            src/pages/Customer/Settings/Users/Users.spec.tsx
+            src/pages/Customer/Settings/Users/Users.spec.tsx \
+            src/utils/apiHelpers.spec.ts \
+            src/hooks/channels/useChannelSubmission.spec.ts \
+            src/hooks/channels/useChannelValidation.spec.ts


### PR DESCRIPTION
As specs que o CRM-114 escreveu para o create de canal recusado entraram no repo, mas não na lista opt-in do `test.yml` — que roda 5 arquivos escolhidos a dedo. Resultado: o bug que o card fechou (o 422 do teto de quota virando "Request failed with status code 422", ou o guard de WhatsApp saindo calado) pode voltar sem nenhum teste vermelho.

As três atendem o critério escrito no próprio workflow — "fully mocked, runs fast, guards a behaviour we do not want silently reverted":

- `src/utils/apiHelpers.spec.ts` — `apiErrorMessage()` lê a mensagem do envelope e devolve `undefined` quando não há nenhuma.
- `src/hooks/channels/useChannelSubmission.spec.ts` — o toast do create carrega a mensagem do backend, e cai no fallback próprio quando a falha não traz envelope.
- `src/hooks/channels/useChannelValidation.spec.ts` — WhatsApp sem provider avisa em vez de sair em silêncio.

A lista vai de 70 para 92 testes e continua rodando em ~6s na minha máquina, sem rede e sem flake. Nada além do `.github/workflows/test.yml` muda.

Follow-up do review do CRM-114; o lado do shell (nenhum vitest roda no CI de lá, porque o token do Actions não acessa o submódulo `vendor/crm`) está registrado em CRM-133.

## Summary by Sourcery

Include CRM-114 channel-related specs in the CI test workflow to prevent regressions in channel creation and validation behaviour.

CI:
- Document in test.yml the behaviours guarded by the newly added CRM-114 channel specs.

Tests:
- Add src/utils/apiHelpers.spec.ts to the opt-in test list in the CI workflow.
- Add src/hooks/channels/useChannelSubmission.spec.ts to the opt-in test list in the CI workflow.
- Add src/hooks/channels/useChannelValidation.spec.ts to the opt-in test list in the CI workflow.