### PR TITLE
fix(journey): zera o saldo de lint deixado pelo épico de tech-debt (CRM-140)

### DIFF
--- a/src/components/journey/SessionsViewer.spec.tsx
+++ b/src/components/journey/SessionsViewer.spec.tsx
@@ -300,3 +300,32 @@ describe('SessionsViewer — search debounce and stale-response guard', () => {
     expect(journeyService.getJourneySessionStats).not.toHaveBeenCalled();
   });
 });
+
+// CRM-140: loadSessions/loadStats viraram useCallback para entrar nas deps dos
+// efeitos de carga. O `t` do i18n troca de identidade a cada render (o mock de
+// useLanguage acima faz exatamente isso), por isso ele ficou num ref — se
+// voltasse para as deps, cada render refaria as duas requisições.
+describe('SessionsViewer — load effects survive re-render', () => {
+  it('does not refetch when the component re-renders with the same props', async () => {
+    vi.mocked(journeyService.getJourneySessions).mockResolvedValue({
+      data: { sessions: [], total: 0 },
+    } as never);
+    vi.mocked(journeyService.getJourneySessionStats).mockResolvedValue({
+      data: { total: 0 },
+    } as never);
+
+    const { rerender } = render(<SessionsViewer {...baseProps} />);
+    await waitFor(() => {
+      expect(journeyService.getJourneySessions).toHaveBeenCalledTimes(1);
+      expect(journeyService.getJourneySessionStats).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      rerender(<SessionsViewer {...baseProps} />);
+      rerender(<SessionsViewer {...baseProps} />);
+    });
+
+    expect(journeyService.getJourneySessions).toHaveBeenCalledTimes(1);
+    expect(journeyService.getJourneySessionStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/journey/SessionsViewer.spec.tsx
+++ b/src/components/journey/SessionsViewer.spec.tsx
@@ -301,10 +301,6 @@ describe('SessionsViewer — search debounce and stale-response guard', () => {
   });
 });
 
-// CRM-140: loadSessions/loadStats viraram useCallback para entrar nas deps dos
-// efeitos de carga. O `t` do i18n troca de identidade a cada render (o mock de
-// useLanguage acima faz exatamente isso), por isso ele ficou num ref — se
-// voltasse para as deps, cada render refaria as duas requisições.
 describe('SessionsViewer — load effects survive re-render', () => {
   it('does not refetch when the component re-renders with the same props', async () => {
     vi.mocked(journeyService.getJourneySessions).mockResolvedValue({

--- a/src/components/journey/SessionsViewer.tsx
+++ b/src/components/journey/SessionsViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Button, Badge, Card, CardContent } from '@evoapi/design-system';
 import { toast } from 'sonner';
 import {
@@ -135,53 +135,65 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
     return () => clearTimeout(handle);
   }, [searchContact]);
 
+  // O `t` do i18n troca de identidade enquanto o bundle de tradução não está
+  // pronto. Como ele só é usado no caminho de erro (assíncrono) das cargas
+  // abaixo, fica num ref — nas deps do useCallback ele religaria o efeito de
+  // carga a cada render.
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
   // `isStale` lets the auto-fetch effect below discard a response that's no
   // longer for the current filters (a slower earlier request resolving after
   // a faster later one used to overwrite `sessions` with stale data).
-  const loadSessions = async (isStale: () => boolean = () => false) => {
-    try {
-      setLoading(true);
-      const params: any = {
-        page,
-        pageSize,
-      };
+  const loadSessions = useCallback(
+    async (isStale: () => boolean = () => false) => {
+      try {
+        setLoading(true);
+        const params: any = {
+          page,
+          pageSize,
+        };
 
-      if (filterStatus !== 'all') {
-        params.status = filterStatus;
+        if (filterStatus !== 'all') {
+          params.status = filterStatus;
+        }
+
+        if (debouncedSearchContact) {
+          params.contactId = debouncedSearchContact;
+        }
+
+        const response = await journeyService.getJourneySessions(journeyId, params);
+        if (isStale()) return;
+
+        setSessions(response.data.sessions || []);
+        setTotal(response.data.total || 0);
+      } catch (error) {
+        if (isStale()) return;
+        console.error('Erro ao carregar sessões:', error);
+        toast.error(tRef.current('sessions.viewer.messages.loadError'));
+      } finally {
+        if (!isStale()) setLoading(false);
       }
-
-      if (debouncedSearchContact) {
-        params.contactId = debouncedSearchContact;
-      }
-
-      const response = await journeyService.getJourneySessions(journeyId, params);
-      if (isStale()) return;
-
-      setSessions(response.data.sessions || []);
-      setTotal(response.data.total || 0);
-    } catch (error) {
-      if (isStale()) return;
-      console.error('Erro ao carregar sessões:', error);
-      toast.error(t('sessions.viewer.messages.loadError'));
-    } finally {
-      if (!isStale()) setLoading(false);
-    }
-  };
+    },
+    [journeyId, filterStatus, debouncedSearchContact, page],
+  );
 
   // Independent of filterStatus/search/page — refetching it on every keystroke
   // was wasted (and doubled) request volume for numbers that hadn't changed.
-  const loadStats = async () => {
+  const loadStats = useCallback(async () => {
     try {
       const response = await journeyService.getJourneySessionStats(journeyId);
       setStats(response.data);
     } catch (error) {
       console.error('Erro ao carregar estatísticas de sessões:', error);
     }
-  };
+  }, [journeyId]);
 
   useEffect(() => {
     loadStats();
-  }, [journeyId]);
+  }, [loadStats]);
 
   useEffect(() => {
     let cancelled = false;
@@ -189,7 +201,7 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
     return () => {
       cancelled = true;
     };
-  }, [journeyId, filterStatus, debouncedSearchContact, page]);
+  }, [loadSessions]);
 
   const handleDeleteSession = async (sessionId: string) => {
     if (!confirm(t('sessions.viewer.actions.confirmDelete'))) return;

--- a/src/components/journey/SessionsViewer.tsx
+++ b/src/components/journey/SessionsViewer.tsx
@@ -135,10 +135,8 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
     return () => clearTimeout(handle);
   }, [searchContact]);
 
-  // O `t` do i18n troca de identidade enquanto o bundle de tradução não está
-  // pronto. Como ele só é usado no caminho de erro (assíncrono) das cargas
-  // abaixo, fica num ref — nas deps do useCallback ele religaria o efeito de
-  // carga a cada render.
+  // `t` troca de identidade a cada render antes do i18n ficar pronto; num ref
+  // para não religar loadSessions/loadStats a cada render.
   const tRef = useRef(t);
   useEffect(() => {
     tRef.current = t;

--- a/src/components/journey/nodes/actions/send-message/components/SendMessageChannelConfig.tsx
+++ b/src/components/journey/nodes/actions/send-message/components/SendMessageChannelConfig.tsx
@@ -68,6 +68,14 @@ const getChannelTypeName = (channelType: string) => {
   }
 };
 
+// O /form_data devolve os canais num payload mais enxuto que o Inbox completo de
+// @/types/channels; este é o recorte que o seletor realmente renderiza.
+export interface SendMessageChannelOption {
+  id: string | number;
+  name: string;
+  channel_type: string;
+}
+
 interface SendMessageChannelConfigProps {
   isTemplateMode: boolean;
   isCloudInbox: boolean;
@@ -75,7 +83,7 @@ interface SendMessageChannelConfigProps {
   useEventChannel: boolean | undefined;
   onUseEventChannelChange: (checked: boolean) => void;
   loading: boolean;
-  filteredInboxes: any[];
+  filteredInboxes: SendMessageChannelOption[];
   inboxId: string | undefined;
   onInboxChange: (inboxId: string) => void;
 }
@@ -176,7 +184,7 @@ export function SendMessageChannelConfig({
                   <SelectValue placeholder={t('panels.sendMessage.chooseChannel')} />
                 </SelectTrigger>
                 <SelectContent>
-                  {filteredInboxes.map((inbox: any) => (
+                  {filteredInboxes.map(inbox => (
                     <SelectItem key={inbox.id} value={String(inbox.id)}>
                       <div className="flex items-center gap-2">
                         {getInboxIcon(inbox.channel_type)}


### PR DESCRIPTION
Follow-up do review da #282: num épico cujo critério era reduzir lint, o saldo no diretório de jornadas tinha ficado neutro. Esta branch fecha os 4 pontos que a própria PR introduziu.

`loadStats` e `loadSessions` viraram `useCallback` e passaram a ser a dependência dos próprios efeitos, no lugar da lista de filtros repetida — os dois warnings de `exhaustive-deps` somem e o comportamento é idêntico, porque as deps do callback são exatamente as que o efeito tinha. O detalhe que decidiu o desenho: o `t` do `useLanguage` troca de identidade a cada render enquanto o i18n não está pronto, então ele foi para um ref em vez das deps. Não é preciosismo — com o `t` nas deps, quatro testes do `SessionsViewer` estouram por timeout, inclusive os de debounce e race guard, porque a carga refaz a requisição a cada render.

Os dois `any` do `SendMessageChannelConfig` viraram um tipo próprio (`SendMessageChannelOption`) com o recorte que o seletor de fato renderiza. O payload de `/form_data` é mais enxuto que o `Inbox` de `@/types/channels`, então declarar o recorte é mais honesto do que reusar o tipo grande.

Uma spec nova rerenderiza o componente com as mesmas props e confere que nenhuma das duas requisições se repete — é ela que quebra se alguém devolver o `t` para as deps. `npx eslint src/components/journey/SessionsViewer.tsx` fica sem warning e o `SendMessageChannelConfig` sem erro; os `any` que sobram no `SessionsViewer` são os de sempre, do escopo do CRM-127. `tsc --noEmit` limpo e os 10 testes do `SessionsViewer` verdes (o arquivo já está na lista do CI).

## Summary by Sourcery

Address lint and type-safety issues in journey components by stabilizing data-loading effects and tightening channel option typings.

Bug Fixes:
- Prevent unnecessary refetching of journey sessions and stats when SessionsViewer re-renders with unchanged props.
- Avoid stale-identity i18n translator from retriggering async load effects and causing repeated requests.

Enhancements:
- Wrap SessionsViewer data-loading functions in memoized callbacks and drive effects from those callbacks to satisfy exhaustive-deps lint rules.
- Introduce a dedicated SendMessageChannelOption type for send-message channel selector options instead of using loosely-typed arrays.

Tests:
- Add a regression test ensuring SessionsViewer does not repeat its data-load requests across re-renders with identical props.