### PR TITLE
fix(chat): consome labels_data e mostra a etiqueta sem F5 (CRM-155)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,11 +53,10 @@ jobs:
       #   - Journey subcomponent labels: every <Label> that names a single
       #     control resolves through getByLabelText, and the ones that cover
       #     a set (webhook headers) expose a named group.
-      #   - eventLabels (CRM-155): a conversation event prefers labels_data
-      #     over the title-only labels field, and an empty labels_data still
-      #     yields an empty list. Losing either brings back the label that
-      #     only shows up after F5 — the merge guard in ChatContext rejects
-      #     every label that reaches it without a colour.
+      #   - eventLabels (CRM-155): a conversation event prefers labels_data over
+      #     the title-only labels field, and an empty labels_data still yields an
+      #     empty list. Losing either brings back the label that only shows up
+      #     after F5, since the ChatContext guard rejects a colourless label.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,11 @@ jobs:
       #   - Journey subcomponent labels: every <Label> that names a single
       #     control resolves through getByLabelText, and the ones that cover
       #     a set (webhook headers) expose a named group.
+      #   - eventLabels (CRM-155): a conversation event prefers labels_data
+      #     over the title-only labels field, and an empty labels_data still
+      #     yields an empty list. Losing either brings back the label that
+      #     only shows up after F5 — the merge guard in ChatContext rejects
+      #     every label that reaches it without a colour.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -92,7 +97,8 @@ jobs:
             src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx \
             src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.spec.tsx \
             src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx \
-            src/components/journey/environment-manager/VariableMapping.spec.tsx
+            src/components/journey/environment-manager/VariableMapping.spec.tsx \
+            src/contexts/chat/eventLabels.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -480,12 +480,9 @@ function useChatIntegration() {
           }
         }
 
-        // Preservar labels existentes quando WS envia dados incompletos (sem título ou cor).
-        // CRM-155: com `labels_data` no payload a cor sempre chega (coluna NOT NULL), então
-        // esta guarda só atua contra backend anterior ao CRM-155 — antes ela reprovava TODO
-        // label do WS. Ela detecta label sem cor, não lista truncada: labels_data já descarta
-        // tag órfã de propósito, igual à REST. Lista vazia continua passando pela guarda, senão
-        // remover etiqueta não refletiria na hora.
+        // Keep the labels on screen when the WS payload is incomplete (no title or colour).
+        // With labels_data the colour always arrives, so this now only guards against a
+        // backend older than CRM-155. An empty list still passes: a removal has to reflect.
         const existingLabels = existingConversation?.labels || [];
         const incomingLabels = conversation.labels || [];
         const incomingLabelsComplete =

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -481,9 +481,11 @@ function useChatIntegration() {
         }
 
         // Preservar labels existentes quando WS envia dados incompletos (sem título ou cor).
-        // CRM-155: com `labels_data` no payload a cor sempre chega, então esta guarda só
-        // atua contra backend anterior ao CRM-155 — antes ela reprovava TODO label do WS.
-        // Lista vazia continua passando: remover etiqueta tem que refletir na hora.
+        // CRM-155: com `labels_data` no payload a cor sempre chega (coluna NOT NULL), então
+        // esta guarda só atua contra backend anterior ao CRM-155 — antes ela reprovava TODO
+        // label do WS. Ela detecta label sem cor, não lista truncada: labels_data já descarta
+        // tag órfã de propósito, igual à REST. Lista vazia continua passando pela guarda, senão
+        // remover etiqueta não refletiria na hora.
         const existingLabels = existingConversation?.labels || [];
         const incomingLabels = conversation.labels || [];
         const incomingLabelsComplete =

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -480,7 +480,10 @@ function useChatIntegration() {
           }
         }
 
-        // Preservar labels existentes quando WS envia dados incompletos (sem título ou cor)
+        // Preservar labels existentes quando WS envia dados incompletos (sem título ou cor).
+        // CRM-155: com `labels_data` no payload a cor sempre chega, então esta guarda só
+        // atua contra backend anterior ao CRM-155 — antes ela reprovava TODO label do WS.
+        // Lista vazia continua passando: remover etiqueta tem que refletir na hora.
         const existingLabels = existingConversation?.labels || [];
         const incomingLabels = conversation.labels || [];
         const incomingLabelsComplete =

--- a/src/contexts/chat/WebSocketContext.tsx
+++ b/src/contexts/chat/WebSocketContext.tsx
@@ -15,6 +15,7 @@ import {
   ConversationReadEvent,
 } from '@/services/chat/websocket/ChatActionCableConnector';
 import { normalizeToUnixSeconds } from '@/utils/time/timeHelpers';
+import { mapEventLabels } from '@/contexts/chat/eventLabels';
 
 /**
  * Converte file_type do formato WebSocket (número ou string) para o formato esperado pelo frontend
@@ -436,15 +437,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
                 avatar_url: undefined,
                 provider: data.meta.provider || '',
               },
-              labels: data.labels.map((labelId: string) => ({
-                id: labelId,
-                title: '',
-                description: '',
-                color: '#000000',
-                show_on_sidebar: false,
-                created_at: data.created_at,
-                updated_at: data.updated_at,
-              })),
+              labels: mapEventLabels(data.labels_data, data.labels, data.created_at, data.updated_at),
               unread_count: data.unread_count,
               messages: [], // Será carregado quando selecionado
               // Grupos: o serializer/preset do chip filtra por is_group; sem popular
@@ -583,29 +576,8 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
                   },
                 }
               : data.meta.team === null ? { team: null } : {}),
-            ...(data.labels && {
-              labels: data.labels.map((label: string | Record<string, unknown>) => {
-                if (typeof label === 'string') {
-                  return {
-                    id: label,
-                    title: label,
-                    description: '',
-                    color: '',
-                    show_on_sidebar: false,
-                    created_at: data.created_at,
-                    updated_at: data.updated_at,
-                  };
-                }
-                return {
-                  id: String(label.id),
-                  title: String(label.title || ''),
-                  description: String(label.description || ''),
-                  color: String(label.color || ''),
-                  show_on_sidebar: Boolean(label.show_on_sidebar),
-                  created_at: String(label.created_at || data.created_at),
-                  updated_at: String(label.updated_at || data.updated_at),
-                };
-              }),
+            ...((data.labels_data || data.labels) && {
+              labels: mapEventLabels(data.labels_data, data.labels, data.created_at, data.updated_at),
             }),
             ...(data.custom_attributes != null && Object.keys(data.custom_attributes).length > 0 && {
               custom_attributes: data.custom_attributes,

--- a/src/contexts/chat/eventLabels.spec.ts
+++ b/src/contexts/chat/eventLabels.spec.ts
@@ -4,6 +4,9 @@ import { mapEventLabels } from './eventLabels';
 const CREATED_AT = '2026-08-14T10:00:00Z';
 const UPDATED_AT = '2026-08-14T11:00:00Z';
 
+// Cobre o mapper. O merge em si (ChatContext.tsx:487-504 — a guarda `title && color`
+// e o override com lista vazia) não é unit-testável sem montar o provider inteiro;
+// os ACs de tela ficam no teste manual do card.
 describe('mapEventLabels (CRM-155)', () => {
   it('usa labels_data e entrega título e cor de verdade', () => {
     const result = mapEventLabels(
@@ -19,10 +22,23 @@ describe('mapEventLabels (CRM-155)', () => {
     expect(result[0].color).toBe('#ff0000');
   });
 
-  it('passa na guarda de merge do ChatContext (title && color)', () => {
-    const result = mapEventLabels([{ id: 'a1', title: 'urgente', color: '#ff0000' }], [], CREATED_AT, UPDATED_AT);
+  it('labels_data manda, mesmo quando é mais curto que labels (tag órfã)', () => {
+    const result = mapEventLabels(
+      [{ id: 'a1', title: 'urgente', color: '#ff0000' }],
+      ['urgente', 'b0b0b0b0-0000-0000-0000-000000000000'],
+      CREATED_AT,
+      UPDATED_AT
+    );
 
-    expect(result.every((label) => Boolean(label.title) && Boolean(label.color))).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a1');
+  });
+
+  it('converte timestamp epoch do evento sem deixar número onde o tipo diz string', () => {
+    const result = mapEventLabels([{ id: 'a1', title: 'urgente', color: '#ff0000' }], [], 1755172800, 1755176400);
+
+    expect(typeof result[0].created_at).toBe('string');
+    expect(result[0].created_at).toBe('1755172800');
   });
 
   it('devolve lista vazia quando labels_data vem vazio — remoção tem que refletir', () => {

--- a/src/contexts/chat/eventLabels.spec.ts
+++ b/src/contexts/chat/eventLabels.spec.ts
@@ -4,11 +4,10 @@ import { mapEventLabels } from './eventLabels';
 const CREATED_AT = '2026-08-14T10:00:00Z';
 const UPDATED_AT = '2026-08-14T11:00:00Z';
 
-// Cobre o mapper. O merge em si (ChatContext.tsx:487-504 — a guarda `title && color`
-// e o override com lista vazia) não é unit-testável sem montar o provider inteiro;
-// os ACs de tela ficam no teste manual do card.
-describe('mapEventLabels (CRM-155)', () => {
-  it('usa labels_data e entrega título e cor de verdade', () => {
+// Covers the mapper only. The merge itself (the `title && color` guard and the
+// empty-list override in ChatContext) needs the whole provider to exercise.
+describe('mapEventLabels', () => {
+  it('takes the real title and colour from labels_data', () => {
     const result = mapEventLabels(
       [{ id: 'a1', title: 'urgente', color: '#ff0000' }],
       ['urgente'],
@@ -22,7 +21,7 @@ describe('mapEventLabels (CRM-155)', () => {
     expect(result[0].color).toBe('#ff0000');
   });
 
-  it('labels_data manda, mesmo quando é mais curto que labels (tag órfã)', () => {
+  it('lets labels_data win even when it is shorter than labels (orphan tag)', () => {
     const result = mapEventLabels(
       [{ id: 'a1', title: 'urgente', color: '#ff0000' }],
       ['urgente', 'b0b0b0b0-0000-0000-0000-000000000000'],
@@ -34,18 +33,18 @@ describe('mapEventLabels (CRM-155)', () => {
     expect(result[0].id).toBe('a1');
   });
 
-  it('converte timestamp epoch do evento sem deixar número onde o tipo diz string', () => {
+  it('coerces the epoch timestamp instead of leaving a number in a string field', () => {
     const result = mapEventLabels([{ id: 'a1', title: 'urgente', color: '#ff0000' }], [], 1755172800, 1755176400);
 
     expect(typeof result[0].created_at).toBe('string');
     expect(result[0].created_at).toBe('1755172800');
   });
 
-  it('devolve lista vazia quando labels_data vem vazio — remoção tem que refletir', () => {
+  it('returns an empty list for an empty labels_data, so a removal reflects', () => {
     expect(mapEventLabels([], ['urgente'], CREATED_AT, UPDATED_AT)).toEqual([]);
   });
 
-  it('cai no fallback de títulos quando o backend ainda não manda labels_data', () => {
+  it('falls back to the titles when the backend does not send labels_data', () => {
     const result = mapEventLabels(undefined, ['urgente'], CREATED_AT, UPDATED_AT);
 
     expect(result[0].id).toBe('urgente');
@@ -53,7 +52,7 @@ describe('mapEventLabels (CRM-155)', () => {
     expect(result[0].color).toBe('');
   });
 
-  it('aceita objeto no campo antigo sem perder id, título e cor', () => {
+  it('keeps id, title and colour of an object in the legacy field', () => {
     const result = mapEventLabels(
       undefined,
       [{ id: 'a1', title: 'urgente', color: '#ff0000', show_on_sidebar: true }],
@@ -64,7 +63,7 @@ describe('mapEventLabels (CRM-155)', () => {
     expect(result[0]).toMatchObject({ id: 'a1', title: 'urgente', color: '#ff0000', show_on_sidebar: true });
   });
 
-  it('não quebra quando o payload não traz nenhum dos dois campos', () => {
+  it('does not break when the payload carries neither field', () => {
     expect(mapEventLabels(undefined, undefined, CREATED_AT, UPDATED_AT)).toEqual([]);
   });
 });

--- a/src/contexts/chat/eventLabels.spec.ts
+++ b/src/contexts/chat/eventLabels.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { mapEventLabels } from './eventLabels';
+
+const CREATED_AT = '2026-08-14T10:00:00Z';
+const UPDATED_AT = '2026-08-14T11:00:00Z';
+
+describe('mapEventLabels (CRM-155)', () => {
+  it('usa labels_data e entrega título e cor de verdade', () => {
+    const result = mapEventLabels(
+      [{ id: 'a1', title: 'urgente', color: '#ff0000' }],
+      ['urgente'],
+      CREATED_AT,
+      UPDATED_AT
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('a1');
+    expect(result[0].title).toBe('urgente');
+    expect(result[0].color).toBe('#ff0000');
+  });
+
+  it('passa na guarda de merge do ChatContext (title && color)', () => {
+    const result = mapEventLabels([{ id: 'a1', title: 'urgente', color: '#ff0000' }], [], CREATED_AT, UPDATED_AT);
+
+    expect(result.every((label) => Boolean(label.title) && Boolean(label.color))).toBe(true);
+  });
+
+  it('devolve lista vazia quando labels_data vem vazio — remoção tem que refletir', () => {
+    expect(mapEventLabels([], ['urgente'], CREATED_AT, UPDATED_AT)).toEqual([]);
+  });
+
+  it('cai no fallback de títulos quando o backend ainda não manda labels_data', () => {
+    const result = mapEventLabels(undefined, ['urgente'], CREATED_AT, UPDATED_AT);
+
+    expect(result[0].id).toBe('urgente');
+    expect(result[0].title).toBe('urgente');
+    expect(result[0].color).toBe('');
+  });
+
+  it('aceita objeto no campo antigo sem perder id, título e cor', () => {
+    const result = mapEventLabels(
+      undefined,
+      [{ id: 'a1', title: 'urgente', color: '#ff0000', show_on_sidebar: true }],
+      CREATED_AT,
+      UPDATED_AT
+    );
+
+    expect(result[0]).toMatchObject({ id: 'a1', title: 'urgente', color: '#ff0000', show_on_sidebar: true });
+  });
+
+  it('não quebra quando o payload não traz nenhum dos dois campos', () => {
+    expect(mapEventLabels(undefined, undefined, CREATED_AT, UPDATED_AT)).toEqual([]);
+  });
+});

--- a/src/contexts/chat/eventLabels.ts
+++ b/src/contexts/chat/eventLabels.ts
@@ -1,0 +1,54 @@
+import type { ConversationEventLabel } from '@/services/chat/websocket/ChatActionCableConnector';
+import type { Label } from '@/types/settings/labels';
+
+/**
+ * Monta as etiquetas de um evento de conversa (CRM-155).
+ *
+ * `labels_data` traz id/título/cor e é a fonte preferida. `labels` continua
+ * sendo lista de títulos (contrato dos webhooks externos) e sobra como fallback
+ * para backend anterior ao CRM-155 — sem cor, o que faz o merge do ChatContext
+ * preservar as etiquetas que já estavam na tela em vez de apagá-las.
+ */
+export function mapEventLabels(
+  labelsData: ConversationEventLabel[] | undefined,
+  labels: unknown,
+  createdAt: string,
+  updatedAt: string
+): Label[] {
+  if (labelsData) {
+    return labelsData.map((label) => ({
+      id: String(label.id),
+      title: String(label.title ?? ''),
+      description: '',
+      color: String(label.color ?? ''),
+      show_on_sidebar: false,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    }));
+  }
+
+  if (!Array.isArray(labels)) return [];
+
+  return labels.map((label: string | Record<string, unknown>) => {
+    if (typeof label === 'string') {
+      return {
+        id: label,
+        title: label,
+        description: '',
+        color: '',
+        show_on_sidebar: false,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      };
+    }
+    return {
+      id: String(label.id),
+      title: String(label.title || ''),
+      description: String(label.description || ''),
+      color: String(label.color || ''),
+      show_on_sidebar: Boolean(label.show_on_sidebar),
+      created_at: String(label.created_at || createdAt),
+      updated_at: String(label.updated_at || updatedAt),
+    };
+  });
+}

--- a/src/contexts/chat/eventLabels.ts
+++ b/src/contexts/chat/eventLabels.ts
@@ -8,12 +8,15 @@ import type { Label } from '@/types/settings/labels';
  * sendo lista de títulos (contrato dos webhooks externos) e sobra como fallback
  * para backend anterior ao CRM-155 — sem cor, o que faz o merge do ChatContext
  * preservar as etiquetas que já estavam na tela em vez de apagá-las.
+ *
+ * `createdAt`/`updatedAt` aceitam número porque o backend manda os timestamps
+ * do evento como epoch (`push_timestamps`), não como string ISO.
  */
 export function mapEventLabels(
   labelsData: ConversationEventLabel[] | undefined,
   labels: unknown,
-  createdAt: string,
-  updatedAt: string
+  createdAt: string | number,
+  updatedAt: string | number
 ): Label[] {
   if (labelsData) {
     return labelsData.map((label) => ({
@@ -22,8 +25,8 @@ export function mapEventLabels(
       description: '',
       color: String(label.color ?? ''),
       show_on_sidebar: false,
-      created_at: createdAt,
-      updated_at: updatedAt,
+      created_at: String(createdAt),
+      updated_at: String(updatedAt),
     }));
   }
 
@@ -37,8 +40,8 @@ export function mapEventLabels(
         description: '',
         color: '',
         show_on_sidebar: false,
-        created_at: createdAt,
-        updated_at: updatedAt,
+        created_at: String(createdAt),
+        updated_at: String(updatedAt),
       };
     }
     return {

--- a/src/contexts/chat/eventLabels.ts
+++ b/src/contexts/chat/eventLabels.ts
@@ -2,15 +2,14 @@ import type { ConversationEventLabel } from '@/services/chat/websocket/ChatActio
 import type { Label } from '@/types/settings/labels';
 
 /**
- * Monta as etiquetas de um evento de conversa (CRM-155).
+ * Builds the labels of a conversation event.
  *
- * `labels_data` traz id/título/cor e é a fonte preferida. `labels` continua
- * sendo lista de títulos (contrato dos webhooks externos) e sobra como fallback
- * para backend anterior ao CRM-155 — sem cor, o que faz o merge do ChatContext
- * preservar as etiquetas que já estavam na tela em vez de apagá-las.
+ * `labels_data` is the preferred source. `labels` stays a list of titles (the
+ * external webhook contract) and is the fallback for a backend older than
+ * CRM-155 — colourless, so the ChatContext merge keeps what is already on
+ * screen instead of wiping it.
  *
- * `createdAt`/`updatedAt` aceitam número porque o backend manda os timestamps
- * do evento como epoch (`push_timestamps`), não como string ISO.
+ * Timestamps arrive as epoch numbers (`push_timestamps`), not ISO strings.
  */
 export function mapEventLabels(
   labelsData: ConversationEventLabel[] | undefined,

--- a/src/services/chat/websocket/ChatActionCableConnector.ts
+++ b/src/services/chat/websocket/ChatActionCableConnector.ts
@@ -137,6 +137,18 @@ export interface MessageUpdatedEvent {
   }>;
 }
 
+/**
+ * Etiqueta completa no payload do evento (CRM-155). `labels` continua lista de
+ * títulos porque o mesmo corpo vai para os webhooks de integrações de cliente;
+ * `labels_data` é o campo aditivo com id e cor. Opcional: backend anterior ao
+ * CRM-155 não envia.
+ */
+export interface ConversationEventLabel {
+  id: string;
+  title: string;
+  color: string;
+}
+
 /** Conversation event payload: id is canonical UUID; display_id is for UI display only (e.g. #12345). */
 export interface ConversationCreatedEvent {
   id: string; // UUID
@@ -175,6 +187,7 @@ export interface ConversationCreatedEvent {
     hmac_verified: boolean;
   };
   labels: string[]; // Evolution usa string[] para labels
+  labels_data?: ConversationEventLabel[];
   unread_count: number;
   is_group?: boolean;
   additional_attributes?: Record<string, unknown>;
@@ -222,6 +235,7 @@ export interface ConversationUpdatedEvent {
     hmac_verified: boolean;
   };
   labels: string[];
+  labels_data?: ConversationEventLabel[];
   unread_count: number;
   is_group?: boolean;
   additional_attributes?: Record<string, unknown>;

--- a/src/services/chat/websocket/ChatActionCableConnector.ts
+++ b/src/services/chat/websocket/ChatActionCableConnector.ts
@@ -138,10 +138,9 @@ export interface MessageUpdatedEvent {
 }
 
 /**
- * Etiqueta completa no payload do evento (CRM-155). `labels` continua lista de
- * títulos porque o mesmo corpo vai para os webhooks de integrações de cliente;
- * `labels_data` é o campo aditivo com id e cor. Opcional: backend anterior ao
- * CRM-155 não envia.
+ * Full label on the event payload. `labels` stays a list of titles because the
+ * same body feeds the customer webhooks; `labels_data` is the additive field
+ * carrying id and colour. Optional: a backend older than CRM-155 omits it.
  */
 export interface ConversationEventLabel {
   id: string;


### PR DESCRIPTION
## Contexto

[CRM-155](https://plane.evosetup.com/evolution/browse/CRM-155/) — etiqueta aplicada por macro (ou automação, jornada, API, outro atendente) **só aparece depois de F5**.

Servidor e transporte sempre estiveram corretos — o frame `conversation.updated` chega ao navegador com a etiqueta. O defeito é no consumo:

1. O payload mandava label como **string** (`labels: label_list`, lista de títulos, sem id e sem cor).
2. `WebSocketContext.tsx` convertia string → objeto com `color: ''`.
3. `ChatContext.tsx` guarda o merge com `incomingLabels.every(l => l.title && l.color)`. Como `color` é `''` (falsy), a condição era **sempre falsa** e o merge caía em `existingLabels`.

Ou seja: a guarda escrita para *tolerar* dado incompleto **descartava 100%** dos labels vindos do WebSocket, porque o WS nunca mandava cor.

**PR 2 de 2.** Depende de [evo-ai-crm-community#269](https://github.com/evolution-foundation/evo-ai-crm-community/pull/269), que adiciona `labels_data` ao payload de realtime. **Mergear o backend primeiro** — senão o front lê um campo que ainda não existe (e cai no fallback, mantendo o comportamento atual).

## O que muda

**`ChatActionCableConnector.ts`** — `labels_data?: ConversationEventLabel[]` (id + título + cor) em `ConversationCreatedEvent` e `ConversationUpdatedEvent`. Opcional, porque backend anterior ao CRM-155 não envia.

**`eventLabels.ts` (novo)** — `mapEventLabels()`, um mapper único para os dois consumidores. Prefere `labels_data`; sem ele, cai no `labels` antigo (string ou objeto), preservando o comportamento atual contra backend velho.

**`WebSocketContext.tsx`** — os dois consumidores passam pelo mapper:

| linha | antes | agora |
|---|---|---|
| `:439` (`conversation.created`) | `data.labels.map((labelId: string) => ...)` com `title: ''` — tratava **título** como id, então conversa nova nascia com etiqueta sem nome | lê `labels_data` |
| `:586` (`conversation.updated`) | montava objeto com `color: ''` | lê `labels_data` |

De quebra, `conversation.created` deixa de estourar se `data.labels` vier ausente (`Array.isArray` no mapper).

**`ChatContext.tsx`** — a guarda de merge foi **revisada e mantida**, não virou dead code: com `labels_data` a cor sempre chega (coluna `NOT NULL`) e ela aprova, mas continua sendo a proteção contra backend anterior ao CRM-155. Só o comentário mudou — e ele agora diz o que a guarda de fato garante: ela detecta **label sem cor**, não lista truncada. Lista vazia continua passando pela guarda, senão **remover** etiqueta não refletiria na hora — o merge não pode só somar.

### Timestamps

O backend manda `created_at`/`updated_at` do evento como **epoch** (`push_timestamps`: `created_at.to_i`, `updated_at.to_f`), não como string ISO. A assinatura do mapper aceita `string | number` e coage com `String()` nos dois ramos, em vez de repassar número num campo tipado como `string`.

## Validação

- `npx tsc -b --force` → **exit 0**.
- `npx vitest run src/contexts/chat/eventLabels.spec.ts` → **7/7 passando**: `labels_data` com cor de verdade; `labels_data` mandando mesmo quando é mais curto que `labels` (tag órfã); coerção de timestamp epoch; lista vazia devolvendo `[]`; fallback de títulos; fallback de objeto; payload sem nenhum dos dois campos.
- `eventLabels.spec.ts` entrou na lista opt-in do `.github/workflows/test.yml`. Sem isso o spec **não rodava em CI nenhuma** — a lista é fechada, então dava para apagar a preferência por `labels_data` e a PR continuar verde. Lane inteira reconferida com a entrada nova: **30 arquivos, 166 testes, verde**.
- `eslint` nos 5 arquivos: **idêntico ao baseline da `develop`** — os 3 errors e 3 warnings que aparecem são pré-existentes (`Record<string, any>` nos tipos de attachment e `react-refresh`), nenhum vem desta PR. Foi por isso que o mapper virou módulo próprio em vez de export do `WebSocketContext.tsx`: exportar função de arquivo de componente adicionaria warning novo.

## Critérios de aceite

Cobertos por esta PR + a de backend, **verificáveis no ambiente só depois de rebuildar a imagem enterprise** (o compose local roda a imagem, não a working tree do community):

Validados manualmente no ecossistema local, com o backend da PR 1 injetado nos dois containers (`enterprise` + `sidekiq`):

- [x] Macro com `add_label` no chat: etiqueta aparece na conversa e na lista **sem F5**, verde (`#00b34a`), não o azul de fallback.
- [x] Etiqueta removida por outro caminho **some** da tela sem F5.
- [x] `conversation.created` chega com nome e cor corretos — conversa nova entrou sozinha na lista com o chip roxo (`#7c3aed`) **e com texto**. É o AC do consumidor da `:439`: antes do fix ele montava a etiqueta com `title: ''`, então o chip nasceria vazio.
- [x] Reflexo sem o navegador agir — **o teste literal de dois navegadores não roda neste ambiente**: existe um único usuário no banco e `auth_controller.rb` (`logout`) revoga **todos** os tokens ativos do usuário, então as duas janelas disputam a mesma sessão. Provado por um caminho equivalente e mais forte: a etiqueta foi trocada **direto no servidor**, sem o navegador emitir request nenhuma, e a tela refletiu. Não há aba que pudesse ter feito refetch.
- [x] **Zero requisição HTTP nova por evento de WebSocket** — o conserto é o payload, não refetch. Nenhuma chamada foi adicionada.
- [x] **Não-regressão `assign_team` / `assign_agent`** — chegam por `meta.assignee` / `meta.team`, não passam pela guarda nem por nada que esta PR toca.

## Limites do teste automatizado, registrados

O merge em si (`ChatContext.tsx:487-504` — a guarda e o override com lista vazia) **não está coberto por unit test**: exigiria montar o provider inteiro. Os testes cobrem o mapper, que é onde a decisão de dado mora; os ACs de tela ficam no teste manual do card.

`labels_data` carrega só id/título/cor, então o mapper preenche `description: ''` e `show_on_sidebar: false`. A REST (`LabelSerializer`) manda esses campos preenchidos, então uma conversa carregada por REST tem `show_on_sidebar` zerado pelo próximo evento de WS. **Hoje isso é latente** — nenhum consumidor lê `show_on_sidebar` a partir de `conversation.labels` (só as telas de settings/modal de label). Não incluí os campos para não engordar o payload de todo broadcast; fica registrado caso apareça consumidor.
