### PR TITLE
fix(chat): auto-scroll condicional ao fim + indicador de mensagem nova (CRM-165)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,10 @@ jobs:
       #   - Journey subcomponent labels: every <Label> that names a single
       #     control resolves through getByLabelText, and the ones that cover
       #     a set (webhook headers) expose a named group.
+      #   - MessageList (CRM-165): a message arriving with the view at the
+      #     bottom keeps auto-scrolling (even while an own send is still in
+      #     flight), reading history is never hijacked — bot replies included —
+      #     and the new-message indicator only fires for real messages.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -92,7 +96,8 @@ jobs:
             src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.spec.tsx \
             src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.spec.tsx \
             src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx \
-            src/components/journey/environment-manager/VariableMapping.spec.tsx
+            src/components/journey/environment-manager/VariableMapping.spec.tsx \
+            src/components/chat/messages/MessageList.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/chat/messages/MessageList.spec.tsx
+++ b/src/components/chat/messages/MessageList.spec.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+// Mock dependencies before importing the component
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/components/chat/messages/MessageBubble', () => ({
+  default: ({ message }: { message: { id: string } }) => <div data-testid={`bubble-${message.id}`} />,
+}));
+
+vi.mock('@/components/chat/messages/SystemMessage', () => ({
+  default: ({ message }: { message: { id: string } }) => <div data-testid={`system-${message.id}`} />,
+}));
+
+vi.mock('@/components/chat/messages/PostPreview', () => ({
+  default: () => <div data-testid="post-preview" />,
+}));
+
+import MessageList from './MessageList';
+import { Message, MESSAGE_TYPE } from '@/types/chat/api';
+
+const NEW_MESSAGE_KEY = 'messages.messageList.newMessage';
+const BASE_TS = 1_700_000_000;
+
+let idCounter = 0;
+const makeMessage = (overrides: Partial<Message> = {}): Message => {
+  idCounter += 1;
+  return {
+    id: `msg-${idCounter}`,
+    content: `content ${idCounter}`,
+    content_attributes: {},
+    content_type: 'text',
+    conversation_id: 'conv-1',
+    created_at: BASE_TS + idCounter,
+    external_source_ids: {},
+    message_type: MESSAGE_TYPE.INCOMING,
+    private: false,
+    sender: { id: 'contact-1', name: 'Contact', type: 'contact' },
+    source_id: null,
+    status: 'delivered',
+    attachments: [],
+    ...overrides,
+  } as Message;
+};
+
+const ownPendingMessage = () =>
+  makeMessage({
+    message_type: MESSAGE_TYPE.OUTGOING,
+    status: 'progress',
+    sender: { id: 'agent-1', name: 'Agent', type: 'user' },
+  });
+
+const renderList = (messages: Message[]) => {
+  const props = {
+    hasMoreMessages: true,
+    isLoadingMore: false,
+    isInitialLoading: false,
+    onLoadMore: vi.fn(),
+    onRetryMessage: vi.fn(),
+    onReplyToMessage: vi.fn(),
+    onCopyMessage: vi.fn(),
+    onDeleteMessage: vi.fn(async () => {}),
+  };
+  const view = render(<MessageList {...props} messages={messages} />);
+  const scroller = view.container.querySelector('.overflow-y-scroll') as HTMLDivElement;
+  // jsdom has no layout: pin the scroll metrics the component reads.
+  Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+  Object.defineProperty(scroller, 'clientHeight', { value: 400, configurable: true });
+  scroller.scrollTo = vi.fn((options: ScrollToOptions) => {
+    scroller.scrollTop = options.top ?? 0;
+  }) as unknown as typeof scroller.scrollTo;
+  const setMessages = (next: Message[]) => view.rerender(<MessageList {...props} messages={next} />);
+  return { scroller, setMessages };
+};
+
+// Sets scrollTop and fires the handler so isNearBottomRef tracks the position.
+const scrollTo = (scroller: HTMLElement, top: number) => {
+  scroller.scrollTop = top;
+  fireEvent.scroll(scroller);
+};
+
+describe('MessageList auto-scroll (CRM-165)', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('scrolls to the end when a message arrives with the view near the bottom', () => {
+    const initial = [makeMessage(), makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 950); // 1000 - 950 - 400 < 100 → near bottom
+
+    setMessages([...initial, makeMessage()]);
+
+    expect(scroller.scrollTop).toBe(600); // scrollHeight - clientHeight
+    expect(screen.queryByText(NEW_MESSAGE_KEY)).toBeNull();
+  });
+
+  it('does not scroll while reading history — raises the new-message indicator instead', () => {
+    const initial = [makeMessage(), makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 150); // far from the bottom
+
+    setMessages([...initial, makeMessage()]);
+
+    expect(scroller.scrollTop).toBe(150);
+    expect(screen.getByText(NEW_MESSAGE_KEY)).toBeTruthy();
+  });
+
+  it('treats a bot outgoing reply as an arrival: never hijacks history reading', () => {
+    const initial = [makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 150);
+
+    setMessages([
+      ...initial,
+      makeMessage({
+        message_type: MESSAGE_TYPE.OUTGOING,
+        status: 'sent',
+        sender: { id: 'bot-1', name: 'Bot', type: 'agent_bot' },
+      }),
+    ]);
+
+    expect(scroller.scrollTop).toBe(150);
+    expect(screen.getByText(NEW_MESSAGE_KEY)).toBeTruthy();
+  });
+
+  it('always scrolls for the user own in-flight send, even from history', () => {
+    const initial = [makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 150);
+
+    setMessages([...initial, ownPendingMessage()]);
+
+    expect(scroller.scrollTop).toBe(600);
+    expect(screen.queryByText(NEW_MESSAGE_KEY)).toBeNull();
+  });
+
+  it('detects an incoming message that lands before an in-flight send tail', () => {
+    const first = makeMessage();
+    const pending = ownPendingMessage();
+    const { scroller, setMessages } = renderList([first, pending]);
+    scrollTo(scroller, 950); // near bottom
+
+    // The store sorts status 'progress' last: the new incoming lands BEFORE the tail.
+    setMessages([first, makeMessage(), pending]);
+
+    expect(scroller.scrollTop).toBe(600);
+  });
+
+  it('does not raise the indicator for system events', () => {
+    const initial = [makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 150);
+
+    setMessages([...initial, makeMessage({ message_type: MESSAGE_TYPE.ACTIVITY })]);
+
+    expect(scroller.scrollTop).toBe(150);
+    expect(screen.queryByText(NEW_MESSAGE_KEY)).toBeNull();
+  });
+
+  it('does not treat a deletion of the newest message as an arrival', () => {
+    const older = makeMessage();
+    const newest = makeMessage();
+    const { scroller, setMessages } = renderList([older, newest]);
+    scrollTo(scroller, 150);
+
+    setMessages([older]);
+
+    expect(scroller.scrollTop).toBe(150);
+    expect(screen.queryByText(NEW_MESSAGE_KEY)).toBeNull();
+  });
+
+  it('clears the indicator and scrolls to the end when the badge is clicked', () => {
+    const initial = [makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 150);
+    setMessages([...initial, makeMessage()]);
+
+    fireEvent.click(screen.getByText(NEW_MESSAGE_KEY));
+
+    expect(scroller.scrollTop).toBe(1000); // scrollTo({ top: scrollHeight })
+    expect(screen.queryByText(NEW_MESSAGE_KEY)).toBeNull();
+  });
+
+  it('exposes the badge as a keyboard-actionable button', () => {
+    const initial = [makeMessage()];
+    const { scroller, setMessages } = renderList(initial);
+    scrollTo(scroller, 150);
+    setMessages([...initial, makeMessage()]);
+
+    const badge = screen.getByText(NEW_MESSAGE_KEY);
+    expect(badge.getAttribute('role')).toBe('button');
+    expect(badge.getAttribute('tabindex')).toBe('0');
+
+    fireEvent.keyDown(badge, { key: 'Enter' });
+
+    expect(screen.queryByText(NEW_MESSAGE_KEY)).toBeNull();
+  });
+});

--- a/src/components/chat/messages/MessageList.tsx
+++ b/src/components/chat/messages/MessageList.tsx
@@ -126,6 +126,8 @@ const MessageList: React.FC<MessageListProps> = ({
   const { t } = useLanguage('chat');
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isNearBottom, setIsNearBottom] = useState(true);
+  const isNearBottomRef = useRef(true);
+  const [hasNewMessage, setHasNewMessage] = useState(false);
   const conversationIdRef = useRef<string | null>(null);
   const hasInitialScrolled = useRef(false);
   const lastLoadTime = useRef(0); // ✅ Throttle do carregamento
@@ -178,7 +180,9 @@ const MessageList: React.FC<MessageListProps> = ({
       // 🧹 Reset scroll height ref
       scrollHeightRef.current = 0;
 
+      isNearBottomRef.current = true;
       setIsNearBottom(true);
+      setHasNewMessage(false);
     }
   }, [currentConversationId, isInitialLoading, messages.length]); // ✅ Incluir dependência necessária para lint
 
@@ -247,26 +251,33 @@ const MessageList: React.FC<MessageListProps> = ({
     }
   }, [isLoadingMore]);
 
-  // 🚀 STEP 4: Auto-scroll quando uma nova mensagem OUTGOING é enviada
+  // 🚀 STEP 4: Auto-scroll quando chega mensagem nova — sempre que o próprio
+  // usuário envia (OUTGOING), ou quando chega qualquer outra mensagem E o
+  // scroll já está no fim. Se o atendente estiver lendo o histórico (scroll
+  // pra cima), NÃO rola — só marca indicador de mensagem nova.
   const lastMessageRef = useRef<Message | null>(null);
   useEffect(() => {
     if (messages.length === 0 || !hasInitialScrolled.current) return;
 
     const lastMessage = messages[messages.length - 1];
+    const isNewMessage = lastMessage && lastMessageRef.current?.id !== lastMessage.id;
 
-    // Auto-scroll quando usuário envia mensagem
-    if (
-      lastMessage &&
-      lastMessageRef.current?.id !== lastMessage.id &&
-      lastMessage.message_type === MESSAGE_TYPE.OUTGOING
-    ) {
-      const container = scrollRef.current;
-      if (container) {
-        requestAnimationFrame(() => {
-          const targetScrollTop = container.scrollHeight - container.clientHeight;
-          container.scrollTop = Math.max(0, targetScrollTop);
-          setIsNearBottom(true);
-        });
+    if (isNewMessage) {
+      const isOwnMessage = lastMessage.message_type === MESSAGE_TYPE.OUTGOING;
+
+      if (isOwnMessage || isNearBottomRef.current) {
+        const container = scrollRef.current;
+        if (container) {
+          requestAnimationFrame(() => {
+            const targetScrollTop = container.scrollHeight - container.clientHeight;
+            container.scrollTop = Math.max(0, targetScrollTop);
+            isNearBottomRef.current = true;
+            setIsNearBottom(true);
+          });
+        }
+        setHasNewMessage(false);
+      } else {
+        setHasNewMessage(true);
       }
     }
 
@@ -280,7 +291,11 @@ const MessageList: React.FC<MessageListProps> = ({
       const nearBottom = scrollHeight - scrollTop - clientHeight < 100;
       const nearTop = scrollTop < 100; // Próximo ao topo
 
+      isNearBottomRef.current = nearBottom;
       setIsNearBottom(nearBottom);
+      if (nearBottom) {
+        setHasNewMessage(false);
+      }
 
       // 🚀 SCROLL INFINITO: Carregar mais quando chega perto do topo (como WhatsApp)
       if (nearTop && hasMoreMessages && !isLoadingMore && hasInitialScrolled.current) {
@@ -303,7 +318,9 @@ const MessageList: React.FC<MessageListProps> = ({
         top: container.scrollHeight,
         behavior: 'smooth',
       });
+      isNearBottomRef.current = true;
       setIsNearBottom(true);
+      setHasNewMessage(false);
     }
   }, []);
 
@@ -609,16 +626,28 @@ const MessageList: React.FC<MessageListProps> = ({
         </div>
       </div>
 
-      {/* Botão voltar ao final */}
+      {/* Botão voltar ao final / indicador de mensagem nova */}
       {!isNearBottom && (
-        <div className="absolute bottom-4 right-4 z-10">
+        <div className="absolute bottom-4 right-4 z-10 flex items-center gap-2">
+          {hasNewMessage && (
+            <Badge
+              variant="default"
+              className="cursor-pointer shadow-lg"
+              onClick={scrollToBottom}
+            >
+              {t('messages.messageList.newMessage')}
+            </Badge>
+          )}
           <Button
             size="icon"
             variant="secondary"
-            className="rounded-full shadow-lg border bg-background/95 backdrop-blur-sm hover:bg-accent"
+            className="relative rounded-full shadow-lg border bg-background/95 backdrop-blur-sm hover:bg-accent"
             onClick={scrollToBottom}
           >
             <ChevronDown className="h-4 w-4" />
+            {hasNewMessage && (
+              <span className="absolute top-0 right-0 h-2.5 w-2.5 rounded-full bg-primary" />
+            )}
           </Button>
         </div>
       )}

--- a/src/components/chat/messages/MessageList.tsx
+++ b/src/components/chat/messages/MessageList.tsx
@@ -128,6 +128,8 @@ const MessageList: React.FC<MessageListProps> = ({
   const [isNearBottom, setIsNearBottom] = useState(true);
   const isNearBottomRef = useRef(true);
   const [hasNewMessage, setHasNewMessage] = useState(false);
+  const lastSettledRef = useRef<{ id: string; timestamp: number } | null>(null);
+  const lastPendingIdRef = useRef<string | null>(null);
   const conversationIdRef = useRef<string | null>(null);
   const hasInitialScrolled = useRef(false);
   const lastLoadTime = useRef(0); // ✅ Throttle do carregamento
@@ -181,6 +183,8 @@ const MessageList: React.FC<MessageListProps> = ({
       scrollHeightRef.current = 0;
 
       isNearBottomRef.current = true;
+      lastSettledRef.current = null;
+      lastPendingIdRef.current = null;
       setIsNearBottom(true);
       setHasNewMessage(false);
     }
@@ -251,37 +255,64 @@ const MessageList: React.FC<MessageListProps> = ({
     }
   }, [isLoadingMore]);
 
-  // 🚀 STEP 4: Auto-scroll quando chega mensagem nova — sempre que o próprio
-  // usuário envia (OUTGOING), ou quando chega qualquer outra mensagem E o
-  // scroll já está no fim. Se o atendente estiver lendo o histórico (scroll
-  // pra cima), NÃO rola — só marca indicador de mensagem nova.
-  const lastMessageRef = useRef<Message | null>(null);
+  // 🚀 STEP 4: auto-scroll on new messages. The user's own optimistic send
+  // (status 'progress', sorted last) always scrolls. A new settled message at
+  // the end — incoming, bot or another agent — scrolls only when the view is
+  // already near the bottom; otherwise it turns on the new-message indicator
+  // (system events don't). Detection uses the newest settled message plus its
+  // timestamp, so an in-flight send tail, a history load or a deletion of the
+  // newest message never counts as an arrival.
   useEffect(() => {
     if (messages.length === 0 || !hasInitialScrolled.current) return;
 
-    const lastMessage = messages[messages.length - 1];
-    const isNewMessage = lastMessage && lastMessageRef.current?.id !== lastMessage.id;
-
-    if (isNewMessage) {
-      const isOwnMessage = lastMessage.message_type === MESSAGE_TYPE.OUTGOING;
-
-      if (isOwnMessage || isNearBottomRef.current) {
-        const container = scrollRef.current;
-        if (container) {
-          requestAnimationFrame(() => {
-            const targetScrollTop = container.scrollHeight - container.clientHeight;
-            container.scrollTop = Math.max(0, targetScrollTop);
-            isNearBottomRef.current = true;
-            setIsNearBottom(true);
-          });
-        }
-        setHasNewMessage(false);
-      } else {
-        setHasNewMessage(true);
+    const scrollToEnd = () => {
+      const container = scrollRef.current;
+      if (container) {
+        requestAnimationFrame(() => {
+          const targetScrollTop = container.scrollHeight - container.clientHeight;
+          container.scrollTop = Math.max(0, targetScrollTop);
+          isNearBottomRef.current = true;
+          setIsNearBottom(true);
+        });
       }
+      setHasNewMessage(false);
+    };
+
+    const lastMessage = messages[messages.length - 1];
+    const isOwnPendingSend =
+      lastMessage.message_type === MESSAGE_TYPE.OUTGOING && lastMessage.status === 'progress';
+
+    if (isOwnPendingSend && lastPendingIdRef.current !== lastMessage.id) {
+      lastPendingIdRef.current = lastMessage.id;
+      scrollToEnd();
     }
 
-    lastMessageRef.current = lastMessage;
+    let lastSettled: Message | null = null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].status !== 'progress') {
+        lastSettled = messages[i];
+        break;
+      }
+    }
+    if (!lastSettled) return;
+
+    const previous = lastSettledRef.current;
+    const settledTimestamp = normalizeMessageTimestamp(lastSettled);
+    lastSettledRef.current = { id: lastSettled.id, timestamp: settledTimestamp };
+
+    if (!previous || previous.id === lastSettled.id || settledTimestamp < previous.timestamp) {
+      return;
+    }
+
+    const isSystemEvent =
+      lastSettled.message_type === MESSAGE_TYPE.ACTIVITY ||
+      lastSettled.message_type === MESSAGE_TYPE.TEMPLATE;
+
+    if (isNearBottomRef.current) {
+      scrollToEnd();
+    } else if (!isSystemEvent) {
+      setHasNewMessage(true);
+    }
   }, [messages]);
 
   // ✅ HANDLE SCROLL: Carregamento automático como WhatsApp/Telegram
@@ -632,8 +663,16 @@ const MessageList: React.FC<MessageListProps> = ({
           {hasNewMessage && (
             <Badge
               variant="default"
+              role="button"
+              tabIndex={0}
               className="cursor-pointer shadow-lg"
               onClick={scrollToBottom}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  scrollToBottom();
+                }
+              }}
             >
               {t('messages.messageList.newMessage')}
             </Badge>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -80,7 +80,8 @@
     "messageList": {
       "loadingConversation": "Loading conversation...",
       "loadingPrevious": "Loading previous messages...",
-      "conversationStart": "Start of conversation"
+      "conversationStart": "Start of conversation",
+      "newMessage": "New message"
     },
     "messageLocation": {
       "sharedLocation": "Shared location",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -79,7 +79,8 @@
     "messageList": {
       "loadingConversation": "Cargando conversación...",
       "loadingPrevious": "Cargando mensajes anteriores...",
-      "conversationStart": "Inicio de la conversación"
+      "conversationStart": "Inicio de la conversación",
+      "newMessage": "Mensaje nuevo"
     },
     "messageLocation": {
       "sharedLocation": "Ubicación compartida",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -79,7 +79,8 @@
     "messageList": {
       "loadingConversation": "Chargement de la conversation...",
       "loadingPrevious": "Chargement des messages précédents...",
-      "conversationStart": "Début de la conversation"
+      "conversationStart": "Début de la conversation",
+      "newMessage": "Nouveau message"
     },
     "messageLocation": {
       "sharedLocation": "Emplacement partagé",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -79,7 +79,8 @@
     "messageList": {
       "loadingConversation": "Caricamento conversazione...",
       "loadingPrevious": "Caricamento messaggi precedenti...",
-      "conversationStart": "Inizio della conversazione"
+      "conversationStart": "Inizio della conversazione",
+      "newMessage": "Nuovo messaggio"
     },
     "messageLocation": {
       "sharedLocation": "Posizione condivisa",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -80,7 +80,8 @@
     "messageList": {
       "loadingConversation": "Carregando conversa...",
       "loadingPrevious": "Carregando mensagens anteriores...",
-      "conversationStart": "Início da conversa"
+      "conversationStart": "Início da conversa",
+      "newMessage": "Nova mensagem"
     },
     "messageLocation": {
       "sharedLocation": "Localização compartilhada",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -79,7 +79,8 @@
     "messageList": {
       "loadingConversation": "Carregando conversa...",
       "loadingPrevious": "Carregando mensagens anteriores...",
-      "conversationStart": "Início da conversa"
+      "conversationStart": "Início da conversa",
+      "newMessage": "Nova mensagem"
     },
     "messageLocation": {
       "sharedLocation": "Localização compartilhada",


### PR DESCRIPTION
Causa raiz: o efeito de auto-scroll só disparava para mensagens OUTGOING (enviadas pelo próprio atendente); mensagens INCOMING chegando via websocket nunca rolavam a view, mesmo com o scroll já no fim.

Agora o auto-scroll considera a posição real do scroll (via ref sincronizado no handler, pra evitar closure velha dentro do effect): mensagem própria sempre rola; mensagem de qualquer outro tipo só rola se o scroll já estiver no fim. Quando chega mensagem nova com o atendente lendo o histórico (scroll pra cima), não rola — em vez disso mostra um indicador "Nova mensagem" ao lado do botão de voltar ao fim, que some assim que o atendente rola pra baixo ou clica nele.

## Test plan
- `tsc -b` limpo
- `eslint` no arquivo tocado sem novos erros