### PR TITLE
[descartavel] sonda do gate CRM-175 — caminho vermelho

### DIFF
--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -227,3 +227,5 @@ export function buildPaginationParams(page: number, pageSize: number): { page: n
   };
 }
 
+
+export const evoGateProbe = (x: any) => x


### PR DESCRIPTION
PR **descartavel**, aberta so para executar o gate do CRM-175 (#305) e fechada em seguida. Nao mergear.

Adiciona um `any` novo ao `apiHelpers.ts`, que ja tem 5 na baseline.

Esperado: gate **vermelho**, reportando as 6 ocorrencias (a baseline nao suprime nada da regra quando a contagem estoura).

## Summary by Sourcery

Enhancements:
- Introduce evoGateProbe helper in apiHelpers for gate probing purposes.