### PR TITLE
fix(journey): tira o dirty fantasma do Mute e do Resolve (CRM-139)

### DIFF
--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MuteConversationPanel } from './MuteConversationPanel';
 import { MuteConversationNodeData } from './MuteConversationNode';
-import '@/i18n/config';
+import i18n from '@/i18n/config';
 
 vi.mock('@/services/automation/automationService', () => ({
   automationService: { getFormData: vi.fn() },
@@ -19,6 +19,8 @@ function makeData(overrides: Partial<MuteConversationNodeData> = {}): MuteConver
 afterEach(() => {
   vi.clearAllMocks();
 });
+
+const j = (key: string) => i18n.t(`journey:${key}`);
 
 describe('MuteConversationPanel — no auto-persist on load', () => {
   it('does not call onUpdate merely from loading form data', async () => {
@@ -43,8 +45,8 @@ describe('MuteConversationPanel — Save gated by real edits', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /cancel|cancelar/i })).not.toBeDisabled(),
+      expect(screen.getByRole('button', { name: j('panels.actions.cancel') })).not.toBeDisabled(),
     );
-    expect(screen.getByRole('button', { name: /save|salvar/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: j('panels.actions.save') })).toBeDisabled();
   });
 });

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
@@ -34,8 +34,6 @@ describe('MuteConversationPanel — no auto-persist on load', () => {
   });
 });
 
-// CRM-139: o painel não tem campo editável, então nada pode ficar sujo — o
-// dirty={!loading} anterior habilitava Salvar sozinho ao fim do carregamento.
 describe('MuteConversationPanel — Save gated by real edits', () => {
   it('keeps Save disabled after the form data finishes loading', async () => {
     mockGetFormData.mockResolvedValueOnce({ agents: [], teams: [] });
@@ -44,8 +42,6 @@ describe('MuteConversationPanel — Save gated by real edits', () => {
       <MuteConversationPanel nodeId="n1" data={makeData()} onUpdate={vi.fn()} onClose={vi.fn()} />,
     );
 
-    // Cancelar reabilita só depois que o loading termina — é o sinal de que o
-    // painel já está no estado final, e não que Salvar está travado pelo spinner.
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /cancel|cancelar/i })).not.toBeDisabled(),
     );

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MuteConversationPanel } from './MuteConversationPanel';
 import { MuteConversationNodeData } from './MuteConversationNode';
@@ -31,5 +31,24 @@ describe('MuteConversationPanel — no auto-persist on load', () => {
 
     await waitFor(() => expect(mockGetFormData).toHaveBeenCalled());
     expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// CRM-139: o painel não tem campo editável, então nada pode ficar sujo — o
+// dirty={!loading} anterior habilitava Salvar sozinho ao fim do carregamento.
+describe('MuteConversationPanel — Save gated by real edits', () => {
+  it('keeps Save disabled after the form data finishes loading', async () => {
+    mockGetFormData.mockResolvedValueOnce({ agents: [], teams: [] });
+
+    render(
+      <MuteConversationPanel nodeId="n1" data={makeData()} onUpdate={vi.fn()} onClose={vi.fn()} />,
+    );
+
+    // Cancelar reabilita só depois que o loading termina — é o sinal de que o
+    // painel já está no estado final, e não que Salvar está travado pelo spinner.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /cancel|cancelar/i })).not.toBeDisabled(),
+    );
+    expect(screen.getByRole('button', { name: /save|salvar/i })).toBeDisabled();
   });
 });

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.spec.tsx
@@ -36,7 +36,7 @@ describe('MuteConversationPanel — no auto-persist on load', () => {
   });
 });
 
-describe('MuteConversationPanel — Save gated by real edits', () => {
+describe('MuteConversationPanel — Save never enables', () => {
   it('keeps Save disabled after the form data finishes loading', async () => {
     mockGetFormData.mockResolvedValueOnce({ agents: [], teams: [] });
 

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
@@ -67,9 +67,7 @@ export function MuteConversationPanel({
       icon={<VolumeX className="h-5 w-5 text-flow-node-control-fg" />}
       onCancel={onClose}
       onSave={handleSave}
-      // Painel puramente informativo: não há campo editável, então nunca há o
-      // que salvar. dirty={!loading} declarava o nó sujo assim que o
-      // carregamento terminava, sem o usuário ter mexido em nada.
+      // Sem campo editável: nunca há o que salvar.
       dirty={false}
       loading={loading}
       saveLabel={t('panels.actions.save')}

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
@@ -67,7 +67,10 @@ export function MuteConversationPanel({
       icon={<VolumeX className="h-5 w-5 text-flow-node-control-fg" />}
       onCancel={onClose}
       onSave={handleSave}
-      dirty={!loading}
+      // Painel puramente informativo: não há campo editável, então nunca há o
+      // que salvar. dirty={!loading} declarava o nó sujo assim que o
+      // carregamento terminava, sem o usuário ter mexido em nada.
+      dirty={false}
       loading={loading}
       saveLabel={t('panels.actions.save')}
       cancelLabel={t('panels.actions.cancel')}

--- a/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/mute-conversation/MuteConversationPanel.tsx
@@ -67,7 +67,7 @@ export function MuteConversationPanel({
       icon={<VolumeX className="h-5 w-5 text-flow-node-control-fg" />}
       onCancel={onClose}
       onSave={handleSave}
-      // Sem campo editável: nunca há o que salvar.
+      // No editable field: there is never anything to save.
       dirty={false}
       loading={loading}
       saveLabel={t('panels.actions.save')}

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
@@ -39,8 +39,6 @@ describe('ResolveConversationPanel — no auto-persist on load', () => {
   });
 });
 
-// CRM-139: o painel não tem campo editável, então nada pode ficar sujo — o
-// dirty={!loading} anterior habilitava Salvar sozinho ao fim do carregamento.
 describe('ResolveConversationPanel — Save gated by real edits', () => {
   it('keeps Save disabled after the form data finishes loading', async () => {
     mockGetFormData.mockResolvedValueOnce({ agents: [], teams: [] });
@@ -54,8 +52,6 @@ describe('ResolveConversationPanel — Save gated by real edits', () => {
       />,
     );
 
-    // Cancelar reabilita só depois que o loading termina — é o sinal de que o
-    // painel já está no estado final, e não que Salvar está travado pelo spinner.
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /cancel|cancelar/i })).not.toBeDisabled(),
     );

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
@@ -41,7 +41,7 @@ describe('ResolveConversationPanel — no auto-persist on load', () => {
   });
 });
 
-describe('ResolveConversationPanel — Save gated by real edits', () => {
+describe('ResolveConversationPanel — Save never enables', () => {
   it('keeps Save disabled after the form data finishes loading', async () => {
     mockGetFormData.mockResolvedValueOnce({ agents: [], teams: [] });
 

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ResolveConversationPanel } from './ResolveConversationPanel';
 import { ResolveConversationNodeData } from './ResolveConversationNode';
@@ -36,5 +36,29 @@ describe('ResolveConversationPanel — no auto-persist on load', () => {
 
     await waitFor(() => expect(mockGetFormData).toHaveBeenCalled());
     expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+// CRM-139: o painel não tem campo editável, então nada pode ficar sujo — o
+// dirty={!loading} anterior habilitava Salvar sozinho ao fim do carregamento.
+describe('ResolveConversationPanel — Save gated by real edits', () => {
+  it('keeps Save disabled after the form data finishes loading', async () => {
+    mockGetFormData.mockResolvedValueOnce({ agents: [], teams: [] });
+
+    render(
+      <ResolveConversationPanel
+        nodeId="n1"
+        data={makeData()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // Cancelar reabilita só depois que o loading termina — é o sinal de que o
+    // painel já está no estado final, e não que Salvar está travado pelo spinner.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /cancel|cancelar/i })).not.toBeDisabled(),
+    );
+    expect(screen.getByRole('button', { name: /save|salvar/i })).toBeDisabled();
   });
 });

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.spec.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ResolveConversationPanel } from './ResolveConversationPanel';
 import { ResolveConversationNodeData } from './ResolveConversationNode';
-import '@/i18n/config';
+import i18n from '@/i18n/config';
 
 vi.mock('@/services/automation/automationService', () => ({
   automationService: { getFormData: vi.fn() },
@@ -19,6 +19,8 @@ function makeData(overrides: Partial<ResolveConversationNodeData> = {}): Resolve
 afterEach(() => {
   vi.clearAllMocks();
 });
+
+const j = (key: string) => i18n.t(`journey:${key}`);
 
 describe('ResolveConversationPanel — no auto-persist on load', () => {
   it('does not call onUpdate merely from loading form data', async () => {
@@ -53,8 +55,8 @@ describe('ResolveConversationPanel — Save gated by real edits', () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole('button', { name: /cancel|cancelar/i })).not.toBeDisabled(),
+      expect(screen.getByRole('button', { name: j('actions.cancel') })).not.toBeDisabled(),
     );
-    expect(screen.getByRole('button', { name: /save|salvar/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: j('actions.save') })).toBeDisabled();
   });
 });

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
@@ -67,9 +67,7 @@ export function ResolveConversationPanel({
       icon={<CheckCircle className="h-5 w-5 text-flow-node-control-fg" />}
       onCancel={onClose}
       onSave={handleSave}
-      // Painel puramente informativo: não há campo editável, então nunca há o
-      // que salvar. dirty={!loading} declarava o nó sujo assim que o
-      // carregamento terminava, sem o usuário ter mexido em nada.
+      // Sem campo editável: nunca há o que salvar.
       dirty={false}
       loading={loading}
       saveLabel={t('actions.save')}

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
@@ -67,7 +67,10 @@ export function ResolveConversationPanel({
       icon={<CheckCircle className="h-5 w-5 text-flow-node-control-fg" />}
       onCancel={onClose}
       onSave={handleSave}
-      dirty={!loading}
+      // Painel puramente informativo: não há campo editável, então nunca há o
+      // que salvar. dirty={!loading} declarava o nó sujo assim que o
+      // carregamento terminava, sem o usuário ter mexido em nada.
+      dirty={false}
       loading={loading}
       saveLabel={t('actions.save')}
       cancelLabel={t('actions.cancel')}

--- a/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
+++ b/src/components/journey/nodes/actions/resolve-conversation/ResolveConversationPanel.tsx
@@ -67,7 +67,7 @@ export function ResolveConversationPanel({
       icon={<CheckCircle className="h-5 w-5 text-flow-node-control-fg" />}
       onCancel={onClose}
       onSave={handleSave}
-      // Sem campo editável: nunca há o que salvar.
+      // No editable field: there is never anything to save.
       dirty={false}
       loading={loading}
       saveLabel={t('actions.save')}


### PR DESCRIPTION
Sobra da CRM-118, apontada no review da #282. Os dois painéis ficaram com `dirty={!loading}`: assim que o `getFormData` retornava, o painel se declarava sujo e o botão Salvar acendia sem o usuário ter tocado em nada.

Diferente dos 4 irmãos do mesmo lote, estes dois não têm campo editável nenhum — são só banners informativos. Não existe snapshot a comparar, então o valor honesto é `dirty={false}`: nunca há o que salvar. O `handleSave` só escrevia `formDataOptions` e `action_params: []` no nó, e nada no editor lê nenhum dos dois nestes tipos de nó (os nós de Mute e Resolve não renderizam agente/time), então o botão deixar de acender não tira capacidade de ninguém.

Uma spec por painel confere que Salvar continua desabilitado depois que o carregamento termina — a espera é pelo Cancelar reabilitar, senão o teste passaria só porque o spinner ainda trava tudo. As duas reprovam no código anterior. Os dois arquivos já estão na lista opt-in do CI.

Nota adjacente, fora do escopo daqui: com o Salvar inalcançável, a chamada de `automationService.getFormData()` nesses dois painéis vira uma requisição sem consumidor a cada abertura. Deixei como está para o diff ficar no que o card pede — vale um card próprio se a decisão for limpar.

## Summary by Sourcery

Ensure Mute and Resolve conversation journey panels remain non-dirty informational panels with Save disabled unless actual edits are possible.

Bug Fixes:
- Prevent Save from becoming enabled automatically after form data load in MuteConversationPanel and ResolveConversationPanel, where no editable fields exist.

Tests:
- Add specs for MuteConversationPanel and ResolveConversationPanel to assert that Save stays disabled after loading while Cancel re-enables once the spinner finishes.