### PR TITLE
fix(ai-credentials): credencial desativada continua na lista e pode ser reativada (CRM-174)

### DIFF
--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -91,6 +91,17 @@ const ALL_PERMISSIONS = [
 // table assertions resolve the row instead of the bare text.
 const findAccountRow = () => screen.findByRole('cell', { name: 'Producao' });
 
+// Mirrors the registry: `active` picks one state, and its absence means "active
+// only" — the default that used to hide a deactivated credential (CRM-174).
+// Mutable so a toggle can be observed across the reload that follows it.
+let registry: ApiKey[] = [];
+const mockRegistry = (keys: ApiKey[]) => {
+  registry = keys;
+  listApiKeys.mockImplementation((_page?: number, _pageSize?: number, options?: { active?: boolean }) =>
+    Promise.resolve(registry.filter(key => key.is_active === (options?.active ?? true))),
+  );
+};
+
 beforeAll(() => {
   globalThis.ResizeObserver = class {
     observe() {}
@@ -102,7 +113,7 @@ beforeAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   granted = [...ALL_PERMISSIONS];
-  listApiKeys.mockResolvedValue([OPENAI_KEY, ANTHROPIC_KEY]);
+  mockRegistry([OPENAI_KEY, ANTHROPIC_KEY]);
   listAgents.mockResolvedValue({ data: [] });
 });
 
@@ -113,8 +124,11 @@ describe('AiCredentials — listing (AC1, AC7)', () => {
     expect(await findAccountRow()).toBeInTheDocument();
     expect(screen.getByText(maskKey('4f2a'))).toBeInTheDocument();
     expect(screen.getByText(maskKey('91bc'))).toBeInTheDocument();
-    // The registry is the only source consulted.
-    expect(listApiKeys).toHaveBeenCalledTimes(1);
+    // The registry is the only source consulted, asked for both states so a
+    // deactivated credential stays on screen (CRM-174).
+    expect(listApiKeys).toHaveBeenCalledTimes(2);
+    expect(listApiKeys).toHaveBeenCalledWith(1, 100, { active: true });
+    expect(listApiKeys).toHaveBeenCalledWith(1, 100, { active: false });
   });
 
   it('says which features each provider serves', async () => {
@@ -260,11 +274,65 @@ describe('AiCredentials — delete warns about agents in use (AC5)', () => {
 });
 
 // EVO-2250 story 1.2: the installation link of the chain.
+describe('AiCredentials — deactivate keeps the row and can be undone (CRM-174)', () => {
+  beforeEach(() => {
+    mockRegistry([OPENAI_KEY]);
+    // Persist the toggle so the reload after it reflects the new state, the
+    // way the core does.
+    updateApiKey.mockImplementation((id: string, data: Partial<ApiKey>) => {
+      registry = registry.map(key => (key.id === id ? { ...key, ...data } : key));
+      return Promise.resolve(registry.find(key => key.id === id));
+    });
+  });
+
+  it('keeps a deactivated credential visible, marked inactive, with the activate action', async () => {
+    const user = userEvent.setup();
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.deactivate'));
+
+    await waitFor(() =>
+      expect(updateApiKey).toHaveBeenCalledWith('key-openai', expect.objectContaining({ is_active: false })),
+    );
+    // Still on screen after the reload — the row used to vanish here.
+    expect(await findAccountRow()).toBeInTheDocument();
+    expect(await screen.findByText('status.inactive')).toBeInTheDocument();
+    expect(screen.getByText('actions.activate')).toBeInTheDocument();
+    expect(screen.queryByText('empty.title')).not.toBeInTheDocument();
+  });
+
+  it('reactivates from the screen, closing the cycle', async () => {
+    const user = userEvent.setup();
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.deactivate'));
+    await user.click(await screen.findByText('actions.activate'));
+
+    await waitFor(() =>
+      expect(updateApiKey).toHaveBeenLastCalledWith('key-openai', expect.objectContaining({ is_active: true })),
+    );
+    expect(await screen.findByText('status.active')).toBeInTheDocument();
+    expect(screen.getByText('actions.deactivate')).toBeInTheDocument();
+    expect(screen.queryByText('status.inactive')).not.toBeInTheDocument();
+  });
+
+  it('asks the registry for the inactive credentials explicitly', async () => {
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    // Without this second call the default (active only) hides the row —
+    // the exact regression this block guards.
+    expect(listApiKeys).toHaveBeenCalledWith(1, 100, { active: false });
+  });
+});
+
 describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
   const findInstallationRow = () => screen.findByRole('cell', { name: 'Chave da casa' });
 
   beforeEach(() => {
-    listApiKeys.mockResolvedValue([OPENAI_KEY, INSTALLATION_KEY]);
+    mockRegistry([OPENAI_KEY, INSTALLATION_KEY]);
   });
 
   it('splits credentials into the account and installation sections', async () => {
@@ -272,8 +340,9 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
 
     await findAccountRow();
     expect(await findInstallationRow()).toBeInTheDocument();
-    // A single listing call feeds both sections.
-    expect(listApiKeys).toHaveBeenCalledTimes(1);
+    // The same listing (active + inactive) feeds both sections; scope is
+    // split on the client.
+    expect(listApiKeys).toHaveBeenCalledTimes(2);
   });
 
   it('lets an installation admin add a credential at that level', async () => {
@@ -332,7 +401,7 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
   });
 
   it('shows the empty hint when the installation has no default', async () => {
-    listApiKeys.mockResolvedValue([OPENAI_KEY]);
+    mockRegistry([OPENAI_KEY]);
     render(<AiCredentials />);
 
     await findAccountRow();
@@ -343,7 +412,7 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
 // The panel answers "which credential is in effect right now" (1.2 AC9).
 describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   it('shows the account credential winning over the installation default', async () => {
-    listApiKeys.mockResolvedValue([INSTALLATION_KEY, OPENAI_KEY]);
+    mockRegistry([INSTALLATION_KEY, OPENAI_KEY]);
     render(<AiCredentials />);
 
     await findAccountRow();
@@ -354,7 +423,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   });
 
   it('falls back to the installation default when the account has none', async () => {
-    listApiKeys.mockResolvedValue([INSTALLATION_KEY]);
+    mockRegistry([INSTALLATION_KEY]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -364,7 +433,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   });
 
   it('ignores an inactive account credential and inherits the default', async () => {
-    listApiKeys.mockResolvedValue([INSTALLATION_KEY, ANTHROPIC_KEY]);
+    mockRegistry([INSTALLATION_KEY, ANTHROPIC_KEY]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -376,7 +445,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   // resolver's legacy fallback, so AI is running while the registry is empty.
   // "No credential" told the user their working AI was off.
   it('reports the legacy fallback, not "none", when the registry is empty', async () => {
-    listApiKeys.mockResolvedValue([]);
+    mockRegistry([]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -384,7 +453,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   });
 
   it('lists the five AI features of the CRM (1.4 completes the panel)', async () => {
-    listApiKeys.mockResolvedValue([OPENAI_KEY]);
+    mockRegistry([OPENAI_KEY]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -397,7 +466,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   // OpenAI-shaped features, which fall through to the installation default.
   it('splits agents from the OpenAI-only features when providers differ', async () => {
     const anthropicActive = { ...ANTHROPIC_KEY, is_active: true };
-    listApiKeys.mockResolvedValue([INSTALLATION_KEY, anthropicActive]);
+    mockRegistry([INSTALLATION_KEY, anthropicActive]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -411,7 +480,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   // installation default while AI Agents keep the account credential.
   it('shows the assist falling back when the account credential is incompatible', async () => {
     const anthropicActive = { ...ANTHROPIC_KEY, is_active: true };
-    listApiKeys.mockResolvedValue([INSTALLATION_KEY, anthropicActive]);
+    mockRegistry([INSTALLATION_KEY, anthropicActive]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -527,7 +596,7 @@ describe('AiCredentials — base_url round trip (ALTO 7)', () => {
 
   it('renders the stored endpoint when editing a credential that has one', async () => {
     const user = userEvent.setup();
-    listApiKeys.mockResolvedValue([
+    mockRegistry([
       { ...OPENAI_KEY, provider: 'custom_openai_compatible', base_url: 'https://gw.example.com/v1' },
     ]);
     render(<AiCredentials />);
@@ -543,7 +612,7 @@ describe('AiCredentials — base_url round trip (ALTO 7)', () => {
   it('carries base_url in the update payload (negative proof of the discard)', async () => {
     const user = userEvent.setup();
     updateApiKey.mockResolvedValue(OPENAI_KEY);
-    listApiKeys.mockResolvedValue([
+    mockRegistry([
       { ...OPENAI_KEY, provider: 'custom_openai_compatible', base_url: 'https://gw.example.com/v1' },
     ]);
     render(<AiCredentials />);
@@ -564,7 +633,7 @@ describe('AiCredentials — base_url round trip (ALTO 7)', () => {
 // EVO-2250 review, MÉDIO 15 and BAIXO 19.
 describe('AiCredentials — panel honesty and full agent count', () => {
   it('says "configured before this screen" instead of "no credential" on a non-migrated install', async () => {
-    listApiKeys.mockResolvedValue([]);
+    mockRegistry([]);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner';
 import AiCredentials from './AiCredentials';
 import { maskKey } from '@/constants/aiProviders';
 import type { ApiKey } from '@/types/agents';
+import type { ListApiKeysOptions } from '@/services/agents/agentService';
 
 // EVO-2250 story 1.1: the page reads the evo_core_api_keys registry only, never
 // returns the key to the browser, and gates every action on ai_api_keys.*.
@@ -97,7 +98,7 @@ const findAccountRow = () => screen.findByRole('cell', { name: 'Producao' });
 let registry: ApiKey[] = [];
 const mockRegistry = (keys: ApiKey[]) => {
   registry = keys;
-  listApiKeys.mockImplementation((_page?: number, _pageSize?: number, options?: { active?: boolean }) =>
+  listApiKeys.mockImplementation((_page?: number, _pageSize?: number, options?: ListApiKeysOptions) =>
     Promise.resolve(registry.filter(key => key.is_active === (options?.active ?? true))),
   );
 };
@@ -318,13 +319,19 @@ describe('AiCredentials — deactivate keeps the row and can be undone (CRM-174)
     expect(screen.queryByText('status.inactive')).not.toBeInTheDocument();
   });
 
-  it('asks the registry for the inactive credentials explicitly', async () => {
+  it('keeps reporting the legacy fallback while the only credential is inactive', async () => {
+    const user = userEvent.setup();
     render(<AiCredentials />);
 
     await findAccountRow();
-    // Without this second call the default (active only) hides the row —
-    // the exact regression this block guards.
-    expect(listApiKeys).toHaveBeenCalledWith(1, 100, { active: false });
+    await user.click(screen.getByText('actions.deactivate'));
+    await screen.findByText('status.inactive');
+
+    // No active credential resolves, so the panel must not claim "none" just
+    // because an inactive row is now listed.
+    const panel = screen.getByLabelText('inUse.title');
+    expect(panel).toHaveTextContent('inUse.legacy');
+    expect(panel).not.toHaveTextContent('inUse.none');
   });
 });
 

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -319,6 +319,35 @@ describe('AiCredentials — deactivate keeps the row and can be undone (CRM-174)
     expect(screen.queryByText('status.inactive')).not.toBeInTheDocument();
   });
 
+  // The inactive listing is a second call: it must not be able to take the
+  // whole screen down with it, which a bare Promise.all rejection would.
+  it('still lists the active credentials when the inactive listing fails', async () => {
+    listApiKeys.mockImplementation((_page?: number, _pageSize?: number, options?: ListApiKeysOptions) =>
+      options?.active === false
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve([OPENAI_KEY]),
+    );
+    render(<AiCredentials />);
+
+    expect(await findAccountRow()).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  // Both calls run concurrently, so a key toggled mid-flight lands in both
+  // listings. The inactive read wins: claiming a deactivated credential is
+  // serving is the worse of the two lies.
+  it('renders a key returned by both listings as inactive', async () => {
+    listApiKeys.mockImplementation((_page?: number, _pageSize?: number, options?: ListApiKeysOptions) =>
+      Promise.resolve([{ ...OPENAI_KEY, is_active: options?.active ?? true }]),
+    );
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    expect(screen.getAllByRole('cell', { name: 'Producao' })).toHaveLength(1);
+    expect(screen.getByText('status.inactive')).toBeInTheDocument();
+    expect(screen.queryByText('status.active')).not.toBeInTheDocument();
+  });
+
   it('keeps reporting the legacy fallback while the only credential is inactive', async () => {
     const user = userEvent.setup();
     render(<AiCredentials />);

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -117,7 +117,14 @@ export default function AiCredentials() {
 
     try {
       setLoading(true);
-      setCredentials(await listApiKeys());
+      // The registry answers "active only" by default, which hid a deactivated
+      // credential and left it with no way back from the screen. Both states
+      // are listed so the row stays visible and can be re-enabled.
+      const [active, inactive] = await Promise.all([
+        listApiKeys(1, 100, { active: true }),
+        listApiKeys(1, 100, { active: false }),
+      ]);
+      setCredentials([...active, ...inactive]);
     } catch (error) {
       console.error('Error loading AI credentials:', error);
       const code = apiErrorCode(error);

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -89,8 +89,9 @@ export default function AiCredentials() {
   // from the server (a credential imported by the 1.5 task marks a migrated
   // install); with the registry empty and no such mark, the panel says
   // "legacy" instead of the flat lie "no credential" (review, MÉDIO 15).
+  // Inactive rows are listed too (CRM-174), so "empty" means no active one.
   const legacyActive = useMemo(
-    () => credentials.length === 0,
+    () => !credentials.some(credential => credential.is_active),
     [credentials],
   );
 
@@ -124,7 +125,12 @@ export default function AiCredentials() {
         listApiKeys(1, 100, { active: true }),
         listApiKeys(1, 100, { active: false }),
       ]);
-      setCredentials([...active, ...inactive]);
+      // A key toggled between the two calls could come back in both.
+      const activeIds = new Set(active.map(credential => credential.id));
+      setCredentials([
+        ...active,
+        ...inactive.filter(credential => !activeIds.has(credential.id)),
+      ]);
     } catch (error) {
       console.error('Error loading AI credentials:', error);
       const code = apiErrorCode(error);
@@ -449,7 +455,8 @@ export default function AiCredentials() {
           </div>
         ))}
 
-        {accountCredentials.length === 0 && installationCredentials.length > 0 && (
+        {!accountCredentials.some(credential => credential.is_active) &&
+          installationCredentials.some(credential => credential.is_active) && (
           <p className="text-xs text-muted-foreground">{t('inUse.inheritingHint')}</p>
         )}
       </section>

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -123,13 +123,22 @@ export default function AiCredentials() {
       // are listed so the row stays visible and can be re-enabled.
       const [active, inactive] = await Promise.all([
         listApiKeys(1, 100, { active: true }),
-        listApiKeys(1, 100, { active: false }),
+        // The inactive listing is additive: losing it must degrade to the
+        // active list, never blank the screen the way a rejected Promise.all
+        // would.
+        listApiKeys(1, 100, { active: false }).catch(error => {
+          console.error('Error loading inactive AI credentials:', error);
+          return [];
+        }),
       ]);
-      // A key toggled between the two calls could come back in both.
-      const activeIds = new Set(active.map(credential => credential.id));
+      // The two calls are concurrent, so a key toggled while they run comes
+      // back in both with no telling which read is newer. The inactive copy
+      // wins: the in-use panel keys off is_active, and under-reporting a live
+      // credential is safer than claiming a deactivated one is serving.
+      const inactiveIds = new Set(inactive.map(credential => credential.id));
       setCredentials([
-        ...active,
-        ...inactive.filter(credential => !activeIds.has(credential.id)),
+        ...active.filter(credential => !inactiveIds.has(credential.id)),
+        ...inactive,
       ]);
     } catch (error) {
       console.error('Error loading AI credentials:', error);

--- a/src/services/agents/agentService.spec.ts
+++ b/src/services/agents/agentService.spec.ts
@@ -34,7 +34,6 @@ describe('agentService.listApiKeys — active filter', () => {
     expect(mockApi.get).toHaveBeenCalledWith('/agents/apikeys', {
       params: { page: 1, pageSize: 100 },
     });
-    expect(mockApi.get.mock.calls[0][1].params).not.toHaveProperty('active');
   });
 
   it('asks for the inactive keys with active=false', async () => {

--- a/src/services/agents/agentService.spec.ts
+++ b/src/services/agents/agentService.spec.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/services/core/apiEvoAI', () => ({
+  default: {
+    get: (...args: unknown[]) => mockApi.get(...args),
+    post: (...args: unknown[]) => mockApi.post(...args),
+    put: (...args: unknown[]) => mockApi.put(...args),
+    delete: (...args: unknown[]) => mockApi.delete(...args),
+  },
+}));
+
+import { listApiKeys } from './agentService';
+
+const envelope = (data: unknown) => ({ data: { success: true, data } });
+
+// The registry lists only active keys unless `active` is sent (CRM-174): the
+// default must stay untouched for the agent pickers, and the value must reach
+// the wire as a boolean string — never empty, which the server rejects.
+describe('agentService.listApiKeys — active filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.get.mockResolvedValue(envelope([]));
+  });
+
+  it('sends no active param by default (active only, server-side)', async () => {
+    await listApiKeys();
+
+    expect(mockApi.get).toHaveBeenCalledWith('/agents/apikeys', {
+      params: { page: 1, pageSize: 100 },
+    });
+    expect(mockApi.get.mock.calls[0][1].params).not.toHaveProperty('active');
+  });
+
+  it('asks for the inactive keys with active=false', async () => {
+    await listApiKeys(1, 100, { active: false });
+
+    expect(mockApi.get).toHaveBeenCalledWith('/agents/apikeys', {
+      params: { page: 1, pageSize: 100, active: 'false' },
+    });
+  });
+
+  it('asks for the active keys explicitly with active=true', async () => {
+    await listApiKeys(2, 50, { active: true });
+
+    expect(mockApi.get).toHaveBeenCalledWith('/agents/apikeys', {
+      params: { page: 2, pageSize: 50, active: 'true' },
+    });
+  });
+
+  it('unwraps the envelope into the key list', async () => {
+    mockApi.get.mockResolvedValue(envelope([{ id: 'k1', is_active: false }]));
+
+    await expect(listApiKeys(1, 100, { active: false })).resolves.toEqual([
+      { id: 'k1', is_active: false },
+    ]);
+  });
+});

--- a/src/services/agents/agentService.spec.ts
+++ b/src/services/agents/agentService.spec.ts
@@ -20,8 +20,8 @@ import { listApiKeys } from './agentService';
 const envelope = (data: unknown) => ({ data: { success: true, data } });
 
 // The registry lists only active keys unless `active` is sent (CRM-174): the
-// default must stay untouched for the agent pickers, and the value must reach
-// the wire as a boolean string — never empty, which the server rejects.
+// default must stay untouched for the agent pickers, and an omitted option must
+// send no param at all, since the server reads an empty one as "active only".
 describe('agentService.listApiKeys — active filter', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/services/agents/agentService.ts
+++ b/src/services/agents/agentService.ts
@@ -17,6 +17,10 @@ import {
 import { processAgentData } from '@/utils/agentUtils';
 import { extractData, buildPaginationParams, extractResponse } from '@/utils/apiHelpers';
 
+export interface ListApiKeysOptions {
+  active?: boolean;
+}
+
 class AgentsService {
   // AI Agents
   async createAgent(data: AgentCreate): Promise<Agent> {
@@ -130,7 +134,7 @@ class AgentsService {
   async listApiKeys(
     page = 1,
     pageSize = 100,
-    options?: { active?: boolean },
+    options?: ListApiKeysOptions,
   ): Promise<ApiKey[]> {
     const params: Record<string, unknown> = buildPaginationParams(page, pageSize);
     if (options?.active !== undefined) {
@@ -196,7 +200,7 @@ export const updateFolder = (folderId: string, data: FolderUpdate) => agentsServ
 export const deleteFolder = (folderId: string) => agentsService.deleteFolder(folderId);
 
 export const createApiKey = (data: ApiKeyCreate) => agentsService.createApiKey(data);
-export const listApiKeys = (page?: number, pageSize?: number, options?: { active?: boolean }) =>
+export const listApiKeys = (page?: number, pageSize?: number, options?: ListApiKeysOptions) =>
   agentsService.listApiKeys(page, pageSize, options);
 export const updateApiKey = (keyId: string, data: ApiKeyUpdate) => agentsService.updateApiKey(keyId, data);
 export const deleteApiKey = (keyId: string) => agentsService.deleteApiKey(keyId);

--- a/src/services/agents/agentService.ts
+++ b/src/services/agents/agentService.ts
@@ -124,10 +124,19 @@ class AgentsService {
     return extractData<ApiKey>(response);
   }
 
-  async listApiKeys(page = 1, pageSize = 100): Promise<ApiKey[]> {
-    const response = await evoaiApi.get('/agents/apikeys', {
-      params: buildPaginationParams(page, pageSize),
-    });
+  // The core lists only active keys unless `active` is sent explicitly, so
+  // callers picking a credential for an agent keep the default and the
+  // settings screen asks for the inactive ones as well.
+  async listApiKeys(
+    page = 1,
+    pageSize = 100,
+    options?: { active?: boolean },
+  ): Promise<ApiKey[]> {
+    const params: Record<string, unknown> = buildPaginationParams(page, pageSize);
+    if (options?.active !== undefined) {
+      params.active = String(options.active);
+    }
+    const response = await evoaiApi.get('/agents/apikeys', { params });
     return extractData<ApiKey[]>(response);
   }
 
@@ -187,7 +196,8 @@ export const updateFolder = (folderId: string, data: FolderUpdate) => agentsServ
 export const deleteFolder = (folderId: string) => agentsService.deleteFolder(folderId);
 
 export const createApiKey = (data: ApiKeyCreate) => agentsService.createApiKey(data);
-export const listApiKeys = (page?: number, pageSize?: number) => agentsService.listApiKeys(page, pageSize);
+export const listApiKeys = (page?: number, pageSize?: number, options?: { active?: boolean }) =>
+  agentsService.listApiKeys(page, pageSize, options);
 export const updateApiKey = (keyId: string, data: ApiKeyUpdate) => agentsService.updateApiKey(keyId, data);
 export const deleteApiKey = (keyId: string) => agentsService.deleteApiKey(keyId);
 


### PR DESCRIPTION
## Summary
- Em `/settings/ai-credentials`, desativar uma credencial a fazia sumir da lista e o botão "Ativar" nunca ficava alcançável — só dava para reverter por API. O core (`GET /agents/apikeys`) lista apenas `is_active=true` quando o parâmetro `active` não vem, e a tela nunca pedia as inativas.
- `agentService.listApiKeys(page, pageSize, { active })` ganha o filtro (enviado como `'true'`/`'false'`, nunca vazio). O default continua "só ativas" — os seletores de credencial do agente (`AgentPage`, `AgentEditPage`, `AgentWizardModal`) não mudam.
- A tela busca ativas + inativas e concatena (dedupe por `id`): a linha inativa fica visível com o badge "Inativa" e a ação "Ativar", que já existiam. Sem toggle novo, sem chave i18n nova.
- Painel "em uso" e dica de herança passam a considerar só credenciais **ativas** — sem isso, uma conta cuja única credencial está inativa diria "nenhuma credencial" em vez de reportar o fallback legado.

## Security
- Só uso de query param já suportado pelo core; mesmo serializer para ativas e inativas (`key_hint`, nunca a chave). Gates da tela (`ai_api_keys.*` / `installation_configs.manage`) inalterados e iguais para linhas inativas.

## Test plan
- `npx vitest run src/pages/Customer/Settings/AiCredentials src/services/agents` → 44/44 (+3 no ciclo desativar → continua visível → reativar; +1 painel legado com única credencial inativa; 4 no service: default sem `active`, `'true'`/`'false'`, unwrap)
- `npx vitest run src/i18n/locales/i18n-parity.spec.ts` → 178/178 (nenhuma chave nova)
- `npx tsc -b --noEmit` · `npx eslint` nos arquivos tocados · `npx vite build` ✓
- Manual: conta com credenciais desativadas → aparecem como Inativa; Ativar → Ativa; Desativar → continua na lista; seletor de credencial do agente segue só com ativas.

## Changed Files
- `src/services/agents/agentService.ts` · `src/services/agents/agentService.spec.ts` (novo)
- `src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx` · `AiCredentials.spec.tsx`

## Fora do escopo
- Ordem das linhas (o core não ordena a listagem) e o teto de 100 por estado sem "carregar mais" — pré-existentes.

## Linked Issue
- CRM-174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure AI credential settings list and status handling include inactive keys while preserving existing agent picker behavior.

Bug Fixes:
- Keep deactivated AI credentials visible in the settings list with proper inactive status and allow reactivation from the UI.
- Make the in-use panel and inheritance hint consider only active credentials, correctly reporting legacy fallbacks when all are inactive.

Enhancements:
- Extend the agent API key listing service to support an explicit active filter while keeping the default behavior unchanged.
- Adjust AI credentials loading to fetch active and inactive keys and deduplicate them client-side.

Tests:
- Add unit tests for the agentService API key listing filter semantics and response unwrapping.
- Expand AI credentials page tests to cover deactivate/reactivate flows, active vs inactive behavior, and updated in-use panel logic.