### PR TITLE
fix(journey): pareia Label com o controle nos subcomponentes de jornadas (CRM-141)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,4 +90,6 @@ jobs:
             src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx \
             src/components/journey/nodes/actions/wait/components/WaitTimeConfig.spec.tsx \
             src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx \
+            src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.spec.tsx \
+            src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx \
             src/components/journey/environment-manager/VariableMapping.spec.tsx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,10 +50,9 @@ jobs:
       #     apply call, SessionsViewer debounces search and keeps stats
       #     isolated from filters, and the locale-driven date/i18n specs
       #     guard against hardcoded pt-BR creeping back in.
-      #   - Journey subcomponent labels (CRM-141): every <Label> that names a
-      #     single control resolves through getByLabelText, and the ones that
-      #     cover a set (webhook headers) expose a named group — the trigger,
-      #     wait, send-webhook and environment-manager folders each have one.
+      #   - Journey subcomponent labels: every <Label> that names a single
+      #     control resolves through getByLabelText, and the ones that cover
+      #     a set (webhook headers) expose a named group.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,10 @@ jobs:
       #     apply call, SessionsViewer debounces search and keeps stats
       #     isolated from filters, and the locale-driven date/i18n specs
       #     guard against hardcoded pt-BR creeping back in.
+      #   - Journey subcomponent labels (CRM-141): every <Label> that names a
+      #     single control resolves through getByLabelText, and the ones that
+      #     cover a set (webhook headers) expose a named group — the trigger,
+      #     wait, send-webhook and environment-manager folders each have one.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -83,4 +87,8 @@ jobs:
             src/components/journey/nodes/actions/send-transcript/SendTranscriptPanel.spec.tsx \
             src/lib/dateFnsLocale.spec.ts \
             src/components/base/BaseFlowCanvas.spec.tsx \
-            src/components/journey/SessionsViewer.spec.tsx
+            src/components/journey/SessionsViewer.spec.tsx \
+            src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx \
+            src/components/journey/nodes/actions/wait/components/WaitTimeConfig.spec.tsx \
+            src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx \
+            src/components/journey/environment-manager/VariableMapping.spec.tsx

--- a/src/components/journey/environment-manager/EnvironmentManager.tsx
+++ b/src/components/journey/environment-manager/EnvironmentManager.tsx
@@ -354,10 +354,14 @@ export function EnvironmentManager({
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <Label className="text-sm font-medium text-sidebar-foreground mb-2 block">
+                  <Label
+                    htmlFor="env-manager-new-name"
+                    className="text-sm font-medium text-sidebar-foreground mb-2 block"
+                  >
                     {t('environmentManager.form.fields.name.label')}
                   </Label>
                   <Input
+                    id="env-manager-new-name"
                     placeholder={t('environmentManager.form.fields.name.placeholder')}
                     value={newVariable.name}
                     onChange={e => setNewVariable(prev => ({ ...prev, name: e.target.value }))}
@@ -369,7 +373,10 @@ export function EnvironmentManager({
                 </div>
 
                 <div>
-                  <Label className="text-sm font-medium text-sidebar-foreground mb-2 block">
+                  <Label
+                    htmlFor="env-manager-new-type"
+                    className="text-sm font-medium text-sidebar-foreground mb-2 block"
+                  >
                     {t('environmentManager.form.fields.type.label')}
                   </Label>
                   <Select
@@ -378,7 +385,7 @@ export function EnvironmentManager({
                       setNewVariable(prev => ({ ...prev, type: value }))
                     }
                   >
-                    <SelectTrigger className="bg-sidebar border-sidebar-border">
+                    <SelectTrigger id="env-manager-new-type" className="bg-sidebar border-sidebar-border">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -391,10 +398,14 @@ export function EnvironmentManager({
                 </div>
 
                 <div>
-                  <Label className="text-sm font-medium text-sidebar-foreground mb-2 block">
+                  <Label
+                    htmlFor="env-manager-new-description"
+                    className="text-sm font-medium text-sidebar-foreground mb-2 block"
+                  >
                     {t('environmentManager.form.fields.description.label')}
                   </Label>
                   <Input
+                    id="env-manager-new-description"
                     placeholder={t('environmentManager.form.fields.description.placeholder')}
                     value={newVariable.description}
                     onChange={e =>
@@ -405,10 +416,14 @@ export function EnvironmentManager({
                 </div>
 
                 <div>
-                  <Label className="text-sm font-medium text-sidebar-foreground mb-2 block">
+                  <Label
+                    htmlFor="env-manager-new-default"
+                    className="text-sm font-medium text-sidebar-foreground mb-2 block"
+                  >
                     {t('environmentManager.form.fields.defaultValue.label')}
                   </Label>
                   <Input
+                    id="env-manager-new-default"
                     placeholder={t('environmentManager.form.fields.defaultValue.placeholder')}
                     value={newVariable.defaultValue}
                     onChange={e =>

--- a/src/components/journey/environment-manager/VariableMapping.spec.tsx
+++ b/src/components/journey/environment-manager/VariableMapping.spec.tsx
@@ -23,9 +23,6 @@ const mappings: DataMapping[] = [
   { id: 'm2', sourcePath: 'webhook.body.timestamp', variableName: 'seenAt', transform: 'date' },
 ];
 
-// CRM-141: as linhas de mapeamento repetem os mesmos rótulos, então o
-// pareamento precisa ser por linha — id fixo colidiria e o label apontaria
-// sempre para a primeira. getAllByLabelText prova que cada linha tem o seu.
 describe('VariableMapping — Label pareado por linha', () => {
   it('gives every row its own label/control pair', () => {
     render(

--- a/src/components/journey/environment-manager/VariableMapping.spec.tsx
+++ b/src/components/journey/environment-manager/VariableMapping.spec.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { VariableMapping, type DataMapping } from './VariableMapping';
+import i18n from '@/i18n/config';
+
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+const j = (key: string) => i18n.t(`journey:${key}`);
+
+const mappings: DataMapping[] = [
+  { id: 'm1', sourcePath: 'webhook.body.contact_id', variableName: 'contactId', transform: 'none' },
+  { id: 'm2', sourcePath: 'webhook.body.timestamp', variableName: 'seenAt', transform: 'date' },
+];
+
+// CRM-141: as linhas de mapeamento repetem os mesmos rótulos, então o
+// pareamento precisa ser por linha — id fixo colidiria e o label apontaria
+// sempre para a primeira. getAllByLabelText prova que cada linha tem o seu.
+describe('VariableMapping — Label pareado por linha', () => {
+  it('gives every row its own label/control pair', () => {
+    render(
+      <VariableMapping
+        mappings={mappings}
+        onMappingsChange={vi.fn()}
+        paths={['webhook.body.contact_id', 'webhook.body.timestamp']}
+        journeyId="journey-1"
+      />,
+    );
+
+    const sources = screen.getAllByLabelText(j('environmentManager.form.fields.description.label'));
+    const variables = screen.getAllByLabelText(j('environmentManager.form.fields.name.label'));
+    const transforms = screen.getAllByLabelText(j('environmentManager.form.fields.type.label'));
+
+    expect(sources).toHaveLength(2);
+    expect(variables).toHaveLength(2);
+    expect(transforms).toHaveLength(2);
+
+    // Os ids carregam o id do mapping — é o que impede uma linha de roubar o
+    // rótulo da outra.
+    expect(sources.map(el => el.id)).toEqual([
+      'variable-mapping-source-m1',
+      'variable-mapping-source-m2',
+    ]);
+    expect(transforms.map(el => el.id)).toEqual([
+      'variable-mapping-transform-m1',
+      'variable-mapping-transform-m2',
+    ]);
+  });
+});

--- a/src/components/journey/environment-manager/VariableMapping.spec.tsx
+++ b/src/components/journey/environment-manager/VariableMapping.spec.tsx
@@ -34,9 +34,9 @@ describe('VariableMapping — Label pareado por linha', () => {
       />,
     );
 
-    const sources = screen.getAllByLabelText(j('environmentManager.form.fields.description.label'));
-    const variables = screen.getAllByLabelText(j('environmentManager.form.fields.name.label'));
-    const transforms = screen.getAllByLabelText(j('environmentManager.form.fields.type.label'));
+    const sources = screen.getAllByLabelText(j('environmentManager.mapping.sourcePathLabel'));
+    const variables = screen.getAllByLabelText(j('environmentManager.mapping.variableLabel'));
+    const transforms = screen.getAllByLabelText(j('environmentManager.mapping.transformLabel'));
 
     expect(sources).toHaveLength(2);
     expect(variables).toHaveLength(2);

--- a/src/components/journey/environment-manager/VariableMapping.tsx
+++ b/src/components/journey/environment-manager/VariableMapping.tsx
@@ -163,7 +163,10 @@ export function VariableMapping({
               <div className="flex items-end gap-2">
                 {/* Caminho de origem */}
                 <div className="flex-1 space-y-1">
-                  <Label className="text-xs text-gray-600 font-medium">
+                  <Label
+                    htmlFor={`variable-mapping-source-${mapping.id}`}
+                    className="text-xs text-gray-600 font-medium"
+                  >
                     {t('environmentManager.form.fields.description.label')}
                   </Label>
                   {paths && paths.length > 0 ? (
@@ -184,7 +187,10 @@ export function VariableMapping({
                         }
                       }}
                     >
-                      <SelectTrigger className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 w-full">
+                      <SelectTrigger
+                        id={`variable-mapping-source-${mapping.id}`}
+                        className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 w-full"
+                      >
                         <SelectValue placeholder={t('environmentManager.searchPlaceholder')} />
                       </SelectTrigger>
                       <SelectContent className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 max-h-[200px]">
@@ -209,6 +215,7 @@ export function VariableMapping({
                     </Select>
                   ) : (
                     <Input
+                      id={`variable-mapping-source-${mapping.id}`}
                       placeholder={t('environmentManager.form.fields.name.placeholder')}
                       value={mapping.sourcePath || ''}
                       onChange={e => updateMapping(mapping.id, 'sourcePath', e.target.value)}
@@ -220,10 +227,14 @@ export function VariableMapping({
                 {/* Input para caminho personalizado quando selecionado */}
                 {showCustomInput[mapping.id] && (
                   <div className="flex-1 space-y-1">
-                    <Label className="text-xs text-gray-600 font-medium">
+                    <Label
+                      htmlFor={`variable-mapping-custom-path-${mapping.id}`}
+                      className="text-xs text-gray-600 font-medium"
+                    >
                       {t('environmentManager.form.fields.name.help')}
                     </Label>
                     <Input
+                      id={`variable-mapping-custom-path-${mapping.id}`}
                       placeholder={t('environmentManager.form.fields.name.placeholder')}
                       value={mapping.sourcePath || ''}
                       onChange={e => {
@@ -248,10 +259,14 @@ export function VariableMapping({
 
                 {/* Variável destino */}
                 <div className="flex-1 space-y-1">
-                  <Label className="text-xs text-gray-600 font-medium">
+                  <Label
+                    htmlFor={`variable-mapping-variable-${mapping.id}`}
+                    className="text-xs text-gray-600 font-medium"
+                  >
                     {t('environmentManager.form.fields.name.label')}
                   </Label>
                   <VariableSelect
+                    id={`variable-mapping-variable-${mapping.id}`}
                     value={mapping.variableName}
                     onValueChange={value => updateMapping(mapping.id, 'variableName', value)}
                     journeyId={journeyId}
@@ -264,14 +279,20 @@ export function VariableMapping({
 
                 {/* Transformação */}
                 <div className="w-24 space-y-1">
-                  <Label className="text-xs text-gray-600 font-medium">
+                  <Label
+                    htmlFor={`variable-mapping-transform-${mapping.id}`}
+                    className="text-xs text-gray-600 font-medium"
+                  >
                     {t('environmentManager.form.fields.type.label')}
                   </Label>
                   <Select
                     value={mapping.transform || 'none'}
                     onValueChange={value => updateMapping(mapping.id, 'transform', value)}
                   >
-                    <SelectTrigger className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 w-full">
+                    <SelectTrigger
+                      id={`variable-mapping-transform-${mapping.id}`}
+                      className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 w-full"
+                    >
                       <SelectValue>
                         {mapping.transform && (
                           <span

--- a/src/components/journey/environment-manager/VariableMapping.tsx
+++ b/src/components/journey/environment-manager/VariableMapping.tsx
@@ -167,7 +167,7 @@ export function VariableMapping({
                     htmlFor={`variable-mapping-source-${mapping.id}`}
                     className="text-xs text-gray-600 font-medium"
                   >
-                    {t('environmentManager.form.fields.description.label')}
+                    {t('environmentManager.mapping.sourcePathLabel')}
                   </Label>
                   {paths && paths.length > 0 ? (
                     <Select
@@ -231,7 +231,7 @@ export function VariableMapping({
                       htmlFor={`variable-mapping-custom-path-${mapping.id}`}
                       className="text-xs text-gray-600 font-medium"
                     >
-                      {t('environmentManager.form.fields.name.help')}
+                      {t('environmentManager.mapping.customPathLabel')}
                     </Label>
                     <Input
                       id={`variable-mapping-custom-path-${mapping.id}`}
@@ -263,7 +263,7 @@ export function VariableMapping({
                     htmlFor={`variable-mapping-variable-${mapping.id}`}
                     className="text-xs text-gray-600 font-medium"
                   >
-                    {t('environmentManager.form.fields.name.label')}
+                    {t('environmentManager.mapping.variableLabel')}
                   </Label>
                   <VariableSelect
                     id={`variable-mapping-variable-${mapping.id}`}
@@ -283,7 +283,7 @@ export function VariableMapping({
                     htmlFor={`variable-mapping-transform-${mapping.id}`}
                     className="text-xs text-gray-600 font-medium"
                   >
-                    {t('environmentManager.form.fields.type.label')}
+                    {t('environmentManager.mapping.transformLabel')}
                   </Label>
                   <Select
                     value={mapping.transform || 'none'}

--- a/src/components/journey/environment-manager/VariableSelect.tsx
+++ b/src/components/journey/environment-manager/VariableSelect.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useId, useState } from 'react';
 import { toast } from 'sonner';
 import {
   Select,
@@ -58,6 +58,9 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
     ref,
   ) => {
     const { t } = useLanguage('journey');
+    // One picker is rendered per mapping row, so the create-variable form
+    // cannot use fixed ids.
+    const formId = useId();
     const [showCreateModal, setShowCreateModal] = useState(false);
     const [contactAttributes, setContactAttributes] = useState<CustomAttributeDefinition[]>([]);
     const [newVariableName, setNewVariableName] = useState('');
@@ -302,11 +305,11 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
 
             <div className="space-y-4">
               <div>
-                <Label htmlFor="variable-select-new-name" className="text-sm font-medium">
+                <Label htmlFor={`${formId}-name`} className="text-sm font-medium">
                   {t('environmentManager.form.fields.name.label')}
                 </Label>
                 <Input
-                  id="variable-select-new-name"
+                  id={`${formId}-name`}
                   value={newVariableName}
                   onChange={e => setNewVariableName(e.target.value)}
                   placeholder={t('environmentManager.form.fields.name.placeholder')}
@@ -318,7 +321,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
               </div>
 
               <div>
-                <Label htmlFor="variable-select-new-type" className="text-sm font-medium">
+                <Label htmlFor={`${formId}-type`} className="text-sm font-medium">
                   {t('environmentManager.form.fields.type.label')}
                 </Label>
                 <Select
@@ -327,7 +330,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                     setNewVariableType(value)
                   }
                 >
-                  <SelectTrigger id="variable-select-new-type" className="mt-1">
+                  <SelectTrigger id={`${formId}-type`} className="mt-1">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -348,11 +351,11 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
               </div>
 
               <div>
-                <Label htmlFor="variable-select-new-description" className="text-sm font-medium">
+                <Label htmlFor={`${formId}-description`} className="text-sm font-medium">
                   {t('environmentManager.form.fields.description.label')}
                 </Label>
                 <Input
-                  id="variable-select-new-description"
+                  id={`${formId}-description`}
                   value={newVariableDescription}
                   onChange={e => setNewVariableDescription(e.target.value)}
                   placeholder={t('environmentManager.form.fields.description.placeholder')}
@@ -361,11 +364,11 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
               </div>
 
               <div>
-                <Label htmlFor="variable-select-new-default" className="text-sm font-medium">
+                <Label htmlFor={`${formId}-default`} className="text-sm font-medium">
                   {t('environmentManager.form.fields.defaultValue.label')}
                 </Label>
                 <Input
-                  id="variable-select-new-default"
+                  id={`${formId}-default`}
                   value={newVariableDefaultValue}
                   onChange={e => setNewVariableDefaultValue(e.target.value)}
                   placeholder={t('environmentManager.form.fields.defaultValue.placeholder')}

--- a/src/components/journey/environment-manager/VariableSelect.tsx
+++ b/src/components/journey/environment-manager/VariableSelect.tsx
@@ -302,10 +302,11 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
 
             <div className="space-y-4">
               <div>
-                <Label className="text-sm font-medium">
+                <Label htmlFor="variable-select-new-name" className="text-sm font-medium">
                   {t('environmentManager.form.fields.name.label')}
                 </Label>
                 <Input
+                  id="variable-select-new-name"
                   value={newVariableName}
                   onChange={e => setNewVariableName(e.target.value)}
                   placeholder={t('environmentManager.form.fields.name.placeholder')}
@@ -317,7 +318,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
               </div>
 
               <div>
-                <Label className="text-sm font-medium">
+                <Label htmlFor="variable-select-new-type" className="text-sm font-medium">
                   {t('environmentManager.form.fields.type.label')}
                 </Label>
                 <Select
@@ -326,7 +327,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                     setNewVariableType(value)
                   }
                 >
-                  <SelectTrigger className="mt-1">
+                  <SelectTrigger id="variable-select-new-type" className="mt-1">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -347,10 +348,11 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
               </div>
 
               <div>
-                <Label className="text-sm font-medium">
+                <Label htmlFor="variable-select-new-description" className="text-sm font-medium">
                   {t('environmentManager.form.fields.description.label')}
                 </Label>
                 <Input
+                  id="variable-select-new-description"
                   value={newVariableDescription}
                   onChange={e => setNewVariableDescription(e.target.value)}
                   placeholder={t('environmentManager.form.fields.description.placeholder')}
@@ -359,10 +361,11 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
               </div>
 
               <div>
-                <Label className="text-sm font-medium">
+                <Label htmlFor="variable-select-new-default" className="text-sm font-medium">
                   {t('environmentManager.form.fields.defaultValue.label')}
                 </Label>
                 <Input
+                  id="variable-select-new-default"
                   value={newVariableDefaultValue}
                   onChange={e => setNewVariableDefaultValue(e.target.value)}
                   placeholder={t('environmentManager.form.fields.defaultValue.placeholder')}

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.spec.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConditionalPanel } from './ConditionalPanel';
 import { ConditionalNodeData } from './ConditionalNode';
-import '@/i18n/config';
+import i18n from '@/i18n/config';
 
 vi.mock('@/services/pipelines/pipelinesService', () => ({
   pipelinesService: {
@@ -36,6 +36,7 @@ const PLAN_INTEREST_ATTR = {
 };
 
 const PIPELINE_STAGE_FIELD = '{{conversation.pipeline_stage_id}}';
+const PATHS_TITLE = i18n.t('journey:panels.conditional.pathsTitle');
 
 const PIPELINES = [{ id: 'pipe-1', name: 'Sales' }];
 const STAGES = [
@@ -332,5 +333,31 @@ describe('ConditionalPanel — expression validation', () => {
     expect(
       await screen.findByRole('button', { name: INSERT_VARIABLE_NAME }),
     ).toBeInTheDocument();
+  });
+});
+
+describe('ConditionalPanel — o rótulo dos caminhos nomeia o grupo (CRM-141)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The group lands on the Radix Tabs root, the only place in CRM-141 where it
+  // is not a plain <div> — assert the props survive the primitive.
+  it('names the paths tabs as a group', async () => {
+    mockGetPipelines.mockResolvedValue({ data: PIPELINES });
+    mockGetPipelineStages.mockResolvedValue({ data: STAGES });
+
+    render(
+      <ConditionalPanel
+        nodeId="n1"
+        data={dataWithStageCondition()}
+        onUpdate={vi.fn()}
+        onClose={vi.fn()}
+        journeyId="j1"
+      />,
+    );
+
+    const group = await screen.findByRole('group', { name: PATHS_TITLE });
+    expect(within(group).getByRole('tablist')).toBeTruthy();
   });
 });

--- a/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalPanel.tsx
@@ -558,7 +558,7 @@ export function ConditionalPanel({
     >
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Label className="text-sidebar-foreground font-medium">
+          <Label id="conditional-paths-label" className="text-sidebar-foreground font-medium">
             {t('panels.conditional.pathsTitle')}
           </Label>
           <Button variant="outline" size="sm" onClick={addPath}>
@@ -569,7 +569,12 @@ export function ConditionalPanel({
 
         {formData.paths.length > 0 ? (
           <>
-            <Tabs value={activePathId} onValueChange={setActivePathId}>
+            <Tabs
+              value={activePathId}
+              onValueChange={setActivePathId}
+              role="group"
+              aria-labelledby="conditional-paths-label"
+            >
               <TabsList
                 className="grid w-full"
                 style={{

--- a/src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx
+++ b/src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx
@@ -1,0 +1,49 @@
+import { createRef } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SendMessageAttachments, type AttachmentFile } from './SendMessageAttachments';
+import i18n from '@/i18n/config';
+
+const j = (key: string) => i18n.t(`journey:${key}`);
+
+function renderAttachments(attachments: AttachmentFile[] = []) {
+  return render(
+    <SendMessageAttachments
+      attachments={attachments}
+      isDragOver={false}
+      loading={false}
+      fileInputRef={createRef<HTMLInputElement>()}
+      onDragOver={vi.fn()}
+      onDragLeave={vi.fn()}
+      onDrop={vi.fn()}
+      onFileInputChange={vi.fn()}
+      onRemoveAttachment={vi.fn()}
+    />,
+  );
+}
+
+describe('SendMessageAttachments — rótulo pareado com o que existe na tela', () => {
+  it('names the dropzone as a group instead of labelling the hidden file input', () => {
+    const { container } = renderAttachments();
+
+    const dropzone = screen.getByRole('group', { name: j('panels.sendMessage.attachments') });
+    expect(within(dropzone).getByRole('button')).toBeTruthy();
+
+    // A display:none input is out of the a11y tree — htmlFor pointing at it
+    // would name nothing and would make the label open the file dialog.
+    const fileInput = container.querySelector('input[type="file"]');
+    expect(fileInput).toBeTruthy();
+    expect(fileInput!.getAttribute('id')).toBeNull();
+  });
+
+  it('names the attachment list as its own group', () => {
+    renderAttachments([
+      { id: 'a1', name: 'brief.pdf', size: 1024, type: 'application/pdf', status: 'uploaded' },
+    ]);
+
+    const list = screen.getByRole('group', {
+      name: i18n.t('journey:panels.sendMessage.attachmentsList', { count: 1 }),
+    });
+    expect(within(list).getByText('brief.pdf')).toBeTruthy();
+  });
+});

--- a/src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.tsx
+++ b/src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.tsx
@@ -51,16 +51,20 @@ export function SendMessageAttachments({
   return (
     <>
       <div className="space-y-2">
-        <Label htmlFor="send-message-attachments-input" className="text-sm font-medium">
+        <Label id="send-message-attachments-label" className="text-sm font-medium">
           {t('panels.sendMessage.attachments')}
         </Label>
 
+        {/* The file input is display:none, so it is out of the a11y tree and
+            cannot carry the label. The dropzone holds the visible control. */}
         <div
           className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${
             isDragOver
               ? 'border-flow-node-action-message-fg bg-flow-node-action-message-bg'
               : 'border-border hover:border-flow-node-action-message-border'
           }`}
+          role="group"
+          aria-labelledby="send-message-attachments-label"
           onDragOver={onDragOver}
           onDragLeave={onDragLeave}
           onDrop={onDrop}
@@ -80,7 +84,6 @@ export function SendMessageAttachments({
             {t('panels.sendMessage.chooseFiles')}
           </Button>
           <input
-            id="send-message-attachments-input"
             ref={fileInputRef}
             type="file"
             multiple

--- a/src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.tsx
+++ b/src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.tsx
@@ -51,7 +51,9 @@ export function SendMessageAttachments({
   return (
     <>
       <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.sendMessage.attachments')}</Label>
+        <Label htmlFor="send-message-attachments-input" className="text-sm font-medium">
+          {t('panels.sendMessage.attachments')}
+        </Label>
 
         <div
           className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${
@@ -78,6 +80,7 @@ export function SendMessageAttachments({
             {t('panels.sendMessage.chooseFiles')}
           </Button>
           <input
+            id="send-message-attachments-input"
             ref={fileInputRef}
             type="file"
             multiple
@@ -90,10 +93,14 @@ export function SendMessageAttachments({
 
       {attachments.length > 0 && (
         <div className="space-y-2">
-          <Label className="text-sm font-medium">
+          <Label id="send-message-attachments-list-label" className="text-sm font-medium">
             {t('panels.sendMessage.attachmentsList', { count: attachments.length })}
           </Label>
-          <div className="space-y-2 max-h-32 overflow-y-auto">
+          <div
+            className="space-y-2 max-h-32 overflow-y-auto"
+            role="group"
+            aria-labelledby="send-message-attachments-list-label"
+          >
             {attachments.map(attachment => (
               <div
                 key={attachment.id}

--- a/src/components/journey/nodes/actions/send-message/components/SendMessageContent.tsx
+++ b/src/components/journey/nodes/actions/send-message/components/SendMessageContent.tsx
@@ -178,8 +178,14 @@ export function SendMessageContent({
 
       {selectedTemplate && (selectedTemplate.variables?.length ?? 0) > 0 && (
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('panels.sendMessage.templateVariables')}</Label>
-          <div className="space-y-3">
+          <Label id="send-message-template-vars-label" className="text-sm font-medium">
+            {t('panels.sendMessage.templateVariables')}
+          </Label>
+          <div
+            className="space-y-3"
+            role="group"
+            aria-labelledby="send-message-template-vars-label"
+          >
             {selectedTemplate.variables!.map(variable => {
               if (!variable.name) return null;
               const mapping = getVariableMapping(variable.name);

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookAuthConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookAuthConfig.tsx
@@ -82,9 +82,12 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
         return (
           <div className="space-y-3">
             <div className="space-y-2">
-              <Label className="text-sm font-medium">{t('panels.sendWebhook.auth.bearerToken')}</Label>
+              <Label htmlFor="send-webhook-auth-token" className="text-sm font-medium">
+                {t('panels.sendWebhook.auth.bearerToken')}
+              </Label>
               <div className="relative">
                 <Input
+                  id="send-webhook-auth-token"
                   type={showSensitive.token ? 'text' : 'password'}
                   value={data.authToken || ''}
                   onChange={e => onChange({ authToken: e.target.value })}
@@ -117,8 +120,11 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
           <div className="space-y-3">
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label className="text-sm font-medium">{t('panels.sendWebhook.auth.username')}</Label>
+                <Label htmlFor="send-webhook-auth-username" className="text-sm font-medium">
+                  {t('panels.sendWebhook.auth.username')}
+                </Label>
                 <VariableInput
+                  id="send-webhook-auth-username"
                   value={data.authUsername || ''}
                   onChange={e => onChange({ authUsername: e.target.value })}
                   placeholder={t('panels.sendWebhook.auth.usernamePlaceholder')}
@@ -127,9 +133,12 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
                 />
               </div>
               <div className="space-y-2">
-                <Label className="text-sm font-medium">{t('panels.sendWebhook.auth.password')}</Label>
+                <Label htmlFor="send-webhook-auth-password" className="text-sm font-medium">
+                  {t('panels.sendWebhook.auth.password')}
+                </Label>
                 <div className="relative">
                   <Input
+                    id="send-webhook-auth-password"
                     type={showSensitive.password ? 'text' : 'password'}
                     value={data.authPassword || ''}
                     onChange={e => onChange({ authPassword: e.target.value })}
@@ -162,8 +171,11 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
         return (
           <div className="space-y-3">
             <div className="space-y-2">
-              <Label className="text-sm font-medium">{t('panels.sendWebhook.auth.headerName')}</Label>
+              <Label htmlFor="send-webhook-auth-apikey-header" className="text-sm font-medium">
+                {t('panels.sendWebhook.auth.headerName')}
+              </Label>
               <VariableInput
+                id="send-webhook-auth-apikey-header"
                 value={data.authApiKeyHeader || ''}
                 onChange={e => onChange({ authApiKeyHeader: e.target.value })}
                 placeholder={t('panels.sendWebhook.auth.headerNamePlaceholder')}
@@ -175,9 +187,12 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
               </p>
             </div>
             <div className="space-y-2">
-              <Label className="text-sm font-medium">{t('panels.sendWebhook.auth.apiKey')}</Label>
+              <Label htmlFor="send-webhook-auth-apikey" className="text-sm font-medium">
+                {t('panels.sendWebhook.auth.apiKey')}
+              </Label>
               <div className="relative">
                 <Input
+                  id="send-webhook-auth-apikey"
                   type={showSensitive.apiKey ? 'text' : 'password'}
                   value={data.authApiKey || ''}
                   onChange={e => onChange({ authApiKey: e.target.value })}
@@ -240,9 +255,14 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
     <div className="space-y-4">
       {/* Tipo de Autenticação */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.auth.authType')}</Label>
+        <Label htmlFor="send-webhook-auth-type" className="text-sm font-medium">
+          {t('panels.sendWebhook.auth.authType')}
+        </Label>
         <Select value={data.authenticationType || 'none'} onValueChange={handleAuthTypeChange}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+          <SelectTrigger
+            id="send-webhook-auth-type"
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="bg-sidebar border-sidebar-border">

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx
@@ -19,8 +19,6 @@ vi.mock('@/hooks/useJourneyVariables', () => ({
 
 const j = (key: string) => i18n.t(`journey:${key}`);
 
-// CRM-141: os 4 campos deste subcomponente tinham <Label> sem htmlFor. Cada
-// getByLabelText abaixo quebra se o pareamento for desfeito.
 describe('WebhookBasicConfig — Label pareado com o controle', () => {
   it('pairs url, method, timeout and retry labels with their controls', () => {
     const data = {

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WebhookBasicConfig } from './WebhookBasicConfig';
+import type { SendWebhookNodeData } from '../SendWebhookNode';
+import i18n from '@/i18n/config';
+
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+const j = (key: string) => i18n.t(`journey:${key}`);
+
+// CRM-141: os 4 campos deste subcomponente tinham <Label> sem htmlFor. Cada
+// getByLabelText abaixo quebra se o pareamento for desfeito.
+describe('WebhookBasicConfig — Label pareado com o controle', () => {
+  it('pairs url, method, timeout and retry labels with their controls', () => {
+    const data = {
+      webhookUrl: 'https://example.test/hook',
+      method: 'PUT',
+      timeout: 42,
+      retryAttempts: 3,
+    } as SendWebhookNodeData;
+
+    render(<WebhookBasicConfig data={data} onChange={vi.fn()} journeyId="journey-1" />);
+
+    expect(
+      (screen.getByLabelText(j('panels.sendWebhook.basic.endpointUrl')) as HTMLInputElement).value,
+    ).toBe('https://example.test/hook');
+    expect(
+      (screen.getByLabelText(j('panels.sendWebhook.basic.timeout')) as HTMLInputElement).value,
+    ).toBe('42');
+    expect(
+      (screen.getByLabelText(j('panels.sendWebhook.basic.retryAttempts')) as HTMLInputElement).value,
+    ).toBe('3');
+
+    const method = screen.getByLabelText(j('panels.sendWebhook.basic.httpMethod'));
+    expect(method.getAttribute('role')).toBe('combobox');
+  });
+});

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.tsx
@@ -50,8 +50,11 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
     <div className="space-y-4">
       {/* URL do Webhook */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.basic.endpointUrl')}</Label>
+        <Label htmlFor="send-webhook-url" className="text-sm font-medium">
+          {t('panels.sendWebhook.basic.endpointUrl')}
+        </Label>
         <VariableInput
+          id="send-webhook-url"
           type="url"
           value={data.webhookUrl || ''}
           onChange={e => handleUrlChange(e.target.value)}
@@ -66,9 +69,14 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
 
       {/* Método HTTP */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.basic.httpMethod')}</Label>
+        <Label htmlFor="send-webhook-method" className="text-sm font-medium">
+          {t('panels.sendWebhook.basic.httpMethod')}
+        </Label>
         <Select value={data.method || 'POST'} onValueChange={handleMethodChange}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+          <SelectTrigger
+            id="send-webhook-method"
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="bg-sidebar border-sidebar-border">
@@ -91,8 +99,11 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
       {/* Configurações avançadas */}
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('panels.sendWebhook.basic.timeout')}</Label>
+          <Label htmlFor="send-webhook-timeout" className="text-sm font-medium">
+            {t('panels.sendWebhook.basic.timeout')}
+          </Label>
           <Input
+            id="send-webhook-timeout"
             type="number"
             min="1"
             max="300"
@@ -106,8 +117,11 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
         </div>
 
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('panels.sendWebhook.basic.retryAttempts')}</Label>
+          <Label htmlFor="send-webhook-retries" className="text-sm font-medium">
+            {t('panels.sendWebhook.basic.retryAttempts')}
+          </Label>
           <Input
+            id="send-webhook-retries"
             type="number"
             min="0"
             max="5"

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
@@ -36,14 +36,16 @@ export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: We
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.body.bodyContent')}</Label>
+        <Label id="send-webhook-body-fields-label" className="text-sm font-medium">
+          {t('panels.sendWebhook.body.bodyContent')}
+        </Label>
         <Button variant="outline" size="sm" onClick={addField}>
           <Plus className="w-4 h-4 mr-1" />
           {t('panels.sendWebhook.body.builder.addField')}
         </Button>
       </div>
 
-      <div className="space-y-3">
+      <div className="space-y-3" role="group" aria-labelledby="send-webhook-body-fields-label">
         {fields.length === 0 ? (
           <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
             <p className="text-sm text-gray-500">{t('panels.sendWebhook.body.builder.noFields')}</p>
@@ -54,8 +56,11 @@ export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: We
               <div className="grid grid-cols-12 gap-3 items-end">
                 {/* Key */}
                 <div className={showTypeColumn ? 'col-span-4' : 'col-span-5'}>
-                  <Label className="text-xs">{t('panels.sendWebhook.body.builder.keyLabel')}</Label>
+                  <Label htmlFor={`send-webhook-body-key-${field.id}`} className="text-xs">
+                    {t('panels.sendWebhook.body.builder.keyLabel')}
+                  </Label>
                   <VariableInput
+                    id={`send-webhook-body-key-${field.id}`}
                     value={field.key}
                     onChange={e => updateField(field.id, { key: e.target.value })}
                     placeholder={t('panels.sendWebhook.body.builder.keyPlaceholder')}
@@ -66,8 +71,11 @@ export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: We
 
                 {/* Value */}
                 <div className={showTypeColumn ? 'col-span-4' : 'col-span-6'}>
-                  <Label className="text-xs">{t('panels.sendWebhook.body.builder.valueLabel')}</Label>
+                  <Label htmlFor={`send-webhook-body-value-${field.id}`} className="text-xs">
+                    {t('panels.sendWebhook.body.builder.valueLabel')}
+                  </Label>
                   <VariableInput
+                    id={`send-webhook-body-value-${field.id}`}
                     value={field.value}
                     onChange={e => updateField(field.id, { value: e.target.value })}
                     placeholder={t('panels.sendWebhook.body.builder.valuePlaceholder')}
@@ -79,12 +87,17 @@ export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: We
                 {/* Type (JSON only) */}
                 {showTypeColumn && (
                   <div className="col-span-3">
-                    <Label className="text-xs">{t('panels.sendWebhook.body.builder.typeLabel')}</Label>
+                    <Label htmlFor={`send-webhook-body-type-${field.id}`} className="text-xs">
+                      {t('panels.sendWebhook.body.builder.typeLabel')}
+                    </Label>
                     <Select
                       value={field.type}
                       onValueChange={(value: WebhookBodyValueType) => updateField(field.id, { type: value })}
                     >
-                      <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+                      <SelectTrigger
+                        id={`send-webhook-body-type-${field.id}`}
+                        className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                      >
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent className="bg-sidebar border-sidebar-border">

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
@@ -176,9 +176,14 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
     <div className="space-y-4">
       {/* Tipo do Body */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.body.contentType')}</Label>
+        <Label htmlFor="send-webhook-body-type" className="text-sm font-medium">
+          {t('panels.sendWebhook.body.contentType')}
+        </Label>
         <Select value={data.bodyType || 'json'} onValueChange={handleBodyTypeChange}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+          <SelectTrigger
+            id="send-webhook-body-type"
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent className="bg-sidebar border-sidebar-border">
@@ -241,8 +246,14 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
           {/* Templates para JSON (apenas modo bruto) */}
           {bodyType === 'json' && (
             <div className="space-y-2">
-              <Label className="text-sm font-medium">{t('panels.sendWebhook.body.jsonTemplates')}</Label>
-              <div className="flex gap-2 flex-wrap">
+              <Label id="send-webhook-body-templates-label" className="text-sm font-medium">
+                {t('panels.sendWebhook.body.jsonTemplates')}
+              </Label>
+              <div
+                className="flex gap-2 flex-wrap"
+                role="group"
+                aria-labelledby="send-webhook-body-templates-label"
+              >
                 {Object.entries(JSON_TEMPLATES).map(([name, template]) => (
                   <Button
                     key={name}
@@ -269,9 +280,12 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
 
           {/* Editor do Body (bruto) */}
           <div className="space-y-2">
-            <Label className="text-sm font-medium">{t('panels.sendWebhook.body.bodyContent')}</Label>
+            <Label htmlFor="send-webhook-body-content" className="text-sm font-medium">
+              {t('panels.sendWebhook.body.bodyContent')}
+            </Label>
             <div className="relative">
               <VariableTextarea
+                id="send-webhook-body-content"
                 value={data.body || ''}
                 onChange={e => handleBodyChange(e.target.value)}
                 placeholder={

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.spec.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WebhookHeadersConfig } from './WebhookHeadersConfig';
+import type { SendWebhookNodeData } from '../SendWebhookNode';
+import i18n from '@/i18n/config';
+
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+const j = (key: string) => i18n.t(`journey:${key}`);
+
+function renderHeaders(headers: SendWebhookNodeData['headers']) {
+  return render(
+    <WebhookHeadersConfig
+      data={{ headers } as SendWebhookNodeData}
+      onChange={vi.fn()}
+      journeyId="journey-1"
+    />,
+  );
+}
+
+describe('WebhookHeadersConfig — grupo nomeado só quando há headers', () => {
+  it('names the header list as a group and pairs each row', () => {
+    renderHeaders([{ key: 'x-token', value: 'abc' }]);
+
+    const group = screen.getByRole('group', { name: j('panels.sendWebhook.headers.httpHeaders') });
+    expect(within(group).getByLabelText(j('panels.sendWebhook.headers.headerName'))).toBeTruthy();
+  });
+
+  it('does not expose an empty group when there is no header', () => {
+    renderHeaders([]);
+
+    expect(
+      screen.queryByRole('group', { name: j('panels.sendWebhook.headers.httpHeaders') }),
+    ).toBeNull();
+    expect(screen.getByText(j('panels.sendWebhook.headers.noHeadersConfigured'))).toBeTruthy();
+  });
+});

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.tsx
@@ -58,7 +58,9 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <Label className="text-sm font-medium">{t('panels.sendWebhook.headers.httpHeaders')}</Label>
+        <Label id="send-webhook-headers-label" className="text-sm font-medium">
+          {t('panels.sendWebhook.headers.httpHeaders')}
+        </Label>
         <div className="flex gap-2">
           {/* Botões para headers comuns */}
           {COMMON_HEADERS.slice(0, 2).map((preset, index) => (
@@ -80,7 +82,7 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
       </div>
 
       {/* Lista de headers */}
-      <div className="space-y-3">
+      <div className="space-y-3" role="group" aria-labelledby="send-webhook-headers-label">
         {headers.length === 0 ? (
           <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
             <p className="text-sm text-gray-500">{t('panels.sendWebhook.headers.noHeadersConfigured')}</p>
@@ -98,8 +100,11 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
                 <div className="grid grid-cols-12 gap-3 items-end">
                   {/* Key */}
                   <div className="col-span-4">
-                    <Label className="text-xs">{t('panels.sendWebhook.headers.headerName')}</Label>
+                    <Label htmlFor={`send-webhook-header-name-${index}`} className="text-xs">
+                      {t('panels.sendWebhook.headers.headerName')}
+                    </Label>
                     <VariableInput
+                      id={`send-webhook-header-name-${index}`}
                       value={header.key}
                       onChange={e => updateHeader(index, { key: e.target.value })}
                       placeholder={t('panels.sendWebhook.headers.headerNamePlaceholder')}
@@ -110,9 +115,12 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
 
                   {/* Value */}
                   <div className="col-span-6">
-                    <Label className="text-xs">{t('panels.sendWebhook.headers.headerValue')}</Label>
+                    <Label htmlFor={`send-webhook-header-value-${index}`} className="text-xs">
+                      {t('panels.sendWebhook.headers.headerValue')}
+                    </Label>
                     <div className="relative">
                       <VariableInput
+                        id={`send-webhook-header-value-${index}`}
                         type={shouldHide ? 'password' : 'text'}
                         value={header.value}
                         onChange={e => updateHeader(index, { value: e.target.value })}
@@ -164,10 +172,17 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
       {/* Headers comuns sugeridos */}
       {headers.length === 0 && (
         <div className="p-4 rounded-lg bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800/30">
-          <Label className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2 block">
+          <Label
+            id="send-webhook-suggested-headers-label"
+            className="text-sm font-medium text-blue-800 dark:text-blue-200 mb-2 block"
+          >
             {t('panels.sendWebhook.headers.suggestedHeaders')}
           </Label>
-          <div className="flex flex-wrap gap-2">
+          <div
+            className="flex flex-wrap gap-2"
+            role="group"
+            aria-labelledby="send-webhook-suggested-headers-label"
+          >
             {COMMON_HEADERS.map((preset, index) => (
               <Button
                 key={index}

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.tsx
@@ -82,7 +82,14 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
       </div>
 
       {/* Lista de headers */}
-      <div className="space-y-3" role="group" aria-labelledby="send-webhook-headers-label">
+      {/* The group only exists once there is something to group — an empty
+          state named "HTTP headers" would announce a set that has no rows. */}
+      <div
+        className="space-y-3"
+        {...(headers.length > 0
+          ? { role: 'group', 'aria-labelledby': 'send-webhook-headers-label' }
+          : {})}
+      >
         {headers.length === 0 ? (
           <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
             <p className="text-sm text-gray-500">{t('panels.sendWebhook.headers.noHeadersConfigured')}</p>

--- a/src/components/journey/nodes/actions/split/SplitPanel.tsx
+++ b/src/components/journey/nodes/actions/split/SplitPanel.tsx
@@ -220,7 +220,7 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
       contentClassName="max-w-3xl"
     >
       <div className="space-y-4">
-        <Label className="text-sidebar-foreground font-medium">
+        <Label id="split-variants-label" className="text-sidebar-foreground font-medium">
           {t('panels.split.configuration')}
         </Label>
 
@@ -234,7 +234,7 @@ export function SplitPanel({ nodeId, data, onUpdate, onClose }: SplitPanelProps)
           </Button>
         </div>
 
-        <div className="space-y-3">
+        <div className="space-y-3" role="group" aria-labelledby="split-variants-label">
           {formData.variants && formData.variants.length > 0 ? (
             formData.variants.map(variant => renderVariant(variant))
           ) : (

--- a/src/components/journey/nodes/actions/wait/WaitPanel.tsx
+++ b/src/components/journey/nodes/actions/wait/WaitPanel.tsx
@@ -222,11 +222,13 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
           </Select>
         </div>
 
-        <div className="space-y-4" role="group" aria-labelledby="wait-config-label">
+        <div className="space-y-4">
           <Label id="wait-config-label" className="text-sidebar-foreground font-medium">
             {t('panels.wait.configuration')} - {currentOption.label}
           </Label>
-          {renderConfigurationSection()}
+          <div role="group" aria-labelledby="wait-config-label">
+            {renderConfigurationSection()}
+          </div>
         </div>
       </div>
     </NodeConfigModal>

--- a/src/components/journey/nodes/actions/wait/WaitPanel.tsx
+++ b/src/components/journey/nodes/actions/wait/WaitPanel.tsx
@@ -222,8 +222,8 @@ export function WaitPanel({ nodeId, data, onUpdate, onClose, journeyId }: WaitPa
           </Select>
         </div>
 
-        <div className="space-y-4">
-          <Label className="text-sidebar-foreground font-medium">
+        <div className="space-y-4" role="group" aria-labelledby="wait-config-label">
+          <Label id="wait-config-label" className="text-sidebar-foreground font-medium">
             {t('panels.wait.configuration')} - {currentOption.label}
           </Label>
           {renderConfigurationSection()}

--- a/src/components/journey/nodes/actions/wait/components/WaitConditionConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitConditionConfig.tsx
@@ -181,12 +181,14 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
 
       {/* Configuração específica do tipo */}
       {conditionType && (
-        <div className="space-y-3" role="group" aria-labelledby="wait-condition-config-label">
+        <div className="space-y-3">
           <Label id="wait-condition-config-label" className="text-sm font-medium">
             {t('panels.waitComponents.condition.configurationLabel')} -{' '}
             {CONDITION_TYPES.find(t => t.value === conditionType)?.label}
           </Label>
-          {renderConditionConfiguration()}
+          <div role="group" aria-labelledby="wait-condition-config-label">
+            {renderConditionConfiguration()}
+          </div>
         </div>
       )}
 

--- a/src/components/journey/nodes/actions/wait/components/WaitConditionConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitConditionConfig.tsx
@@ -155,11 +155,14 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
     <div className="space-y-4">
       {/* Seletor de Tipo */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">
+        <Label htmlFor="wait-condition-type" className="text-sm font-medium">
           {t('panels.waitComponents.condition.typeLabel')}
         </Label>
         <Select value={conditionType} onValueChange={handleConditionTypeChange}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+          <SelectTrigger
+            id="wait-condition-type"
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          >
             <SelectValue placeholder={t('panels.waitComponents.condition.selectTypePlaceholder')} />
           </SelectTrigger>
           <SelectContent className="bg-sidebar border-sidebar-border">
@@ -178,8 +181,8 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
 
       {/* Configuração específica do tipo */}
       {conditionType && (
-        <div className="space-y-3">
-          <Label className="text-sm font-medium">
+        <div className="space-y-3" role="group" aria-labelledby="wait-condition-config-label">
+          <Label id="wait-condition-config-label" className="text-sm font-medium">
             {t('panels.waitComponents.condition.configurationLabel')} -{' '}
             {CONDITION_TYPES.find(t => t.value === conditionType)?.label}
           </Label>
@@ -189,13 +192,14 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
 
       {/* Seleção de Variável para Comparação */}
       <div className="space-y-3">
-        <Label className="text-sm font-medium">
+        <Label htmlFor="wait-condition-variable" className="text-sm font-medium">
           {t('panels.waitComponents.condition.variableLabel')}
         </Label>
         <p className="text-xs text-gray-500 dark:text-gray-400">
           {t('panels.waitComponents.condition.variableDescription')}
         </p>
         <VariableSelect
+          id="wait-condition-variable"
           value={data.conditionValue || ''}
           onValueChange={variable => onChange({ conditionValue: variable })}
           placeholder={t('panels.waitComponents.condition.variablePlaceholder')}
@@ -224,10 +228,11 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
         {data.enableFallback && (
           <div className="grid grid-cols-2 gap-3 pl-6">
             <div className="space-y-2">
-              <Label className="text-xs">
+              <Label htmlFor="wait-condition-fallback-time" className="text-xs">
                 {t('panels.waitComponents.condition.fallbackTimeLabel')}
               </Label>
               <Input
+                id="wait-condition-fallback-time"
                 type="number"
                 min="1"
                 value={data.fallbackTime || 1}
@@ -237,11 +242,14 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
               />
             </div>
             <div className="space-y-2">
-              <Label className="text-xs">
+              <Label htmlFor="wait-condition-fallback-unit" className="text-xs">
                 {t('panels.waitComponents.condition.fallbackUnitLabel')}
               </Label>
               <Select value={data.fallbackUnit || 'hours'} onValueChange={handleFallbackUnitChange}>
-                <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+                <SelectTrigger
+                  id="wait-condition-fallback-unit"
+                  className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-sidebar border-sidebar-border">

--- a/src/components/journey/nodes/actions/wait/components/WaitEventConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitEventConfig.tsx
@@ -211,9 +211,14 @@ export function WaitEventConfig({ data, onChange, journeyId }: WaitEventConfigPr
     <div className="space-y-4">
       {/* Seletor de Tipo */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">{t('panels.waitComponents.event.typeLabel')}</Label>
+        <Label htmlFor="wait-event-type" className="text-sm font-medium">
+          {t('panels.waitComponents.event.typeLabel')}
+        </Label>
         <Select value={eventType} onValueChange={handleEventTypeChange}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+          <SelectTrigger
+            id="wait-event-type"
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          >
             <SelectValue placeholder={t('panels.waitComponents.event.selectTypePlaceholder')} />
           </SelectTrigger>
           <SelectContent className="bg-sidebar border-sidebar-border">
@@ -232,8 +237,8 @@ export function WaitEventConfig({ data, onChange, journeyId }: WaitEventConfigPr
 
       {/* Configuração específica do tipo */}
       {eventType && (
-        <div className="space-y-3">
-          <Label className="text-sm font-medium">
+        <div className="space-y-3" role="group" aria-labelledby="wait-event-config-label">
+          <Label id="wait-event-config-label" className="text-sm font-medium">
             {t('panels.waitComponents.event.configurationLabel')} -{' '}
             {EVENT_TYPE_OPTIONS.find(t => t.value === eventType)?.label}
           </Label>
@@ -261,10 +266,11 @@ export function WaitEventConfig({ data, onChange, journeyId }: WaitEventConfigPr
         {data.enableFallback && (
           <div className="grid grid-cols-2 gap-3 pl-6">
             <div className="space-y-2">
-              <Label className="text-xs">
+              <Label htmlFor="wait-event-fallback-time" className="text-xs">
                 {t('panels.waitComponents.event.fallbackTimeLabel')}
               </Label>
               <Input
+                id="wait-event-fallback-time"
                 type="number"
                 min="1"
                 value={data.fallbackTime || 1}
@@ -274,11 +280,14 @@ export function WaitEventConfig({ data, onChange, journeyId }: WaitEventConfigPr
               />
             </div>
             <div className="space-y-2">
-              <Label className="text-xs">
+              <Label htmlFor="wait-event-fallback-unit" className="text-xs">
                 {t('panels.waitComponents.event.fallbackUnitLabel')}
               </Label>
               <Select value={data.fallbackUnit || 'hours'} onValueChange={handleFallbackUnitChange}>
-                <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+                <SelectTrigger
+                  id="wait-event-fallback-unit"
+                  className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-sidebar border-sidebar-border">

--- a/src/components/journey/nodes/actions/wait/components/WaitEventConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitEventConfig.tsx
@@ -237,12 +237,14 @@ export function WaitEventConfig({ data, onChange, journeyId }: WaitEventConfigPr
 
       {/* Configuração específica do tipo */}
       {eventType && (
-        <div className="space-y-3" role="group" aria-labelledby="wait-event-config-label">
+        <div className="space-y-3">
           <Label id="wait-event-config-label" className="text-sm font-medium">
             {t('panels.waitComponents.event.configurationLabel')} -{' '}
             {EVENT_TYPE_OPTIONS.find(t => t.value === eventType)?.label}
           </Label>
-          {renderEventConfiguration()}
+          <div role="group" aria-labelledby="wait-event-config-label">
+            {renderEventConfiguration()}
+          </div>
         </div>
       )}
 

--- a/src/components/journey/nodes/actions/wait/components/WaitHybridConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitHybridConfig.tsx
@@ -105,14 +105,20 @@ export function WaitHybridConfig({ data, onChange, journeyId }: WaitHybridConfig
     <div className="space-y-4">
       {/* Tempo Máximo de Espera (obrigatório) */}
       <div className="p-4 rounded-lg bg-purple-50 dark:bg-purple-950/20 border border-purple-200 dark:border-purple-800/30">
-        <Label className="text-sm font-medium text-purple-800 dark:text-purple-200 mb-3 block">
+        <Label
+          id="wait-hybrid-max-label"
+          className="text-sm font-medium text-purple-800 dark:text-purple-200 mb-3 block"
+        >
           {t('panels.waitComponents.hybrid.maxWaitTimeLabel')}
         </Label>
 
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3" role="group" aria-labelledby="wait-hybrid-max-label">
           <div className="space-y-2">
-            <Label className="text-xs">{t('panels.waitComponents.hybrid.timeLabel')}</Label>
+            <Label htmlFor="wait-hybrid-max-time" className="text-xs">
+              {t('panels.waitComponents.hybrid.timeLabel')}
+            </Label>
             <VariableInput
+              id="wait-hybrid-max-time"
               type="number"
               min="1"
               value={data.maxWaitTime?.toString() || '1'}
@@ -126,9 +132,14 @@ export function WaitHybridConfig({ data, onChange, journeyId }: WaitHybridConfig
             />
           </div>
           <div className="space-y-2">
-            <Label className="text-xs">{t('panels.waitComponents.hybrid.unitLabel')}</Label>
+            <Label htmlFor="wait-hybrid-max-unit" className="text-xs">
+              {t('panels.waitComponents.hybrid.unitLabel')}
+            </Label>
             <Select value={data.maxWaitUnit || 'hours'} onValueChange={handleMaxWaitUnitChange}>
-              <SelectTrigger className="bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectTrigger
+                id="wait-hybrid-max-unit"
+                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="bg-sidebar border-sidebar-border">
@@ -148,8 +159,8 @@ export function WaitHybridConfig({ data, onChange, journeyId }: WaitHybridConfig
       </div>
 
       {/* Condição ou Evento */}
-      <div className="space-y-3">
-        <Label className="text-sm font-medium">
+      <div className="space-y-3" role="group" aria-labelledby="wait-hybrid-stop-label">
+        <Label id="wait-hybrid-stop-label" className="text-sm font-medium">
           {t('panels.waitComponents.hybrid.stopConditionLabel')}
         </Label>
 

--- a/src/components/journey/nodes/actions/wait/components/WaitHybridConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitHybridConfig.tsx
@@ -159,7 +159,7 @@ export function WaitHybridConfig({ data, onChange, journeyId }: WaitHybridConfig
       </div>
 
       {/* Condição ou Evento */}
-      <div className="space-y-3" role="group" aria-labelledby="wait-hybrid-stop-label">
+      <div className="space-y-3">
         <Label id="wait-hybrid-stop-label" className="text-sm font-medium">
           {t('panels.waitComponents.hybrid.stopConditionLabel')}
         </Label>
@@ -167,6 +167,8 @@ export function WaitHybridConfig({ data, onChange, journeyId }: WaitHybridConfig
         <Tabs
           value={triggerType}
           onValueChange={(value: string) => handleTriggerTypeChange(value as 'event' | 'condition')}
+          role="group"
+          aria-labelledby="wait-hybrid-stop-label"
         >
           <TabsList className="grid w-full grid-cols-2">
             <TabsTrigger value="event">{t('panels.waitComponents.hybrid.tabs.event')}</TabsTrigger>

--- a/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.spec.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.spec.tsx
@@ -19,9 +19,6 @@ vi.mock('@/hooks/useJourneyVariables', () => ({
 
 const j = (key: string) => i18n.t(`journey:${key}`);
 
-// CRM-141: a CRM-123 pareou os 23 painéis de topo; os subcomponentes ficaram
-// com <Label> solto. getByLabelText só resolve com htmlFor/id de verdade — some
-// se o pareamento for desfeito.
 describe('WaitTimeConfig — Label pareado com o controle', () => {
   it('pairs the duration and time-unit labels with their controls', () => {
     const data = { duration: 5, timeUnit: 'hours' } as WaitNodeData;

--- a/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.spec.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.spec.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WaitTimeConfig } from './WaitTimeConfig';
+import type { WaitNodeData } from '../WaitNode';
+import i18n from '@/i18n/config';
+
+vi.mock('@/hooks/useJourneyVariables', () => ({
+  useJourneyVariables: () => ({
+    variables: [],
+    loading: false,
+    error: null,
+    fetchVariables: vi.fn(),
+    updateVariables: vi.fn(),
+    addVariable: vi.fn(),
+    updateVariable: vi.fn(),
+    deleteVariable: vi.fn(),
+  }),
+}));
+
+const j = (key: string) => i18n.t(`journey:${key}`);
+
+// CRM-141: a CRM-123 pareou os 23 painéis de topo; os subcomponentes ficaram
+// com <Label> solto. getByLabelText só resolve com htmlFor/id de verdade — some
+// se o pareamento for desfeito.
+describe('WaitTimeConfig — Label pareado com o controle', () => {
+  it('pairs the duration and time-unit labels with their controls', () => {
+    const data = { duration: 5, timeUnit: 'hours' } as WaitNodeData;
+    render(<WaitTimeConfig data={data} onChange={vi.fn()} journeyId="journey-1" />);
+
+    const duration = screen.getByLabelText(j('panels.waitComponents.time.durationLabel'));
+    expect(duration.tagName).toBe('INPUT');
+    expect((duration as HTMLInputElement).value).toBe('5');
+
+    const unit = screen.getByLabelText(j('panels.waitComponents.time.timeUnitLabel'));
+    expect(unit.getAttribute('role')).toBe('combobox');
+  });
+});

--- a/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.tsx
@@ -63,10 +63,11 @@ export function WaitTimeConfig({ data, onChange, journeyId }: WaitTimeConfigProp
     <div className="space-y-4">
       {/* Duração */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">
+        <Label htmlFor="wait-time-duration" className="text-sm font-medium">
           {t('panels.waitComponents.time.durationLabel')}
         </Label>
         <VariableInput
+          id="wait-time-duration"
           type="number"
           min="1"
           value={data.duration?.toString() || '1'}
@@ -85,11 +86,14 @@ export function WaitTimeConfig({ data, onChange, journeyId }: WaitTimeConfigProp
 
       {/* Unidade de Tempo */}
       <div className="space-y-2">
-        <Label className="text-sm font-medium">
+        <Label htmlFor="wait-time-unit" className="text-sm font-medium">
           {t('panels.waitComponents.time.timeUnitLabel')}
         </Label>
         <Select value={data.timeUnit || 'minutes'} onValueChange={handleTimeUnitChange}>
-          <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+          <SelectTrigger
+            id="wait-time-unit"
+            className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+          >
             <SelectValue placeholder={t('panels.waitComponents.time.timeUnitPlaceholder')} />
           </SelectTrigger>
           <SelectContent className="bg-sidebar border-sidebar-border">

--- a/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
@@ -170,14 +170,17 @@ export function ContactConfiguration({
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                   {/* Campo */}
                   <div className="space-y-2">
-                    <Label className="text-xs font-medium">
+                    <Label htmlFor={`contact-trigger-field-${index}`} className="text-xs font-medium">
                       {t('triggerComponents.contact.field')}
                     </Label>
                     <Select
                       value={field.field}
                       onValueChange={value => updateField(index, { field: value })}
                     >
-                      <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+                      <SelectTrigger
+                        id={`contact-trigger-field-${index}`}
+                        className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+                      >
                         <SelectValue placeholder={t('triggerComponents.contact.selectField')} />
                       </SelectTrigger>
                       <SelectContent className="bg-sidebar border-sidebar-border">
@@ -196,14 +199,20 @@ export function ContactConfiguration({
 
                   {/* Operador */}
                   <div className="space-y-2">
-                    <Label className="text-xs font-medium">
+                    <Label
+                      htmlFor={`contact-trigger-operator-${index}`}
+                      className="text-xs font-medium"
+                    >
                       {t('triggerComponents.contact.condition')}
                     </Label>
                     <Select
                       value={field.operator}
                       onValueChange={value => updateField(index, { operator: value })}
                     >
-                      <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+                      <SelectTrigger
+                        id={`contact-trigger-operator-${index}`}
+                        className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+                      >
                         <SelectValue placeholder={t('triggerComponents.contact.selectCondition')} />
                       </SelectTrigger>
                       <SelectContent className="bg-sidebar border-sidebar-border">
@@ -223,10 +232,11 @@ export function ContactConfiguration({
                   {/* Valor */}
                   {needsValue(field.operator) && (
                     <div className="space-y-2">
-                      <Label className="text-xs font-medium">
+                      <Label htmlFor={`contact-trigger-value-${index}`} className="text-xs font-medium">
                         {t('triggerComponents.contact.value')}
                       </Label>
                       <VariableInput
+                        id={`contact-trigger-value-${index}`}
                         value={typeof field.value === 'string' ? field.value : ''}
                         onChange={e => updateField(index, { value: e.target.value })}
                         placeholder={t('triggerComponents.contact.enterValue')}
@@ -292,8 +302,8 @@ export function ContactConfiguration({
         {onVariableMappingsChange && (
           <>
             <Separator />
-            <div className="space-y-3">
-              <Label className="text-sm font-medium">
+            <div className="space-y-3" role="group" aria-labelledby="contact-trigger-capture-label">
+              <Label id="contact-trigger-capture-label" className="text-sm font-medium">
                 {t('triggerComponents.contact.captureContactData')}
               </Label>
               <VariableMapping

--- a/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
@@ -302,17 +302,19 @@ export function ContactConfiguration({
         {onVariableMappingsChange && (
           <>
             <Separator />
-            <div className="space-y-3" role="group" aria-labelledby="contact-trigger-capture-label">
+            <div className="space-y-3">
               <Label id="contact-trigger-capture-label" className="text-sm font-medium">
                 {t('triggerComponents.contact.captureContactData')}
               </Label>
-              <VariableMapping
-                mappings={variableMappings}
-                onMappingsChange={onVariableMappingsChange}
-                paths={generateContactPaths()}
-                journeyId={journeyId}
-                className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
-              />
+              <div role="group" aria-labelledby="contact-trigger-capture-label">
+                <VariableMapping
+                  mappings={variableMappings}
+                  onMappingsChange={onVariableMappingsChange}
+                  paths={generateContactPaths()}
+                  journeyId={journeyId}
+                  className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+                />
+              </div>
             </div>
           </>
         )}

--- a/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
@@ -328,21 +328,19 @@ export function CustomAttributeConfiguration({
         {onVariableMappingsChange && (
           <>
             <Separator />
-            <div
-              className="space-y-3"
-              role="group"
-              aria-labelledby="custom-attribute-trigger-capture-label"
-            >
+            <div className="space-y-3">
               <Label id="custom-attribute-trigger-capture-label" className="text-sm font-medium">
                 {t('triggerComponents.customAttribute.captureAttributeData')}
               </Label>
-              <VariableMapping
-                mappings={variableMappings}
-                onMappingsChange={onVariableMappingsChange}
-                paths={generateCustomAttributePaths()}
-                journeyId={journeyId}
-                className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
-              />
+              <div role="group" aria-labelledby="custom-attribute-trigger-capture-label">
+                <VariableMapping
+                  mappings={variableMappings}
+                  onMappingsChange={onVariableMappingsChange}
+                  paths={generateCustomAttributePaths()}
+                  journeyId={journeyId}
+                  className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+                />
+              </div>
             </div>
           </>
         )}

--- a/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
@@ -136,7 +136,7 @@ export function CustomAttributeConfiguration({
 
         {/* Seleção do Atributo */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">
+          <Label htmlFor="custom-attribute-trigger-attribute" className="text-sm font-medium">
             {t('triggerComponents.customAttribute.customAttribute')}
           </Label>
           {error ? (
@@ -157,7 +157,10 @@ export function CustomAttributeConfiguration({
               }}
               disabled={loadingAttributes}
             >
-              <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectTrigger
+                id="custom-attribute-trigger-attribute"
+                className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              >
                 <SelectValue
                   placeholder={
                     loadingAttributes
@@ -208,11 +211,14 @@ export function CustomAttributeConfiguration({
 
         {/* Operador */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">
+          <Label htmlFor="custom-attribute-trigger-operator" className="text-sm font-medium">
             {t('triggerComponents.customAttribute.condition')}
           </Label>
           <Select value={operator} onValueChange={onOperatorChange}>
-            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+            <SelectTrigger
+              id="custom-attribute-trigger-operator"
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            >
               <SelectValue placeholder={t('triggerComponents.customAttribute.selectCondition')} />
             </SelectTrigger>
             <SelectContent className="bg-sidebar border-sidebar-border">
@@ -232,10 +238,11 @@ export function CustomAttributeConfiguration({
         {/* Valor */}
         {needsValue(operator) && (
           <div className="space-y-2">
-            <Label className="text-sm font-medium">
+            <Label htmlFor="custom-attribute-trigger-value" className="text-sm font-medium">
               {t('triggerComponents.customAttribute.value')}
             </Label>
             <VariableInput
+              id="custom-attribute-trigger-value"
               value={value}
               onChange={e => onValueChange(e.target.value)}
               placeholder={t('triggerComponents.customAttribute.enterValue')}
@@ -321,8 +328,12 @@ export function CustomAttributeConfiguration({
         {onVariableMappingsChange && (
           <>
             <Separator />
-            <div className="space-y-3">
-              <Label className="text-sm font-medium">
+            <div
+              className="space-y-3"
+              role="group"
+              aria-labelledby="custom-attribute-trigger-capture-label"
+            >
+              <Label id="custom-attribute-trigger-capture-label" className="text-sm font-medium">
                 {t('triggerComponents.customAttribute.captureAttributeData')}
               </Label>
               <VariableMapping

--- a/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
@@ -36,8 +36,8 @@ export function EventAdvancedConfig({
   return (
     <>
       <Separator />
-      <div className="space-y-3">
-        <Label className="text-sm font-medium">
+      <div className="space-y-3" role="group" aria-labelledby="event-trigger-capture-label">
+        <Label id="event-trigger-capture-label" className="text-sm font-medium">
           {t('triggerComponents.event.captureEventData')}
         </Label>
         <VariableMapping

--- a/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
@@ -36,17 +36,19 @@ export function EventAdvancedConfig({
   return (
     <>
       <Separator />
-      <div className="space-y-3" role="group" aria-labelledby="event-trigger-capture-label">
+      <div className="space-y-3">
         <Label id="event-trigger-capture-label" className="text-sm font-medium">
           {t('triggerComponents.event.captureEventData')}
         </Label>
-        <VariableMapping
-          mappings={variableMappings}
-          onMappingsChange={onVariableMappingsChange}
-          paths={paths}
-          journeyId={journeyId}
-          className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
-        />
+        <div role="group" aria-labelledby="event-trigger-capture-label">
+          <VariableMapping
+            mappings={variableMappings}
+            onMappingsChange={onVariableMappingsChange}
+            paths={paths}
+            journeyId={journeyId}
+            className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+          />
+        </div>
       </div>
     </>
   );

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
@@ -169,8 +169,11 @@ export function EventBasicConfig({
 
         {/* Nome do evento */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('triggerComponents.event.eventName')}</Label>
+          <Label htmlFor="event-trigger-name" className="text-sm font-medium">
+            {t('triggerComponents.event.eventName')}
+          </Label>
           <EventSelector
+            id="event-trigger-name"
             value={selectorValue || undefined}
             onChange={handleSelectorChange}
             className="bg-sidebar border-sidebar-border text-sidebar-foreground"
@@ -199,8 +202,11 @@ export function EventBasicConfig({
         </div>
 
         {/* Propriedades do evento */}
-        <div className="space-y-3">
-          <Label className="text-sidebar-foreground font-medium text-sm">
+        <div className="space-y-3" role="group" aria-labelledby="event-trigger-properties-label">
+          <Label
+            id="event-trigger-properties-label"
+            className="text-sidebar-foreground font-medium text-sm"
+          >
             {t('triggerComponents.event.eventProperties')}
           </Label>
           <EventPropertiesForm

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
@@ -202,18 +202,20 @@ export function EventBasicConfig({
         </div>
 
         {/* Propriedades do evento */}
-        <div className="space-y-3" role="group" aria-labelledby="event-trigger-properties-label">
+        <div className="space-y-3">
           <Label
             id="event-trigger-properties-label"
             className="text-sidebar-foreground font-medium text-sm"
           >
             {t('triggerComponents.event.eventProperties')}
           </Label>
-          <EventPropertiesForm
-            eventName={formEventName}
-            value={record}
-            onChange={handlePropertiesRecordChange}
-          />
+          <div role="group" aria-labelledby="event-trigger-properties-label">
+            <EventPropertiesForm
+              eventName={formEventName}
+              value={record}
+              onChange={handlePropertiesRecordChange}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/components/journey/nodes/trigger/components/LabelConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/LabelConfiguration.tsx
@@ -69,12 +69,17 @@ export function LabelConfiguration({
 
         {/* Ação da Etiqueta */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('triggerComponents.label.labelAction')}</Label>
+          <Label htmlFor="label-trigger-action" className="text-sm font-medium">
+            {t('triggerComponents.label.labelAction')}
+          </Label>
           <Select
             value={labelAction}
             onValueChange={(value: 'applied' | 'removed') => onLabelActionChange(value)}
           >
-            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+            <SelectTrigger
+              id="label-trigger-action"
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            >
               <SelectValue placeholder={t('triggerComponents.label.selectAction')} />
             </SelectTrigger>
             <SelectContent className="bg-sidebar border-sidebar-border">
@@ -98,7 +103,9 @@ export function LabelConfiguration({
 
         {/* Seleção da Etiqueta */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('triggerComponents.label.label')}</Label>
+          <Label htmlFor="label-trigger-label" className="text-sm font-medium">
+            {t('triggerComponents.label.label')}
+          </Label>
           {error ? (
             <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
               <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
@@ -112,7 +119,10 @@ export function LabelConfiguration({
               }}
               disabled={loadingLabels}
             >
-              <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectTrigger
+                id="label-trigger-label"
+                className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              >
                 <SelectValue
                   placeholder={
                     loadingLabels

--- a/src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/PipelineStageChangedConfiguration.tsx
@@ -144,7 +144,7 @@ export function PipelineStageChangedConfiguration({
       )}
 
       <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
+        <Label htmlFor="pipeline-stage-trigger-pipeline" className="text-sidebar-foreground font-medium">
           {t('triggerComponents.pipelineStageChanged.pipeline')}
         </Label>
         <Select
@@ -153,8 +153,8 @@ export function PipelineStageChangedConfiguration({
           disabled={loadingPipelines}
         >
           <SelectTrigger
+            id="pipeline-stage-trigger-pipeline"
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
-            aria-label={t('triggerComponents.pipelineStageChanged.pipeline')}
           >
             <SelectValue
               placeholder={
@@ -180,7 +180,7 @@ export function PipelineStageChangedConfiguration({
       </div>
 
       <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
+        <Label htmlFor="pipeline-stage-trigger-from" className="text-sidebar-foreground font-medium">
           {t('triggerComponents.pipelineStageChanged.fromStage')}
         </Label>
         <Select
@@ -189,8 +189,8 @@ export function PipelineStageChangedConfiguration({
           disabled={!selection.pipelineId || loadingStages}
         >
           <SelectTrigger
+            id="pipeline-stage-trigger-from"
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
-            aria-label={t('triggerComponents.pipelineStageChanged.fromStage')}
           >
             <SelectValue
               placeholder={
@@ -214,7 +214,7 @@ export function PipelineStageChangedConfiguration({
       </div>
 
       <div className="space-y-2">
-        <Label className="text-sidebar-foreground font-medium">
+        <Label htmlFor="pipeline-stage-trigger-to" className="text-sidebar-foreground font-medium">
           {t('triggerComponents.pipelineStageChanged.toStage')}
         </Label>
         <Select
@@ -223,8 +223,8 @@ export function PipelineStageChangedConfiguration({
           disabled={!selection.pipelineId || loadingStages}
         >
           <SelectTrigger
+            id="pipeline-stage-trigger-to"
             className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
-            aria-label={t('triggerComponents.pipelineStageChanged.toStage')}
           >
             <SelectValue
               placeholder={

--- a/src/components/journey/nodes/trigger/components/SegmentConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/SegmentConfiguration.tsx
@@ -72,14 +72,17 @@ export function SegmentConfiguration({
 
         {/* Ação do Segmento */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">
+          <Label htmlFor="segment-trigger-action" className="text-sm font-medium">
             {t('triggerComponents.segment.segmentAction')}
           </Label>
           <Select
             value={segmentAction}
             onValueChange={(value: 'entered' | 'exited') => onSegmentActionChange(value)}
           >
-            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+            <SelectTrigger
+              id="segment-trigger-action"
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+            >
               <SelectValue placeholder={t('triggerComponents.segment.selectAction')} />
             </SelectTrigger>
             <SelectContent className="bg-sidebar border-sidebar-border">
@@ -103,7 +106,9 @@ export function SegmentConfiguration({
 
         {/* Seleção do Segmento */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('triggerComponents.segment.segment')}</Label>
+          <Label htmlFor="segment-trigger-segment" className="text-sm font-medium">
+            {t('triggerComponents.segment.segment')}
+          </Label>
           {error ? (
             <div className="p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800/30">
               <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
@@ -117,7 +122,10 @@ export function SegmentConfiguration({
               }}
               disabled={loadingSegments}
             >
-              <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+              <SelectTrigger
+                id="segment-trigger-segment"
+                className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              >
                 <SelectValue
                   placeholder={
                     loadingSegments

--- a/src/components/journey/nodes/trigger/components/TriggerTypeSelector.tsx
+++ b/src/components/journey/nodes/trigger/components/TriggerTypeSelector.tsx
@@ -18,11 +18,14 @@ export function TriggerTypeSelector({ value, onChange }: TriggerTypeSelectorProp
 
   return (
     <div className="space-y-2">
-      <Label className="text-sidebar-foreground font-medium">
+      <Label htmlFor="trigger-type-select" className="text-sidebar-foreground font-medium">
         {t('triggerComponents.triggerType')}
       </Label>
       <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+        <SelectTrigger
+          id="trigger-type-select"
+          className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+        >
           <SelectValue placeholder={t('triggerComponents.selectType')} />
         </SelectTrigger>
         <SelectContent className="bg-sidebar border-sidebar-border">

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx
@@ -1,7 +1,7 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WebhookConfiguration } from './WebhookConfiguration';
-import '@/i18n/config';
+import i18n from '@/i18n/config';
 
 // WebhookConfiguration auto-generates its trigger URL from the REAL journey id.
 // journeyId optional and removed the campaign sentinel, so this pins
@@ -34,6 +34,8 @@ function renderWebhook(journeyId?: string) {
   return { onWebhookUrlChange };
 }
 
+const j = (key: string) => i18n.t(`journey:${key}`);
+
 describe('WebhookConfiguration — trigger URL generation', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -54,5 +56,41 @@ describe('WebhookConfiguration — trigger URL generation', () => {
     // Give the effect a tick; it must stay silent without a journey (no sentinel URL).
     await new Promise(resolve => setTimeout(resolve, 0));
     expect(onWebhookUrlChange).not.toHaveBeenCalled();
+  });
+});
+
+// CRM-141: os rótulos que apontam para um controle único passaram a usar
+// htmlFor; os que cobrem um conjunto (a lista de headers) usam role="group" +
+// aria-labelledby. Os cabeçalhos de seção sem controle correspondente ficam
+// deliberadamente como estão.
+describe('WebhookConfiguration — Label pareado com o controle', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pairs the URL and payload labels with their fields', () => {
+    renderWebhook('journey-uuid-123');
+
+    expect(screen.getByLabelText(j('triggerComponents.webhook.webhookUrl')).tagName).toBe('INPUT');
+    expect(screen.getByLabelText(j('triggerComponents.webhook.payloadStructure')).tagName).toBe(
+      'TEXTAREA',
+    );
+  });
+
+  it('names the header list as a group instead of leaving a loose label', () => {
+    const onExpectedHeadersChange = vi.fn();
+    render(
+      <WebhookConfiguration
+        webhookUrl="https://example.test/hook"
+        expectedHeaders={[{ name: 'x-token', value: 'abc' }]}
+        onWebhookUrlChange={vi.fn()}
+        onExpectedHeadersChange={onExpectedHeadersChange}
+        journeyId="journey-uuid-123"
+      />,
+    );
+
+    expect(
+      screen.getByRole('group', { name: j('triggerComponents.webhook.expectedHeaders') }),
+    ).toBeTruthy();
   });
 });

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.spec.tsx
@@ -59,10 +59,6 @@ describe('WebhookConfiguration — trigger URL generation', () => {
   });
 });
 
-// CRM-141: os rótulos que apontam para um controle único passaram a usar
-// htmlFor; os que cobrem um conjunto (a lista de headers) usam role="group" +
-// aria-labelledby. Os cabeçalhos de seção sem controle correspondente ficam
-// deliberadamente como estão.
 describe('WebhookConfiguration — Label pareado com o controle', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
@@ -115,9 +115,12 @@ export function WebhookConfiguration({
 
         {/* URL do Webhook */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">{t('triggerComponents.webhook.webhookUrl')}</Label>
+          <Label htmlFor="webhook-trigger-url" className="text-sm font-medium">
+            {t('triggerComponents.webhook.webhookUrl')}
+          </Label>
           <div className="flex gap-2">
             <Input
+              id="webhook-trigger-url"
               type="url"
               value={webhookUrl || generatedUrl}
               placeholder={t('triggerComponents.webhook.urlPlaceholder')}
@@ -164,7 +167,7 @@ export function WebhookConfiguration({
         {/* Headers Esperados */}
         <div className="space-y-2">
           <div className="flex items-center justify-between">
-            <Label className="text-sm font-medium">
+            <Label id="webhook-trigger-headers-label" className="text-sm font-medium">
               {t('triggerComponents.webhook.expectedHeaders')}
             </Label>
             <Button onClick={addHeader} variant="outline" size="sm" className="h-8 text-xs">
@@ -179,7 +182,7 @@ export function WebhookConfiguration({
               </p>
             </div>
           ) : (
-            <div className="space-y-2">
+            <div className="space-y-2" role="group" aria-labelledby="webhook-trigger-headers-label">
               {localHeaders.map((header, index) => (
                 <div
                   key={index}
@@ -221,7 +224,7 @@ export function WebhookConfiguration({
 
         {/* Payload de Exemplo */}
         <div className="space-y-2">
-          <Label className="text-sm font-medium">
+          <Label htmlFor="webhook-trigger-payload-example" className="text-sm font-medium">
             {t('triggerComponents.webhook.payloadStructure')}
           </Label>
           <div className="p-2 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800/30 rounded-md">
@@ -231,6 +234,7 @@ export function WebhookConfiguration({
             </p>
           </div>
           <Textarea
+            id="webhook-trigger-payload-example"
             value={JSON.stringify(
               {
                 contact_id: '<contact_id>',
@@ -300,8 +304,8 @@ export function WebhookConfiguration({
         {onVariableMappingsChange && (
           <>
             <Separator />
-            <div className="space-y-3">
-              <Label className="text-sm font-medium">
+            <div className="space-y-3" role="group" aria-labelledby="webhook-trigger-capture-label">
+              <Label id="webhook-trigger-capture-label" className="text-sm font-medium">
                 {t('triggerComponents.webhook.captureWebhookData')}
               </Label>
               <VariableMapping

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
@@ -304,17 +304,19 @@ export function WebhookConfiguration({
         {onVariableMappingsChange && (
           <>
             <Separator />
-            <div className="space-y-3" role="group" aria-labelledby="webhook-trigger-capture-label">
+            <div className="space-y-3">
               <Label id="webhook-trigger-capture-label" className="text-sm font-medium">
                 {t('triggerComponents.webhook.captureWebhookData')}
               </Label>
-              <VariableMapping
-                mappings={variableMappings}
-                onMappingsChange={onVariableMappingsChange}
-                paths={webhookPaths}
-                journeyId={journeyId}
-                className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
-              />
+              <div role="group" aria-labelledby="webhook-trigger-capture-label">
+                <VariableMapping
+                  mappings={variableMappings}
+                  onMappingsChange={onVariableMappingsChange}
+                  paths={webhookPaths}
+                  journeyId={journeyId}
+                  className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+                />
+              </div>
             </div>
           </>
         )}

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventPropertiesForm, type EventPropertiesValue } from './EventPropertiesForm';
-import '@/i18n/config';
+import i18n from '@/i18n/config';
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -130,5 +130,36 @@ describe('EventPropertiesForm', () => {
     expect(screen.queryByText('previous_status')).toBeNull();
     // contact.created shows its own required fields
     expect(screen.getByText('id')).toBeTruthy();
+  });
+});
+
+describe('EventPropertiesForm — section labels name a group (CRM-141)', () => {
+  const e = (key: string) => i18n.t(`events:${key}`);
+
+  it('names the schema-driven sections as groups', () => {
+    render(<Harness eventName="message.delivered" />);
+
+    const required = screen.getByRole('group', { name: e('propertiesForm.requiredSectionLabel') });
+    expect(within(required).getByText('message_id')).toBeTruthy();
+
+    expect(
+      screen.getByRole('group', { name: e('propertiesForm.optionalSectionLabel') }),
+    ).toBeTruthy();
+  });
+
+  it('names the custom key/value editor as a group and keeps its id per instance', () => {
+    render(
+      <>
+        <Harness eventName="custom" />
+        <Harness eventName="custom" />
+      </>,
+    );
+
+    const groups = screen.getAllByRole('group', { name: e('propertiesForm.customSectionLabel') });
+    expect(groups).toHaveLength(2);
+    // Two editors on screen must not share the label id, or the second group
+    // would borrow the first one's name.
+    const [first, second] = groups.map(g => g.getAttribute('aria-labelledby'));
+    expect(first).not.toBe(second);
   });
 });

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -187,12 +187,15 @@ function SchemaDrivenFields({
 }
 
 function FieldSection({ title, children }: { title: string; children: React.ReactNode }) {
+  const labelId = useId();
   return (
     <div className="space-y-3">
-      <Label className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+      <Label id={labelId} className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
         {title}
       </Label>
-      <div className="space-y-2">{children}</div>
+      <div className="space-y-2" role="group" aria-labelledby={labelId}>
+        {children}
+      </div>
     </div>
   );
 }
@@ -431,12 +434,19 @@ function CustomKeyValueEditor({
   };
 
   return (
-    <div className={cn('space-y-3', className)}>
+    <div
+      className={cn('space-y-3', className)}
+      role="group"
+      aria-labelledby="event-properties-custom-label"
+    >
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
         <span>{t('propertiesForm.customWarning')}</span>
       </div>
-      <Label className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+      <Label
+        id="event-properties-custom-label"
+        className="text-sm font-medium uppercase tracking-wide text-muted-foreground"
+      >
         {t('propertiesForm.customSectionLabel')}
       </Label>
       {pairs.map((pair, index) => (

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -435,50 +435,51 @@ function CustomKeyValueEditor({
   };
 
   return (
-    <div
-      className={cn('space-y-3', className)}
-      role="group"
-      aria-labelledby={labelId}
-    >
+    <div className={cn('space-y-3', className)}>
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
         <span>{t('propertiesForm.customWarning')}</span>
       </div>
-      <Label id={labelId} className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+      <Label
+        id={labelId}
+        className="text-sm font-medium uppercase tracking-wide text-muted-foreground"
+      >
         {t('propertiesForm.customSectionLabel')}
       </Label>
-      {pairs.map((pair, index) => (
-        <div key={index} className="flex gap-2">
-          <Input
-            placeholder={t('propertiesForm.customKeyPlaceholder')}
-            aria-label={t('propertiesForm.customKeyPlaceholder')}
-            value={pair.key}
-            onChange={(e) => update(index, { key: e.target.value })}
-            disabled={disabled}
-          />
-          <Input
-            placeholder={t('propertiesForm.customValuePlaceholder')}
-            aria-label={t('propertiesForm.customValuePlaceholder')}
-            value={pair.value}
-            onChange={(e) => update(index, { value: e.target.value })}
-            disabled={disabled}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => remove(index)}
-            disabled={disabled}
-            aria-label={t('propertiesForm.customRemoveAriaLabel')}
-          >
-            <X className="h-4 w-4" aria-hidden="true" />
-          </Button>
-        </div>
-      ))}
-      <Button type="button" variant="outline" size="sm" onClick={add} disabled={disabled}>
-        <Plus className="mr-1 h-3 w-3" aria-hidden="true" />
-        {t('propertiesForm.customAddLabel')}
-      </Button>
+      <div className="space-y-3" role="group" aria-labelledby={labelId}>
+        {pairs.map((pair, index) => (
+          <div key={index} className="flex gap-2">
+            <Input
+              placeholder={t('propertiesForm.customKeyPlaceholder')}
+              aria-label={t('propertiesForm.customKeyPlaceholder')}
+              value={pair.key}
+              onChange={(e) => update(index, { key: e.target.value })}
+              disabled={disabled}
+            />
+            <Input
+              placeholder={t('propertiesForm.customValuePlaceholder')}
+              aria-label={t('propertiesForm.customValuePlaceholder')}
+              value={pair.value}
+              onChange={(e) => update(index, { value: e.target.value })}
+              disabled={disabled}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => remove(index)}
+              disabled={disabled}
+              aria-label={t('propertiesForm.customRemoveAriaLabel')}
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+        ))}
+        <Button type="button" variant="outline" size="sm" onClick={add} disabled={disabled}>
+          <Plus className="mr-1 h-3 w-3" aria-hidden="true" />
+          {t('propertiesForm.customAddLabel')}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -395,6 +395,7 @@ function CustomKeyValueEditor({
   className?: string;
   t: (key: string) => string;
 }) {
+  const labelId = useId();
   const [pairs, setPairs] = useState<Pair[]>(() => pairsFromValue(value));
 
   // F5 fix: resync pairs when the value's KEY SET changes upstream (e.g.,
@@ -437,16 +438,13 @@ function CustomKeyValueEditor({
     <div
       className={cn('space-y-3', className)}
       role="group"
-      aria-labelledby="event-properties-custom-label"
+      aria-labelledby={labelId}
     >
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
         <span>{t('propertiesForm.customWarning')}</span>
       </div>
-      <Label
-        id="event-properties-custom-label"
-        className="text-sm font-medium uppercase tracking-wide text-muted-foreground"
-      >
+      <Label id={labelId} className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
         {t('propertiesForm.customSectionLabel')}
       </Label>
       {pairs.map((pair, index) => (

--- a/src/components/journey/shared/EventSelector/EventSelector.tsx
+++ b/src/components/journey/shared/EventSelector/EventSelector.tsx
@@ -52,6 +52,9 @@ export interface EventSelectorProps {
   disabled?: boolean;
   placeholder?: string;
   className?: string;
+  // Lets a caller pair its own <Label htmlFor> with the trigger. Omitted → the
+  // generated id is used, as before.
+  id?: string;
 }
 
 const CATEGORY_ICON: Record<EventCategory, LucideIcon> = {
@@ -70,9 +73,11 @@ export function EventSelector({
   disabled,
   placeholder,
   className,
+  id: idProp,
 }: EventSelectorProps) {
   const { t, currentLanguage } = useLanguage('events');
-  const id = useId();
+  const generatedId = useId();
+  const id = idProp ?? generatedId;
   const [open, setOpen] = useState(false);
 
   const visibleCategories = filterByCategory ?? EVENT_CATEGORIES;

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -554,6 +554,12 @@
         "deleteError": "Error deleting variable. Please try again."
       }
     },
+    "mapping": {
+      "sourcePathLabel": "Source path",
+      "customPathLabel": "Custom path",
+      "variableLabel": "Target variable",
+      "transformLabel": "Transform"
+    },
     "customVariables": {
       "empty": {
         "title": "No variable created",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -537,6 +537,12 @@
         "deleteError": "Error al eliminar variable. Intente nuevamente."
       }
     },
+    "mapping": {
+      "sourcePathLabel": "Ruta de origen",
+      "customPathLabel": "Ruta personalizada",
+      "variableLabel": "Variable de destino",
+      "transformLabel": "Transformación"
+    },
     "customVariables": {
       "empty": {
         "title": "Ninguna variable creada",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -537,6 +537,12 @@
         "deleteError": "Erreur lors de la suppression de la variable. Réessayez."
       }
     },
+    "mapping": {
+      "sourcePathLabel": "Chemin source",
+      "customPathLabel": "Chemin personnalisé",
+      "variableLabel": "Variable cible",
+      "transformLabel": "Transformation"
+    },
     "customVariables": {
       "empty": {
         "title": "Aucune variable créée",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -549,6 +549,12 @@
         "deleteError": "Errore nell'eliminazione della variabile. Riprova."
       }
     },
+    "mapping": {
+      "sourcePathLabel": "Percorso di origine",
+      "customPathLabel": "Percorso personalizzato",
+      "variableLabel": "Variabile di destinazione",
+      "transformLabel": "Trasformazione"
+    },
     "customVariables": {
       "empty": {
         "title": "Nessuna variabile creata",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -554,6 +554,12 @@
         "deleteError": "Erro ao excluir variável. Tente novamente."
       }
     },
+    "mapping": {
+      "sourcePathLabel": "Caminho de origem",
+      "customPathLabel": "Caminho personalizado",
+      "variableLabel": "Variável de destino",
+      "transformLabel": "Transformação"
+    },
     "customVariables": {
       "empty": {
         "title": "Nenhuma variável criada",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -537,6 +537,12 @@
         "deleteError": "Erro ao excluir variável. Tente novamente."
       }
     },
+    "mapping": {
+      "sourcePathLabel": "Caminho de origem",
+      "customPathLabel": "Caminho personalizado",
+      "variableLabel": "Variável de destino",
+      "transformLabel": "Transformação"
+    },
     "customVariables": {
       "empty": {
         "title": "Nenhuma variável criada",


### PR DESCRIPTION
Continuação da CRM-123, apontada no review da #282: a PR cobriu os 23 painéis de topo, mas o levantamento original dizia "no diretório inteiro" — 94 `<Label>` soltos ficaram de fora, concentrados em `trigger/` (32), `send-webhook/` (22), `wait/` (15) e `environment-manager/` (13).

Mesmo critério da CRM-123: `htmlFor`/`id` onde o rótulo nomeia um controle único, `role="group"` + `aria-labelledby` onde cobre um conjunto (a lista de headers do webhook, os mapeamentos de variável, a lista de anexos, as abas de caminho do Conditional), e cabeçalhos de seção sobre conteúdo estático ficam como estão — não há controle pra parear. Sobraram 14 desses, listados no diff.

Duas decisões de desenho:
- Nas listas (`VariableMapping`, headers do webhook, campos do body builder), o id carrega o id do item/índice da linha — um id fixo faria a segunda linha roubar o rótulo da primeira. A spec nova do `VariableMapping` prova isso com `getAllByLabelText`.
- O `EventSelector` (usado no trigger de evento) ganhou uma prop `id` opcional, no mesmo padrão que `VariableSelect`/`VariableTextarea` já tinham — sem isso não dava pra apontar o `<Label>` externo pra ele.

5 specs novas/estendidas (`WaitTimeConfig`, `WebhookBasicConfig`, `VariableMapping`, e a extensão do `WebhookConfiguration` do trigger com 2 casos) usam `getByLabelText`/`getByRole('group', {name})` — todas reprovam no código anterior, testei revertendo o diff. Entraram na lista opt-in do CI.

`tsc --noEmit` limpo, lint sem regressão (mesma contagem de erros/warnings antes e depois nos arquivos tocados — os que restam já eram preexistentes, fora do escopo de a11y), prettier sem diferença, e a suíte `journey`+`base` com 287 testes verdes.

## Summary by Sourcery

Improve accessibility of journey subcomponents by properly associating labels with their controls and grouping related UI elements, and add tests to validate these label relationships.

Enhancements:
- Associate previously loose Label components with their corresponding inputs, selects, textareas, and custom components across trigger, wait, send-webhook, environment-manager, and other journey subcomponents using htmlFor/id and ARIA grouping.
- Update EventSelector to accept an optional id prop so external labels can reference its trigger element, and adjust various composite sections to expose named groups via role="group" and aria-labelledby for lists, tabs, and collections.

CI:
- Extend the targeted CI test job to run the new journey accessibility specs for label pairing and grouping.

Tests:
- Add new specs for WebhookConfiguration, WaitTimeConfig, WebhookBasicConfig, and VariableMapping to assert label-to-control pairing and group naming via getByLabelText/getByRole, and include them in the opt-in CI test list.