### PR TITLE
fix(chat): achados do code review do #298 (CRM-168)

### DIFF
--- a/src/components/chat/messages/MessageBubble.tsx
+++ b/src/components/chat/messages/MessageBubble.tsx
@@ -333,7 +333,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
             <div
               className={`rounded-lg px-3 py-1.5 ${isPrivate
                 ? 'bg-orange-50 border border-orange-200 dark:bg-orange-950/20 dark:border-orange-800/50'
-                : 'bg-muted/50 hover:bg-muted/70 border border-border/50'
+                : 'bg-muted/50 border border-border/50'
                 }`}
             >
               {/* Indicador de mensagem privada */}
@@ -477,11 +477,11 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({
             } ${isPrivate
                 ? 'bg-orange-50 border-2 border-orange-200 border-l-4 border-l-orange-400 dark:bg-orange-950/20 dark:border-orange-800/50 dark:border-l-orange-600'
                 : isFromAgent
-                  ? 'bg-primary text-primary-foreground hover:bg-primary/85'
+                  ? 'bg-primary text-primary-foreground'
                   : isFromBot
                     ? 'bg-purple-600 text-white dark:bg-purple-700'
                     : isOwn
-                      ? 'bg-primary text-primary-foreground hover:bg-primary/85'
+                      ? 'bg-primary text-primary-foreground'
                       : isThreadReply
                         ? 'bg-muted/70 border border-l-2 border-l-primary/40 dark:bg-muted/50' // Estilo mais sutil para replies
                         : 'bg-muted border'

--- a/src/components/chat/messages/MessageFile.tsx
+++ b/src/components/chat/messages/MessageFile.tsx
@@ -68,33 +68,33 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
   const getFileIcon = (extension?: string) => {
     if (!extension)
       return (
-        <File className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <File className="h-6 w-6 opacity-80" />
       );
 
     const ext = extension.toLowerCase();
 
     if (['jpg', 'jpeg', 'png', 'gif', 'webp'].includes(ext)) {
       return (
-        <Image className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <Image className="h-6 w-6 opacity-80" />
       );
     }
     if (['mp3', 'wav', 'ogg', 'm4a'].includes(ext)) {
       return (
-        <Music className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <Music className="h-6 w-6 opacity-80" />
       );
     }
     if (['mp4', 'avi', 'mov', 'wmv'].includes(ext)) {
       return (
-        <Video className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <Video className="h-6 w-6 opacity-80" />
       );
     }
     if (['pdf', 'doc', 'docx', 'txt'].includes(ext)) {
       return (
-        <FileText className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />
+        <FileText className="h-6 w-6 opacity-80" />
       );
     }
 
-    return <File className="h-6 w-6 text-primary-foreground/80 dark:text-primary-foreground/70" />;
+    return <File className="h-6 w-6 opacity-80" />;
   };
 
   return (
@@ -119,7 +119,7 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
             <div className="font-medium truncate text-xs">
               {attachment.fallback_title || t('messages.messageFile.fileFallbackTitle')}
             </div>
-            <div className="text-xs text-muted-foreground/70">
+            <div className="text-xs opacity-70">
               {formatFileSize(attachment.file_size)}
               {attachment.extension && ` • ${attachment.extension.toUpperCase()}`}
             </div>
@@ -129,7 +129,7 @@ const MessageFile: React.FC<MessageFileProps> = ({ attachments }) => {
             size="sm"
             variant="ghost"
             onClick={() => downloadFile(attachment)}
-            className="h-8 w-8 rounded-full hover:bg-primary-foreground/20 text-primary-foreground/80 dark:text-primary-foreground/70 flex-shrink-0 p-0 cursor-pointer"
+            className="h-8 w-8 rounded-full hover:bg-primary-foreground/20 opacity-80 flex-shrink-0 p-0 cursor-pointer"
           >
             <Download className="h-3 w-3" />
           </Button>

--- a/src/contexts/chat/MessagesContext.tsx
+++ b/src/contexts/chat/MessagesContext.tsx
@@ -636,7 +636,11 @@ export function MessagesProvider({ children }: { children: React.ReactNode }) {
         conversation_id: conversationId,
         sender: {
           id: currentUser?.id ?? '0',
-          name: currentUser?.display_name || currentUser?.name || t('messages.messageBubble.userFallback'),
+          name:
+            currentUser?.available_name ||
+            currentUser?.display_name ||
+            currentUser?.name ||
+            t('messages.messageBubble.userFallback'),
           type: 'agent',
         } as MessageSender,
         content_attributes: contentAttributes,


### PR DESCRIPTION
Correções dos achados do code review do #298. Base é a branch do #298 (não a `develop`), para serem revisadas separadamente e depois juntadas às correções originais.

Três commits independentes, um por achado, para dar pra derrubar qualquer um sem desfazer os outros.

## 1. `MessageFile` — cores herdam o foreground da bolha

O `#298` trocou a linha do tamanho do arquivo de `text-primary-foreground/80 dark:text-primary-foreground/70` para `text-muted-foreground/70`. Os dois tokens assumem um fundo fixo, mas `MessageFile` renderiza dentro de bolhas com fundos diferentes: `bg-primary` quando a mensagem é outgoing/agente (`MessageBubble.tsx:480,484`) e `bg-muted` quando é incoming.

Com os tokens do design system — claro: `--primary` `oklch(67.35% 0.153 159.64)` contra `--muted-foreground` `oklch(0.556 0 0)`; escuro: `oklch(88.18% …)` contra `oklch(0.708 0 0)` — cinza sobre verde fica com luminância quase igual, e ainda a 70% de opacidade. Ou seja: a classe antiga era legível na bolha de saída e ilegível na de entrada, e a nova inverteu isso, em vez de resolver.

O ícone do arquivo (6 variações) e o botão de download continuavam com a classe antiga, então a mesma linha do anexo ficava com dois palettes misturados.

Aqui os três passam a não declarar cor, herdando o foreground da bolha — que é o que a linha do **nome** do arquivo já fazia. `opacity-70`/`opacity-80` preservam a hierarquia visual entre nome, tamanho e ícone.

> Ficou de fora: o `hover:bg-primary-foreground/20` do botão de download tem o mesmo problema de premissa (quase invisível em bolha `bg-muted`), mas o Tailwind não gera modificador de opacidade em `bg-current`, então corrigir exigiria escolher outra abordagem. Não mexi para não ampliar o escopo — dá um card se valer.

## 2. `MessagesContext` — `available_name` no remetente otimista

`available_name` é o campo que a API já entrega resolvido e o que o resto do app lê para nome de remetente (`SearchResultMessage.tsx:13`). `display_name || name` recalcula o mesmo valor na mão e passa a divergir se a regra mudar no servidor. Os fallbacks anteriores continuam depois dele.

## 3. `MessageBubble` — hover sem alvo de clique

O `#298` removeu (corretamente) o `cursor-pointer` da bolha, mas ficaram `hover:bg-primary/85` e `hover:bg-muted/70`. A bolha não tem `onClick`/`onDoubleClick`, nem no wrapper dela em `MessageList.tsx:587`, e não revela ação nenhuma no hover — o menu é de botão direito. O realce anunciava uma interação que não existe, que é o mesmo problema de affordance do item 1 do card.

Este é o mais discutível dos três: é mudança visual, não defeito funcional. Se a preferência for manter o realce como referência de leitura em conversa densa, é só derrubar o commit.

## O que NÃO está aqui

**Tamanho de fonte (item 2 do card).** `MessageText` ganhou `text-sm` e o título do `MessageFile` desceu para `text-xs`. Como nenhum ancestral define `font-size` (conferi `globals.css` e a árvore do `MessageList`), o corpo da mensagem vinha do default do browser em 16px — então 16 vs 14 virou 14 vs 12, e a diferença que o card reclama continua igual. Há duas correções opostas e ambas válidas (alinhar o título do anexo para cima, ou reverter o `text-sm` do corpo), e o `text-sm` encolhe o texto de toda mensagem do produto de 16 para 14px. É decisão de design, não de review.

**`max-w-[180px]` no badge do `AssignmentModal`.** Levantei como número mágico, mas retiro: o `Badge` do design system vem com `shrink-0 w-fit overflow-hidden` na base, então a alternativa que sugeri (`min-w-0` + `truncate`) não funcionaria sem antes derrubar o `shrink-0`. O cap fixo é solução legítima nesse contexto.

## Test plan

- `tsc -b --force` limpo
- `eslint` nos 3 arquivos: mesmos 2 erros e 1 warning pré-existentes do `#298`, nenhum novo (o gate `ESLint (diff)` está quebrado para todo mundo e já tem card próprio)
- Mudanças são só de classe CSS + ordem de fallback; sem alteração de comportamento para verificar em runtime

## Summary by Sourcery

Adjust chat message UI styling and sender naming to address code review feedback and improve consistency and readability.

Bug Fixes:
- Ensure optimistic message sender names use the resolved available_name field for consistency with backend and search results.

Enhancements:
- Align MessageFile attachment icons, metadata text, and download button to inherit bubble foreground color with reduced opacity for better contrast across themes and bubble types.
- Remove hover highlight styles from non-interactive message bubbles and private indicators to avoid suggesting nonexistent click actions.