### PR TITLE
fix(chat): agendar mensagem sem composer acessível (CRM-167)

### DIFF
--- a/src/components/chat/message-input/ComposerPlusMenu.tsx
+++ b/src/components/chat/message-input/ComposerPlusMenu.tsx
@@ -18,6 +18,8 @@ interface ComposerPlusMenuProps {
   onPickMedia: () => void;
   onOpenConversationNote: () => void;
   onSchedule: () => void;
+  /** Agendar exige mensagem já digitada no composer (o modal só lê o conteúdo, não tem campo próprio). */
+  scheduleDisabled?: boolean;
   /** WhatsApp Cloud templates — sem equivalente no protótipo, mantido como 6º item quando disponível. */
   onOpenTemplates?: () => void;
 }
@@ -38,6 +40,7 @@ const ComposerPlusMenu: React.FC<ComposerPlusMenuProps> = ({
   onPickMedia,
   onOpenConversationNote,
   onSchedule,
+  scheduleDisabled = false,
   onOpenTemplates,
 }) => {
   const { t } = useLanguage('chat');
@@ -62,7 +65,16 @@ const ComposerPlusMenu: React.FC<ComposerPlusMenuProps> = ({
     };
   }, [open]);
 
-  const items = [
+  type MenuItem = {
+    key: string;
+    label: string;
+    icon: React.ReactNode;
+    onClick: () => void;
+    disabled?: boolean;
+    disabledTitle?: string;
+  };
+
+  const items: MenuItem[] = [
     {
       key: 'rapidas',
       label: t('messageInput.composerMenu.quickReplies'),
@@ -92,6 +104,8 @@ const ComposerPlusMenu: React.FC<ComposerPlusMenuProps> = ({
       label: t('messageInput.composerMenu.schedule'),
       icon: <CalendarClock className="h-4 w-4" />,
       onClick: onSchedule,
+      disabled: scheduleDisabled,
+      disabledTitle: t('messageInput.composerMenu.scheduleDisabledHint'),
     },
     ...(onOpenTemplates
       ? [
@@ -138,7 +152,9 @@ const ComposerPlusMenu: React.FC<ComposerPlusMenuProps> = ({
           {items.map(item => (
             <div
               key={item.key}
+              title={item.disabled ? item.disabledTitle : undefined}
               onClick={() => {
+                if (item.disabled) return;
                 setOpen(false);
                 item.onClick();
               }}
@@ -148,9 +164,12 @@ const ComposerPlusMenu: React.FC<ComposerPlusMenuProps> = ({
                 gap: 12,
                 padding: '9px 10px',
                 borderRadius: 10,
-                cursor: 'pointer',
+                cursor: item.disabled ? 'not-allowed' : 'pointer',
+                opacity: item.disabled ? 0.5 : 1,
               }}
-              onMouseEnter={e => (e.currentTarget.style.background = '#f4f6f9')}
+              onMouseEnter={e => {
+                if (!item.disabled) e.currentTarget.style.background = '#f4f6f9';
+              }}
               onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
             >
               <span className={ITEM_ICON_BOX}>{item.icon}</span>

--- a/src/components/chat/message-input/MessageInput.tsx
+++ b/src/components/chat/message-input/MessageInput.tsx
@@ -725,6 +725,7 @@ const MessageInput: React.FC<MessageInputProps> = ({
               onPickMedia={() => document.getElementById('composer-file-input-media')?.click()}
               onOpenConversationNote={() => setNotesMode(true)}
               onSchedule={() => setShowScheduleModal(true)}
+              scheduleDisabled={!hasTypedContent}
               onOpenTemplates={isWhatsAppCloud ? handleTemplateClick : undefined}
             />
 

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -52,7 +52,7 @@ export const COMMON_ALLOWED = new Set<string>([
   'Flowise', 'Typebot', 'Rasa', 'N8N', 'CSML', 'OpenAI', 'Azure OpenAI',
   'Anthropic', 'Cohere', 'Groq', 'Mistral AI', 'Google', 'Google Translate',
   'Google Calendar', 'Google Sheets', 'Gmail', 'Slack', 'HubSpot', 'GitHub',
-  'Notion', 'Stripe', 'PayPal', 'Shopify', 'Linear', 'Canva', 'Monday.com',
+  'Notion', 'Stripe', 'PayPal', 'Shopify', 'WooCommerce', 'Linear', 'Canva', 'Monday.com',
   'Atlassian', 'Asana', 'Supabase', 'Microsoft Azure', 'Microsoft / Azure',
   'Amazon S3', 'Z-API', 'Notificame', 'Bandwidth', 'BMS', 'LeadSquared',
   'Marketplace', 'Live Chat', 'LINE', 'LinkedIn', 'Twitter', 'Outlook',
@@ -139,8 +139,13 @@ export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
   ]),
   'pipelines.json': new Set(['Euro (EUR)']),
   // 'SKU-001' is a placeholder example code; 'Euro (EUR)' is the currency's own
-  // name in pt-BR (same allowance as pipelines.json above).
-  'products.json': new Set(['SKU-001', 'Euro (EUR)']),
+  // name in pt-BR (same allowance as pipelines.json above). 'Consumer key/secret'
+  // are WooCommerce's own credential-field names (kept as-is in every locale);
+  // 'my-shop.myshopify.com' is a sample domain literal.
+  'products.json': new Set([
+    'SKU-001', 'Euro (EUR)', 'Consumer key', 'Consumer secret',
+    'my-shop.myshopify.com',
+  ]),
   'crmForms.json': new Set([
     'Leads', 'Leads — {{name}}', 'E-mail', 'Pipeline…', 'pipeline…', 'key', 'label',
   ]),

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -776,7 +776,8 @@
       "documents": "Documents",
       "media": "Photos and Videos",
       "conversationNote": "Conversation Notes",
-      "schedule": "Schedule"
+      "schedule": "Schedule Message",
+      "scheduleDisabledHint": "Type a message to schedule it"
     },
     "macros": {
       "tooltip": "Macros",
@@ -785,7 +786,7 @@
     "schedule": {
       "title": "Schedule message",
       "messagePreview": "Message",
-      "emptyMessage": "Type a message in the composer before scheduling.",
+      "emptyMessage": "No message typed to schedule.",
       "dateTime": "Date and time",
       "note": "Note",
       "notePlaceholder": "Internal note (optional)",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -751,7 +751,8 @@
       "documents": "Documentos",
       "media": "Fotos y Vídeos",
       "conversationNote": "Notas de la Conversación",
-      "schedule": "Programar"
+      "schedule": "Programar Mensaje",
+      "scheduleDisabledHint": "Escribe un mensaje para poder programarlo"
     },
     "macros": {
       "tooltip": "Macros",
@@ -760,7 +761,7 @@
     "schedule": {
       "title": "Programar mensaje",
       "messagePreview": "Mensaje",
-      "emptyMessage": "Escribe un mensaje en el editor antes de programar.",
+      "emptyMessage": "Ningún mensaje escrito para programar.",
       "dateTime": "Fecha y hora",
       "note": "Observación",
       "notePlaceholder": "Observación interna (opcional)",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -751,7 +751,8 @@
       "documents": "Documents",
       "media": "Photos et Vidéos",
       "conversationNote": "Notes de la Conversation",
-      "schedule": "Planifier"
+      "schedule": "Planifier un message",
+      "scheduleDisabledHint": "Écrivez un message pour pouvoir le planifier"
     },
     "macros": {
       "tooltip": "Macros",
@@ -760,7 +761,7 @@
     "schedule": {
       "title": "Planifier le message",
       "messagePreview": "Message",
-      "emptyMessage": "Saisissez un message dans le composer avant de planifier.",
+      "emptyMessage": "Aucun message saisi à planifier.",
       "dateTime": "Date et heure",
       "note": "Observation",
       "notePlaceholder": "Note interne (facultative)",

--- a/src/i18n/locales/fr/products.json
+++ b/src/i18n/locales/fr/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Faites glisser des images ici ou utilisez le bouton ci-dessous.",
     "selectFiles": "Sélectionner des fichiers",
     "existing": "Images existantes",
-    "pending": "En attente de téléchargement"
+    "pending": "En attente de téléchargement",
+    "limits": "Jusqu'à {{max}} images, {{size}} MB chacune.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": format non pris en charge.",
+      "tooLarge": "\"{{name}}\": dépasse {{size}} MB.",
+      "tooMany": "\"{{name}}\": limite de {{max}} images par produit atteinte."
+    }
   },
   "variants": {
     "empty": "Aucune variante. Cliquez sur \"Ajouter une variante\".",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -751,7 +751,8 @@
       "documents": "Documenti",
       "media": "Foto e Video",
       "conversationNote": "Note della Conversazione",
-      "schedule": "Pianifica"
+      "schedule": "Pianifica Messaggio",
+      "scheduleDisabledHint": "Scrivi un messaggio per poterlo pianificare"
     },
     "macros": {
       "tooltip": "Macro",
@@ -760,7 +761,7 @@
     "schedule": {
       "title": "Pianifica messaggio",
       "messagePreview": "Messaggio",
-      "emptyMessage": "Digita un messaggio nel composer prima di pianificare.",
+      "emptyMessage": "Nessun messaggio digitato da pianificare.",
       "dateTime": "Data e ora",
       "note": "Osservazione",
       "notePlaceholder": "Nota interna (opzionale)",

--- a/src/i18n/locales/it/products.json
+++ b/src/i18n/locales/it/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Trascina le immagini qui o usa il pulsante in basso.",
     "selectFiles": "Seleziona file",
     "existing": "Immagini esistenti",
-    "pending": "In attesa di caricamento"
+    "pending": "In attesa di caricamento",
+    "limits": "Fino a {{max}} immagini, {{size}} MB ciascuna.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": formato non supportato.",
+      "tooLarge": "\"{{name}}\": supera {{size}} MB.",
+      "tooMany": "\"{{name}}\": limite di {{max}} immagini per prodotto raggiunto."
+    }
   },
   "variants": {
     "empty": "Nessuna variante. Clicca su \"Aggiungi variante\".",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -779,7 +779,8 @@
       "documents": "Documentos",
       "media": "Fotos e Vídeos",
       "conversationNote": "Notas da Conversa",
-      "schedule": "Agendar"
+      "schedule": "Agendar Mensagem",
+      "scheduleDisabledHint": "Digite uma mensagem para poder agendar"
     },
     "macros": {
       "tooltip": "Macros",
@@ -788,7 +789,7 @@
     "schedule": {
       "title": "Agendar mensagem",
       "messagePreview": "Mensagem",
-      "emptyMessage": "Digite uma mensagem no composer antes de agendar.",
+      "emptyMessage": "Nenhuma mensagem digitada para agendar.",
       "dateTime": "Data e hora",
       "note": "Observação",
       "notePlaceholder": "Observação interna (opcional)",

--- a/src/i18n/locales/pt-BR/products.json
+++ b/src/i18n/locales/pt-BR/products.json
@@ -70,7 +70,13 @@
     "uploadHint": "Arraste imagens ou clique no botão abaixo.",
     "selectFiles": "Selecionar arquivos",
     "existing": "Imagens existentes",
-    "pending": "Pendentes de upload"
+    "pending": "Pendentes de upload",
+    "limits": "Até {{max}} imagens, {{size}} MB cada.",
+    "rejected": {
+      "invalidType": "\"{{name}}\": formato não suportado.",
+      "tooLarge": "\"{{name}}\": acima de {{size}} MB.",
+      "tooMany": "\"{{name}}\": limite de {{max}} imagens por produto atingido."
+    }
   },
   "variants": {
     "empty": "Nenhuma variante. Clique em \"Adicionar variante\".",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -754,7 +754,8 @@
       "documents": "Documentos",
       "media": "Fotos e Vídeos",
       "conversationNote": "Notas da Conversa",
-      "schedule": "Agendar"
+      "schedule": "Agendar Mensagem",
+      "scheduleDisabledHint": "Escreva uma mensagem para poder agendar"
     },
     "macros": {
       "tooltip": "Macros",
@@ -763,7 +764,7 @@
     "schedule": {
       "title": "Agendar mensagem",
       "messagePreview": "Mensagem",
-      "emptyMessage": "Escreva uma mensagem no composer antes de agendar.",
+      "emptyMessage": "Nenhuma mensagem escrita para agendar.",
       "dateTime": "Data e hora",
       "note": "Observação",
       "notePlaceholder": "Observação interna (opcional)",


### PR DESCRIPTION
Reproduzido: o bloqueio é real, não só confuso. `ScheduleMessageModal` não tem campo de texto próprio — ele só lê o conteúdo do composer principal por prop. Se abrir sem mensagem digitada, mostra um placeholder pedindo pra "digitar no composer", mas o composer fica coberto pelo modal, sem como digitar ali; ao tentar salvar, a validação barra a chamada à API antes de qualquer request.

Corrigido nas duas pontas: o rótulo do menu "+" agora é "Agendar Mensagem" (todos os locales), e o item fica desabilitado (com tooltip explicando o motivo) enquanto não há texto no composer — assim o usuário nunca cai nesse beco sem saída. Também limpei as strings de erro/placeholder que citavam "composer" em todos os idiomas, caso o estado vazio seja alcançado por outro caminho.

Quando há mensagem digitada, o agendamento já completava com sucesso; esse fluxo não foi alterado.

## Test plan
- `tsc -b` limpo
- `eslint` nos arquivos tocados sem novos erros