### PR TITLE
[descartavel] sonda do gate CRM-175 — caminho verde + notice

### DIFF
--- a/src/services/chat/websocket/ChatActionCableConnector.ts
+++ b/src/services/chat/websocket/ChatActionCableConnector.ts
@@ -640,3 +640,5 @@ export class ChatActionCableConnector extends BaseActionCableConnector {
 }
 
 export default ChatActionCableConnector;
+
+// touched by the CRM-175 gate probe: legacy debt left untouched on purpose

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -37,7 +37,7 @@ export function extractData<T>(response: AxiosResponse): T {
 export function extractResponse<T>(response: AxiosResponse): { 
   success: true;
   data: T[];
-  meta: any;
+  meta: unknown;
   message: string;
 } {
   return {


### PR DESCRIPTION
PR **descartavel**, aberta so para executar o gate do CRM-175 (#305) e fechada em seguida. Nao mergear.

Faz duas coisas de uma vez:
- **paga divida legada**: troca um `any` por `unknown` no `apiHelpers.ts` (baseline diz 5, arquivo passa a ter 4)
- **toca outro arquivo legado sem consertar nada**: um comentario no `ChatActionCableConnector.ts`

Esperado: gate **verde**, e o passo `Baseline shrank` disparando o `::notice` com o summary.

## Summary by Sourcery

Tighten API response typing and mark legacy chat connector code as intentionally untouched for the CRM-175 gate probe.

Enhancements:
- Improve type safety of API helper responses by changing the metadata field from any to unknown.

Chores:
- Add a marker comment in the chat WebSocket connector indicating legacy code was intentionally left unchanged for the CRM-175 gate probe.