### PR TITLE
fix(channels): keep the caller's fallback when the envelope has no message

### DIFF
--- a/src/hooks/channels/useChannelSubmission.spec.ts
+++ b/src/hooks/channels/useChannelSubmission.spec.ts
@@ -173,4 +173,18 @@ describe('useChannelSubmission.submitCreate', () => {
 
     expect(toast.error).toHaveBeenCalledWith('Network Error');
   });
+
+  // An envelope with a code and no message must fall THROUGH, not pick up the
+  // English default extractError would have supplied for that shape.
+  it('does not invent a message when the envelope carries none', async () => {
+    createChannelMock.mockRejectedValue({
+      response: { status: 422, data: { success: false, error: { code: 'QUOTA_EXCEEDED' } } },
+      message: 'Request failed with status code 422',
+    } as never);
+
+    await submit('api', 'api', { name: 'api-inbox', webhook_url: 'https://hook' });
+
+    expect(toast.error).not.toHaveBeenCalledWith('An error occurred');
+    expect(toast.error).toHaveBeenCalledWith('Request failed with status code 422');
+  });
 });

--- a/src/utils/apiHelpers.spec.ts
+++ b/src/utils/apiHelpers.spec.ts
@@ -28,6 +28,19 @@ describe('apiErrorMessage', () => {
     expect(apiErrorMessage(rejection(null))).toBeUndefined();
   });
 
+  it('returns undefined for an envelope that carries a code but no message', () => {
+    expect(apiErrorMessage(rejection({ success: false, error: { code: 'QUOTA_EXCEEDED' } }))).toBeUndefined();
+    expect(apiErrorMessage(rejection({ success: false, error: {} }))).toBeUndefined();
+    expect(apiErrorMessage(rejection({ success: false, error: { code: 'X', message: '  ' } }))).toBeUndefined();
+  });
+
+  it('ignores 5xx bodies, whose message is not written for the person on screen', () => {
+    expect(apiErrorMessage(rejection({ message: 'PG::UndefinedTable: relation "x"' }, 500))).toBeUndefined();
+    expect(
+      apiErrorMessage(rejection({ success: false, error: { code: 'INTERNAL', message: 'NoMethodError' } }, 503)),
+    ).toBeUndefined();
+  });
+
   it('returns undefined for a rejection with no response at all', () => {
     expect(apiErrorMessage(new Error('Network Error'))).toBeUndefined();
   });

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -110,17 +110,30 @@ export function extractError(error: any): ErrorInfo {
 /**
  * The backend's message from the error envelope, or undefined if it has none —
  * so each caller keeps its own localized fallback instead of a raw HTTP status text.
+ * 5xx bodies are skipped: those messages are written for whoever operates the API,
+ * not for the person on screen.
  * @param error - Value caught from a rejected request
  * @returns The server-authored message, or undefined
  */
 export function apiErrorMessage(error: unknown): string | undefined {
   if (!error || typeof error !== 'object') return undefined;
 
-  const data = (error as { response?: { data?: unknown } }).response?.data;
+  const response = (error as { response?: { status?: number; data?: unknown } }).response;
+  if (typeof response?.status === 'number' && response.status >= 500) return undefined;
+
+  const data = response?.data;
   if (!data || typeof data !== 'object') return undefined;
 
-  const { code, message } = extractError(error);
-  return code.startsWith('HTTP_') ? undefined : message;
+  // Read the envelope directly instead of going through extractError, which
+  // substitutes English defaults of its own ('An error occurred') for the shapes
+  // that carry a code but no message — those must fall through to the caller.
+  const body = data as { error?: { message?: unknown } | string | null; message?: unknown };
+  const candidates = [
+    typeof body.error === 'string' ? body.error : body.error?.message,
+    body.message,
+  ];
+
+  return candidates.find((value): value is string => typeof value === 'string' && value.trim() !== '');
 }
 
 /**


### PR DESCRIPTION
Follow-up do review do CRM-114, sobre o `apiErrorMessage` que a #280 introduziu.

O helper passava pelo `extractError`, que substitui defaults em inglês próprios (`An error occurred`) para um envelope que traz `code` e nenhum `message`. Como esse texto não é `HTTP_`-coded, ele voltava como se fosse a mensagem do backend — o fallback do call site nunca rodava e o operador lia prosa em inglês numa tela pt-BR:

```
apiErrorMessage(rej({success:false, error:{code:"QUOTA_EXCEEDED"}}))  ->  "An error occurred"
```

Agora lê as três formas do envelope direto (`error.message`, `error` string, `message`) e cai fora quando nenhuma traz texto.

Junto vai um guard de `status >= 500`: o que um 500 renderiza é escrito pra quem opera a API, não pra quem está na tela. Sem ele, um `{message: "PG::UndefinedTable: relation \"x\" ..."}` ia verbatim pro toast — comportamento novo, que a #280 abriu ao surfacear qualquer mensagem de corpo em qualquer status.

Os specs cobrem os dois buracos, incluindo o `error: {code}` sem message, que era justamente o caso que a suíte da #280 não exercitava.

Suíte de canais: 20/20. `tsc -b` limpo.

## Summary by Sourcery

Adjust error handling to avoid surfacing internal or invented messages and ensure callers retain their own fallbacks when the backend provides no user-facing text.

Bug Fixes:
- Prevent apiErrorMessage from returning a generic English default when the error envelope includes a code but no message, allowing localized caller fallbacks to be used.
- Skip 5xx response bodies in apiErrorMessage so internal server errors are not shown verbatim to end users.

Tests:
- Extend apiErrorMessage and channel submission tests to cover envelopes with codes but no messages and 5xx responses, ensuring correct fallback behavior.