### PR TITLE
fix(ai-credentials): toast de erro ao salvar carrega o código da API (CRM-163)

### DIFF
--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -65,6 +65,7 @@
   "messages": {
     "loadError": "Failed to load credentials",
     "saveError": "Failed to save the credential",
+    "saveErrorWithCode": "Failed to save the credential ({{code}})",
     "deleteError": "Failed to delete the credential",
     "createSuccess": "Credential created successfully",
     "updateSuccess": "Credential updated successfully",

--- a/src/i18n/locales/en/aiCredentials.json
+++ b/src/i18n/locales/en/aiCredentials.json
@@ -64,9 +64,11 @@
   },
   "messages": {
     "loadError": "Failed to load credentials",
+    "loadErrorWithCode": "Failed to load credentials ({{code}})",
     "saveError": "Failed to save the credential",
     "saveErrorWithCode": "Failed to save the credential ({{code}})",
     "deleteError": "Failed to delete the credential",
+    "deleteErrorWithCode": "Failed to delete the credential ({{code}})",
     "createSuccess": "Credential created successfully",
     "updateSuccess": "Credential updated successfully",
     "deleteSuccess": "Credential deleted successfully",

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -64,9 +64,11 @@
   },
   "messages": {
     "loadError": "Error al cargar las credenciales",
+    "loadErrorWithCode": "Error al cargar las credenciales ({{code}})",
     "saveError": "Error al guardar la credencial",
     "saveErrorWithCode": "Error al guardar la credencial ({{code}})",
     "deleteError": "Error al eliminar la credencial",
+    "deleteErrorWithCode": "Error al eliminar la credencial ({{code}})",
     "createSuccess": "Credencial creada con éxito",
     "updateSuccess": "Credencial actualizada con éxito",
     "deleteSuccess": "Credencial eliminada con éxito",

--- a/src/i18n/locales/es/aiCredentials.json
+++ b/src/i18n/locales/es/aiCredentials.json
@@ -65,6 +65,7 @@
   "messages": {
     "loadError": "Error al cargar las credenciales",
     "saveError": "Error al guardar la credencial",
+    "saveErrorWithCode": "Error al guardar la credencial ({{code}})",
     "deleteError": "Error al eliminar la credencial",
     "createSuccess": "Credencial creada con éxito",
     "updateSuccess": "Credencial actualizada con éxito",

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -65,6 +65,7 @@
   "messages": {
     "loadError": "Échec du chargement des identifiants",
     "saveError": "Échec de l'enregistrement de l'identifiant",
+    "saveErrorWithCode": "Échec de l'enregistrement de l'identifiant ({{code}})",
     "deleteError": "Échec de la suppression de l'identifiant",
     "createSuccess": "Identifiant créé avec succès",
     "updateSuccess": "Identifiant mis à jour avec succès",

--- a/src/i18n/locales/fr/aiCredentials.json
+++ b/src/i18n/locales/fr/aiCredentials.json
@@ -64,9 +64,11 @@
   },
   "messages": {
     "loadError": "Échec du chargement des identifiants",
+    "loadErrorWithCode": "Échec du chargement des identifiants ({{code}})",
     "saveError": "Échec de l'enregistrement de l'identifiant",
     "saveErrorWithCode": "Échec de l'enregistrement de l'identifiant ({{code}})",
     "deleteError": "Échec de la suppression de l'identifiant",
+    "deleteErrorWithCode": "Échec de la suppression de l'identifiant ({{code}})",
     "createSuccess": "Identifiant créé avec succès",
     "updateSuccess": "Identifiant mis à jour avec succès",
     "deleteSuccess": "Identifiant supprimé avec succès",

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -64,9 +64,11 @@
   },
   "messages": {
     "loadError": "Errore nel caricamento delle credenziali",
+    "loadErrorWithCode": "Errore nel caricamento delle credenziali ({{code}})",
     "saveError": "Errore nel salvataggio della credenziale",
     "saveErrorWithCode": "Errore nel salvataggio della credenziale ({{code}})",
     "deleteError": "Errore nell'eliminazione della credenziale",
+    "deleteErrorWithCode": "Errore nell'eliminazione della credenziale ({{code}})",
     "createSuccess": "Credenziale creata con successo",
     "updateSuccess": "Credenziale aggiornata con successo",
     "deleteSuccess": "Credenziale eliminata con successo",

--- a/src/i18n/locales/it/aiCredentials.json
+++ b/src/i18n/locales/it/aiCredentials.json
@@ -65,6 +65,7 @@
   "messages": {
     "loadError": "Errore nel caricamento delle credenziali",
     "saveError": "Errore nel salvataggio della credenziale",
+    "saveErrorWithCode": "Errore nel salvataggio della credenziale ({{code}})",
     "deleteError": "Errore nell'eliminazione della credenziale",
     "createSuccess": "Credenziale creata con successo",
     "updateSuccess": "Credenziale aggiornata con successo",

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -64,9 +64,11 @@
   },
   "messages": {
     "loadError": "Erro ao carregar as credenciais",
+    "loadErrorWithCode": "Erro ao carregar as credenciais ({{code}})",
     "saveError": "Erro ao salvar a credencial",
     "saveErrorWithCode": "Erro ao salvar a credencial ({{code}})",
     "deleteError": "Erro ao excluir a credencial",
+    "deleteErrorWithCode": "Erro ao excluir a credencial ({{code}})",
     "createSuccess": "Credencial criada com sucesso",
     "updateSuccess": "Credencial atualizada com sucesso",
     "deleteSuccess": "Credencial excluída com sucesso",

--- a/src/i18n/locales/pt-BR/aiCredentials.json
+++ b/src/i18n/locales/pt-BR/aiCredentials.json
@@ -65,6 +65,7 @@
   "messages": {
     "loadError": "Erro ao carregar as credenciais",
     "saveError": "Erro ao salvar a credencial",
+    "saveErrorWithCode": "Erro ao salvar a credencial ({{code}})",
     "deleteError": "Erro ao excluir a credencial",
     "createSuccess": "Credencial criada com sucesso",
     "updateSuccess": "Credencial atualizada com sucesso",

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -64,9 +64,11 @@
   },
   "messages": {
     "loadError": "Erro ao carregar as credenciais",
+    "loadErrorWithCode": "Erro ao carregar as credenciais ({{code}})",
     "saveError": "Erro ao salvar a credencial",
     "saveErrorWithCode": "Erro ao salvar a credencial ({{code}})",
     "deleteError": "Erro ao excluir a credencial",
+    "deleteErrorWithCode": "Erro ao excluir a credencial ({{code}})",
     "createSuccess": "Credencial criada com sucesso",
     "updateSuccess": "Credencial atualizada com sucesso",
     "deleteSuccess": "Credencial excluída com sucesso",

--- a/src/i18n/locales/pt/aiCredentials.json
+++ b/src/i18n/locales/pt/aiCredentials.json
@@ -65,6 +65,7 @@
   "messages": {
     "loadError": "Erro ao carregar as credenciais",
     "saveError": "Erro ao salvar a credencial",
+    "saveErrorWithCode": "Erro ao salvar a credencial ({{code}})",
     "deleteError": "Erro ao excluir a credencial",
     "createSuccess": "Credencial criada com sucesso",
     "updateSuccess": "Credencial atualizada com sucesso",

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
 import AiCredentials from './AiCredentials';
 import { maskKey } from '@/constants/aiProviders';
 import type { ApiKey } from '@/types/agents';
@@ -18,7 +19,11 @@ vi.mock('@/contexts/PermissionsContext', () => ({
 }));
 
 vi.mock('@/hooks/useLanguage', () => ({
-  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+  useLanguage: () => ({
+    // Echo the interpolated code so the error-path test can see it reach the toast.
+    t: (key: string, opts?: { code?: string }) => (opts?.code ? `${key}:${opts.code}` : key),
+    currentLanguage: 'en',
+  }),
 }));
 
 const listApiKeys = vi.fn();
@@ -431,6 +436,37 @@ describe('AiCredentials — creating (AC2)', () => {
 
     // Provider is required, so an untouched select must block the save.
     await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+  });
+});
+
+// The API answers a 500 with a machine-readable code (e.g. ERR_UNDEFINED_COLUMN when
+// the schema is behind the binary). The toast must carry that code instead of the
+// bare "failed to save", or the person on screen has nothing to report.
+describe('AiCredentials — save error carries the API code', () => {
+  it('shows the envelope code on the toast when the save fails', async () => {
+    const user = userEvent.setup();
+    updateApiKey.mockRejectedValue({
+      response: { status: 500, data: { success: false, error: { code: 'ERR_UNDEFINED_COLUMN', message: 'Undefined column' } } },
+    });
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await user.click(await screen.findByText('actions.save'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.saveErrorWithCode:ERR_UNDEFINED_COLUMN'));
+  });
+
+  it('keeps the plain message when the failure has no envelope code', async () => {
+    const user = userEvent.setup();
+    updateApiKey.mockRejectedValue(new Error('network down'));
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.edit')[0]);
+    await user.click(await screen.findByText('actions.save'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.saveError'));
   });
 });
 

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -468,6 +468,42 @@ describe('AiCredentials — save error carries the API code', () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.saveError'));
   });
+
+  // AC4 is written for the whole screen, not just the save: load, toggle and delete
+  // must surface the same code, or the person on screen is blind on three of four paths.
+  const ENVELOPE_500 = {
+    response: { status: 500, data: { success: false, error: { code: 'ERR_UNDEFINED_COLUMN', message: 'Undefined column' } } },
+  };
+
+  it('shows the envelope code when the list fails to load', async () => {
+    listApiKeys.mockRejectedValue(ENVELOPE_500);
+    render(<AiCredentials />);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.loadErrorWithCode:ERR_UNDEFINED_COLUMN'));
+  });
+
+  it('shows the envelope code when the activate/deactivate toggle fails', async () => {
+    const user = userEvent.setup();
+    updateApiKey.mockRejectedValue(ENVELOPE_500);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByText('actions.deactivate')[0]);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.saveErrorWithCode:ERR_UNDEFINED_COLUMN'));
+  });
+
+  it('shows the envelope code when the delete fails', async () => {
+    const user = userEvent.setup();
+    deleteApiKey.mockRejectedValue(ENVELOPE_500);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+    await user.click(await screen.findByText('deleteDialog.confirm'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.deleteErrorWithCode:ERR_UNDEFINED_COLUMN'));
+  });
 });
 
 // EVO-2250 review, ALTO 7: the screen has always sent base_url, but the field

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -120,7 +120,8 @@ export default function AiCredentials() {
       setCredentials(await listApiKeys());
     } catch (error) {
       console.error('Error loading AI credentials:', error);
-      toast.error(t('messages.loadError'));
+      const code = apiErrorCode(error);
+      toast.error(code ? t('messages.loadErrorWithCode', { code }) : t('messages.loadError'));
     } finally {
       setLoading(false);
     }
@@ -240,7 +241,8 @@ export default function AiCredentials() {
       loadCredentials();
     } catch (error) {
       console.error('Error toggling AI credential:', error);
-      toast.error(t('messages.saveError'));
+      const code = apiErrorCode(error);
+      toast.error(code ? t('messages.saveErrorWithCode', { code }) : t('messages.saveError'));
     } finally {
       setSaving(false);
     }
@@ -298,7 +300,8 @@ export default function AiCredentials() {
       loadCredentials();
     } catch (error) {
       console.error('Error deleting AI credential:', error);
-      toast.error(t('messages.deleteError'));
+      const code = apiErrorCode(error);
+      toast.error(code ? t('messages.deleteErrorWithCode', { code }) : t('messages.deleteError'));
     } finally {
       setSaving(false);
     }

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -29,6 +29,7 @@ import {
   resolveCredentialState,
 } from '@/constants/aiProviders';
 import { createApiKey, deleteApiKey, listApiKeys, listAgents, updateApiKey } from '@/services/agents';
+import { apiErrorCode } from '@/utils/apiHelpers';
 import type { ApiKey, ApiKeyCreate, ApiKeyScope, ApiKeyUpdate } from '@/types/agents';
 
 interface CredentialDraft {
@@ -220,7 +221,8 @@ export default function AiCredentials() {
       loadCredentials();
     } catch (error) {
       console.error('Error saving AI credential:', error);
-      toast.error(t('messages.saveError'));
+      const code = apiErrorCode(error);
+      toast.error(code ? t('messages.saveErrorWithCode', { code }) : t('messages.saveError'));
     } finally {
       setSaving(false);
     }

--- a/src/utils/apiHelpers.spec.ts
+++ b/src/utils/apiHelpers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { apiErrorMessage } from './apiHelpers';
+import { apiErrorCode, apiErrorMessage } from './apiHelpers';
 
 // Mirrors app/controllers/concerns/api_response_helper.rb#error_response.
 function rejection(data: unknown, status = 422) {
@@ -47,5 +47,21 @@ describe('apiErrorMessage', () => {
 
   it.each([null, undefined, 'boom', 42])('returns undefined without throwing for %p', value => {
     expect(apiErrorMessage(value)).toBeUndefined();
+  });
+});
+
+describe('apiErrorCode', () => {
+  it('returns the envelope code even on a 5xx', () => {
+    const error = {
+      response: { status: 500, data: { success: false, error: { code: 'ERR_UNDEFINED_COLUMN', message: 'Undefined column' } } },
+    };
+    expect(apiErrorCode(error)).toBe('ERR_UNDEFINED_COLUMN');
+  });
+
+  it('is undefined when the envelope has no code', () => {
+    expect(apiErrorCode({ response: { status: 422, data: { error: { message: 'x' } } } })).toBeUndefined();
+    expect(apiErrorCode({ response: { status: 500, data: { error: { code: '' } } } })).toBeUndefined();
+    expect(apiErrorCode(new Error('network'))).toBeUndefined();
+    expect(apiErrorCode(undefined)).toBeUndefined();
   });
 });

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -137,6 +137,21 @@ export function apiErrorMessage(error: unknown): string | undefined {
 }
 
 /**
+ * The backend's error code from the envelope (`{ error: { code } }`), or undefined.
+ * Unlike apiErrorMessage this does not skip 5xx: a code such as ERR_UNDEFINED_COLUMN
+ * is exactly what a 500 needs to surface so the person on screen can report it.
+ * @param error - Value caught from a rejected request
+ * @returns The machine-readable code, or undefined
+ */
+export function apiErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const data = (error as { response?: { data?: unknown } }).response?.data;
+  if (!data || typeof data !== 'object') return undefined;
+  const code = (data as { error?: { code?: unknown } | null }).error?.code;
+  return typeof code === 'string' && code.trim() !== '' ? code : undefined;
+}
+
+/**
  * Extract success message from response
  * @param response - Axios response object
  * @returns Success message or undefined


### PR DESCRIPTION
## Summary
- O `catch` do save em `AiCredentials.tsx` descartava o erro e mostrava só "Erro ao salvar a credencial" — um 500 com `{error:{code:'ERR_UNDEFINED_COLUMN'}}` ficava indistinguível de queda de rede.
- `apiErrorMessage` (CRM-114) não serve aqui de propósito: pula 5xx e nunca devolve `code`. Entra `apiErrorCode` em `utils/apiHelpers.ts`, que lê só o código do envelope, e a mensagem interpola `{{code}}` (`messages.saveErrorWithCode`, 6 locales) quando ele existe — `messages.saveError` continua o fallback.

## Security
- Só leitura do envelope de erro já recebido; nada novo sai do cliente.

## Test plan
- `npx vitest run src/pages/Customer/Settings/AiCredentials src/utils/apiHelpers.spec.ts` → 46/46 (2 novos: toast com código em 500 com envelope; fallback sem envelope; +2 no helper)
- `npx tsc --noEmit` · `npx eslint` nos arquivos tocados sem violação nova (os 5 `no-explicit-any` em `apiHelpers.ts` são pré-existentes)

## Changed Files
- `src/utils/apiHelpers.ts` · `src/utils/apiHelpers.spec.ts`
- `src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx` · `AiCredentials.spec.tsx`
- `src/i18n/locales/{pt-BR,pt,en,es,fr,it}/aiCredentials.json`

## Fora do escopo
- `load`/`toggle`/`delete` na mesma tela têm o mesmo descarte de erro (mesmo padrão, follow-up).

## Linked Issue
- CRM-163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface backend error codes in AI credential save failures via localized toasts.

Bug Fixes:
- Ensure AI credential save error toasts include machine-readable API error codes when available, instead of always showing a generic failure message.

Enhancements:
- Introduce apiErrorCode helper to extract backend error codes from error envelopes, including 5xx responses.
- Add translations for save error messages that interpolate backend error codes across supported locales.

Tests:
- Add unit tests for apiErrorCode, covering 5xx responses and missing codes.
- Extend AiCredentials tests to verify error toasts show the API code when present and fall back to the generic message otherwise.