### PR TITLE
fix(chat): passe de acabamento no chat (CRM-168)

### DIFF
--- a/src/components/chat/assignment/AssignmentModal.tsx
+++ b/src/components/chat/assignment/AssignmentModal.tsx
@@ -237,10 +237,10 @@ const AssignmentModal: React.FC<AssignmentModalProps> = ({
                 if (!option) return null;
 
                 return (
-                  <Badge key={id} variant="secondary" className="flex items-center gap-1">
-                    {option.name}
+                  <Badge key={id} variant="secondary" className="flex items-center gap-1 max-w-[180px]">
+                    <span className="truncate">{option.name}</span>
                     <X
-                      className="h-3 w-3 cursor-pointer hover:text-destructive"
+                      className="h-3 w-3 shrink-0 cursor-pointer hover:text-destructive"
                       onClick={e => {
                         e.stopPropagation();
                         handleToggleSelection(id);

--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -333,7 +333,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
             <div
               className={`rounded-lg px-3 py-1.5 ${isPrivate
                 ? 'bg-orange-50 border border-orange-200 dark:bg-orange-950/20 dark:border-orange-800/50'
-                : 'bg-muted/50 hover:bg-muted/70 border border-border/50'
+                : 'bg-muted/50 border border-border/50'
                 }`}
             >
               {/* Indicador de mensagem privada */}
@@ -477,11 +477,11 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
             } ${isPrivate
                 ? 'bg-orange-50 border-2 border-orange-200 border-l-4 border-l-orange-400 dark:bg-orange-950/20 dark:border-orange-800/50 dark:border-l-orange-600'
                 : isFromAgent
-                  ? 'bg-primary text-primary-foreground hover:bg-primary/85'
+                  ? 'bg-primary text-primary-foreground'
                   : isFromBot
                     ? 'bg-purple-600 text-white dark:bg-purple-700'
                     : isOwn
-                      ? 'bg-primary text-primary-foreground hover:bg-primary/85'
+                      ? 'bg-primary text-primary-foreground'
                       : isThreadReply
                         ? 'bg-muted/70 border border-l-2 border-l-primary/40 dark:bg-muted/50' // Estilo mais sutil para replies
                         : 'bg-muted border'

--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -331,7 +331,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
         <div className="mb-1">
           {renderContextMenu(
             <div
-              className={`rounded-lg px-3 py-1.5 ${isDeleted ? 'cursor-default' : 'cursor-pointer'} ${isPrivate
+              className={`rounded-lg px-3 py-1.5 ${isPrivate
                 ? 'bg-orange-50 border border-orange-200 dark:bg-orange-950/20 dark:border-orange-800/50'
                 : 'bg-muted/50 hover:bg-muted/70 border border-border/50'
                 }`}
@@ -472,7 +472,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
 
         {renderContextMenu(
           <div
-            className={`rounded-lg px-3 py-2 ${isDeleted ? 'cursor-default' : 'cursor-pointer'} ${
+            className={`rounded-lg px-3 py-2 ${
               isOwn ? 'rounded-tr-[4px]' : isThreadReply ? 'rounded-tl-md' : ''
             } ${isPrivate
                 ? 'bg-orange-50 border-2 border-orange-200 border-l-4 border-l-orange-400 dark:bg-orange-950/20 dark:border-orange-800/50 dark:border-l-orange-600'

--- a/src/components/chat/messages/MessageFile.tsx
+++ b/src/components/chat/messages/MessageFile.tsx
@@ -116,10 +116,10 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
           {getFileIcon(attachment.extension!)}
 
           <div className="flex-1 min-w-0">
-            <div className="font-medium truncate text-sm">
+            <div className="font-medium truncate text-xs">
               {attachment.fallback_title || t('messages.messageFile.fileFallbackTitle')}
             </div>
-            <div className="text-xs text-primary-foreground/80 dark:text-primary-foreground/70">
+            <div className="text-xs text-muted-foreground/70">
               {formatFileSize(attachment.file_size)}
               {attachment.extension && ` • ${attachment.extension.toUpperCase()}`}
             </div>
@@ -129,7 +129,7 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
             size="sm"
             variant="ghost"
             onClick={() => downloadFile(attachment)}
-            className="h-8 w-8 rounded-full hover:bg-primary-foreground/20 text-primary-foreground/80 dark:text-primary-foreground/70 flex-shrink-0 p-0"
+            className="h-8 w-8 rounded-full hover:bg-primary-foreground/20 text-primary-foreground/80 dark:text-primary-foreground/70 flex-shrink-0 p-0 cursor-pointer"
           >
             <Download className="h-3 w-3" />
           </Button>

--- a/src/components/chat/messages/MessageFile.tsx
+++ b/src/components/chat/messages/MessageFile.tsx
@@ -68,33 +68,33 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
   const getFileIcon = (extension?: string) => {
     if (!extension)
       return (
-        <File className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <File className="h-6 w-6 opacity-80" />
       );
 
     const ext = extension.toLowerCase();
 
     if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(ext)) {
       return (
-        <Image className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <Image className="h-6 w-6 opacity-80" />
       );
     }
     if (['mp3', 'wav', 'ogg', 'm4a'].includes(ext)) {
       return (
-        <Music className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <Music className="h-6 w-6 opacity-80" />
       );
     }
     if (['mp4', 'avi', 'mov', 'wmv'].includes(ext)) {
       return (
-        <Video className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <Video className="h-6 w-6 opacity-80" />
       );
     }
     if (['pdf', 'doc', 'docx', 'txt'].includes(ext)) {
       return (
-        <FileText className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <FileText className="h-6 w-6 opacity-80" />
       );
     }
 
-    return <File className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />;
+    return <File className="h-6 w-6 opacity-80" />;
   };
 
   return (
@@ -119,7 +119,7 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
             <div className="font-medium truncate text-xs">
               {attachment.fallback_title || t('messages.messageFile.fileFallbackTitle')}
             </div>
-            <div className="text-xs text-muted-foreground/70">
+            <div className="text-xs opacity-70">
               {formatFileSize(attachment.file_size)}
               {attachment.extension && ` • ${attachment.extension.toUpperCase()}`}
             </div>
@@ -129,7 +129,7 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
             size="sm"
             variant="ghost"
             onClick={() => downloadFile(attachment)}
-            className="h-8 w-8 rounded-full hover:bg-primary-foreground/20 text-primary-foreground/80 dark:text-primary-foreground/70 flex-shrink-0 p-0 cursor-pointer"
+            className="h-8 w-8 rounded-full hover:bg-primary-foreground/20 opacity-80 flex-shrink-0 p-0 cursor-pointer"
           >
             <Download className="h-3 w-3" />
           </Button>

--- a/src/components/chat/messages/MessageImage.tsx
+++ b/src/components/chat/messages/MessageImage.tsx
@@ -140,7 +140,7 @@ const MessageImage: React.FC<MessageImageProps> = ({ attachments }) => {
                       e.stopPropagation();
                       openImageModal(attachment);
                     }}
-                    className="bg-white/95 text-black hover:bg-white shadow-lg"
+                    className="bg-white/95 text-black hover:bg-white shadow-lg cursor-pointer"
                   >
                     <ZoomIn className="h-4 w-4" />
                   </Button>
@@ -151,7 +151,7 @@ const MessageImage: React.FC<MessageImageProps> = ({ attachments }) => {
                       e.stopPropagation();
                       await downloadFile(attachment);
                     }}
-                    className="bg-white/95 text-black hover:bg-white shadow-lg"
+                    className="bg-white/95 text-black hover:bg-white shadow-lg cursor-pointer"
                   >
                     <Download className="h-4 w-4" />
                   </Button>

--- a/src/components/chat/messages/MessageText.tsx
+++ b/src/components/chat/messages/MessageText.tsx
@@ -233,7 +233,7 @@ const MessageText: React.FC<MessageTextProps> = ({
   const parsedContent = parseMessageContent(safeContent);
 
   return (
-    <div className="whitespace-pre-wrap break-words">
+    <div className="whitespace-pre-wrap break-words text-sm">
       {parsedContent.elements}
       {parsedContent.detectedUrls.length > 0 && (
         <div className="mt-1">

--- a/src/contexts/chat/MessagesContext.tsx
+++ b/src/contexts/chat/MessagesContext.tsx
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useReducer, useCallback, useRef } from 'react';
 import { toast } from 'sonner';
 import { chatService } from '@/services/chat/chatService';
+import { useAuthStore } from '@/store/authStore';
 import { useUnansweredConversationsStore } from '@/store/unansweredConversationsStore';
 import { extractMessagesData } from '@/utils/chat/responseHelpers';
 import { Attachment, Message, MessageSender, MessageTypeValue } from '@/types/chat/api';
@@ -587,6 +588,8 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         isRecordedAudio,
       } = options;
 
+      const currentUser = useAuthStore.getState().currentUser;
+
       // 1. 🔧 REPLY TO: Preparar content_attributes com in_reply_to se houver reply
       const contentAttributes: Record<string, unknown> = {};
       if (state.replyToMessage?.id && !isPrivate) {
@@ -632,8 +635,8 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         created_at: Math.floor(Date.now() / 1000).toString(),
         conversation_id: conversationId,
         sender: {
-          id: '0',
-          name: 'Você',
+          id: currentUser?.id ?? '0',
+          name: currentUser?.display_name || currentUser?.name || t('messages.messageBubble.userFallback'),
           type: 'agent',
         } as MessageSender,
         content_attributes: contentAttributes,

--- a/src/contexts/chat/MessagesContext.tsx
+++ b/src/contexts/chat/MessagesContext.tsx
@@ -636,7 +636,11 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         conversation_id: conversationId,
         sender: {
           id: currentUser?.id ?? '0',
-          name: currentUser?.display_name || currentUser?.name || t('messages.messageBubble.userFallback'),
+          name:
+            currentUser?.available_name ||
+            currentUser?.display_name ||
+            currentUser?.name ||
+            t('messages.messageBubble.userFallback'),
           type: 'agent',
         } as MessageSender,
         content_attributes: contentAttributes,


### PR DESCRIPTION
Quatro ajustes visuais agrupados no chat:

- Cursor no hover de imagem/documento estava invertido: `pointer` na bolha inteira (não clicável) e cursor padrão nos botões de zoom/download (clicáveis). Trocado: removido da bolha, adicionado nos botões.
- Tipografia divergia entre bolha de texto e bolhas de imagem/documento. `MessageText` ganhou tamanho explícito; `MessageFile` alinhado ao padrão de cor/tamanho já usado em `MessageImage` (o hardcode anterior também quebrava contraste em bolhas não coloridas).
- Nome de contato/agente longo estourava o modal de Atribuir Atendente na área de seleção atual — badge agora trunca.
- Nome do remetente mostrava "Você" fixo durante o envio e só trocava pelo nome real depois de persistida — agora usa o usuário logado desde o início.

## Test plan
- `tsc -b` limpo
- `eslint` nos arquivos tocados sem novos erros (os 2 pré-existentes em `MessageBubble.tsx` são anteriores a esta mudança)