### PR TITLE
test(contacts): cover notes list against the standard response envelope (CRM-177)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,10 @@ jobs:
       #     bottom keeps auto-scrolling (even while an own send is still in
       #     flight), reading history is never hijacked — bot replies included —
       #     and the new-message indicator only fires for real messages.
+      #   - ContactNotesCard (CRM-177): the notes list keeps reading the standard
+      #     `{ success, data, meta }` envelope. Reading it wrong is invisible —
+      #     the card shows its empty state with the notes in the database, which
+      #     the person on screen reports as "the note did not save".
       #   - eventLabels (CRM-155): a conversation event prefers labels_data over
       #     the title-only labels field, and an empty labels_data still yields an
       #     empty list. Losing either brings back the label that only shows up
@@ -102,7 +106,8 @@ jobs:
             src/components/journey/nodes/actions/send-message/components/SendMessageAttachments.spec.tsx \
             src/components/journey/environment-manager/VariableMapping.spec.tsx \
             src/components/chat/messages/MessageList.spec.tsx \
-            src/contexts/chat/eventLabels.spec.ts
+            src/contexts/chat/eventLabels.spec.ts \
+            src/components/contacts/ContactNotesCard.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/contacts/ContactNotesCard.spec.tsx
+++ b/src/components/contacts/ContactNotesCard.spec.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ContactNotesCard from './ContactNotesCard';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({ can: () => true, isReady: true }),
+}));
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+vi.mock('@/services/core/api', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// The envelope the Rails controller answers post-fix, matching
+// spec/requests/api/v1/contacts/notes_spec.rb: `{ success, data, meta }`,
+// same as every other contacts endpoint. Before the fix this was a bare
+// array and getContactNotes' extractResponse(response.data.data) read
+// undefined off it, so the list rendered empty no matter what was saved.
+const backendIndexEnvelope = (data: unknown) => ({
+  data: { success: true, data, meta: { timestamp: '2026-08-17T12:00:00.000Z' } },
+});
+
+const note = {
+  id: 'note-1',
+  content: 'nota existente',
+  contact_id: 'contact-1',
+  user_id: 'user-1',
+  user: { id: 'user-1', name: 'Agente', email: 'agente@example.com' },
+  created_at: '2026-08-17T12:00:00.000Z',
+  updated_at: '2026-08-17T12:00:00.000Z',
+};
+
+describe('ContactNotesCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the notes the backend returns', async () => {
+    mockGet.mockResolvedValue(backendIndexEnvelope([note]));
+
+    render(<ContactNotesCard contactId="contact-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('nota existente')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the empty state when there really are no notes', async () => {
+    mockGet.mockResolvedValue(backendIndexEnvelope([]));
+
+    render(<ContactNotesCard contactId="contact-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('notes.empty')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/services/contacts/contactsService.ts
+++ b/src/services/contacts/contactsService.ts
@@ -15,6 +15,7 @@ import type {
   ContactImportResponse,
   ContactExportResponse,
   ContactNote,
+  ContactNoteDeleteResponse,
   ContactConversation,
   ContactableInboxes,
 } from '@/types/contacts';
@@ -230,9 +231,9 @@ class ContactsService {
     return extractData<ContactNote>(response);
   }
 
-  async deleteContactNote(contactId: string, noteId: string): Promise<{ message: string }> {
+  async deleteContactNote(contactId: string, noteId: string): Promise<ContactNoteDeleteResponse> {
     const response = await api.delete(`/contacts/${contactId}/notes/${noteId}`);
-    return extractData<{ message: string }>(response);
+    return response.data as ContactNoteDeleteResponse;
   }
 
   // Contact Conversations

--- a/src/types/contacts/contact.ts
+++ b/src/types/contacts/contact.ts
@@ -278,7 +278,9 @@ export interface ContactResponse extends StandardResponse<Contact> {}
 
 export interface ContactNotesResponse extends StandardResponse<ContactNote[]> {}
 
-export interface ContactNoteDeleteResponse extends StandardResponse<{ message: string }> {}
+// The delete answers `success_response(data: {}, message: ...)`, so the message
+// is a sibling of `data` (StandardResponse.message), never inside it.
+export interface ContactNoteDeleteResponse extends StandardResponse<Record<string, never>> {}
 
 export interface ContactConversationsResponse extends PaginatedResponse<ContactConversation> {}
 

--- a/src/types/contacts/contact.ts
+++ b/src/types/contacts/contact.ts
@@ -276,7 +276,7 @@ export interface ContactsResponse extends PaginatedResponse<Contact> {}
 
 export interface ContactResponse extends StandardResponse<Contact> {}
 
-export interface ContactNotesResponse extends PaginatedResponse<ContactNote> {}
+export interface ContactNotesResponse extends StandardResponse<ContactNote[]> {}
 
 export interface ContactNoteDeleteResponse extends StandardResponse<{ message: string }> {}
 


### PR DESCRIPTION
## O que muda

`ContactNotesResponse` estava tipado como `PaginatedResponse<ContactNote>`, mas o endpoint nunca pagina — nem o controller nem a tela. Ajustado para `StandardResponse<ContactNote[]>`, o formato real depois do fix no `evo-ai-crm-community` (evolution-foundation/evo-ai-crm-community#271 — envelopa `index`/`show`/`create`/`update`/`destroy`).

Sem mudança de comportamento em produção: `getContactNotes`/`ContactNotesCard` já tratavam a resposta certa, só faltava a cobertura de regressão e o tipo estava desalinhado do contrato real.

## Test plan
- [x] `ContactNotesCard.spec.tsx` novo — renderiza notas a partir do envelope real e mantém o estado vazio quando a lista é vazia de fato
- [x] `npx vitest run src/components/contacts` — 44 testes, verde
- [x] `npx tsc -b`
- [x] `npx eslint` nos arquivos tocados

## Summary by Sourcery

Align contact notes typing with the standard response envelope and add regression coverage for the notes card.

Enhancements:
- Update ContactNotesResponse type to use the shared standard response envelope shape for an array of notes.

Tests:
- Add ContactNotesCard tests to validate rendering of notes from the standard response envelope and the empty state when no notes are returned.