### PR TITLE
fix(ai-credentials): painel Em uso usa o sinal do servidor para o fallback legado (CRM-187)

### DIFF
--- a/src/constants/aiProviders.ts
+++ b/src/constants/aiProviders.ts
@@ -108,9 +108,12 @@ function byCreatedAtAsc(a: ResolvableCredential, b: ResolvableCredential): numbe
 
 /** Resolves what the panel should render for a feature.
  *
- * `legacyActive` comes from the server (the migration guard), never from a
- * guess: only the backend can tell "the registry is empty AND the legacy
- * fallback is serving" apart from "nothing is configured".
+ * `legacyActive` is the server's answer (the migration guard): only the backend
+ * can tell "the registry is empty AND the legacy fallback is serving" apart
+ * from "nothing is configured". It is consulted only when nothing resolves from
+ * the registry, so a caller that does not have the answer yet should withhold
+ * that branch rather than pass a guess — the pre-existing heuristic is a
+ * documented last resort for a CRM that does not serve the signal at all.
  */
 export function resolveCredentialState<T extends ResolvableCredential>(
   credentials: T[],

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -43,10 +43,20 @@ vi.mock('@/services/agents', () => ({
   getAiCredentialMigrationState: (...args: unknown[]) => getAiCredentialMigrationState(...args),
 }));
 
+type MigrationState = { migrated: boolean; legacy_fallback_active: boolean };
+
 // The server's word on the legacy fallback (Ai::MigrationState). Tests that
 // need the fallback alive say so explicitly; the default is a migrated install.
 const serverSaysLegacy = (active: boolean) =>
   getAiCredentialMigrationState.mockResolvedValue({ migrated: !active, legacy_fallback_active: active });
+
+// Persists the toggle so the reload after it reflects the new state, the way
+// the core does.
+const mockToggleWritesThrough = () =>
+  updateApiKey.mockImplementation((id: string, data: Partial<ApiKey>) => {
+    registry = registry.map(key => (key.id === id ? { ...key, ...data } : key));
+    return Promise.resolve(registry.find(key => key.id === id));
+  });
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -744,17 +754,89 @@ describe('AiCredentials — panel honesty and full agent count', () => {
   // "legacy" that flips to "none" a moment later is the very lie this fixes.
   it('shows no verdict while the migration state is still loading', async () => {
     mockRegistry([]);
-    let answer: (state: { migrated: boolean; legacy_fallback_active: boolean }) => void = () => {};
+    let answer: (state: MigrationState) => void = () => {};
     getAiCredentialMigrationState.mockReturnValue(new Promise(resolve => { answer = resolve; }));
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
-    await waitFor(() => expect(listApiKeys).toHaveBeenCalled());
+    // The empty state proves the list already settled, so the signal is the
+    // only thing still missing — otherwise `loading` alone would satisfy this.
+    await screen.findByText('empty.title');
     expect(panel).not.toHaveTextContent('inUse.legacy');
     expect(panel).not.toHaveTextContent('inUse.none');
 
     answer({ migrated: true, legacy_fallback_active: false });
     await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+  });
+
+  // The signal decides "legacy" vs "none" and nothing else: a credential that
+  // resolves from the registry is settled by the list alone, so waiting on the
+  // CRM would hide a name the screen already knows.
+  it('shows the resolved credential without waiting for the migration state', async () => {
+    mockRegistry([OPENAI_KEY]);
+    getAiCredentialMigrationState.mockReturnValue(new Promise(() => {}));
+    render(<AiCredentials />);
+
+    await findAccountRow();
+
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Producao'));
+  });
+
+  // A refresh re-asks the server, and the previous answer describes the
+  // previous registry: rendering it against the new list is the same flip this
+  // story removed from the first load.
+  it('withholds the verdict while a refreshed signal is in flight', async () => {
+    const user = userEvent.setup();
+    mockRegistry([OPENAI_KEY]);
+    let answerSecond: (state: MigrationState) => void = () => {};
+    getAiCredentialMigrationState
+      .mockResolvedValueOnce({ migrated: true, legacy_fallback_active: false })
+      .mockReturnValueOnce(new Promise(resolve => { answerSecond = resolve; }));
+    mockToggleWritesThrough();
+
+    render(<AiCredentials />);
+    await findAccountRow();
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('Producao'));
+
+    await user.click(screen.getByText('actions.deactivate'));
+    await screen.findByText('status.inactive');
+
+    // The list came back deactivated; the refreshed signal has not. Neither
+    // verdict may show — least of all the one from before the toggle.
+    expect(panel).not.toHaveTextContent('inUse.none');
+    expect(panel).not.toHaveTextContent('inUse.legacy');
+
+    answerSecond({ migrated: false, legacy_fallback_active: true });
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
+  });
+
+  it('ignores a stale migration state answer that lands after a newer one', async () => {
+    const user = userEvent.setup();
+    mockRegistry([OPENAI_KEY]);
+    let answerFirst: (state: MigrationState) => void = () => {};
+    let answerSecond: (state: MigrationState) => void = () => {};
+    getAiCredentialMigrationState
+      .mockReturnValueOnce(new Promise(resolve => { answerFirst = resolve; }))
+      .mockReturnValueOnce(new Promise(resolve => { answerSecond = resolve; }));
+    mockToggleWritesThrough();
+
+    render(<AiCredentials />);
+    await findAccountRow();
+    await user.click(screen.getByText('actions.deactivate'));
+    await screen.findByText('status.inactive');
+    expect(getAiCredentialMigrationState).toHaveBeenCalledTimes(2);
+
+    answerSecond({ migrated: true, legacy_fallback_active: false });
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+
+    // The first request finally answers, describing the registry before the
+    // toggle. It must not overwrite the newer verdict.
+    answerFirst({ migrated: false, legacy_fallback_active: true });
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+    expect(panel).not.toHaveTextContent('inUse.legacy');
   });
 
   it('asks the server for the migration state on load', async () => {

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -719,13 +719,42 @@ describe('AiCredentials — panel honesty and full agent count', () => {
   // the pre-existing heuristic instead of trading one lie for another, and the
   // credential list itself is unaffected.
   it('falls back to the heuristic and still lists the credentials when the signal fails', async () => {
-    mockRegistry([]);
+    mockRegistry([ANTHROPIC_KEY]);
     getAiCredentialMigrationState.mockRejectedValue(new Error('404'));
+    render(<AiCredentials />);
+
+    // The list still renders — the inactive row, from the second listing call.
+    expect(await screen.findByRole('cell', { name: 'Testes' })).toBeInTheDocument();
+    const panel = screen.getByLabelText('inUse.title');
+    // Heuristic: no active credential → legacy, as before this change.
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('treats a malformed answer as unknown and keeps the heuristic', async () => {
+    mockRegistry([]);
+    getAiCredentialMigrationState.mockResolvedValue({ legacy_fallback_active: 'yes' });
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
     await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
-    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  // Before the server answers, the panel must show neither verdict: a guessed
+  // "legacy" that flips to "none" a moment later is the very lie this fixes.
+  it('shows no verdict while the migration state is still loading', async () => {
+    mockRegistry([]);
+    let answer: (state: { migrated: boolean; legacy_fallback_active: boolean }) => void = () => {};
+    getAiCredentialMigrationState.mockReturnValue(new Promise(resolve => { answer = resolve; }));
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(listApiKeys).toHaveBeenCalled());
+    expect(panel).not.toHaveTextContent('inUse.legacy');
+    expect(panel).not.toHaveTextContent('inUse.none');
+
+    answer({ migrated: true, legacy_fallback_active: false });
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
   });
 
   it('asks the server for the migration state on load', async () => {

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -32,6 +32,7 @@ const createApiKey = vi.fn();
 const updateApiKey = vi.fn();
 const deleteApiKey = vi.fn();
 const listAgents = vi.fn();
+const getAiCredentialMigrationState = vi.fn();
 
 vi.mock('@/services/agents', () => ({
   listApiKeys: (...args: unknown[]) => listApiKeys(...args),
@@ -39,7 +40,13 @@ vi.mock('@/services/agents', () => ({
   updateApiKey: (...args: unknown[]) => updateApiKey(...args),
   deleteApiKey: (...args: unknown[]) => deleteApiKey(...args),
   listAgents: (...args: unknown[]) => listAgents(...args),
+  getAiCredentialMigrationState: (...args: unknown[]) => getAiCredentialMigrationState(...args),
 }));
+
+// The server's word on the legacy fallback (Ai::MigrationState). Tests that
+// need the fallback alive say so explicitly; the default is a migrated install.
+const serverSaysLegacy = (active: boolean) =>
+  getAiCredentialMigrationState.mockResolvedValue({ migrated: !active, legacy_fallback_active: active });
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -116,6 +123,7 @@ beforeEach(() => {
   granted = [...ALL_PERMISSIONS];
   mockRegistry([OPENAI_KEY, ANTHROPIC_KEY]);
   listAgents.mockResolvedValue({ data: [] });
+  serverSaysLegacy(false);
 });
 
 describe('AiCredentials — listing (AC1, AC7)', () => {
@@ -348,16 +356,32 @@ describe('AiCredentials — deactivate keeps the row and can be undone (CRM-174)
     expect(screen.queryByText('status.active')).not.toBeInTheDocument();
   });
 
-  it('keeps reporting the legacy fallback while the only credential is inactive', async () => {
+
+  // The panel used to guess "legacy" from "no active credential". On a migrated
+  // install that reads as "AI still runs" while it is simply off (CRM-187).
+  it('says "none", not "legacy", when the only credential is deactivated on a migrated install', async () => {
     const user = userEvent.setup();
+    serverSaysLegacy(false);
     render(<AiCredentials />);
 
     await findAccountRow();
     await user.click(screen.getByText('actions.deactivate'));
     await screen.findByText('status.inactive');
 
-    // No active credential resolves, so the panel must not claim "none" just
-    // because an inactive row is now listed.
+    const panel = screen.getByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+    expect(panel).not.toHaveTextContent('inUse.legacy');
+  });
+
+  it('keeps saying "legacy" while the server reports the fallback alive', async () => {
+    const user = userEvent.setup();
+    serverSaysLegacy(true);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.deactivate'));
+    await screen.findByText('status.inactive');
+
     const panel = screen.getByLabelText('inUse.title');
     expect(panel).toHaveTextContent('inUse.legacy');
     expect(panel).not.toHaveTextContent('inUse.none');
@@ -480,8 +504,9 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
   // MÉDIO 15 names: an installation that has not migrated resolves through the
   // resolver's legacy fallback, so AI is running while the registry is empty.
   // "No credential" told the user their working AI was off.
-  it('reports the legacy fallback, not "none", when the registry is empty', async () => {
+  it('reports the legacy fallback, not "none", when the registry is empty on a non-migrated install', async () => {
     mockRegistry([]);
+    serverSaysLegacy(true);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -670,6 +695,7 @@ describe('AiCredentials — base_url round trip (ALTO 7)', () => {
 describe('AiCredentials — panel honesty and full agent count', () => {
   it('says "configured before this screen" instead of "no credential" on a non-migrated install', async () => {
     mockRegistry([]);
+    serverSaysLegacy(true);
     render(<AiCredentials />);
 
     const panel = await screen.findByLabelText('inUse.title');
@@ -677,6 +703,36 @@ describe('AiCredentials — panel honesty and full agent count', () => {
     // claiming "no credential" told the user their working AI was off.
     await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
     expect(panel).not.toHaveTextContent('inUse.none');
+  });
+
+  it('says "none" on an empty registry once the server reports the install migrated', async () => {
+    mockRegistry([]);
+    serverSaysLegacy(false);
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.none'));
+    expect(panel).not.toHaveTextContent('inUse.legacy');
+  });
+
+  // An older CRM without the endpoint, or a transient failure: the panel keeps
+  // the pre-existing heuristic instead of trading one lie for another, and the
+  // credential list itself is unaffected.
+  it('falls back to the heuristic and still lists the credentials when the signal fails', async () => {
+    mockRegistry([]);
+    getAiCredentialMigrationState.mockRejectedValue(new Error('404'));
+    render(<AiCredentials />);
+
+    const panel = await screen.findByLabelText('inUse.title');
+    await waitFor(() => expect(panel).toHaveTextContent('inUse.legacy'));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('asks the server for the migration state on load', async () => {
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    expect(getAiCredentialMigrationState).toHaveBeenCalledTimes(1);
   });
 
   it('counts agents beyond the first page before confirming a delete', async () => {

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -28,7 +28,14 @@ import {
   maskKey,
   resolveCredentialState,
 } from '@/constants/aiProviders';
-import { createApiKey, deleteApiKey, listApiKeys, listAgents, updateApiKey } from '@/services/agents';
+import {
+  createApiKey,
+  deleteApiKey,
+  getAiCredentialMigrationState,
+  listApiKeys,
+  listAgents,
+  updateApiKey,
+} from '@/services/agents';
 import { apiErrorCode } from '@/utils/apiHelpers';
 import type { ApiKey, ApiKeyCreate, ApiKeyScope, ApiKeyUpdate } from '@/types/agents';
 
@@ -54,6 +61,9 @@ export default function AiCredentials() {
   const { can, isReady: permissionsReady } = usePermissions();
 
   const [credentials, setCredentials] = useState<ApiKey[]>([]);
+  // null until the server answered (or failed): the panel must not claim
+  // "legacy" from a guess while the request is in flight.
+  const [legacyFallbackActive, setLegacyFallbackActive] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [formOpen, setFormOpen] = useState(false);
@@ -85,14 +95,16 @@ export default function AiCredentials() {
   // reach any provider; the other four build OpenAI-shaped requests, so they
   // resolve with the same compatibility filter the backend applies.
   // An installation that has not migrated resolves through the resolver's
-  // legacy fallback, so AI works while the registry is empty. The signal comes
-  // from the server (a credential imported by the 1.5 task marks a migrated
-  // install); with the registry empty and no such mark, the panel says
-  // "legacy" instead of the flat lie "no credential" (review, MÉDIO 15).
-  // Inactive rows are listed too (CRM-174), so "empty" means no active one.
+  // legacy fallback, so AI works while the registry is empty. Only the server
+  // (Ai::MigrationState) can tell that apart from "migrated and off": a
+  // migrated install with its last credential deactivated used to read
+  // "configured before this screen" while AI was simply disabled (CRM-187).
+  // While the signal is unknown (request pending or an older CRM without the
+  // endpoint) the pre-existing heuristic — no active credential — stands in,
+  // so a deploy window swaps no lie for another.
   const legacyActive = useMemo(
-    () => !credentials.some(credential => credential.is_active),
-    [credentials],
+    () => legacyFallbackActive ?? !credentials.some(credential => credential.is_active),
+    [legacyFallbackActive, credentials],
   );
 
   const featuresInUse = useMemo(() => {
@@ -115,6 +127,18 @@ export default function AiCredentials() {
       toast.error(t('messages.permissionDenied.read'));
       return;
     }
+
+    // Advisory: a failure here must not block the list, it only leaves the
+    // panel on the heuristic.
+    getAiCredentialMigrationState()
+      .then(state => {
+        const active = state?.legacy_fallback_active;
+        setLegacyFallbackActive(typeof active === 'boolean' ? active : null);
+      })
+      .catch(error => {
+        console.error('Error loading AI credential migration state:', error);
+        setLegacyFallbackActive(null);
+      });
 
     try {
       setLoading(true);

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { toast } from 'sonner';
@@ -61,9 +61,12 @@ export default function AiCredentials() {
   const { can, isReady: permissionsReady } = usePermissions();
 
   const [credentials, setCredentials] = useState<ApiKey[]>([]);
-  // null until the server answered (or failed): the panel must not claim
+  // The server's word on the legacy fallback: 'pending' until the first answer
+  // (or failure) lands, then a boolean, or null when it stays unknown (older
+  // CRM without the endpoint, transient failure). The panel must not claim
   // "legacy" from a guess while the request is in flight.
-  const [legacyFallbackActive, setLegacyFallbackActive] = useState<boolean | null>(null);
+  const [legacyFallbackActive, setLegacyFallbackActive] = useState<boolean | null | 'pending'>('pending');
+  const migrationStateRequest = useRef(0);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [formOpen, setFormOpen] = useState(false);
@@ -99,13 +102,17 @@ export default function AiCredentials() {
   // (Ai::MigrationState) can tell that apart from "migrated and off": a
   // migrated install with its last credential deactivated used to read
   // "configured before this screen" while AI was simply disabled (CRM-187).
-  // While the signal is unknown (request pending or an older CRM without the
-  // endpoint) the pre-existing heuristic — no active credential — stands in,
+  // While the signal stays unknown (an older CRM without the endpoint, a
+  // failure) the pre-existing heuristic — no active credential — stands in,
   // so a deploy window swaps no lie for another.
   const legacyActive = useMemo(
-    () => legacyFallbackActive ?? !credentials.some(credential => credential.is_active),
+    () =>
+      typeof legacyFallbackActive === 'boolean'
+        ? legacyFallbackActive
+        : !credentials.some(credential => credential.is_active),
     [legacyFallbackActive, credentials],
   );
+  const inUsePending = loading || legacyFallbackActive === 'pending';
 
   const featuresInUse = useMemo(() => {
     const openAIOnly = resolveCredentialState(credentials, {
@@ -129,13 +136,17 @@ export default function AiCredentials() {
     }
 
     // Advisory: a failure here must not block the list, it only leaves the
-    // panel on the heuristic.
+    // panel on the heuristic. Refreshed with the list because deleting the last
+    // imported credential can flip it. Last response wins.
+    const request = ++migrationStateRequest.current;
     getAiCredentialMigrationState()
       .then(state => {
+        if (request !== migrationStateRequest.current) return;
         const active = state?.legacy_fallback_active;
         setLegacyFallbackActive(typeof active === 'boolean' ? active : null);
       })
       .catch(error => {
+        if (request !== migrationStateRequest.current) return;
         console.error('Error loading AI credential migration state:', error);
         setLegacyFallbackActive(null);
       });
@@ -471,7 +482,9 @@ export default function AiCredentials() {
         {featuresInUse.map(feature => (
           <div key={feature.key} className="flex items-baseline gap-2 text-sm">
             <span className="text-muted-foreground">{t(`inUse.features.${feature.key}`)}</span>
-            {feature.resolution.state === 'registry' ? (
+            {inUsePending ? (
+              <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-hidden="true" />
+            ) : feature.resolution.state === 'registry' ? (
               <>
                 <span className="font-medium">{feature.resolution.credential.name}</span>
                 <span className="text-xs text-muted-foreground">

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -61,10 +61,11 @@ export default function AiCredentials() {
   const { can, isReady: permissionsReady } = usePermissions();
 
   const [credentials, setCredentials] = useState<ApiKey[]>([]);
-  // The server's word on the legacy fallback: 'pending' until the first answer
-  // (or failure) lands, then a boolean, or null when it stays unknown (older
-  // CRM without the endpoint, transient failure). The panel must not claim
-  // "legacy" from a guess while the request is in flight.
+  // The server's word on the legacy fallback: 'pending' while a request is in
+  // flight, then a boolean, or null when it stays unknown (older CRM without
+  // the endpoint, transient failure). It goes back to 'pending' on every
+  // refresh: an answer about the previous registry must not be rendered
+  // against the new one.
   const [legacyFallbackActive, setLegacyFallbackActive] = useState<boolean | null | 'pending'>('pending');
   const migrationStateRequest = useRef(0);
   const [loading, setLoading] = useState(false);
@@ -112,7 +113,12 @@ export default function AiCredentials() {
         : !credentials.some(credential => credential.is_active),
     [legacyFallbackActive, credentials],
   );
-  const inUsePending = loading || legacyFallbackActive === 'pending';
+  // Each half of the verdict waits only for what it depends on. A credential
+  // resolved from the registry follows the list alone, so a slow signal must
+  // not hide a name the screen already knows; "legacy" vs "none" is the only
+  // branch the signal decides, and that one waits.
+  const listPending = loading;
+  const signalPending = legacyFallbackActive === 'pending';
 
   const featuresInUse = useMemo(() => {
     const openAIOnly = resolveCredentialState(credentials, {
@@ -131,14 +137,20 @@ export default function AiCredentials() {
 
   const loadCredentials = useCallback(async () => {
     if (!canRead) {
+      // Never reached through the route (PermissionRoute gates on
+      // ai_api_keys.read), but leaving the signal 'pending' here would spin
+      // forever instead of degrading.
+      setLegacyFallbackActive(null);
       toast.error(t('messages.permissionDenied.read'));
       return;
     }
 
     // Advisory: a failure here must not block the list, it only leaves the
     // panel on the heuristic. Refreshed with the list because deleting the last
-    // imported credential can flip it. Last response wins.
+    // imported credential can flip it, and reset to 'pending' first so the
+    // previous answer is not rendered against the new list. Last response wins.
     const request = ++migrationStateRequest.current;
+    setLegacyFallbackActive('pending');
     getAiCredentialMigrationState()
       .then(state => {
         if (request !== migrationStateRequest.current) return;
@@ -147,7 +159,10 @@ export default function AiCredentials() {
       })
       .catch(error => {
         if (request !== migrationStateRequest.current) return;
-        console.error('Error loading AI credential migration state:', error);
+        // Expected while a CRM without the endpoint is still deployed: the
+        // panel falls back to the heuristic, so this is a degradation notice,
+        // not a failure.
+        console.warn('AI credential migration state unavailable, using the heuristic:', error);
         setLegacyFallbackActive(null);
       });
 
@@ -482,7 +497,7 @@ export default function AiCredentials() {
         {featuresInUse.map(feature => (
           <div key={feature.key} className="flex items-baseline gap-2 text-sm">
             <span className="text-muted-foreground">{t(`inUse.features.${feature.key}`)}</span>
-            {inUsePending ? (
+            {listPending || (signalPending && feature.resolution.state !== 'registry') ? (
               <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-hidden="true" />
             ) : feature.resolution.state === 'registry' ? (
               <>

--- a/src/services/agents/aiCredentialMigrationService.spec.ts
+++ b/src/services/agents/aiCredentialMigrationService.spec.ts
@@ -20,7 +20,7 @@ describe('getAiCredentialMigrationState', () => {
       migrated: false,
       legacy_fallback_active: true,
     });
-    expect(mockApi.get).toHaveBeenCalledWith('/ai/credentials/migration_state');
+    expect(mockApi.get).toHaveBeenCalledWith('/ai_credentials/migration_state');
   });
 
   it('propagates a failure so the caller decides how to degrade', async () => {

--- a/src/services/agents/aiCredentialMigrationService.spec.ts
+++ b/src/services/agents/aiCredentialMigrationService.spec.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The CRM Ruby client (:3000), not the core: Ai::MigrationState lives in Rails.
+const mockApi = { get: vi.fn() };
+vi.mock('@/services/core/api', () => ({
+  default: { get: (...args: unknown[]) => mockApi.get(...args) },
+}));
+
+import { getAiCredentialMigrationState } from './aiCredentialMigrationService';
+
+describe('getAiCredentialMigrationState', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the two booleans out of the CRM envelope', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { success: true, data: { migrated: false, legacy_fallback_active: true } },
+    });
+
+    await expect(getAiCredentialMigrationState()).resolves.toEqual({
+      migrated: false,
+      legacy_fallback_active: true,
+    });
+    expect(mockApi.get).toHaveBeenCalledWith('/ai/credentials/migration_state');
+  });
+
+  it('propagates a failure so the caller decides how to degrade', async () => {
+    mockApi.get.mockRejectedValue(new Error('404'));
+
+    await expect(getAiCredentialMigrationState()).rejects.toThrow('404');
+  });
+});

--- a/src/services/agents/aiCredentialMigrationService.ts
+++ b/src/services/agents/aiCredentialMigrationService.ts
@@ -1,4 +1,5 @@
 import api from '@/services/core/api';
+import { extractData } from '@/utils/apiHelpers';
 
 /**
  * Whether the CRM still resolves AI credentials through the legacy sources
@@ -14,5 +15,5 @@ export interface AiCredentialMigrationState {
 
 export async function getAiCredentialMigrationState(): Promise<AiCredentialMigrationState> {
   const response = await api.get('/ai/credentials/migration_state');
-  return response.data?.data as AiCredentialMigrationState;
+  return extractData<AiCredentialMigrationState>(response);
 }

--- a/src/services/agents/aiCredentialMigrationService.ts
+++ b/src/services/agents/aiCredentialMigrationService.ts
@@ -1,0 +1,18 @@
+import api from '@/services/core/api';
+
+/**
+ * Whether the CRM still resolves AI credentials through the legacy sources
+ * (global OPENAI_API_SECRET / openai hook). Comes from the CRM Ruby backend
+ * (`GET /api/v1/ai/credentials/migration_state`, `Ai::MigrationState`) — the
+ * only place that knows; the credential list cannot tell "migrated and off"
+ * from "not migrated and served by the fallback".
+ */
+export interface AiCredentialMigrationState {
+  migrated: boolean;
+  legacy_fallback_active: boolean;
+}
+
+export async function getAiCredentialMigrationState(): Promise<AiCredentialMigrationState> {
+  const response = await api.get('/ai/credentials/migration_state');
+  return response.data?.data as AiCredentialMigrationState;
+}

--- a/src/services/agents/aiCredentialMigrationService.ts
+++ b/src/services/agents/aiCredentialMigrationService.ts
@@ -4,7 +4,7 @@ import { extractData } from '@/utils/apiHelpers';
 /**
  * Whether the CRM still resolves AI credentials through the legacy sources
  * (global OPENAI_API_SECRET / openai hook). Comes from the CRM Ruby backend
- * (`GET /api/v1/ai/credentials/migration_state`, `Ai::MigrationState`) — the
+ * (`GET /api/v1/ai_credentials/migration_state`, `Ai::MigrationState`) — the
  * only place that knows; the credential list cannot tell "migrated and off"
  * from "not migrated and served by the fallback".
  */
@@ -14,6 +14,6 @@ export interface AiCredentialMigrationState {
 }
 
 export async function getAiCredentialMigrationState(): Promise<AiCredentialMigrationState> {
-  const response = await api.get('/ai/credentials/migration_state');
+  const response = await api.get('/ai_credentials/migration_state');
   return extractData<AiCredentialMigrationState>(response);
 }

--- a/src/services/agents/index.ts
+++ b/src/services/agents/index.ts
@@ -5,3 +5,4 @@ export * from './customToolsService';
 export * from './mcpServerService';
 export * from './customMcpServerService';
 export * from './integrationCredentialService';
+export * from './aiCredentialMigrationService';


### PR DESCRIPTION
## Summary
- O painel "Em uso" de `/settings/ai-credentials` chutava "configurado antes desta tela" (fallback legado) sempre que não havia credencial ativa. Num install migrado — chaves cadastradas à mão, sem `OPENAI_API_SECRET` — isso diz que a IA roda quando ela está desligada.
- Agora o sinal vem do CRM: `getAiCredentialMigrationState()` (`GET /api/v1/ai/credentials/migration_state`, `Ai::MigrationState`, PR evo-ai-crm-community#280). O painel só diz "legado" quando o backend diz que o fallback está vivo; "nenhuma" no resto.
- Enquanto a resposta não chega, o painel mostra um spinner (sem veredito — nada de chutar "legado" e trocar para "nenhuma" logo depois). Se o sinal fica **desconhecido** (CRM antigo sem o endpoint, falha), a heurística anterior segue valendo, sem bloquear a lista nem toast — uma janela de deploy não troca uma mentira por outra. Última resposta vence quando a lista recarrega (o sinal é refeito junto porque apagar a última credencial importada pode mudá-lo — CRM-186).
- Reescreve o teste da #309 que afirmava o chute ("keeps reporting the legacy fallback while the only credential is inactive"): agora servidor migrado + única inativa → **"nenhuma"** (AC3); servidor não migrado → "legado" (AC4).

## Security
- Só leitura; permissão da tela (`ai_api_keys.read`) — o request só sai depois do `canRead`. Nada novo sai do cliente.

## Test plan
- `npx vitest run src/pages/Customer/Settings/AiCredentials src/services/agents/aiCredentialMigrationService.spec.ts` → 54/54 (+7 vs. develop: migrado+inativa → nenhuma; servidor legado → legado; registro vazio + migrado → nenhuma; sinal falhando → heurística com a credencial ainda listada; resposta malformada → heurística; sem veredito durante o carregamento; chama o servidor no load; service happy/reject)
- `npx vitest run src/i18n/locales/i18n-parity.spec.ts` → 178/178 (nenhuma chave nova) · `npx tsc -b --noEmit` · `npx eslint` nos arquivos · `npx vite build` ✓
- Manual (dev, CRM rebuildado com o endpoint): Conta Sul com as 3 credenciais inativas → painel "Nenhuma credencial" (antes: "configurado antes desta tela"); ativar uma → nome; desativar → "Nenhuma".

## Changed Files
- `src/services/agents/aiCredentialMigrationService.ts` (novo) · `aiCredentialMigrationService.spec.ts` (novo) · `src/services/agents/index.ts`
- `src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx` · `AiCredentials.spec.tsx`

## Related PRs
- Backend: https://github.com/evolution-foundation/evo-ai-crm-community/pull/280 (deploy primeiro; esta tela degrada se faltar)
- Depende da #309 (CRM-174), já mergeada — esta branch foi rebaseada em cima (inclui o commit df651b8 do review).

## Linked Issue
- CRM-187 (origem: review do CRM-174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make the AI credentials usage panel report legacy fallback status from the CRM instead of inferring it solely from inactive credentials.

Bug Fixes:
- Use the CRM migration-state signal to distinguish an active legacy AI credential fallback from an installation with no active credentials.

Enhancements:
- Show an indeterminate loading state while migration status is pending and retain the existing heuristic when the CRM signal is unavailable or malformed.
- Refresh migration status with credential data and ignore stale responses so the in-use panel reflects the latest account state.

Tests:
- Update in-use panel coverage for migrated, non-migrated, loading, fallback, refresh, and stale-response scenarios.
- Add service tests for reading and propagating CRM migration-state responses.