### PR TITLE
fix(journey): pares Save/Cancel órfãos em pt/es/fr/it + guard anti-leak (CRM-147)

### DIFF
--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -1997,5 +1997,12 @@
       "captureWebhookData": "Capturar Datos del Webhook",
       "urlCopied": "URL del Webhook copiada al portapapeles"
     }
+  },
+  "sessions": {
+    "viewer": {
+      "actions": {
+        "cancel": "Cancelar"
+      }
+    }
   }
 }

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -1322,8 +1322,8 @@
       }
     },
     "actions": {
-      "save": "Save",
-      "cancel": "Cancel"
+      "save": "Guardar",
+      "cancel": "Cancelar"
     },
     "trigger": {
       "title": "Configure Trigger",
@@ -1349,8 +1349,8 @@
         "or": "OR"
       },
       "nextCondition": "next condition",
-      "cancel": "Cancel",
-      "save": "Save",
+      "cancel": "Cancelar",
+      "save": "Guardar",
       "tabs": {
         "basic": "Básico",
         "advanced": "Avanzado",
@@ -1420,8 +1420,8 @@
         "timestamp": "Timestamp"
       },
       "buttons": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Guardar",
         "configureVariable": "Configure the Variable"
       },
       "placeholders": {
@@ -1482,8 +1482,8 @@
       "actions": {
         "addVariant": "Add Variant",
         "distributeEqually": "Distribute Equally",
-        "cancel": "Cancel",
-        "save": "Save"
+        "cancel": "Cancelar",
+        "save": "Guardar"
       },
       "status": {
         "total": "Total",
@@ -1527,8 +1527,8 @@
         "inactive": "Inactive"
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Guardar",
         "configureJourney": "Configure the Journey"
       },
       "messages": {
@@ -1570,8 +1570,8 @@
         "description": "Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Guardar",
         "configureFields": "Configure the Fields"
       }
     },
@@ -1611,8 +1611,8 @@
         "description": "Custom attributes allow you to store specific business information in each contact. Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Guardar",
         "configureAttribute": "Configure the Attribute"
       },
       "validation": {

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -1997,5 +1997,12 @@
       "captureWebhookData": "Capturer les données du webhook",
       "urlCopied": "URL du webhook copiée dans le presse-papiers"
     }
+  },
+  "sessions": {
+    "viewer": {
+      "actions": {
+        "cancel": "Annuler"
+      }
+    }
   }
 }

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -1322,8 +1322,8 @@
       }
     },
     "actions": {
-      "save": "Save",
-      "cancel": "Cancel"
+      "save": "Enregistrer",
+      "cancel": "Annuler"
     },
     "trigger": {
       "title": "Configure Trigger",
@@ -1349,8 +1349,8 @@
         "or": "OR"
       },
       "nextCondition": "next condition",
-      "cancel": "Cancel",
-      "save": "Save",
+      "cancel": "Annuler",
+      "save": "Enregistrer",
       "tabs": {
         "basic": "Basique",
         "advanced": "Avancé",
@@ -1420,8 +1420,8 @@
         "timestamp": "Timestamp"
       },
       "buttons": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annuler",
+        "save": "Enregistrer",
         "configureVariable": "Configure the Variable"
       },
       "placeholders": {
@@ -1482,8 +1482,8 @@
       "actions": {
         "addVariant": "Add Variant",
         "distributeEqually": "Distribute Equally",
-        "cancel": "Cancel",
-        "save": "Save"
+        "cancel": "Annuler",
+        "save": "Enregistrer"
       },
       "status": {
         "total": "Total",
@@ -1527,8 +1527,8 @@
         "inactive": "Inactive"
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annuler",
+        "save": "Enregistrer",
         "configureJourney": "Configure the Journey"
       },
       "messages": {
@@ -1570,8 +1570,8 @@
         "description": "Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annuler",
+        "save": "Enregistrer",
         "configureFields": "Configure the Fields"
       }
     },
@@ -1611,8 +1611,8 @@
         "description": "Custom attributes allow you to store specific business information in each contact. Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annuler",
+        "save": "Enregistrer",
         "configureAttribute": "Configure the Attribute"
       },
       "validation": {

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -1334,8 +1334,8 @@
       }
     },
     "actions": {
-      "save": "Save",
-      "cancel": "Cancel"
+      "save": "Salva",
+      "cancel": "Annulla"
     },
     "trigger": {
       "title": "Configure Trigger",
@@ -1361,8 +1361,8 @@
         "or": "OR"
       },
       "nextCondition": "next condition",
-      "cancel": "Cancel",
-      "save": "Save",
+      "cancel": "Annulla",
+      "save": "Salva",
       "tabs": {
         "basic": "Base",
         "advanced": "Avanzato",
@@ -1432,8 +1432,8 @@
         "timestamp": "Timestamp"
       },
       "buttons": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annulla",
+        "save": "Salva",
         "configureVariable": "Configure the Variable"
       },
       "placeholders": {
@@ -1494,8 +1494,8 @@
       "actions": {
         "addVariant": "Add Variant",
         "distributeEqually": "Distribute Equally",
-        "cancel": "Cancel",
-        "save": "Save"
+        "cancel": "Annulla",
+        "save": "Salva"
       },
       "status": {
         "total": "Total",
@@ -1539,8 +1539,8 @@
         "inactive": "Inactive"
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annulla",
+        "save": "Salva",
         "configureJourney": "Configure the Journey"
       },
       "messages": {
@@ -1582,8 +1582,8 @@
         "description": "Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annulla",
+        "save": "Salva",
         "configureFields": "Configure the Fields"
       }
     },
@@ -1623,8 +1623,8 @@
         "description": "Custom attributes allow you to store specific business information in each contact. Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Annulla",
+        "save": "Salva",
         "configureAttribute": "Configure the Attribute"
       },
       "validation": {

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -2009,5 +2009,12 @@
       "captureWebhookData": "Cattura Dati del Webhook",
       "urlCopied": "URL del Webhook copiato negli appunti"
     }
+  },
+  "sessions": {
+    "viewer": {
+      "actions": {
+        "cancel": "Annulla"
+      }
+    }
   }
 }

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -257,4 +257,31 @@ describe('journey i18n parity (EVO-1260)', () => {
     const leaks = findLeaks(en, ptBR, JOURNEY_ALLOWED_IDENTICAL);
     expect(leaks).toEqual([]);
   });
+
+  // CRM-147: MuteConversationPanel showed literal "Save"/"Cancel" in pt/es/fr/it
+  // while the sibling ResolveConversationPanel (a different key with the same
+  // meaning) showed the translated label — the anti-leak check above only ever
+  // ran for pt-BR, so pt/es/fr/it never had ANY leak guard. The audit for this
+  // card found the same leak on every Save/Cancel button-label pair in the file
+  // (7 pairs, not just panels.actions) — pt-BR was fine everywhere, pt/es/fr/it
+  // leaked everywhere. Rather than pin an explicit key list (which would stop
+  // growing the day an N+1th pair is added), discover every EN leaf whose value
+  // is exactly "Save" or "Cancel" and assert none come back identical in
+  // pt/es/fr/it — narrower than a full-file leak check (pt/es/fr/it carry ~700
+  // lines of pre-existing, out-of-scope drift elsewhere in this file), but it
+  // covers any future orphaned save/cancel key for free.
+  const saveCancelKeys = flatten(en).filter((k) => {
+    const v = getAtPath(en, k);
+    return v === 'Save' || v === 'Cancel';
+  });
+
+  it.each([
+    ['pt', pt],
+    ['es', es],
+    ['fr', fr],
+    ['it', itLocale],
+  ])('%s translates every Save/Cancel button-label key', (_name, locale) => {
+    const leaks = saveCancelKeys.filter((k) => getAtPath(locale, k) === getAtPath(en, k));
+    expect(leaks).toEqual([]);
+  });
 });

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -258,26 +258,14 @@ describe('journey i18n parity (EVO-1260)', () => {
     expect(leaks).toEqual([]);
   });
 
-  // CRM-147: MuteConversationPanel showed literal "Save"/"Cancel" in pt/es/fr/it
-  // while the sibling ResolveConversationPanel (a different key with the same
-  // meaning) showed the translated label — the anti-leak check above only ever
-  // ran for pt-BR, so pt/es/fr/it never had ANY leak guard. The audit for this
-  // card found the same leak on every Save/Cancel button-label pair in the file
-  // (7 pairs, not just panels.actions) — pt-BR was fine everywhere, pt/es/fr/it
-  // leaked everywhere. Rather than pin an explicit key list (which would stop
-  // growing the day an N+1th pair is added), discover every EN leaf whose value
-  // is exactly "Save" or "Cancel" and assert none come back identical in
-  // pt/es/fr/it — narrower than a full-file leak check (pt/es/fr/it carry ~700
-  // lines of pre-existing, out-of-scope drift elsewhere in this file), but it
-  // covers any future orphaned save/cancel key for free.
+  // Every EN leaf labelled exactly "Save" or "Cancel". Discovered, not listed,
+  // so a newly orphaned pair is covered without editing this file.
   const saveCancelKeys = flatten(en).filter((k) => {
     const v = getAtPath(en, k);
     return v === 'Save' || v === 'Cancel';
   });
 
-  // The set above is derived from EN copy. Reword "Save"/"Cancel" in EN and it
-  // silently shrinks — possibly to empty — leaving the cases below passing
-  // vacuously. Assert it found something before trusting a green run.
+  // Reworded EN copy empties the set and passes the cases below vacuously.
   it('discovers the Save/Cancel keys it guards', () => {
     expect(saveCancelKeys.length).toBeGreaterThan(0);
   });
@@ -288,10 +276,8 @@ describe('journey i18n parity (EVO-1260)', () => {
     ['fr', fr],
     ['it', itLocale],
   ])('%s translates every Save/Cancel key', (_name, locale) => {
-    // An absent key leaks too: fallbackLng is 'en' (src/i18n/config.ts), so a
-    // key missing from the locale renders the English literal on screen — the
-    // same symptom as a key present with the English value. Missing is also the
-    // likelier regression: new keys land in en + pt-BR and skip these four.
+    // An absent key renders the EN literal via fallbackLng, so it leaks the
+    // same as a key holding the EN value.
     const leaks = saveCancelKeys.filter((k) => {
       const v = getAtPath(locale, k);
       return v === undefined || v === getAtPath(en, k);

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -275,13 +275,27 @@ describe('journey i18n parity (EVO-1260)', () => {
     return v === 'Save' || v === 'Cancel';
   });
 
+  // The set above is derived from EN copy. Reword "Save"/"Cancel" in EN and it
+  // silently shrinks — possibly to empty — leaving the cases below passing
+  // vacuously. Assert it found something before trusting a green run.
+  it('discovers the Save/Cancel keys it guards', () => {
+    expect(saveCancelKeys.length).toBeGreaterThan(0);
+  });
+
   it.each([
     ['pt', pt],
     ['es', es],
     ['fr', fr],
     ['it', itLocale],
-  ])('%s translates every Save/Cancel button-label key', (_name, locale) => {
-    const leaks = saveCancelKeys.filter((k) => getAtPath(locale, k) === getAtPath(en, k));
+  ])('%s translates every Save/Cancel key', (_name, locale) => {
+    // An absent key leaks too: fallbackLng is 'en' (src/i18n/config.ts), so a
+    // key missing from the locale renders the English literal on screen — the
+    // same symptom as a key present with the English value. Missing is also the
+    // likelier regression: new keys land in en + pt-BR and skip these four.
+    const leaks = saveCancelKeys.filter((k) => {
+      const v = getAtPath(locale, k);
+      return v === undefined || v === getAtPath(en, k);
+    });
     expect(leaks).toEqual([]);
   });
 });

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -1322,8 +1322,8 @@
       }
     },
     "actions": {
-      "save": "Save",
-      "cancel": "Cancel"
+      "save": "Salvar",
+      "cancel": "Cancelar"
     },
     "trigger": {
       "title": "Configure Trigger",
@@ -1349,8 +1349,8 @@
         "or": "OR"
       },
       "nextCondition": "next condition",
-      "cancel": "Cancel",
-      "save": "Save",
+      "cancel": "Cancelar",
+      "save": "Salvar",
       "tabs": {
         "basic": "Básico",
         "advanced": "Avançado",
@@ -1420,8 +1420,8 @@
         "timestamp": "Timestamp"
       },
       "buttons": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Salvar",
         "configureVariable": "Configure the Variable"
       },
       "placeholders": {
@@ -1482,8 +1482,8 @@
       "actions": {
         "addVariant": "Add Variant",
         "distributeEqually": "Distribute Equally",
-        "cancel": "Cancel",
-        "save": "Save"
+        "cancel": "Cancelar",
+        "save": "Salvar"
       },
       "status": {
         "total": "Total",
@@ -1527,8 +1527,8 @@
         "inactive": "Inactive"
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Salvar",
         "configureJourney": "Configure the Journey"
       },
       "messages": {
@@ -1570,8 +1570,8 @@
         "description": "Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Salvar",
         "configureFields": "Configure the Fields"
       }
     },
@@ -1611,8 +1611,8 @@
         "description": "Custom attributes allow you to store specific business information in each contact. Use variables clicking on the (x) button."
       },
       "actions": {
-        "cancel": "Cancel",
-        "save": "Save",
+        "cancel": "Cancelar",
+        "save": "Salvar",
         "configureAttribute": "Configure the Attribute"
       },
       "validation": {


### PR DESCRIPTION
O card apontava só o par do MuteConversationPanel (`panels.actions.*`) vazando inglês em pt/es/fr/it enquanto o do ResolveConversationPanel (`actions.*`, chave diferente) saía traduzido. Varri os outros painéis de jornada como o card pedia e achei o mesmo vazamento em mais 6 pares — `panels.trigger.*`, `panels.setVariable.buttons.*`, `panels.split.actions.*`, `panels.transferJourney.actions.*`, `panels.updateContact.actions.*` e `panels.updateCustomAttribute.actions.*` — todos com "Save"/"Cancel" literal nos quatro idiomas, todos corretos em pt-BR e en.

Não convergi tudo pra uma chave só: `panels.actions.*` é consumida por 18 painéis contra 4 de `actions.*`, então trocar a chave seria um refactor grande em 18 arquivos sem ganho funcional. Só traduzi os 7 pares nos 4 locales, usando a mesma tradução já estabelecida em `actions.save/cancel` de cada idioma (Salvar/Cancelar, Guardar/Cancelar, Enregistrer/Annuler, Salva/Annulla).

Sobre o guard: `journey-parity.spec.ts` só tinha checagem anti-leak (`findLeaks`) pra pt-BR — pt/es/fr/it nunca tiveram nenhuma, só checagem de presença de chave (é por isso que esse bug sobreviveu com CI verde). Não liguei o `findLeaks` completo pra essas 4 locales porque o arquivo já documenta ~700 linhas de drift pré-existente fora de escopo nelas. Em vez disso, o novo guard descobre em runtime toda chave cujo valor em EN é literalmente "Save" ou "Cancel" e falha se algum dos 4 locales repetir o mesmo valor — cobre qualquer par órfão futuro sem precisar listar manualmente.

## Test plan
- `npx vitest run src/i18n/locales/journey-parity.spec.ts` → 40/40 verde (4 testes novos)
- `tsc -b` e `eslint` limpos