### PR TITLE
feat(rbac): group pipeline_items under Pipelines in the role editor (CRM-178)

### DIFF
--- a/src/config/permissionDomains.ts
+++ b/src/config/permissionDomains.ts
@@ -24,7 +24,7 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
   {
     key: 'crm',
     labelKey: 'domains.crm',
-    resources: ['pipelines', 'pipeline_stages', 'products', 'crm_forms'], // pipeline_stages nested under pipelines (AC6)
+    resources: ['pipelines', 'pipeline_stages', 'pipeline_items', 'products', 'crm_forms'], // pipeline_stages + pipeline_items nested under pipelines (AC6, CRM-178)
   },
   {
     key: 'automation',
@@ -64,6 +64,7 @@ export const PERMISSION_DOMAINS: PermissionDomain[] = [
 // (AC6), never as their own card and never under "Others".
 export const RESOURCE_NESTING: Record<string, string> = {
   pipeline_stages: 'pipelines',
+  pipeline_items: 'pipelines',
   working_hours: 'inboxes',
 };
 

--- a/src/i18n/locales/en/roles.json
+++ b/src/i18n/locales/en/roles.json
@@ -57,6 +57,7 @@
     "filterPlaceholder": "Search permissions...",
     "nested": {
       "pipelineStages": "Stages",
+      "pipelineItems": "Cards",
       "workingHours": "Working hours"
     },
     "lock": {

--- a/src/i18n/locales/es/roles.json
+++ b/src/i18n/locales/es/roles.json
@@ -57,6 +57,7 @@
     "filterPlaceholder": "Buscar permisos...",
     "nested": {
       "pipelineStages": "Etapas",
+      "pipelineItems": "Tarjetas",
       "workingHours": "Horario de atención"
     },
     "lock": {

--- a/src/i18n/locales/fr/roles.json
+++ b/src/i18n/locales/fr/roles.json
@@ -57,6 +57,7 @@
     "filterPlaceholder": "Rechercher des permissions...",
     "nested": {
       "pipelineStages": "Étapes",
+      "pipelineItems": "Cartes",
       "workingHours": "Heures d'ouverture"
     },
     "lock": {

--- a/src/i18n/locales/it/roles.json
+++ b/src/i18n/locales/it/roles.json
@@ -57,6 +57,7 @@
     "filterPlaceholder": "Cerca permessi...",
     "nested": {
       "pipelineStages": "Fasi",
+      "pipelineItems": "Schede",
       "workingHours": "Orari di lavoro"
     },
     "lock": {

--- a/src/i18n/locales/pt-BR/roles.json
+++ b/src/i18n/locales/pt-BR/roles.json
@@ -57,6 +57,7 @@
     "filterPlaceholder": "Buscar permissões...",
     "nested": {
       "pipelineStages": "Etapas",
+      "pipelineItems": "Cards",
       "workingHours": "Horário de atendimento"
     },
     "lock": {

--- a/src/i18n/locales/pt/roles.json
+++ b/src/i18n/locales/pt/roles.json
@@ -57,6 +57,7 @@
     "filterPlaceholder": "Procurar permissões...",
     "nested": {
       "pipelineStages": "Etapas",
+      "pipelineItems": "Cards",
       "workingHours": "Horário de funcionamento"
     },
     "lock": {

--- a/src/pages/Admin/Roles/RoleDetail.spec.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.spec.tsx
@@ -91,7 +91,7 @@ vi.mock('@/services/permissions', () => ({
               stats: { name: 'Statistics', description: '', basic: false, implied_by: null },
             },
           },
-          // CRM domain, with a nested child (pipeline_stages under pipelines).
+          // CRM domain, with nested children (pipeline_stages, pipeline_items) under pipelines.
           pipelines: {
             name: 'Pipelines',
             description: '',
@@ -105,6 +105,14 @@ vi.mock('@/services/permissions', () => ({
             actions: {
               read: { name: 'View', description: '', basic: false, implied_by: null },
               create: { name: 'Create', description: '', basic: false, implied_by: null },
+            },
+          },
+          // CRM-178: card writes, write-only (reads stay on pipelines.read).
+          pipeline_items: {
+            name: 'Pipeline Cards',
+            description: '',
+            actions: {
+              update: { name: 'Manage cards', description: '', basic: false, implied_by: null },
             },
           },
           // Channels domain: nested child (working_hours) + an inbox template action.
@@ -482,9 +490,11 @@ describe('RoleDetail — bulk select', () => {
 
     const savedKeys = bulkUpdateMock.mock.calls[0][1] as string[];
     expect(savedKeys).toContain('pipelines.read');
-    // pipeline_stages renders inside the pipelines row but is its own resource.
+    // pipeline_stages/pipeline_items render inside the pipelines row but are their
+    // own resources.
     expect(savedKeys).toContain('pipeline_stages.read');
     expect(savedKeys).toContain('pipeline_stages.create');
+    expect(savedKeys).toContain('pipeline_items.update');
     // Another section is untouched.
     expect(savedKeys).not.toContain('conversations.read');
   });
@@ -645,5 +655,17 @@ describe('RoleDetail — domain grouping, system filter, search, nesting', () =>
 
     expect(screen.getByText('detail.nested.pipelineStages')).toBeTruthy();
     expect(screen.getByText('detail.nested.workingHours')).toBeTruthy();
+  });
+
+  // CRM-178: pipeline_items joined RESOURCE_NESTING. Without a matching
+  // NESTED_LABEL_KEYS entry the row renders t(undefined) — checkboxes with no name.
+  it('nests pipeline_items under Pipelines WITH a label (CRM-178, AC6)', async () => {
+    render(<RoleDetail />);
+    await waitFor(() => expect(cb('group-pipelines-read')).not.toBeNull());
+
+    expect(cb('group-pipeline_items-write')).not.toBeNull();
+    expect(cb('resource-pipeline_items')).toBeNull();
+
+    expect(screen.getByText('detail.nested.pipelineItems')).toBeTruthy();
   });
 });

--- a/src/pages/Admin/Roles/RoleDetail.tsx
+++ b/src/pages/Admin/Roles/RoleDetail.tsx
@@ -34,8 +34,11 @@ import {
 } from '@/config/permissionDomains';
 
 // Nested resource -> i18n key for its sub-label inside the parent card (AC6).
+// Every key in RESOURCE_NESTING needs an entry here: the nested row renders its label
+// through this map, so a missing one is t(undefined) — an unnamed row of checkboxes.
 const NESTED_LABEL_KEYS: Record<string, string> = {
   pipeline_stages: 'detail.nested.pipelineStages',
+  pipeline_items: 'detail.nested.pipelineItems',
   working_hours: 'detail.nested.workingHours',
 };
 


### PR DESCRIPTION
## CRM-178 (lado front) — agrupa `pipeline_items` em Pipelines

O novo resource `pipeline_items` (catálogo do evo-auth) cairia no balde "Others" do editor de papéis. Adiciona ele ao domínio `crm` e o aninha sob `pipelines` (como `pipeline_stages`), então "Pipeline Cards" renderiza dentro do card de Pipelines.

Achado 🟢 LOW da review do Guilherme (escopo do CRM-178). Sem teste acoplado a `PERMISSION_DOMAINS`/`RESOURCE_NESTING`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Group pipeline item permissions under Pipelines in the role editor.

New Features:
- Group the `pipeline_items` resource under Pipelines in the role editor and display it as Pipeline Cards.

Enhancements:
- Keep pipeline card permissions within the CRM domain and provide a localized nested label for the resource.

Tests:
- Add role editor coverage for nested pipeline item rendering and bulk permission selection.