### PR TITLE
ci(lint): gate de eslint nos arquivos do diff da PR (CRM-148)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,3 +93,42 @@ jobs:
             src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.spec.tsx \
             src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx \
             src/components/journey/environment-manager/VariableMapping.spec.tsx
+
+  # Lint gate scoped to the files the PR touched.
+  eslint:
+    name: ESLint (diff)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The base commit has to be in the clone for the diff below to resolve.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ACMR skips deletions (nothing left to lint) and takes the new path on a
+      # rename. Only .ts/.tsx: they are what eslint.config.js covers.
+      - name: ESLint on changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          mapfile -d '' -t files < <(
+            git diff --name-only -z --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.ts' '*.tsx'
+          )
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No .ts/.tsx file changed — nothing to lint."
+            exit 0
+          fi
+          printf 'Linting %d changed file(s):\n' "${#files[@]}"
+          printf '  %s\n' "${files[@]}"
+          npx eslint --no-warn-ignored --max-warnings=0 "${files[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,13 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          # A git failure inside the process substitution below is swallowed by
+          # mapfile and would pass the gate with an empty file list. Make sure
+          # the base resolves before trusting the diff.
+          if ! git rev-parse -q --verify "$BASE_SHA^{commit}" >/dev/null; then
+            echo "Base sha $BASE_SHA not found in the clone — refusing to skip the lint gate." >&2
+            exit 1
+          fi
           mapfile -d '' -t files < <(
             git diff --name-only -z --diff-filter=ACMR "$BASE_SHA"...HEAD -- '*.ts' '*.tsx'
           )


### PR DESCRIPTION
O repo tinha o script `lint` no `package.json` e nenhum workflow que o executasse — `tsc -b` e o vitest eram enforced, o eslint não. Ligar `npm run lint` direto era inviável: a develop acusa 1075 problemas (943 errors, 132 warnings), e um gate abrangente reprovaria a primeira PR que passasse por ele.

O job novo (`ESLint (diff)`, no mesmo `test.yml`) roda o eslint apenas nos `.ts`/`.tsx` que a PR alterou, com `--max-warnings=0`. O autor responde só pelo que tocou, a dívida preexistente não trava ninguém e o saldo do repo só pode encolher. É o mesmo recorte opt-in que a lista de specs do vitest já usa, pelo mesmo motivo.

Detalhes: `fetch-depth: 0` no checkout porque o commit base precisa estar no clone; o diff é `--diff-filter=ACMR` (deleção não tem o que lintar, rename pega o caminho novo) contra `github.event.pull_request.base.sha` com três pontos, então é exatamente o que a PR mudou; `--no-warn-ignored` para um arquivo ignorado pelo config não virar warning e reprovar sozinho; e o job é `pull_request` only, já que em push não há diff contra o que recortar.

Cinco cenários rodados localmente com o script idêntico ao do step, com `BASE_SHA=origin/develop`: PR sem `.ts`/`.tsx` passa; arquivo novo limpo passa mesmo com os 943 errors ainda no repo; o mesmo arquivo com um `no-unused-vars` reprova; arquivo só com warning (`react-refresh/only-export-components`) reprova pelo `--max-warnings=0`; e PR que só deleta `.tsx` passa.

Falta marcar `Tests / ESLint (diff)` como check obrigatória na proteção da `develop` — é config do repositório, não do workflow, e depende de permissão de admin.

## Summary by Sourcery

CI:
- Introduce an ESLint (diff) workflow job that runs on pull_request events and lints only modified .ts/.tsx files using the existing lint configuration.