### PR TITLE
fix(journey): devolve o updater funcional ao setNodes do BaseFlowCanvas (CRM-138)

### DIFF
--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -431,7 +431,8 @@ describe('BaseFlowCanvas — customApplyNodeChanges runs once per change', () =>
   });
 
   it('preserves both changes when handleNodesChange fires twice in one batch', () => {
-    renderCanvas({ customHelperLines: true });
+    const onFlowDataChange = vi.fn();
+    renderCanvas({ customHelperLines: true, onFlowDataChange });
     const onNodesChange = reactFlowMocks.capturedProps.current!.onNodesChange as (
       changes: Array<Record<string, unknown>>,
     ) => void;
@@ -447,5 +448,12 @@ describe('BaseFlowCanvas — customApplyNodeChanges runs once per change', () =>
     }>;
     expect(nodes.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
     expect(nodes.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
+
+    // O store recebe o mesmo estado acumulado que o canvas: um payload rebaseado
+    // no closure devolveria n1 para {0,0} e um save logo depois desfaria o
+    // primeiro arrasto.
+    const payload = onFlowDataChange.mock.lastCall![0] as typeof nodes;
+    expect(payload.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
+    expect(payload.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
   });
 });

--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -429,4 +429,26 @@ describe('BaseFlowCanvas — customApplyNodeChanges runs once per change', () =>
 
     expect(getHelperLines).toHaveBeenCalledTimes(1);
   });
+
+  // CRM-138: a deduplicação acima trocou o updater funcional de setNodes pela
+  // forma direta, computada do `nodes` do closure. Duas chamadas no mesmo batch
+  // do React partem do mesmo `nodes`, e a segunda descarta a primeira.
+  it('preserves both changes when handleNodesChange fires twice in one batch', () => {
+    renderCanvas({ customHelperLines: true });
+    const onNodesChange = reactFlowMocks.capturedProps.current!.onNodesChange as (
+      changes: Array<Record<string, unknown>>,
+    ) => void;
+
+    act(() => {
+      onNodesChange([{ type: 'position', id: 'n1', position: { x: 10, y: 10 } }]);
+      onNodesChange([{ type: 'position', id: 'n2', position: { x: 300, y: 50 } }]);
+    });
+
+    const nodes = reactFlowMocks.capturedProps.current!.nodes as Array<{
+      id: string;
+      position: { x: number; y: number };
+    }>;
+    expect(nodes.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
+    expect(nodes.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
+  });
 });

--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -413,10 +413,12 @@ describe('BaseFlowCanvas — EVO-1643 mutation propagation', () => {
   });
 });
 
-// handleNodesChange used to run customApplyNodeChanges twice per drag move
-// (once for setNodes, once again to compute the onFlowDataChange payload) —
-// each run re-executes getHelperLines and re-mutates changes[0].position.
-describe('BaseFlowCanvas — customApplyNodeChanges runs once per change', () => {
+// CRM-119: handleNodesChange used to apply the changes twice per drag move
+// (once for the state write, once again to compute the onFlowDataChange
+// payload), re-running getHelperLines and re-mutating changes[0].position.
+// CRM-138: the dedup that fixed it rebased every write on the `nodes` closure,
+// so a second call in the same React batch overwrote the first.
+describe('BaseFlowCanvas — helper line snap and batched node changes', () => {
   it('calls getHelperLines exactly once per node drag when customHelperLines is on', () => {
     renderCanvas({ customHelperLines: true });
     const props = reactFlowMocks.capturedProps.current!;
@@ -430,30 +432,66 @@ describe('BaseFlowCanvas — customApplyNodeChanges runs once per change', () =>
     expect(getHelperLines).toHaveBeenCalledTimes(1);
   });
 
-  it('preserves both changes when handleNodesChange fires twice in one batch', () => {
+  // Both editors share this handler: the journey editor drives it with
+  // customHelperLines on, the segment editor with it off. The payload is built
+  // before that branch, so both need the guard.
+  it.each([true, false])(
+    'preserves both changes when handleNodesChange fires twice in one batch (customHelperLines=%s)',
+    customHelperLines => {
+      const onFlowDataChange = vi.fn();
+      renderCanvas({ customHelperLines, onFlowDataChange });
+      const onNodesChange = reactFlowMocks.capturedProps.current!.onNodesChange as (
+        changes: Array<Record<string, unknown>>,
+      ) => void;
+
+      act(() => {
+        onNodesChange([{ type: 'position', id: 'n1', position: { x: 10, y: 10 } }]);
+        onNodesChange([{ type: 'position', id: 'n2', position: { x: 300, y: 50 } }]);
+      });
+
+      const nodes = reactFlowMocks.capturedProps.current!.nodes as Array<{
+        id: string;
+        position: { x: number; y: number };
+      }>;
+      expect(nodes.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
+      expect(nodes.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
+
+      // The store gets the same accumulated state as the canvas: a payload
+      // rebased on the closure would send n1 back to {0,0}, and a save right
+      // after the batch would undo the first drag.
+      const payload = onFlowDataChange.mock.lastCall![0] as typeof nodes;
+      expect(payload.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
+      expect(payload.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
+    },
+  );
+
+  // Every node writer must advance the mirror, since the mirror is what builds
+  // the callback payloads. A drop plus a move in one batch catches a writer
+  // that sets state without going through commitNodes: the canvas keeps both
+  // changes, the store would only hear about the move.
+  it('keeps the payload correct when a drop and a node move land in one batch', () => {
     const onFlowDataChange = vi.fn();
-    renderCanvas({ customHelperLines: true, onFlowDataChange });
-    const onNodesChange = reactFlowMocks.capturedProps.current!.onNodesChange as (
-      changes: Array<Record<string, unknown>>,
-    ) => void;
+    renderCanvasForDrop({ onFlowDataChange, dndType: 'send-canned-response-node' });
+
+    const props = reactFlowMocks.capturedProps.current!;
+    onFlowDataChange.mockClear();
 
     act(() => {
-      onNodesChange([{ type: 'position', id: 'n1', position: { x: 10, y: 10 } }]);
-      onNodesChange([{ type: 'position', id: 'n2', position: { x: 300, y: 50 } }]);
+      (props.onDrop as (e: unknown) => void)({
+        preventDefault: () => {},
+        clientX: 120,
+        clientY: 120,
+      });
+      (props.onNodesChange as (changes: Array<Record<string, unknown>>) => void)([
+        { type: 'position', id: 'trigger-1', position: { x: 10, y: 10 } },
+      ]);
     });
 
-    const nodes = reactFlowMocks.capturedProps.current!.nodes as Array<{
+    const payload = onFlowDataChange.mock.lastCall![0] as Array<{
       id: string;
       position: { x: number; y: number };
     }>;
-    expect(nodes.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
-    expect(nodes.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
-
-    // O store recebe o mesmo estado acumulado que o canvas: um payload rebaseado
-    // no closure devolveria n1 para {0,0} e um save logo depois desfaria o
-    // primeiro arrasto.
-    const payload = onFlowDataChange.mock.lastCall![0] as typeof nodes;
-    expect(payload.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
-    expect(payload.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
+    expect(payload).toHaveLength(2);
+    expect(payload.find(n => n.id === 'trigger-1')!.position).toEqual({ x: 10, y: 10 });
   });
 });

--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -90,17 +90,10 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-// EVO-1573 review coverage map (each test fails on the pre-fix `develop`):
-//  - AC1 happy path: handleConnect did not call onFlowDataChange at all → tests 1+2 fail
-//  - AC1 parity: handleEdgesChange did not call onFlowDataChange → test 3 fails (delete dropped)
-//  - AC3 no-regression: the workaround path (connect + node move) still
-//    persists the edge — test 4 guards that handleNodesChange's closure
-//    reads the updated edges array after setEdges flushed
-//  - M1 (review): edge selection-only changes are volatile UI state and
-//    must NOT mark the editor store as dirty — test 5 guards that
-//    handleEdgesChange filters `select`-type changes before propagating
-describe('BaseFlowCanvas — EVO-1573 edge propagation', () => {
-  it('handleConnect propagates the new edge to onFlowDataChange (AC1)', () => {
+// Edge edits reach the editor store only through these handlers, and
+// selection-only changes must not.
+describe('BaseFlowCanvas — edge propagation', () => {
+  it('handleConnect propagates the new edge to onFlowDataChange', () => {
     const onFlowDataChange = vi.fn();
     renderCanvas({ onFlowDataChange });
 
@@ -160,7 +153,7 @@ describe('BaseFlowCanvas — EVO-1573 edge propagation', () => {
     );
   });
 
-  it('handleEdgesChange propagates deletes to onFlowDataChange (parity fix)', () => {
+  it('handleEdgesChange propagates deletes to onFlowDataChange', () => {
     const onFlowDataChange = vi.fn();
     renderCanvas({
       onFlowDataChange,
@@ -186,7 +179,7 @@ describe('BaseFlowCanvas — EVO-1573 edge propagation', () => {
     expect(lastCall![1].map(e => e.id)).toEqual(['e2']);
   });
 
-  it('preserves the new edge across a subsequent node movement (AC3 — workaround path no regression)', () => {
+  it('preserves the new edge across a subsequent node movement', () => {
     const onFlowDataChange = vi.fn();
     renderCanvas({ onFlowDataChange });
     const connectProps = reactFlowMocks.capturedProps.current!;
@@ -220,7 +213,7 @@ describe('BaseFlowCanvas — EVO-1573 edge propagation', () => {
     );
   });
 
-  it('does not propagate volatile select-only edge changes to onFlowDataChange (M1 review)', () => {
+  it('does not propagate volatile select-only edge changes to onFlowDataChange', () => {
     const onFlowDataChange = vi.fn();
     renderCanvas({
       onFlowDataChange,
@@ -239,10 +232,8 @@ describe('BaseFlowCanvas — EVO-1573 edge propagation', () => {
   });
 });
 
-// EVO-1643: dropping an action node from the palette went through handleDrop's
-// default branch, which added the node to canvas state via setNodes but never
-// notified the editor store — so the save snapshot kept only the trigger and
-// dropped every action node. These tests fail on pre-fix `develop`.
+// Drops bypass xyflow's NodeChange path, so handleDrop is the only place the
+// store hears about a node dragged in from the palette.
 function DnDTypeSetter({ value }: { value: string }) {
   const { setType } = useDnD();
   useEffect(() => {
@@ -276,7 +267,7 @@ function renderCanvasForDrop(opts: {
   );
 }
 
-describe('BaseFlowCanvas — EVO-1643 drop propagation', () => {
+describe('BaseFlowCanvas — drop propagation', () => {
   it('propagates a dropped node to onFlowDataChange so the save snapshot keeps it', () => {
     const onFlowDataChange = vi.fn();
     renderCanvasForDrop({ onFlowDataChange, dndType: 'send-canned-response-node' });
@@ -326,10 +317,9 @@ describe('BaseFlowCanvas — EVO-1643 drop propagation', () => {
   });
 });
 
-// EVO-1643 (extended): node delete + duplicate (context menu) and edge delete
-// (trash button) also bypassed the store pre-fix. Each is now routed through a
-// BaseFlowCanvas handler that fires onFlowDataChange.
-describe('BaseFlowCanvas — EVO-1643 mutation propagation', () => {
+// Context-menu delete/duplicate and edge delete also bypass the change
+// pipeline, so each notifies the store from its own handler.
+describe('BaseFlowCanvas — mutation propagation', () => {
   function openContextMenu(props: Record<string, unknown>, nodeId: string) {
     act(() => {
       (props.onNodeContextMenu as (e: unknown, n: unknown) => void)(
@@ -413,11 +403,8 @@ describe('BaseFlowCanvas — EVO-1643 mutation propagation', () => {
   });
 });
 
-// CRM-119: handleNodesChange used to apply the changes twice per drag move
-// (once for the state write, once again to compute the onFlowDataChange
-// payload), re-running getHelperLines and re-mutating changes[0].position.
-// CRM-138: the dedup that fixed it rebased every write on the `nodes` closure,
-// so a second call in the same React batch overwrote the first.
+// The snap runs once per batch, and changes batched together must all survive
+// in both the canvas and the payload.
 describe('BaseFlowCanvas — helper line snap and batched node changes', () => {
   it('calls getHelperLines exactly once per node drag when customHelperLines is on', () => {
     renderCanvas({ customHelperLines: true });
@@ -432,9 +419,8 @@ describe('BaseFlowCanvas — helper line snap and batched node changes', () => {
     expect(getHelperLines).toHaveBeenCalledTimes(1);
   });
 
-  // Both editors share this handler: the journey editor drives it with
-  // customHelperLines on, the segment editor with it off. The payload is built
-  // before that branch, so both need the guard.
+  // The payload is built before the customHelperLines branch, so the journey
+  // and segment editors both need the guard.
   it.each([true, false])(
     'preserves both changes when handleNodesChange fires twice in one batch (customHelperLines=%s)',
     customHelperLines => {
@@ -456,19 +442,16 @@ describe('BaseFlowCanvas — helper line snap and batched node changes', () => {
       expect(nodes.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
       expect(nodes.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
 
-      // The store gets the same accumulated state as the canvas: a payload
-      // rebased on the closure would send n1 back to {0,0}, and a save right
-      // after the batch would undo the first drag.
+      // The store gets the same accumulated state as the canvas; anything
+      // rebased on the closure would send n1 back to {0,0}.
       const payload = onFlowDataChange.mock.lastCall![0] as typeof nodes;
       expect(payload.find(n => n.id === 'n1')!.position).toEqual({ x: 10, y: 10 });
       expect(payload.find(n => n.id === 'n2')!.position).toEqual({ x: 300, y: 50 });
     },
   );
 
-  // Every node writer must advance the mirror, since the mirror is what builds
-  // the callback payloads. A drop plus a move in one batch catches a writer
-  // that sets state without going through commitNodes: the canvas keeps both
-  // changes, the store would only hear about the move.
+  // Every node writer must advance the mirror that builds the payloads: a
+  // writer that skips commitNodes leaves the store behind the canvas.
   it('keeps the payload correct when a drop and a node move land in one batch', () => {
     const onFlowDataChange = vi.fn();
     renderCanvasForDrop({ onFlowDataChange, dndType: 'send-canned-response-node' });

--- a/src/components/base/BaseFlowCanvas.spec.tsx
+++ b/src/components/base/BaseFlowCanvas.spec.tsx
@@ -430,9 +430,6 @@ describe('BaseFlowCanvas — customApplyNodeChanges runs once per change', () =>
     expect(getHelperLines).toHaveBeenCalledTimes(1);
   });
 
-  // CRM-138: a deduplicação acima trocou o updater funcional de setNodes pela
-  // forma direta, computada do `nodes` do closure. Duas chamadas no mesmo batch
-  // do React partem do mesmo `nodes`, e a segunda descarta a primeira.
   it('preserves both changes when handleNodesChange fires twice in one batch', () => {
     renderCanvas({ customHelperLines: true });
     const onNodesChange = reactFlowMocks.capturedProps.current!.onNodesChange as (

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -174,15 +174,30 @@ export function BaseFlowCanvas({
   const { type, setPointerEvents, setType } = useDnD();
 
   // Estados do canvas
-  const [nodes, setNodes, onNodesChangeInternal] = useNodesState(initialNodes);
+  const [nodes, setNodesState] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChangeInternal] = useEdgesState(initialEdges);
 
-  // Espelho síncrono de `nodes`. Dentro de um mesmo batch do React o closure não
-  // reflete a mudança anterior, então o payload dos callbacks sairia de um
-  // estado que o setNodes já superou — o store receberia um snapshot desfazendo
-  // a primeira mudança do batch.
+  // Synchronous mirror of `nodes`: React batches events, so inside one batch the
+  // `nodes` closure still holds the pre-batch value and a payload derived from it
+  // would undo the changes the batch already applied.
   const nodesRef = useRef(nodes);
-  nodesRef.current = nodes;
+
+  // Single writer for node state — advances the mirror and the React state
+  // together. Build callback payloads from `nodesRef.current`, never from the
+  // `nodes` closure; `nodes` is for rendering only. Calling `setNodesState`
+  // anywhere else desyncs the mirror, so it stays private to this function.
+  // The updater runs here, not inside React's setter, so it never has to be
+  // pure for StrictMode's benefit.
+  const commitNodes = useCallback(
+    (update: Node[] | ((current: Node[]) => Node[])): Node[] => {
+      const next = typeof update === 'function' ? update(nodesRef.current) : update;
+      nodesRef.current = next;
+      setNodesState(next);
+      return next;
+    },
+    [setNodesState],
+  );
+
   const [showNodePanel, setShowNodePanel] = useState(showNodePanelByDefault);
 
   // Context menu
@@ -238,21 +253,11 @@ export function BaseFlowCanvas({
   // Handlers de mudanças
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
+      // Runs first: it mutates changes[0].position for the snap, and must fire
+      // once per batch — hence outside the state write.
       applyHelperLineSnap(changes, nodesRef.current);
 
-      // Avança o espelho junto: é ele que mantém o payload dos callbacks
-      // alinhado com o estado que o setNodes aplica.
-      const updatedNodes = applyNodeChanges(changes, nodesRef.current);
-      nodesRef.current = updatedNodes;
-
-      if (customHelperLines) {
-        // Updater funcional: com o efeito colateral fora, é seguro de novo —
-        // uma segunda chamada no mesmo batch do React parte do resultado da
-        // primeira em vez de sobrescrevê-lo.
-        setNodes(current => applyNodeChanges(changes, current));
-      } else {
-        onNodesChangeInternal(changes);
-      }
+      const updatedNodes = commitNodes(current => applyNodeChanges(changes, current));
 
       if (onNodesChange) {
         onNodesChange(changes);
@@ -272,15 +277,13 @@ export function BaseFlowCanvas({
       }
     },
     [
-      onNodesChangeInternal,
+      commitNodes,
       onNodesChange,
       onFlowDataChange,
       onFlowDataChangeExtended,
       edges,
       flowVariables,
-      customHelperLines,
       applyHelperLineSnap,
-      setNodes,
     ],
   );
 
@@ -300,11 +303,11 @@ export function BaseFlowCanvas({
       if (persistChanges.length > 0) {
         const updatedEdges = applyEdgeChanges(persistChanges, edges);
         if (onFlowDataChange) {
-          onFlowDataChange(nodes, updatedEdges);
+          onFlowDataChange(nodesRef.current, updatedEdges);
         }
         if (onFlowDataChangeExtended) {
           onFlowDataChangeExtended({
-            nodes,
+            nodes: nodesRef.current,
             edges: updatedEdges,
             variables: flowVariables,
           });
@@ -320,7 +323,6 @@ export function BaseFlowCanvas({
       onEdgesChange,
       onFlowDataChange,
       onFlowDataChangeExtended,
-      nodes,
       edges,
       flowVariables,
     ],
@@ -339,11 +341,11 @@ export function BaseFlowCanvas({
       const updatedEdges = addEdge(edge, edges);
       setEdges(updatedEdges);
       if (onFlowDataChange) {
-        onFlowDataChange(nodes, updatedEdges);
+        onFlowDataChange(nodesRef.current, updatedEdges);
       }
       if (onFlowDataChangeExtended) {
         onFlowDataChangeExtended({
-          nodes,
+          nodes: nodesRef.current,
           edges: updatedEdges,
           variables: flowVariables,
         });
@@ -358,7 +360,6 @@ export function BaseFlowCanvas({
       onConnect,
       onFlowDataChange,
       onFlowDataChangeExtended,
-      nodes,
       flowVariables,
     ],
   );
@@ -397,11 +398,9 @@ export function BaseFlowCanvas({
         // EVO-1643: drops bypass xyflow's NodeChange path, so the new node
         // reached canvas state via setNodes but never the editor store — on
         // save the snapshot kept only the trigger and dropped every action
-        // node. Mirror the EVO-1573 edge fix: set the bare value and fire the
-        // store callbacks after (keep setNodes pure so StrictMode's
-        // double-invoke can't double-notify).
-        const updatedNodes = nodes.concat(newNode);
-        setNodes(updatedNodes);
+        // node. Mirror the EVO-1573 edge fix: commit the node first, fire the
+        // store callbacks after.
+        const updatedNodes = commitNodes(current => current.concat(newNode));
         if (onFlowDataChange) {
           onFlowDataChange(updatedNodes, edges);
         }
@@ -418,11 +417,11 @@ export function BaseFlowCanvas({
         
         // Selecionar o novo node após um pequeno delay para garantir que foi adicionado
         setTimeout(() => {
-          setNodes(nds => 
-            nds.map(node => ({ 
-              ...node, 
-              selected: node.id === newNodeId 
-            }))
+          commitNodes(current =>
+            current.map(node => ({
+              ...node,
+              selected: node.id === newNodeId,
+            })),
           );
         }, 10);
       }
@@ -431,9 +430,8 @@ export function BaseFlowCanvas({
       type,
       screenToFlowPosition,
       onDrop,
-      setNodes,
+      commitNodes,
       setType,
-      nodes,
       edges,
       onFlowDataChange,
       onFlowDataChangeExtended,
@@ -482,24 +480,20 @@ export function BaseFlowCanvas({
 
   // 🆕 Função para atualizar node (sistema de painéis de configuração).
   // Config-panel updates bypass xyflow's NodeChange path because they mutate
-  // `node.data` directly via `setNodes`. The parent's `onFlowDataChange`
-  // listener would otherwise never see the edit, so the journey editor's
-  // dirty/autosave/IDB pipeline would stay clean despite a real change in
-  // a panel field. Wire the callbacks here so the data path matches what
-  // `handleNodesChange` does for canvas-level edits.
+  // `node.data` directly. The parent's `onFlowDataChange` listener would
+  // otherwise never see the edit, so the journey editor's dirty/autosave/IDB
+  // pipeline would stay clean despite a real change in a panel field. Wire the
+  // callbacks here so the data path matches what `handleNodesChange` does for
+  // canvas-level edits.
   //
-  // IMPORTANT: side effects (onFlowDataChange / onFlowDataChangeExtended)
-  // run AFTER setNodes returns, NOT inside the updater callback. Updaters
-  // must be pure — React (and StrictMode in particular) double-invokes
-  // them in dev to surface non-idempotency, which would cause the store
-  // notifications to fire twice. This mirrors the pattern used by
-  // `handleNodesChange` above.
+  // IMPORTANT: side effects (onFlowDataChange / onFlowDataChangeExtended) run
+  // AFTER commitNodes returns, never inside the updater it receives — same
+  // shape as `handleNodesChange` above.
   const updateNode = useCallback(
     (nodeId: string, newData: any) => {
-      const updated = nodes.map(node =>
-        node.id === nodeId ? { ...node, data: newData } : node,
+      const updated = commitNodes(current =>
+        current.map(node => (node.id === nodeId ? { ...node, data: newData } : node)),
       );
-      setNodes(updated);
       if (onFlowDataChange) {
         onFlowDataChange(updated, edges);
       }
@@ -511,7 +505,7 @@ export function BaseFlowCanvas({
         });
       }
     },
-    [nodes, setNodes, onFlowDataChange, onFlowDataChangeExtended, edges, flowVariables],
+    [commitNodes, onFlowDataChange, onFlowDataChangeExtended, edges, flowVariables],
   );
 
   // Controle de conexões
@@ -548,22 +542,25 @@ export function BaseFlowCanvas({
       const updatedEdges = edges.filter(edge => edge.id !== id);
       setEdges(updatedEdges);
       if (onFlowDataChange) {
-        onFlowDataChange(nodes, updatedEdges);
+        onFlowDataChange(nodesRef.current, updatedEdges);
       }
       if (onFlowDataChangeExtended) {
-        onFlowDataChangeExtended({ nodes, edges: updatedEdges, variables: flowVariables });
+        onFlowDataChangeExtended({
+          nodes: nodesRef.current,
+          edges: updatedEdges,
+          variables: flowVariables,
+        });
       }
     },
-    [edges, setEdges, nodes, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
+    [edges, setEdges, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
   );
 
   const handleDeleteNode = useCallback(
     (nodeId: string) => {
-      const updatedNodes = nodes.filter(node => node.id !== nodeId);
       const updatedEdges = edges.filter(
         edge => edge.source !== nodeId && edge.target !== nodeId,
       );
-      setNodes(updatedNodes);
+      const updatedNodes = commitNodes(current => current.filter(node => node.id !== nodeId));
       setEdges(updatedEdges);
       if (onFlowDataChange) {
         onFlowDataChange(updatedNodes, updatedEdges);
@@ -576,12 +573,12 @@ export function BaseFlowCanvas({
         });
       }
     },
-    [nodes, edges, setNodes, setEdges, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
+    [edges, commitNodes, setEdges, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
   );
 
   const handleDuplicateNode = useCallback(
     (nodeId: string) => {
-      const original = nodes.find(node => node.id === nodeId);
+      const original = nodesRef.current.find(node => node.id === nodeId);
       if (!original) return;
       const copy: Node = {
         ...original,
@@ -590,8 +587,7 @@ export function BaseFlowCanvas({
         selected: false,
         dragging: false,
       };
-      const updatedNodes = nodes.concat(copy);
-      setNodes(updatedNodes);
+      const updatedNodes = commitNodes(current => current.concat(copy));
       if (onFlowDataChange) {
         onFlowDataChange(updatedNodes, edges);
       }
@@ -599,7 +595,7 @@ export function BaseFlowCanvas({
         onFlowDataChangeExtended({ nodes: updatedNodes, edges, variables: flowVariables });
       }
     },
-    [nodes, edges, setNodes, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
+    [edges, commitNodes, onFlowDataChange, onFlowDataChangeExtended, flowVariables],
   );
 
   return (

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -195,10 +195,8 @@ export function BaseFlowCanvas({
   const [configNodeData, setConfigNodeData] = useState<any>(null);
   const [configPanelType, setConfigPanelType] = useState<string>('');
 
-  // 🆕 Helper lines customizado: só o efeito colateral (publica as linhas e
-  // aplica o snap mutando changes[0].position). Fica separado da aplicação das
-  // mudanças para poder rodar exatamente uma vez por batch, fora do updater de
-  // setNodes — o StrictMode invoca updater duas vezes de propósito.
+  // 🆕 Só o efeito colateral do helper lines, separado de applyNodeChanges para
+  // rodar uma vez por batch fora do updater de setNodes.
   const applyHelperLineSnap = useCallback(
     (changes: NodeChange[], nodes: Node[]) => {
       if (!customHelperLines) {
@@ -233,16 +231,12 @@ export function BaseFlowCanvas({
   // Handlers de mudanças
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      // Antes de qualquer applyNodeChanges: o snap muta changes[0].position, e
-      // roda uma vez só por batch.
       applyHelperLineSnap(changes, nodes);
 
       if (customHelperLines) {
-        // Updater funcional (o que a doc do xyflow pede): se handleNodesChange
-        // for chamado duas vezes no mesmo batch do React, a segunda parte do
-        // resultado da primeira em vez de sobrescrevê-lo com o `nodes` do
-        // closure. Só é seguro porque o efeito colateral saiu daqui — o
-        // updater é puro e aguenta o double-invoke do StrictMode.
+        // Updater funcional: com o efeito colateral fora, é seguro de novo —
+        // uma segunda chamada no mesmo batch do React parte do resultado da
+        // primeira em vez de sobrescrevê-lo.
         setNodes(current => applyNodeChanges(changes, current));
       } else {
         onNodesChangeInternal(changes);
@@ -253,9 +247,6 @@ export function BaseFlowCanvas({
       }
 
       if (onFlowDataChange || onFlowDataChangeExtended) {
-        // Payload dos callbacks derivado do closure, como nos demais handlers
-        // do arquivo. applyNodeChanges é puro, então recomputar aqui não repete
-        // efeito colateral nenhum.
         const updatedNodes = applyNodeChanges(changes, nodes);
 
         if (onFlowDataChange) {

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -31,22 +31,21 @@ import BaseDefaultEdge from './BaseDefaultEdge';
 import { cn, getHelperLines, createMiniMapNodeColors } from '@/lib/utils';
 import { flowTokens } from '@/components/journey/_ui/tokens';
 
-// Edge types padrão
+// Default edge types
 const defaultEdgeTypes = {
   default: BaseDefaultEdge,
   'base-default': BaseDefaultEdge,
 };
 
-// Tipos base para configuração do canvas
 export interface BaseFlowCanvasProps {
-  // Dados do flow
+  // Flow data
   initialNodes?: Node[];
   initialEdges?: Edge[];
 
-  // Configurações do canvas
+  // Canvas config
   nodeTypes: Record<string, React.ComponentType<any>>;
 
-  // Callbacks essenciais
+  // Core callbacks
   onNodesChange?: (changes: NodeChange[]) => void;
   onEdgesChange?: (changes: any[]) => void;
   onConnect?: OnConnect;
@@ -55,32 +54,32 @@ export interface BaseFlowCanvasProps {
   onDrop?: (event: React.DragEvent) => void;
   onFlowDataChange?: (nodes: Node[], edges: Edge[]) => void;
 
-  // 🆕 Callback estendido com variables (compatibilidade com automação)
+  // Extended callback carrying the flow variables
   onFlowDataChangeExtended?: (flowData: { nodes: Node[]; edges: Edge[]; variables: any[] }) => void;
-  flowVariables?: any[]; // Variables do flow para compatibilidade
+  flowVariables?: any[];
 
-  // Configurações visuais
+  // Visual config
   showMiniMap?: boolean;
   showControls?: boolean;
   showBackground?: boolean;
   backgroundVariant?: 'dots' | 'lines' | 'cross';
 
-  // Painel lateral
+  // Side panel
   NodePanelComponent?: React.ComponentType<{ onClose: () => void }>;
   showNodePanelByDefault?: boolean;
 
-  // Configurações adicionais
+  // Extra config
   connectionMode?: ConnectionMode;
   snapToGrid?: boolean;
   snapGrid?: [number, number];
 
-  // Cores do MiniMap por tipo de node
+  // MiniMap colors keyed by node type
   miniMapNodeColors?: Record<string, string>;
 
-  // Renderização de painéis customizados
+  // Custom panel rendering
   renderCustomPanels?: () => React.ReactNode;
 
-  // Componentes customizados
+  // Custom components
   ContextMenuComponent?: React.ComponentType<{
     x: number;
     y: number;
@@ -93,7 +92,7 @@ export interface BaseFlowCanvasProps {
     vertical?: number;
   }>;
 
-  // Configurações de helper lines
+  // Helper line config
   enableHelperLines?: boolean;
   helperLinesConfig?: {
     strokeColor?: string;
@@ -102,15 +101,15 @@ export interface BaseFlowCanvasProps {
     opacity?: number;
   };
 
-  // 🆕 Helper lines customizado (compatibilidade com automação)
+  // Use the custom snap instead of xyflow's own change handler
   customHelperLines?: boolean;
 
-  // Classes CSS customizadas
+  // Custom CSS classes
   className?: string;
   canvasClassName?: string;
   style?: React.CSSProperties;
 
-  // 🆕 Sistema de painéis de configuração (compatibilidade com automação)
+  // Config panel system
   configPanelSystem?: boolean;
   renderConfigPanel?: (
     nodeType: string,
@@ -120,7 +119,7 @@ export interface BaseFlowCanvasProps {
     onClose: () => void,
   ) => React.ReactNode;
 
-  // 🆕 Configurações específicas do ReactFlow (compatibilidade com automação)
+  // ReactFlow overrides
   reactFlowProps?: {
     minZoom?: number;
     maxZoom?: number;
@@ -173,21 +172,17 @@ export function BaseFlowCanvas({
   const { screenToFlowPosition } = useReactFlow();
   const { type, setPointerEvents, setType } = useDnD();
 
-  // Estados do canvas
+  // Canvas state
   const [nodes, setNodesState] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChangeInternal] = useEdgesState(initialEdges);
 
-  // Synchronous mirror of `nodes`: React batches events, so inside one batch the
-  // `nodes` closure still holds the pre-batch value and a payload derived from it
-  // would undo the changes the batch already applied.
+  // Synchronous mirror of `nodes`: inside one React batch the closure still
+  // holds the pre-batch value, so a payload built from it undoes the changes
+  // the batch already applied.
   const nodesRef = useRef(nodes);
 
-  // Single writer for node state — advances the mirror and the React state
-  // together. Build callback payloads from `nodesRef.current`, never from the
-  // `nodes` closure; `nodes` is for rendering only. Calling `setNodesState`
-  // anywhere else desyncs the mirror, so it stays private to this function.
-  // The updater runs here, not inside React's setter, so it never has to be
-  // pure for StrictMode's benefit.
+  // Single writer for node state, keeping the mirror and React state in step.
+  // Payloads read `nodesRef.current`; `nodes` is for rendering only.
   const commitNodes = useCallback(
     (update: Node[] | ((current: Node[]) => Node[])): Node[] => {
       const next = typeof update === 'function' ? update(nodesRef.current) : update;
@@ -208,17 +203,17 @@ export function BaseFlowCanvas({
     nodeId?: string;
   }>({ show: false, x: 0, y: 0 });
 
-  // Helper lines para snap visual
+  // Helper lines for visual snapping
   const [helperLineHorizontal, setHelperLineHorizontal] = useState<number | undefined>(undefined);
   const [helperLineVertical, setHelperLineVertical] = useState<number | undefined>(undefined);
 
-  // 🆕 Estados para sistema de painéis de configuração
+  // Config panel state
   const [showConfigPanel, setShowConfigPanel] = useState(false);
   const [configNodeData, setConfigNodeData] = useState<any>(null);
   const [configPanelType, setConfigPanelType] = useState<string>('');
 
-  // 🆕 Só o efeito colateral do helper lines, separado de applyNodeChanges para
-  // rodar uma vez por batch fora do updater de setNodes.
+  // Helper line side effect only, kept out of the state updater so it runs
+  // once per batch.
   const applyHelperLineSnap = useCallback(
     (changes: NodeChange[], nodes: Node[]) => {
       if (!customHelperLines) {
@@ -229,7 +224,7 @@ export function BaseFlowCanvas({
       setHelperLineHorizontal(undefined);
       setHelperLineVertical(undefined);
 
-      // Se single node sendo arrastado
+      // Single node being dragged
       if (
         changes.length === 1 &&
         changes[0].type === 'position' &&
@@ -250,11 +245,10 @@ export function BaseFlowCanvas({
     [customHelperLines],
   );
 
-  // Handlers de mudanças
+  // Change handlers
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      // Runs first: it mutates changes[0].position for the snap, and must fire
-      // once per batch — hence outside the state write.
+      // Mutates changes[0].position for the snap; must run once per batch.
       applyHelperLineSnap(changes, nodesRef.current);
 
       const updatedNodes = commitNodes(current => applyNodeChanges(changes, current));
@@ -267,7 +261,6 @@ export function BaseFlowCanvas({
         onFlowDataChange(updatedNodes, edges);
       }
 
-      // 🆕 Callback estendido com variables
       if (onFlowDataChangeExtended) {
         onFlowDataChangeExtended({
           nodes: updatedNodes,
@@ -291,14 +284,9 @@ export function BaseFlowCanvas({
     (changes: EdgeChange[]) => {
       onEdgesChangeInternal(changes);
 
-      // EVO-1573: real edge edits (add/remove/replace) must propagate to
-      // the editor store so the snapshot includes them on the next save;
-      // pre-fix, only handleNodesChange notified the store, which silently
-      // dropped fresh connections and deletes when no node was moved
-      // afterwards. Selection-type changes are volatile UI state and
-      // would mark the journey dirty without a real edit — the store
-      // already strips volatile fields for nodes (stripVolatileNodeFields)
-      // but has no equivalent for edges, so filter at the source here.
+      // Selection is volatile UI state: propagating it would mark the journey
+      // dirty without a real edit. Nodes are stripped downstream, edges are
+      // not, so filter here.
       const persistChanges = changes.filter(c => c.type !== 'select');
       if (persistChanges.length > 0) {
         const updatedEdges = applyEdgeChanges(persistChanges, edges);
@@ -331,13 +319,8 @@ export function BaseFlowCanvas({
   const handleConnect = useCallback(
     (connection: Parameters<OnConnect>[0]) => {
       const edge = { ...connection, animated: true, type: 'default' };
-      // EVO-1573: compute the updated edges from the closure and call
-      // setEdges with the bare value (NOT a functional updater) so the
-      // setter stays pure. React 18 StrictMode runs functional updaters
-      // twice to surface impurity — embedding side effects in the
-      // updater would fire onFlowDataChange twice per connection in dev.
-      // Match the shape of handleEdgesChange: state set first, side
-      // effects fired after.
+      // Bare value, not a functional updater: the side effects fire after the
+      // state write, matching handleEdgesChange.
       const updatedEdges = addEdge(edge, edges);
       setEdges(updatedEdges);
       if (onFlowDataChange) {
@@ -386,7 +369,7 @@ export function BaseFlowCanvas({
       if (onDrop) {
         onDrop(event);
       } else {
-        // Comportamento padrão de drop com auto-seleção
+        // Default drop behaviour, with auto-select
         const newNodeId = `${type}-${Date.now()}`;
         const newNode: Node = {
           id: newNodeId,
@@ -395,11 +378,8 @@ export function BaseFlowCanvas({
           data: { label: `${type} node` },
         };
 
-        // EVO-1643: drops bypass xyflow's NodeChange path, so the new node
-        // reached canvas state via setNodes but never the editor store — on
-        // save the snapshot kept only the trigger and dropped every action
-        // node. Mirror the EVO-1573 edge fix: commit the node first, fire the
-        // store callbacks after.
+        // Drops bypass xyflow's NodeChange path, so this is the only place the
+        // store hears about the new node: commit first, notify after.
         const updatedNodes = commitNodes(current => current.concat(newNode));
         if (onFlowDataChange) {
           onFlowDataChange(updatedNodes, edges);
@@ -412,10 +392,10 @@ export function BaseFlowCanvas({
           });
         }
         
-        // Limpar o type do DnD context para sair do modo de drag
+        // Leave drag mode
         setType(null);
         
-        // Selecionar o novo node após um pequeno delay para garantir que foi adicionado
+        // Select the new node once it has been added
         setTimeout(() => {
           commitNodes(current =>
             current.map(node => ({
@@ -452,7 +432,7 @@ export function BaseFlowCanvas({
 
   const handlePaneClick = useCallback(() => {
     setContextMenu({ show: false, x: 0, y: 0 });
-    // 🆕 Fechar painel de configuração também
+    // Close the config panel too
     if (configPanelSystem) {
       setShowConfigPanel(false);
       setConfigNodeData(null);
@@ -460,7 +440,7 @@ export function BaseFlowCanvas({
     }
   }, [configPanelSystem]);
 
-  // 🆕 Handler para click em node (sistema de painéis de configuração)
+  // Node click handler for the config panel system
   const handleNodeClickInternal = useCallback(
     (event: React.MouseEvent, node: Node) => {
       if (configPanelSystem) {
@@ -470,7 +450,6 @@ export function BaseFlowCanvas({
         setShowConfigPanel(true);
       }
 
-      // Callback original
       if (onNodeClick) {
         onNodeClick(event, node);
       }
@@ -478,17 +457,9 @@ export function BaseFlowCanvas({
     [configPanelSystem, onNodeClick],
   );
 
-  // 🆕 Função para atualizar node (sistema de painéis de configuração).
-  // Config-panel updates bypass xyflow's NodeChange path because they mutate
-  // `node.data` directly. The parent's `onFlowDataChange` listener would
-  // otherwise never see the edit, so the journey editor's dirty/autosave/IDB
-  // pipeline would stay clean despite a real change in a panel field. Wire the
-  // callbacks here so the data path matches what `handleNodesChange` does for
-  // canvas-level edits.
-  //
-  // IMPORTANT: side effects (onFlowDataChange / onFlowDataChangeExtended) run
-  // AFTER commitNodes returns, never inside the updater it receives — same
-  // shape as `handleNodesChange` above.
+  // Config panel edits mutate `node.data` outside xyflow's NodeChange path, so
+  // this is the only place the store hears about them. Side effects run after
+  // commitNodes returns, never inside the updater it receives.
   const updateNode = useCallback(
     (nodeId: string, newData: any) => {
       const updated = commitNodes(current =>
@@ -508,7 +479,7 @@ export function BaseFlowCanvas({
     [commitNodes, onFlowDataChange, onFlowDataChangeExtended, edges, flowVariables],
   );
 
-  // Controle de conexões
+  // Connection lifecycle
   const handleConnectStart = useCallback(() => {
     setPointerEvents('auto');
   }, [setPointerEvents]);
@@ -517,26 +488,23 @@ export function BaseFlowCanvas({
     setPointerEvents('none');
   }, [setPointerEvents]);
 
-  // Cores padrão do MiniMap usando utilitário
   const defaultMiniMapColors = createMiniMapNodeColors(miniMapNodeColors);
 
-  // 🆕 Configurações do ReactFlow com defaults e customizações
+  // ReactFlow config: defaults plus caller overrides
   const finalReactFlowProps = {
-    // Defaults padrão
+    // Defaults
     minZoom: 0.1,
     maxZoom: 10,
     fitView: false,
     defaultViewport: { x: 0, y: 0, zoom: 1 },
     elevateEdgesOnSelect: true,
     elevateNodesOnSelect: true,
-    // Customizações do usuário
+    // Caller overrides
     ...reactFlowProps,
   };
 
-  // EVO-1643: every mutation that bypasses xyflow's change pipeline must
-  // notify the editor store, otherwise the change is lost on the next save
-  // (same class as the drop fix). Compute the bare value, set it, fire the
-  // store callbacks after — never inside the updater (StrictMode purity).
+  // Edge deletion bypasses xyflow's change pipeline, so notify the store here
+  // or the next save loses it.
   const handleDeleteEdge = useCallback(
     (id: string) => {
       const updatedEdges = edges.filter(edge => edge.id !== id);
@@ -604,9 +572,8 @@ export function BaseFlowCanvas({
       ref={reactFlowWrapper}
       style={style}
     >
-      {/* colorMode="light": editor de Jornada é SEMPRE light. Isso pinta a chrome do React
-          Flow (Controls/zoom + MiniMap) clara e evita que o RF injete .dark no .react-flow
-          (o que re-escurecia os cards dentro do wrapper .light do shell). */}
+      {/* colorMode="light" keeps the ReactFlow chrome light and stops RF from
+          injecting .dark into .react-flow, which would darken the cards. */}
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -637,7 +604,7 @@ export function BaseFlowCanvas({
         zoomOnDoubleClick={false}
         selectNodesOnDrag={false}
         connectionLineType={ConnectionLineType.Bezier}
-        // 🆕 Props customizáveis
+        // Caller overrides
         {...finalReactFlowProps}
         fitViewOptions={{
           padding: 0.1,
@@ -692,7 +659,7 @@ export function BaseFlowCanvas({
           />
         )}
 
-        {/* Botão do painel de nodes */}
+        {/* Node panel toggle */}
         {NodePanelComponent && (
           <Panel position="top-right">
             <Button
@@ -710,7 +677,7 @@ export function BaseFlowCanvas({
           </Panel>
         )}
 
-        {/* Painel de nodes */}
+        {/* Node panel */}
         {NodePanelComponent && showNodePanel && (
           <Panel position="top-right" className="mt-12">
             <NodePanelComponent onClose={() => setShowNodePanel(false)} />
@@ -729,7 +696,7 @@ export function BaseFlowCanvas({
             />
           ))}
 
-        {/* Painéis customizados */}
+        {/* Custom panels */}
         {renderCustomPanels && renderCustomPanels()}
       </ReactFlow>
 

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -176,6 +176,13 @@ export function BaseFlowCanvas({
   // Estados do canvas
   const [nodes, setNodes, onNodesChangeInternal] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChangeInternal] = useEdgesState(initialEdges);
+
+  // Espelho síncrono de `nodes`. Dentro de um mesmo batch do React o closure não
+  // reflete a mudança anterior, então o payload dos callbacks sairia de um
+  // estado que o setNodes já superou — o store receberia um snapshot desfazendo
+  // a primeira mudança do batch.
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
   const [showNodePanel, setShowNodePanel] = useState(showNodePanelByDefault);
 
   // Context menu
@@ -231,7 +238,12 @@ export function BaseFlowCanvas({
   // Handlers de mudanças
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      applyHelperLineSnap(changes, nodes);
+      applyHelperLineSnap(changes, nodesRef.current);
+
+      // Avança o espelho junto: é ele que mantém o payload dos callbacks
+      // alinhado com o estado que o setNodes aplica.
+      const updatedNodes = applyNodeChanges(changes, nodesRef.current);
+      nodesRef.current = updatedNodes;
 
       if (customHelperLines) {
         // Updater funcional: com o efeito colateral fora, é seguro de novo —
@@ -246,21 +258,17 @@ export function BaseFlowCanvas({
         onNodesChange(changes);
       }
 
-      if (onFlowDataChange || onFlowDataChangeExtended) {
-        const updatedNodes = applyNodeChanges(changes, nodes);
+      if (onFlowDataChange) {
+        onFlowDataChange(updatedNodes, edges);
+      }
 
-        if (onFlowDataChange) {
-          onFlowDataChange(updatedNodes, edges);
-        }
-
-        // 🆕 Callback estendido com variables
-        if (onFlowDataChangeExtended) {
-          onFlowDataChangeExtended({
-            nodes: updatedNodes,
-            edges,
-            variables: flowVariables,
-          });
-        }
+      // 🆕 Callback estendido com variables
+      if (onFlowDataChangeExtended) {
+        onFlowDataChangeExtended({
+          nodes: updatedNodes,
+          edges,
+          variables: flowVariables,
+        });
       }
     },
     [
@@ -268,7 +276,6 @@ export function BaseFlowCanvas({
       onNodesChange,
       onFlowDataChange,
       onFlowDataChangeExtended,
-      nodes,
       edges,
       flowVariables,
       customHelperLines,

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -195,35 +195,37 @@ export function BaseFlowCanvas({
   const [configNodeData, setConfigNodeData] = useState<any>(null);
   const [configPanelType, setConfigPanelType] = useState<string>('');
 
-  // 🆕 Custom onNodesChange com helper lines customizado
-  const customApplyNodeChanges = useCallback(
-    (changes: NodeChange[], nodes: Node[]): Node[] => {
+  // 🆕 Helper lines customizado: só o efeito colateral (publica as linhas e
+  // aplica o snap mutando changes[0].position). Fica separado da aplicação das
+  // mudanças para poder rodar exatamente uma vez por batch, fora do updater de
+  // setNodes — o StrictMode invoca updater duas vezes de propósito.
+  const applyHelperLineSnap = useCallback(
+    (changes: NodeChange[], nodes: Node[]) => {
+      if (!customHelperLines) {
+        return;
+      }
+
       // Reset helper lines
       setHelperLineHorizontal(undefined);
       setHelperLineVertical(undefined);
 
-      // Se helper lines customizado está habilitado
-      if (customHelperLines) {
-        // Se single node sendo arrastado
-        if (
-          changes.length === 1 &&
-          changes[0].type === 'position' &&
-          changes[0].dragging &&
-          changes[0].position
-        ) {
-          const helperLines = getHelperLines(changes[0], nodes);
+      // Se single node sendo arrastado
+      if (
+        changes.length === 1 &&
+        changes[0].type === 'position' &&
+        changes[0].dragging &&
+        changes[0].position
+      ) {
+        const helperLines = getHelperLines(changes[0], nodes);
 
-          // Snap to helper line position
-          changes[0].position.x = helperLines.snapPosition.x ?? changes[0].position.x;
-          changes[0].position.y = helperLines.snapPosition.y ?? changes[0].position.y;
+        // Snap to helper line position
+        changes[0].position.x = helperLines.snapPosition.x ?? changes[0].position.x;
+        changes[0].position.y = helperLines.snapPosition.y ?? changes[0].position.y;
 
-          // Set helper lines for display
-          setHelperLineHorizontal(helperLines.horizontal);
-          setHelperLineVertical(helperLines.vertical);
-        }
+        // Set helper lines for display
+        setHelperLineHorizontal(helperLines.horizontal);
+        setHelperLineVertical(helperLines.vertical);
       }
-
-      return applyNodeChanges(changes, nodes);
     },
     [customHelperLines],
   );
@@ -231,16 +233,17 @@ export function BaseFlowCanvas({
   // Handlers de mudanças
   const handleNodesChange = useCallback(
     (changes: NodeChange[]) => {
-      // customApplyNodeChanges tem efeito colateral (seta as helper lines e muta
-      // changes[0].position no snap) — computar uma vez só e reusar, senão o
-      // segundo call reprocessa o snap em cima do primeiro e refaz o setState
-      // das helper lines à toa.
-      const updatedNodes = customHelperLines
-        ? customApplyNodeChanges(changes, nodes)
-        : applyNodeChanges(changes, nodes);
+      // Antes de qualquer applyNodeChanges: o snap muta changes[0].position, e
+      // roda uma vez só por batch.
+      applyHelperLineSnap(changes, nodes);
 
       if (customHelperLines) {
-        setNodes(updatedNodes);
+        // Updater funcional (o que a doc do xyflow pede): se handleNodesChange
+        // for chamado duas vezes no mesmo batch do React, a segunda parte do
+        // resultado da primeira em vez de sobrescrevê-lo com o `nodes` do
+        // closure. Só é seguro porque o efeito colateral saiu daqui — o
+        // updater é puro e aguenta o double-invoke do StrictMode.
+        setNodes(current => applyNodeChanges(changes, current));
       } else {
         onNodesChangeInternal(changes);
       }
@@ -249,17 +252,24 @@ export function BaseFlowCanvas({
         onNodesChange(changes);
       }
 
-      if (onFlowDataChange) {
-        onFlowDataChange(updatedNodes, edges);
-      }
+      if (onFlowDataChange || onFlowDataChangeExtended) {
+        // Payload dos callbacks derivado do closure, como nos demais handlers
+        // do arquivo. applyNodeChanges é puro, então recomputar aqui não repete
+        // efeito colateral nenhum.
+        const updatedNodes = applyNodeChanges(changes, nodes);
 
-      // 🆕 Callback estendido com variables
-      if (onFlowDataChangeExtended) {
-        onFlowDataChangeExtended({
-          nodes: updatedNodes,
-          edges,
-          variables: flowVariables,
-        });
+        if (onFlowDataChange) {
+          onFlowDataChange(updatedNodes, edges);
+        }
+
+        // 🆕 Callback estendido com variables
+        if (onFlowDataChangeExtended) {
+          onFlowDataChangeExtended({
+            nodes: updatedNodes,
+            edges,
+            variables: flowVariables,
+          });
+        }
       }
     },
     [
@@ -271,7 +281,8 @@ export function BaseFlowCanvas({
       edges,
       flowVariables,
       customHelperLines,
-      customApplyNodeChanges,
+      applyHelperLineSnap,
+      setNodes,
     ],
   );
 


### PR DESCRIPTION
Follow-up do code review da #282. A deduplicação da chamada de `customApplyNodeChanges` (CRM-119) estava certa, mas trocou a forma funcional do `setNodes` pela direta, computada do `nodes` do closure. Se `handleNodesChange` cair duas vezes no mesmo batch do React, a segunda parte de um `nodes` desatualizado e sobrescreve o resultado da primeira — perda de posição/seleção num componente compartilhado entre o editor de jornadas e o de segmentos.

A dificuldade era que `customApplyNodeChanges` misturava efeito colateral (publicar as helper lines e mutar `changes[0].position` no snap) com o cálculo puro. Separei as duas coisas: `applyHelperLineSnap` faz só o efeito e roda uma vez por batch, antes de qualquer `applyNodeChanges`; o `setNodes` volta ao updater funcional, que agora é puro e aguenta o double-invoke do StrictMode. O payload dos callbacks continua derivado do closure, como nos demais handlers do arquivo.

A spec nova aplica duas mudanças de posição dentro do mesmo `act()` e confere que as duas sobrevivem — ela reprova no código anterior (a primeira posição volta para `{0,0}`). O teste do CRM-119, que trava `getHelperLines` rodando uma vez só, segue verde, e o arquivo já está na lista do CI.

`tsc --noEmit` limpo, 360 testes verdes em `base` + `journey` + `lib` (a falha de `tokens.contrast.spec.ts` é local, `colorjs.io` não instalado, e é anterior a esta branch). Lint do arquivo sem erro novo.

## Summary by Sourcery

Ensure BaseFlowCanvas node updates are robust to React StrictMode double-invocation while preserving custom helper line snapping and change callbacks.

Bug Fixes:
- Prevent loss of node position updates when handleNodesChange is invoked multiple times in the same React batch with custom helper lines enabled.

Enhancements:
- Separate helper line snapping into a dedicated side-effect function and restore a pure functional updater for setNodes in BaseFlowCanvas.
- Align flow data change callbacks to recompute updated nodes from the latest closure state, keeping behavior consistent across handlers.

Tests:
- Add a regression test verifying that two position changes in a single React batch both persist when custom helper lines are active.