### PR TITLE
fix(permissions): falha ao carregar permissões deixa de ser servida como negação (CRM-164)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,14 +69,11 @@ jobs:
       #     can() denies and renders when it grants. The paired positive case is
       #     what keeps the negative ones honest — a control that stopped
       #     rendering for everyone would satisfy the denial assertions too.
-      #   - permissions service (CRM-164): a fetch that fails with no cache to
-      #     serve rejects instead of resolving to []. PermissionsContext.spec
-      #     mocks this service away, so without these examples putting the two
-      #     `return []` back restores the "load failure shown as denial" bug
-      #     with every other spec here still green.
-      #   - RouterGuard (CRM-164): the load-failure panel is the half of that
-      #     fix the user sees, and the path split is what keeps a logged-in
-      #     visitor on /widget or /f/:slug from being blocked by it.
+      #   - permissions service (CRM-164): a fetch with no cache to serve must
+      #     reject, not resolve to []. The context spec mocks the service away,
+      #     so these are the only examples guarding it.
+      #   - RouterGuard (CRM-164): the load-failure panel, and the path split
+      #     that keeps public pages reachable for a logged-in visitor.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,11 @@ jobs:
       #     can() denies and renders when it grants. The paired positive case is
       #     what keeps the negative ones honest — a control that stopped
       #     rendering for everyone would satisfy the denial assertions too.
+      #   - permissions service (CRM-164): a fetch that fails with no cache to
+      #     serve rejects instead of resolving to []. PermissionsContext.spec
+      #     mocks this service away, so without these examples putting the two
+      #     `return []` back restores the "load failure shown as denial" bug
+      #     with every other spec here still green.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -81,6 +86,7 @@ jobs:
         run: |
           npx vitest run --reporter=basic \
             src/contexts/PermissionsContext.spec.tsx \
+            src/services/permissions.spec.ts \
             src/pages/Admin/Roles/RoleDetail.spec.tsx \
             src/pages/Admin/Roles/RolesList.spec.tsx \
             src/services/campaigns/campaignsService.spec.ts \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,9 @@ jobs:
       #     mocks this service away, so without these examples putting the two
       #     `return []` back restores the "load failure shown as denial" bug
       #     with every other spec here still green.
+      #   - RouterGuard (CRM-164): the load-failure panel is the half of that
+      #     fix the user sees, and the path split is what keeps a logged-in
+      #     visitor on /widget or /f/:slug from being blocked by it.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -87,6 +90,7 @@ jobs:
           npx vitest run --reporter=basic \
             src/contexts/PermissionsContext.spec.tsx \
             src/services/permissions.spec.ts \
+            src/guards/RouterGuard.spec.tsx \
             src/pages/Admin/Roles/RoleDetail.spec.tsx \
             src/pages/Admin/Roles/RolesList.spec.tsx \
             src/services/campaigns/campaignsService.spec.ts \

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,10 +64,8 @@ function App() {
         <DarkModeProvider>
           <GlobalConfigProvider>
             <UISettingsApplier />
-            {/* The provider's own failure panel is off here: AppRouter's
-                RouterGuard renders the same panel and, unlike the provider,
-                knows which paths are public — a logged-in visitor on /widget or
-                /f/:slug must not be blocked by it (CRM-164). */}
+            {/* RouterGuard renders the same panel and knows which paths are
+                public, so the provider must not block here (CRM-164). */}
             <PermissionsProvider blockOnLoadFailure={false}>
             <NotificationsProvider>
               <AppInitializer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,11 @@ function App() {
         <DarkModeProvider>
           <GlobalConfigProvider>
             <UISettingsApplier />
-            <PermissionsProvider>
+            {/* The provider's own failure panel is off here: AppRouter's
+                RouterGuard renders the same panel and, unlike the provider,
+                knows which paths are public — a logged-in visitor on /widget or
+                /f/:slug must not be blocked by it (CRM-164). */}
+            <PermissionsProvider blockOnLoadFailure={false}>
             <NotificationsProvider>
               <AppInitializer>
                 <PluginSlot id="notifications.banner" />

--- a/src/components/permissions/PermissionsLoadFailure.tsx
+++ b/src/components/permissions/PermissionsLoadFailure.tsx
@@ -1,0 +1,62 @@
+import { ShieldAlert } from 'lucide-react';
+import EmptyState from '@/components/base/EmptyState';
+import { useAuth } from '@/contexts/AuthContext';
+import { usePermissions } from '@/contexts/PermissionsContext';
+import { useLanguage } from '@/hooks/useLanguage';
+import { cn } from '@/utils/cn';
+
+interface PermissionsLoadFailureProps {
+  className?: string;
+}
+
+/**
+ * Shown when the permission fetch blew up and left no list to answer `can()`
+ * with. Without it every screen below renders as if nothing were granted — the
+ * load failure reaching the user as a denial (CRM-164).
+ *
+ * Two hosts render it, which is why it lives here instead of inside either one:
+ * RouterGuard, for the standalone app, because it is the piece that knows which
+ * paths are public; and PermissionsProvider, because the embedded shell mounts
+ * the vendor providers and pages but never the vendor router.
+ */
+const PermissionsLoadFailure: React.FC<PermissionsLoadFailureProps> = ({ className }) => {
+  const { t } = useLanguage('common');
+  const { logout } = useAuth();
+  const { loading, refreshPermissions } = usePermissions();
+
+  return (
+    <div
+      data-testid="permissions-load-failure"
+      className={cn('flex flex-col items-center justify-center h-full', className)}
+    >
+      <EmptyState
+        icon={ShieldAlert}
+        title={t('permissions.loadFailed.title')}
+        description={t('permissions.loadFailed.description')}
+        action={{
+          label: loading ? t('permissions.loadFailed.retrying') : t('permissions.loadFailed.retry'),
+          onClick: () => {
+            void refreshPermissions();
+          },
+          disabled: loading,
+        }}
+      />
+      {/* A deterministic failure (403 from the membership gate, auth-service
+          down) retries into the same error forever, and this panel replaces
+          every protected screen. Without a way out the user cannot even sign
+          out to try another account. */}
+      <button
+        type="button"
+        data-testid="permissions-load-failure-signout"
+        className="mt-2 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+        onClick={() => {
+          void logout();
+        }}
+      >
+        {t('permissions.loadFailed.signOut')}
+      </button>
+    </div>
+  );
+};
+
+export default PermissionsLoadFailure;

--- a/src/components/permissions/PermissionsLoadFailure.tsx
+++ b/src/components/permissions/PermissionsLoadFailure.tsx
@@ -10,14 +10,9 @@ interface PermissionsLoadFailureProps {
 }
 
 /**
- * Shown when the permission fetch blew up and left no list to answer `can()`
- * with. Without it every screen below renders as if nothing were granted — the
- * load failure reaching the user as a denial (CRM-164).
- *
- * Two hosts render it, which is why it lives here instead of inside either one:
- * RouterGuard, for the standalone app, because it is the piece that knows which
- * paths are public; and PermissionsProvider, because the embedded shell mounts
- * the vendor providers and pages but never the vendor router.
+ * Shown when the permission fetch left no list to answer `can()` with (CRM-164).
+ * Lives here because two hosts render it: RouterGuard, for the standalone app,
+ * and PermissionsProvider, which is all the embedded shell mounts.
  */
 const PermissionsLoadFailure: React.FC<PermissionsLoadFailureProps> = ({ className }) => {
   const { t } = useLanguage('common');
@@ -41,10 +36,8 @@ const PermissionsLoadFailure: React.FC<PermissionsLoadFailureProps> = ({ classNa
           disabled: loading,
         }}
       />
-      {/* A deterministic failure (403 from the membership gate, auth-service
-          down) retries into the same error forever, and this panel replaces
-          every protected screen. Without a way out the user cannot even sign
-          out to try another account. */}
+      {/* A deterministic failure retries into itself forever, and this panel
+          replaces every protected screen — so it needs a way out. */}
       <button
         type="button"
         data-testid="permissions-load-failure-signout"

--- a/src/contexts/PermissionsContext.spec.tsx
+++ b/src/contexts/PermissionsContext.spec.tsx
@@ -13,8 +13,10 @@ import { PermissionsProvider, usePermissions } from './PermissionsContext';
 
 const mockUser = vi.fn();
 
+const mockLogout = vi.fn();
+
 vi.mock('./AuthContext', () => ({
-  useAuth: () => ({ user: mockUser() }),
+  useAuth: () => ({ user: mockUser(), logout: mockLogout }),
 }));
 
 vi.mock('@/store/authStore', () => ({
@@ -65,10 +67,13 @@ const Probe: React.FC = () => {
   );
 };
 
+// `blockOnLoadFailure={false}` mirrors the standalone app (App.tsx), where the
+// RouterGuard owns the failure panel. The default — the embedded shell — is
+// covered by its own describe below.
 function renderProbe(role = 'agent') {
   mockUser.mockReturnValue({ id: 'user-1', name: 'Someone', role });
   render(
-    <PermissionsProvider>
+    <PermissionsProvider blockOnLoadFailure={false}>
       <Probe />
     </PermissionsProvider>,
   );
@@ -174,5 +179,74 @@ describe('PermissionsContext — a failed load is not a denial (CRM-164)', () =>
     await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('true'));
     expect(screen.getByTestId('load-failed').textContent).toBe('false');
     expect(screen.getByTestId('contacts-read').textContent).toBe('false');
+  });
+});
+
+// CRM-164. The panel is the half of the fix the user actually sees, and it has
+// two hosts: RouterGuard (standalone, path-aware — see RouterGuard.spec.tsx)
+// and this provider, which is the ONLY one the embedded shell mounts. Without
+// the provider host, a failed load in the shell leaves every CRM screen
+// rendering an empty list forever, with no message and no retry.
+describe('PermissionsProvider — the failure panel replaces the tree it wraps (CRM-164)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserPermissions.mockResolvedValue([]);
+    mockAccountPermissions.mockResolvedValue([]);
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  function renderBlocking() {
+    mockUser.mockReturnValue({ id: 'user-1', name: 'Someone', role: 'agent' });
+    render(
+      <PermissionsProvider>
+        <span data-testid="app">app</span>
+      </PermissionsProvider>,
+    );
+  }
+
+  it('renders the panel instead of the children when the load fails', async () => {
+    mockAccountPermissions.mockRejectedValue(new Error('network down'));
+    renderBlocking();
+
+    await waitFor(() => expect(screen.getByTestId('permissions-load-failure')).toBeTruthy());
+    expect(screen.queryByTestId('app')).toBeNull();
+  });
+
+  it('keeps rendering the children when the load succeeds', async () => {
+    renderBlocking();
+
+    await waitFor(() => expect(screen.getByTestId('app')).toBeTruthy());
+    expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
+  });
+
+  it('gives the panel a way out of a failure that retries into itself', async () => {
+    mockAccountPermissions.mockRejectedValue(new Error('network down'));
+    renderBlocking();
+
+    await waitFor(() => expect(screen.getByTestId('permissions-load-failure')).toBeTruthy());
+    fireEvent.click(screen.getByTestId('permissions-load-failure-signout'));
+
+    expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it('restores the children when the panel retry recovers', async () => {
+    mockAccountPermissions.mockRejectedValueOnce(new Error('network down'));
+    mockAccountPermissions.mockResolvedValue(['contacts.read']);
+    renderBlocking();
+
+    await waitFor(() => expect(screen.getByTestId('permissions-load-failure')).toBeTruthy());
+    const retry = screen
+      .getAllByRole('button')
+      .find(button => button.getAttribute('data-testid') !== 'permissions-load-failure-signout');
+    fireEvent.click(retry!);
+
+    await waitFor(() => expect(screen.getByTestId('app')).toBeTruthy());
+    expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
   });
 });

--- a/src/contexts/PermissionsContext.spec.tsx
+++ b/src/contexts/PermissionsContext.spec.tsx
@@ -67,9 +67,8 @@ const Probe: React.FC = () => {
   );
 };
 
-// `blockOnLoadFailure={false}` mirrors the standalone app (App.tsx), where the
-// RouterGuard owns the failure panel. The default — the embedded shell — is
-// covered by its own describe below.
+// `blockOnLoadFailure={false}` mirrors the standalone app, where RouterGuard
+// owns the panel. The default is covered by its own describe below.
 function renderProbe(role = 'agent') {
   mockUser.mockReturnValue({ id: 'user-1', name: 'Someone', role });
   render(
@@ -116,13 +115,10 @@ describe('PermissionsContext — can() stays data-driven (no role short-circuit)
   });
 });
 
-// CRM-164. The service used to swallow a failed fetch and return [], so the
-// context reported `isReady` with an empty list and every `can()` answered
-// false — a load failure reaching the user as "you don't have permission".
-// The two windows the bug was reported through (reloading with a conversation
-// open, and switching accounts — which the shell serves with a full
-// window.location.reload) are the same boot path, so they are the same
-// examples: a fetch that throws must leave the context not-ready and flagged.
+// CRM-164. A swallowed fetch error used to flip `isReady` with an empty list,
+// so every `can()` answered false — a load failure served as a denial. Both
+// reported windows (reload, and account switch, which the shell serves with a
+// full page reload) are this same boot path.
 describe('PermissionsContext — a failed load is not a denial (CRM-164)', () => {
   let consoleError: ReturnType<typeof vi.spyOn>;
 
@@ -161,8 +157,7 @@ describe('PermissionsContext — a failed load is not a denial (CRM-164)', () =>
     renderProbe();
 
     await waitFor(() => expect(screen.getByTestId('load-failed').textContent).toBe('true'));
-    // Pinned so the recovery below cannot be credited to an effect refiring on
-    // its own — the click has to be what refetches.
+    // Pinned so the recovery cannot be credited to an effect refiring on its own.
     const callsBeforeRetry = mockAccountPermissions.mock.calls.length;
 
     fireEvent.click(screen.getByText('retry'));
@@ -182,11 +177,9 @@ describe('PermissionsContext — a failed load is not a denial (CRM-164)', () =>
   });
 });
 
-// CRM-164. The panel is the half of the fix the user actually sees, and it has
-// two hosts: RouterGuard (standalone, path-aware — see RouterGuard.spec.tsx)
-// and this provider, which is the ONLY one the embedded shell mounts. Without
-// the provider host, a failed load in the shell leaves every CRM screen
-// rendering an empty list forever, with no message and no retry.
+// CRM-164. The panel has two hosts: RouterGuard (see its spec) and this
+// provider, the only one the embedded shell mounts — without it a failed load
+// leaves every CRM screen rendering an empty list, with no message and no retry.
 describe('PermissionsProvider — the failure panel replaces the tree it wraps (CRM-164)', () => {
   let consoleError: ReturnType<typeof vi.spyOn>;
 

--- a/src/contexts/PermissionsContext.spec.tsx
+++ b/src/contexts/PermissionsContext.spec.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { PermissionsProvider, usePermissions } from './PermissionsContext';
 
@@ -22,6 +22,7 @@ vi.mock('@/store/authStore', () => ({
 }));
 
 const mockAccountPermissions = vi.fn<[], Promise<string[]>>();
+const mockUserPermissions = vi.fn<[], Promise<string[]>>();
 
 vi.mock('@/services/permissions', () => ({
   permissionsService: {
@@ -34,31 +35,49 @@ vi.mock('@/services/permissions', () => ({
           ],
         },
       }),
-    getUserPermissions: () => Promise.resolve([]),
+    getUserPermissions: () => mockUserPermissions(),
     getAccountPermissions: () => mockAccountPermissions(),
   },
 }));
 
 const Probe: React.FC = () => {
-  const { can, isReady } = usePermissions();
-  if (!isReady) return <span>loading</span>;
+  const { can, isReady, loadFailed, refreshPermissions } = usePermissions();
   return (
     <>
-      <span data-testid="contacts-read">{String(can('contacts', 'read'))}</span>
-      <span data-testid="installation-manage">{String(can('installation_configs', 'manage'))}</span>
+      <span data-testid="ready">{String(isReady)}</span>
+      <span data-testid="load-failed">{String(loadFailed)}</span>
+      <button
+        onClick={() => {
+          void refreshPermissions();
+        }}
+      >
+        retry
+      </button>
+      {isReady ? (
+        <>
+          <span data-testid="contacts-read">{String(can('contacts', 'read'))}</span>
+          <span data-testid="installation-manage">{String(can('installation_configs', 'manage'))}</span>
+        </>
+      ) : (
+        <span>loading</span>
+      )}
     </>
   );
 };
 
-async function renderWith(role: string, granted: string[]) {
+function renderProbe(role = 'agent') {
   mockUser.mockReturnValue({ id: 'user-1', name: 'Someone', role });
-  mockAccountPermissions.mockResolvedValue(granted);
-
   render(
     <PermissionsProvider>
       <Probe />
     </PermissionsProvider>,
   );
+}
+
+async function renderWith(role: string, granted: string[]) {
+  mockUserPermissions.mockResolvedValue([]);
+  mockAccountPermissions.mockResolvedValue(granted);
+  renderProbe(role);
 
   await waitFor(() => expect(screen.queryByText('loading')).toBeNull());
 }
@@ -89,5 +108,71 @@ describe('PermissionsContext — can() stays data-driven (no role short-circuit)
 
     expect(screen.getByTestId('contacts-read').textContent).toBe('false');
     expect(screen.getByTestId('installation-manage').textContent).toBe('false');
+  });
+});
+
+// CRM-164. The service used to swallow a failed fetch and return [], so the
+// context reported `isReady` with an empty list and every `can()` answered
+// false — a load failure reaching the user as "you don't have permission".
+// The two windows the bug was reported through (reloading with a conversation
+// open, and switching accounts — which the shell serves with a full
+// window.location.reload) are the same boot path, so they are the same
+// examples: a fetch that throws must leave the context not-ready and flagged.
+describe('PermissionsContext — a failed load is not a denial (CRM-164)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserPermissions.mockResolvedValue([]);
+    mockAccountPermissions.mockResolvedValue([]);
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('stays not-ready and reports loadFailed when the account fetch throws', async () => {
+    mockAccountPermissions.mockRejectedValue(new Error('network down'));
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('load-failed').textContent).toBe('true'));
+    expect(screen.getByTestId('ready').textContent).toBe('false');
+    // Nothing evaluated `can()`, so no screen could have rendered a denial.
+    expect(screen.queryByTestId('contacts-read')).toBeNull();
+  });
+
+  it('stays not-ready and reports loadFailed when the user fetch throws', async () => {
+    mockUserPermissions.mockRejectedValue(new Error('network down'));
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('load-failed').textContent).toBe('true'));
+    expect(screen.getByTestId('ready').textContent).toBe('false');
+  });
+
+  it('recovers on retry: refreshPermissions clears the failure and grants access', async () => {
+    mockAccountPermissions.mockRejectedValueOnce(new Error('network down'));
+    mockAccountPermissions.mockResolvedValue(['contacts.read']);
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('load-failed').textContent).toBe('true'));
+    // Pinned so the recovery below cannot be credited to an effect refiring on
+    // its own — the click has to be what refetches.
+    const callsBeforeRetry = mockAccountPermissions.mock.calls.length;
+
+    fireEvent.click(screen.getByText('retry'));
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('true'));
+    expect(screen.getByTestId('load-failed').textContent).toBe('false');
+    expect(screen.getByTestId('contacts-read').textContent).toBe('true');
+    expect(mockAccountPermissions.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
+  });
+
+  it('treats a successfully empty list as a real denial, not a failure', async () => {
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('true'));
+    expect(screen.getByTestId('load-failed').textContent).toBe('false');
+    expect(screen.getByTestId('contacts-read').textContent).toBe('false');
   });
 });

--- a/src/contexts/PermissionsContext.tsx
+++ b/src/contexts/PermissionsContext.tsx
@@ -17,6 +17,7 @@ interface PermissionsContextValue {
   // Estado
   loading: boolean;
   isReady: boolean;
+  loadFailed: boolean;
   error: string | null;
 
   // Métodos utilitários
@@ -25,6 +26,8 @@ interface PermissionsContextValue {
   isValidPermission: (permission: string) => boolean;
   getPermissionDisplayName: (permission: string) => string;
 }
+
+type FetchStatus = 'pending' | 'loaded' | 'failed';
 
 export const PermissionsContext = createContext<PermissionsContextValue | undefined>(undefined);
 
@@ -40,22 +43,26 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Tracks whether the permission fetches have completed for the current user.
-  // Starts false so we never report `isReady` true with empty permissions during
-  // the brief render between user appearing and the fetch effect running — that
-  // window used to flash the Unauthorized page after a fresh login.
-  const [userPermsLoaded, setUserPermsLoaded] = useState(false);
-  const [accountPermsLoaded, setAccountPermsLoaded] = useState(false);
+  // Outcome of each permission fetch for the current user. `pending` keeps
+  // `isReady` false during the render between user appearing and the fetch
+  // effect running — that window used to flash the Unauthorized page after a
+  // fresh login. `failed` keeps it false too: a fetch that blew up leaves an
+  // empty list that is indistinguishable from a real denial (CRM-164), so the
+  // app must not act on it. Only `loaded` means the list can be trusted —
+  // including a legitimately empty one.
+  const [userPermsStatus, setUserPermsStatus] = useState<FetchStatus>('pending');
+  const [accountPermsStatus, setAccountPermsStatus] = useState<FetchStatus>('pending');
 
   // Config state
   const [resourceActions, setResourceActions] = useState<ResourceActionsResponse | null>(null);
   const [configLoading, setConfigLoading] = useState(false);
 
-  // Reset loaded flags whenever the logged-in user changes so the next user's
-  // permissions go through the fetch cycle before `isReady` flips back to true.
+  // Reset the fetch status whenever the logged-in user changes so the next
+  // user's permissions go through the fetch cycle before `isReady` flips back
+  // to true.
   useEffect(() => {
-    setUserPermsLoaded(false);
-    setAccountPermsLoaded(false);
+    setUserPermsStatus('pending');
+    setAccountPermsStatus('pending');
   }, [user?.id]);
 
   // Load permissions config (metadata)
@@ -83,33 +90,48 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
   useEffect(() => {
     if (!user?.id) {
       setUserPermissions([]);
-      setUserPermsLoaded(true);
+      setUserPermsStatus('loaded');
       return;
     }
+
+    // Nothing cancels an in-flight request, and the fetch can outlive the effect
+    // (user changes, or a retry supersedes it). Without this flag an orphaned
+    // rejection landing after a newer success would stamp `failed` over a
+    // perfectly loaded context and bounce the user to the failure screen.
+    let cancelled = false;
 
     const loadUserPermissions = async () => {
       try {
         const isAuthenticated = useAuthStore.getState().isLoggedIn;
         if (!isAuthenticated) {
+          if (cancelled) return;
           setUserPermissions([]);
+          setUserPermsStatus('loaded');
           return;
         }
 
         setLoading(true);
         setError(null);
         const permissions = await permissionsService.getUserPermissions();
+        if (cancelled) return;
         setUserPermissions(permissions);
+        setUserPermsStatus('loaded');
       } catch (error) {
+        if (cancelled) return;
         console.error('Erro ao carregar permissões do usuário:', error);
         setError('Erro ao carregar permissões do usuário');
         setUserPermissions([]);
+        setUserPermsStatus('failed');
       } finally {
-        setLoading(false);
-        setUserPermsLoaded(true);
+        if (!cancelled) setLoading(false);
       }
     };
 
     loadUserPermissions();
+
+    return () => {
+      cancelled = true;
+    };
   }, [user?.id]);
 
   // Load account permissions (específicas do account baseadas no AccountUser role)
@@ -118,22 +140,28 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
     const isAuthenticated = useAuthStore.getState().isLoggedIn;
     if (!isAuthenticated || !user) {
       setAccountPermissions([]);
-      setAccountPermsLoaded(true);
+      setAccountPermsStatus('loaded');
       return;
     }
 
     // ⚡ Proteção: não carregar se já tem permissões (evita recarregar desnecessariamente)
     if (accountPermissions.length > 0) {
-      setAccountPermsLoaded(true);
+      setAccountPermsStatus('loaded');
       return;
     }
+
+    // See the user-permissions effect: an orphaned rejection must not overwrite
+    // a newer result.
+    let cancelled = false;
 
     const loadAccountPermissions = async () => {
       try {
         const isAuthenticated = useAuthStore.getState().isLoggedIn;
 
         if (!isAuthenticated) {
+          if (cancelled) return;
           setAccountPermissions([]);
+          setAccountPermsStatus('loaded');
           return;
         }
 
@@ -141,18 +169,25 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
         setError(null);
         const permissions = await permissionsService.getAccountPermissions();
 
+        if (cancelled) return;
         setAccountPermissions(permissions);
+        setAccountPermsStatus('loaded');
       } catch (error) {
+        if (cancelled) return;
         console.error('Erro ao carregar permissões do account:', error);
         setError('Erro ao carregar permissões do account');
         setAccountPermissions([]);
+        setAccountPermsStatus('failed');
       } finally {
-        setLoading(false);
-        setAccountPermsLoaded(true);
+        if (!cancelled) setLoading(false);
       }
     };
 
     loadAccountPermissions();
+
+    return () => {
+      cancelled = true;
+    };
   }, [user, accountPermissions.length]);
 
   const createPermission = useCallback((resource: string, action: string): string => {
@@ -237,36 +272,63 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
   const refreshPermissions = useCallback(async () => {
     if (!user?.id) return;
 
-    try {
-      setLoading(true);
-      setError(null);
+    setLoading(true);
+    setError(null);
 
-      // Carregar user permissions
-      const userPerms = await permissionsService.getUserPermissions(true);
-      setUserPermissions(userPerms);
+    // The two fetches are independent, and each drives its own status. Awaiting
+    // them in sequence meant a rejected user fetch skipped the account fetch
+    // entirely, so the retry offered on a failure could never refresh a stale
+    // account list. A failed leg keeps its last known list rather than blanking
+    // it — `isReady` is false either way, so nothing acts on it.
+    const [userResult, accountResult] = await Promise.allSettled([
+      permissionsService.getUserPermissions(true),
+      permissionsService.getAccountPermissions(true),
+    ]);
 
-      // Carregar account permissions
-      const accountPerms = await permissionsService.getAccountPermissions(true);
-      setAccountPermissions(accountPerms);
-    } catch {
-      setError('Erro ao recarregar permissões');
-    } finally {
-      setLoading(false);
+    if (userResult.status === 'fulfilled') {
+      setUserPermissions(userResult.value);
+      setUserPermsStatus('loaded');
+    } else {
+      console.error('Erro ao recarregar permissões do usuário:', userResult.reason);
+      setUserPermsStatus('failed');
     }
+
+    if (accountResult.status === 'fulfilled') {
+      setAccountPermissions(accountResult.value);
+      setAccountPermsStatus('loaded');
+    } else {
+      console.error('Erro ao recarregar permissões do account:', accountResult.reason);
+      setAccountPermsStatus('failed');
+    }
+
+    if (userResult.status === 'rejected' || accountResult.status === 'rejected') {
+      setError('Erro ao recarregar permissões');
+    }
+
+    setLoading(false);
   }, [user?.id]);
 
   // isReady: true when user is loaded, config finished, and both permission
-  // fetches completed at least once for the current user. Tracking completion
-  // (rather than just `!loading`) prevents PermissionRoute from evaluating
-  // `can()` against empty arrays during the render window between user
-  // appearing and the fetch effect firing — that flashed Unauthorized after
-  // a fresh login.
+  // fetches SUCCEEDED at least once for the current user. Tracking the outcome
+  // (rather than just `!loading`) prevents consumers from evaluating `can()`
+  // against empty arrays — during the render window between user appearing and
+  // the fetch effect firing (flashed Unauthorized after a fresh login), and
+  // after a failed fetch (served the failure as a denial, CRM-164).
   const isReady = useMemo(() => {
     if (!user) return false;
     if (configLoading) return false;
     if (loading) return false;
-    return userPermsLoaded && accountPermsLoaded;
-  }, [configLoading, loading, user, userPermsLoaded, accountPermsLoaded]);
+    return userPermsStatus === 'loaded' && accountPermsStatus === 'loaded';
+  }, [configLoading, loading, user, userPermsStatus, accountPermsStatus]);
+
+  // Only report a failure once BOTH fetches have settled. `loading` cannot serve
+  // as the gate here: it is one shared flag, so whichever fetch finishes first
+  // clears it while the other is still in flight. Reporting on the first
+  // rejection alone flashed the failure screen mid-boot — the same "transient
+  // wrong state shown to the user" this fix exists to remove.
+  const permissionsSettled = userPermsStatus !== 'pending' && accountPermsStatus !== 'pending';
+  const loadFailed =
+    permissionsSettled && (userPermsStatus === 'failed' || accountPermsStatus === 'failed');
 
   const value: PermissionsContextValue = {
     userPermissions,
@@ -276,6 +338,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
     canAll,
     loading: loading || configLoading,
     isReady,
+    loadFailed,
     error,
     refreshPermissions,
     createPermission,

--- a/src/contexts/PermissionsContext.tsx
+++ b/src/contexts/PermissionsContext.tsx
@@ -34,14 +34,9 @@ export const PermissionsContext = createContext<PermissionsContextValue | undefi
 
 interface PermissionsProviderProps {
   children: React.ReactNode;
-  // Whether a failed load replaces the tree with the failure panel. Default
-  // true, because the embedded shell mounts this provider around the vendor
-  // pages WITHOUT the vendor router — RouterGuard, the other host of the panel,
-  // never runs there, so a failure would leave every CRM screen rendering as an
-  // empty list forever with no message and no retry (CRM-164).
-  // The standalone app opts out: its RouterGuard shows the same panel and knows
-  // which paths are public, and a logged-in visitor on /widget or /f/:slug must
-  // still get the page.
+  // Whether a failed load replaces the tree with the failure panel (CRM-164).
+  // Default true for the embedded shell, which mounts this provider but not
+  // RouterGuard. The standalone app opts out — see App.tsx.
   blockOnLoadFailure?: boolean;
 }
 
@@ -56,13 +51,10 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Outcome of each permission fetch for the current user. `pending` keeps
-  // `isReady` false during the render between user appearing and the fetch
-  // effect running — that window used to flash the Unauthorized page after a
-  // fresh login. `failed` keeps it false too: a fetch that blew up leaves an
-  // empty list that is indistinguishable from a real denial (CRM-164), so the
-  // app must not act on it. Only `loaded` means the list can be trusted —
-  // including a legitimately empty one.
+  // Outcome of each permission fetch. Only `loaded` means the list can be
+  // trusted, including a legitimately empty one: `pending` covers the render
+  // before the fetch effect runs, `failed` an empty list that is really a load
+  // error and not a denial (CRM-164).
   const [userPermsStatus, setUserPermsStatus] = useState<FetchStatus>('pending');
   const [accountPermsStatus, setAccountPermsStatus] = useState<FetchStatus>('pending');
 
@@ -70,9 +62,8 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
   const [resourceActions, setResourceActions] = useState<ResourceActionsResponse | null>(null);
   const [configLoading, setConfigLoading] = useState(false);
 
-  // Reset the fetch status whenever the logged-in user changes so the next
-  // user's permissions go through the fetch cycle before `isReady` flips back
-  // to true.
+  // Reset on user change so the next user's fetch cycle runs before `isReady`
+  // flips back to true.
   useEffect(() => {
     setUserPermsStatus('pending');
     setAccountPermsStatus('pending');
@@ -104,16 +95,12 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     if (!user?.id) {
       setUserPermissions([]);
       setUserPermsStatus('loaded');
-      // The cancelled leg of a previous run no longer clears this in its
-      // `finally`, so an early return has to.
-      setLoading(false);
+      setLoading(false); // a cancelled leg no longer clears it in its `finally`
       return;
     }
 
-    // Nothing cancels an in-flight request, and the fetch can outlive the effect
-    // (user changes, or a retry supersedes it). Without this flag an orphaned
-    // rejection landing after a newer success would stamp `failed` over a
-    // perfectly loaded context and bounce the user to the failure screen.
+    // The fetch can outlive the effect. Without this flag an orphaned rejection
+    // would stamp `failed` over a context a newer success already loaded.
     let cancelled = false;
 
     const loadUserPermissions = async () => {
@@ -157,9 +144,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     if (!isAuthenticated || !user) {
       setAccountPermissions([]);
       setAccountPermsStatus('loaded');
-      // See the user-permissions effect: an early return releases the flag a
-      // cancelled leg leaves set.
-      setLoading(false);
+      setLoading(false); // see the user-permissions effect
       return;
     }
 
@@ -170,8 +155,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
       return;
     }
 
-    // See the user-permissions effect: an orphaned rejection must not overwrite
-    // a newer result.
+    // See the user-permissions effect.
     let cancelled = false;
 
     const loadAccountPermissions = async () => {
@@ -295,11 +279,9 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     setLoading(true);
     setError(null);
 
-    // The two fetches are independent, and each drives its own status. Awaiting
-    // them in sequence meant a rejected user fetch skipped the account fetch
-    // entirely, so the retry offered on a failure could never refresh a stale
-    // account list. A failed leg keeps its last known list rather than blanking
-    // it — `isReady` is false either way, so nothing acts on it.
+    // allSettled, not sequential awaits: a rejected user fetch used to skip the
+    // account one, so a retry could never refresh a stale account list. A failed
+    // leg keeps its last list — `isReady` is false either way.
     const [userResult, accountResult] = await Promise.allSettled([
       permissionsService.getUserPermissions(true),
       permissionsService.getAccountPermissions(true),
@@ -328,12 +310,9 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     setLoading(false);
   }, [user?.id]);
 
-  // isReady: true when user is loaded, config finished, and both permission
-  // fetches SUCCEEDED at least once for the current user. Tracking the outcome
-  // (rather than just `!loading`) prevents consumers from evaluating `can()`
-  // against empty arrays — during the render window between user appearing and
-  // the fetch effect firing (flashed Unauthorized after a fresh login), and
-  // after a failed fetch (served the failure as a denial, CRM-164).
+  // True once user, config and BOTH fetches succeeded. Tracking the outcome
+  // rather than `!loading` keeps consumers from evaluating `can()` against an
+  // empty array — before the fetch effect fires, or after it failed (CRM-164).
   const isReady = useMemo(() => {
     if (!user) return false;
     if (configLoading) return false;
@@ -341,11 +320,8 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     return userPermsStatus === 'loaded' && accountPermsStatus === 'loaded';
   }, [configLoading, loading, user, userPermsStatus, accountPermsStatus]);
 
-  // Only report a failure once BOTH fetches have settled. `loading` cannot serve
-  // as the gate here: it is one shared flag, so whichever fetch finishes first
-  // clears it while the other is still in flight. Reporting on the first
-  // rejection alone flashed the failure screen mid-boot — the same "transient
-  // wrong state shown to the user" this fix exists to remove.
+  // Both must settle first: `loading` is one shared flag that the faster fetch
+  // clears, so reporting on the first rejection flashed the panel mid-boot.
   const permissionsSettled = userPermsStatus !== 'pending' && accountPermsStatus !== 'pending';
   const loadFailed =
     permissionsSettled && (userPermsStatus === 'failed' || accountPermsStatus === 'failed');

--- a/src/contexts/PermissionsContext.tsx
+++ b/src/contexts/PermissionsContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback, use
 import { useAuth } from './AuthContext';
 import { useAuthStore } from '@/store/authStore';
 import { permissionsService } from '@/services/permissions';
+import PermissionsLoadFailure from '@/components/permissions/PermissionsLoadFailure';
 import type { ResourceActionsResponse } from '@/types/auth';
 
 interface PermissionsContextValue {
@@ -33,9 +34,21 @@ export const PermissionsContext = createContext<PermissionsContextValue | undefi
 
 interface PermissionsProviderProps {
   children: React.ReactNode;
+  // Whether a failed load replaces the tree with the failure panel. Default
+  // true, because the embedded shell mounts this provider around the vendor
+  // pages WITHOUT the vendor router — RouterGuard, the other host of the panel,
+  // never runs there, so a failure would leave every CRM screen rendering as an
+  // empty list forever with no message and no retry (CRM-164).
+  // The standalone app opts out: its RouterGuard shows the same panel and knows
+  // which paths are public, and a logged-in visitor on /widget or /f/:slug must
+  // still get the page.
+  blockOnLoadFailure?: boolean;
 }
 
-export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ children }) => {
+export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
+  children,
+  blockOnLoadFailure = true,
+}) => {
   const { user } = useAuth();
 
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
@@ -91,6 +104,9 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
     if (!user?.id) {
       setUserPermissions([]);
       setUserPermsStatus('loaded');
+      // The cancelled leg of a previous run no longer clears this in its
+      // `finally`, so an early return has to.
+      setLoading(false);
       return;
     }
 
@@ -141,12 +157,16 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
     if (!isAuthenticated || !user) {
       setAccountPermissions([]);
       setAccountPermsStatus('loaded');
+      // See the user-permissions effect: an early return releases the flag a
+      // cancelled leg leaves set.
+      setLoading(false);
       return;
     }
 
     // ⚡ Proteção: não carregar se já tem permissões (evita recarregar desnecessariamente)
     if (accountPermissions.length > 0) {
       setAccountPermsStatus('loaded');
+      setLoading(false);
       return;
     }
 
@@ -346,7 +366,11 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({ childr
     getPermissionDisplayName,
   };
 
-  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+  return (
+    <PermissionsContext.Provider value={value}>
+      {loadFailed && blockOnLoadFailure ? <PermissionsLoadFailure /> : children}
+    </PermissionsContext.Provider>
+  );
 };
 
 export const usePermissions = (): PermissionsContextValue => {

--- a/src/guards/RouterGuard.spec.tsx
+++ b/src/guards/RouterGuard.spec.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import RouterGuard from './RouterGuard';
+
+// CRM-164. The guard is where the standalone app turns a failed permission load
+// into something the user can read and act on, instead of the spinner that can
+// never end (`isReady` stays false for as long as the fetch keeps failing).
+// The path split is the part worth pinning: a logged-in visitor opening a
+// public page — /widget, /f/:slug, /chat/:slug — must still get the page.
+
+const mockLocation = { pathname: '/conversations', search: '' };
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useLocation: () => mockLocation,
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: () => ({ isLoading: false }),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1' }, isAuthenticated: true, logout: vi.fn() }),
+}));
+
+const mockUsePermissions = vi.fn();
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => mockUsePermissions(),
+}));
+
+vi.mock('@/contexts/GlobalConfigContext', () => ({
+  useGlobalConfig: () => ({ setupRequired: false, setupLoading: false }),
+}));
+
+vi.mock('@/utils/requestMonitor', () => ({
+  markBootstrapPhaseStart: vi.fn(),
+  markBootstrapPhaseEnd: vi.fn(),
+}));
+
+function permissions(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    isReady: false,
+    loadFailed: false,
+    loading: false,
+    refreshPermissions: vi.fn(),
+    ...overrides,
+  };
+}
+
+function renderGuard(pathname: string) {
+  mockLocation.pathname = pathname;
+  render(
+    <RouterGuard>
+      <span data-testid="app">app</span>
+    </RouterGuard>,
+  );
+}
+
+describe('RouterGuard — a failed permission load is not a denial (CRM-164)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the load-failure panel on a protected path instead of spinning forever', () => {
+    mockUsePermissions.mockReturnValue(permissions({ loadFailed: true }));
+
+    renderGuard('/conversations');
+
+    expect(screen.getByTestId('permissions-load-failure')).toBeTruthy();
+    expect(screen.queryByTestId('app')).toBeNull();
+  });
+
+  it('does not block a public path a logged-in visitor may legitimately open', () => {
+    mockUsePermissions.mockReturnValue(permissions({ loadFailed: true }));
+
+    renderGuard('/f/lead-form-slug');
+
+    expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
+    expect(screen.getByTestId('app')).toBeTruthy();
+  });
+
+  it('still spins while the permissions are merely in flight', () => {
+    mockUsePermissions.mockReturnValue(permissions());
+
+    renderGuard('/conversations');
+
+    // Not-ready without a failure is the boot window, not an error: no panel,
+    // and the children stay withheld so nothing evaluates can() against [].
+    expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
+    expect(screen.queryByTestId('app')).toBeNull();
+  });
+
+  it('renders the app once the permissions are ready', () => {
+    mockUsePermissions.mockReturnValue(permissions({ isReady: true }));
+
+    renderGuard('/conversations');
+
+    expect(screen.getByTestId('app')).toBeTruthy();
+    expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
+  });
+});

--- a/src/guards/RouterGuard.spec.tsx
+++ b/src/guards/RouterGuard.spec.tsx
@@ -3,11 +3,9 @@ import { render, screen } from '@testing-library/react';
 import React from 'react';
 import RouterGuard from './RouterGuard';
 
-// CRM-164. The guard is where the standalone app turns a failed permission load
-// into something the user can read and act on, instead of the spinner that can
-// never end (`isReady` stays false for as long as the fetch keeps failing).
-// The path split is the part worth pinning: a logged-in visitor opening a
-// public page — /widget, /f/:slug, /chat/:slug — must still get the page.
+// CRM-164. The guard turns a failed permission load into a panel instead of a
+// spinner that can never end. The path split is the part worth pinning: a
+// logged-in visitor on /widget, /f/:slug or /chat/:slug must still get the page.
 
 const mockLocation = { pathname: '/conversations', search: '' };
 
@@ -86,8 +84,7 @@ describe('RouterGuard — a failed permission load is not a denial (CRM-164)', (
 
     renderGuard('/conversations');
 
-    // Not-ready without a failure is the boot window, not an error: no panel,
-    // and the children stay withheld so nothing evaluates can() against [].
+    // Not-ready without a failure is the boot window, not an error.
     expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
     expect(screen.queryByTestId('app')).toBeNull();
   });

--- a/src/guards/RouterGuard.tsx
+++ b/src/guards/RouterGuard.tsx
@@ -133,14 +133,9 @@ const RouterGuard: React.FC<RouterGuardProps> = ({ children }) => {
     location.pathname.startsWith(route)
   );
 
-  // A permission fetch that blew up leaves `permissionsReady` false forever, so
-  // the spinner below would never end. Say what actually happened instead — the
-  // whole point of CRM-164 is that a failure to load is not a denial, and the
-  // user has to be able to tell the two apart and retry. Public paths are
-  // excluded here and nowhere else: a logged-in visitor opening /widget or
-  // /f/:slug must still get the page, and this guard is the only piece that
-  // knows which paths those are (PermissionsProvider renders the same panel for
-  // the embedded shell, which mounts protected screens only).
+  // A failed fetch leaves `permissionsReady` false forever, so the spinner
+  // below would never end (CRM-164). Public paths are excluded here because
+  // this guard is the only host of the panel that knows which ones they are.
   if (!isLoading && !isCurrentPathPublic && isAuthenticated && permissionsLoadFailed) {
     return <PermissionsLoadFailure className="min-h-screen" />;
   }

--- a/src/guards/RouterGuard.tsx
+++ b/src/guards/RouterGuard.tsx
@@ -4,6 +4,9 @@ import { useAuthStore } from '@/store/authStore';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { useGlobalConfig } from '@/contexts/GlobalConfigContext';
+import { useLanguage } from '@/hooks/useLanguage';
+import EmptyState from '@/components/base/EmptyState';
+import { ShieldAlert } from 'lucide-react';
 import { markBootstrapPhaseEnd, markBootstrapPhaseStart } from '@/utils/requestMonitor';
 
 interface RouterGuardProps {
@@ -27,8 +30,14 @@ const RouterGuard: React.FC<RouterGuardProps> = ({ children }) => {
   const location = useLocation();
   const { isLoading } = useAuthStore();
   const { user, isAuthenticated, logout } = useAuth();
-  const { isReady: permissionsReady } = usePermissions();
+  const {
+    isReady: permissionsReady,
+    loadFailed: permissionsLoadFailed,
+    loading: permissionsLoading,
+    refreshPermissions,
+  } = usePermissions();
   const { setupRequired, setupLoading } = useGlobalConfig();
+  const { t } = useLanguage('common');
 
   useEffect(() => {
     const handleSetupRequired = async () => {
@@ -131,6 +140,42 @@ const RouterGuard: React.FC<RouterGuardProps> = ({ children }) => {
   const isCurrentPathPublic = SPECIAL_ROUTES.PUBLIC_ROUTES.some(route =>
     location.pathname.startsWith(route)
   );
+
+  // A permission fetch that blew up leaves `permissionsReady` false forever, so
+  // the spinner below would never end. Say what actually happened instead — the
+  // whole point of CRM-164 is that a failure to load is not a denial, and the
+  // user has to be able to tell the two apart and retry.
+  if (!isLoading && !isCurrentPathPublic && isAuthenticated && permissionsLoadFailed) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen">
+        <EmptyState
+          icon={ShieldAlert}
+          title={t('permissions.loadFailed.title')}
+          description={t('permissions.loadFailed.description')}
+          action={{
+            label: t('permissions.loadFailed.retry'),
+            onClick: () => {
+              void refreshPermissions();
+            },
+            disabled: permissionsLoading,
+          }}
+        />
+        {/* A deterministic failure (403 from the membership gate, auth-service
+            down) retries into the same error forever, and this screen replaces
+            every protected route. Without a way out the user cannot even sign
+            out to try another account. */}
+        <button
+          type="button"
+          className="mt-2 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+          onClick={() => {
+            void logout();
+          }}
+        >
+          {t('permissions.loadFailed.signOut')}
+        </button>
+      </div>
+    );
+  }
 
   if (isLoading || (!isCurrentPathPublic && isAuthenticated && !permissionsReady)) {
     return (

--- a/src/guards/RouterGuard.tsx
+++ b/src/guards/RouterGuard.tsx
@@ -4,9 +4,7 @@ import { useAuthStore } from '@/store/authStore';
 import { useAuth } from '@/contexts/AuthContext';
 import { usePermissions } from '@/contexts/PermissionsContext';
 import { useGlobalConfig } from '@/contexts/GlobalConfigContext';
-import { useLanguage } from '@/hooks/useLanguage';
-import EmptyState from '@/components/base/EmptyState';
-import { ShieldAlert } from 'lucide-react';
+import PermissionsLoadFailure from '@/components/permissions/PermissionsLoadFailure';
 import { markBootstrapPhaseEnd, markBootstrapPhaseStart } from '@/utils/requestMonitor';
 
 interface RouterGuardProps {
@@ -30,14 +28,8 @@ const RouterGuard: React.FC<RouterGuardProps> = ({ children }) => {
   const location = useLocation();
   const { isLoading } = useAuthStore();
   const { user, isAuthenticated, logout } = useAuth();
-  const {
-    isReady: permissionsReady,
-    loadFailed: permissionsLoadFailed,
-    loading: permissionsLoading,
-    refreshPermissions,
-  } = usePermissions();
+  const { isReady: permissionsReady, loadFailed: permissionsLoadFailed } = usePermissions();
   const { setupRequired, setupLoading } = useGlobalConfig();
-  const { t } = useLanguage('common');
 
   useEffect(() => {
     const handleSetupRequired = async () => {
@@ -144,37 +136,13 @@ const RouterGuard: React.FC<RouterGuardProps> = ({ children }) => {
   // A permission fetch that blew up leaves `permissionsReady` false forever, so
   // the spinner below would never end. Say what actually happened instead — the
   // whole point of CRM-164 is that a failure to load is not a denial, and the
-  // user has to be able to tell the two apart and retry.
+  // user has to be able to tell the two apart and retry. Public paths are
+  // excluded here and nowhere else: a logged-in visitor opening /widget or
+  // /f/:slug must still get the page, and this guard is the only piece that
+  // knows which paths those are (PermissionsProvider renders the same panel for
+  // the embedded shell, which mounts protected screens only).
   if (!isLoading && !isCurrentPathPublic && isAuthenticated && permissionsLoadFailed) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen">
-        <EmptyState
-          icon={ShieldAlert}
-          title={t('permissions.loadFailed.title')}
-          description={t('permissions.loadFailed.description')}
-          action={{
-            label: t('permissions.loadFailed.retry'),
-            onClick: () => {
-              void refreshPermissions();
-            },
-            disabled: permissionsLoading,
-          }}
-        />
-        {/* A deterministic failure (403 from the membership gate, auth-service
-            down) retries into the same error forever, and this screen replaces
-            every protected route. Without a way out the user cannot even sign
-            out to try another account. */}
-        <button
-          type="button"
-          className="mt-2 text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
-          onClick={() => {
-            void logout();
-          }}
-        >
-          {t('permissions.loadFailed.signOut')}
-        </button>
-      </div>
-    );
+    return <PermissionsLoadFailure className="min-h-screen" />;
   }
 
   if (isLoading || (!isCurrentPathPublic && isAuthenticated && !permissionsReady)) {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -166,6 +166,7 @@
       "title": "Could not load your permissions",
       "description": "This does not mean you lack access — the permission check failed. Try again.",
       "retry": "Try again",
+      "retrying": "Trying again…",
       "signOut": "Sign out"
     }
   }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -160,5 +160,13 @@
   },
   "validation": {
     "required": "This field is required"
+  },
+  "permissions": {
+    "loadFailed": {
+      "title": "Could not load your permissions",
+      "description": "This does not mean you lack access — the permission check failed. Try again.",
+      "retry": "Try again",
+      "signOut": "Sign out"
+    }
   }
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -150,5 +150,13 @@
   },
   "validation": {
     "required": "Este campo es obligatorio"
+  },
+  "permissions": {
+    "loadFailed": {
+      "title": "No fue posible cargar tus permisos",
+      "description": "Esto no significa que no tengas acceso — la verificación de permisos falló. Inténtalo de nuevo.",
+      "retry": "Intentar de nuevo",
+      "signOut": "Cerrar sesión"
+    }
   }
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -156,6 +156,7 @@
       "title": "No fue posible cargar tus permisos",
       "description": "Esto no significa que no tengas acceso — la verificación de permisos falló. Inténtalo de nuevo.",
       "retry": "Intentar de nuevo",
+      "retrying": "Intentando de nuevo…",
       "signOut": "Cerrar sesión"
     }
   }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -150,5 +150,13 @@
   },
   "validation": {
     "required": "Ce champ est obligatoire"
+  },
+  "permissions": {
+    "loadFailed": {
+      "title": "Impossible de charger vos permissions",
+      "description": "Cela ne signifie pas que vous n'avez pas accès — la vérification des permissions a échoué. Réessayez.",
+      "retry": "Réessayer",
+      "signOut": "Se déconnecter"
+    }
   }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -156,6 +156,7 @@
       "title": "Impossible de charger vos permissions",
       "description": "Cela ne signifie pas que vous n'avez pas accès — la vérification des permissions a échoué. Réessayez.",
       "retry": "Réessayer",
+      "retrying": "Nouvel essai…",
       "signOut": "Se déconnecter"
     }
   }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -150,5 +150,13 @@
   },
   "validation": {
     "required": "Questo campo è obbligatorio"
+  },
+  "permissions": {
+    "loadFailed": {
+      "title": "Impossibile caricare i tuoi permessi",
+      "description": "Questo non significa che non hai accesso — la verifica dei permessi è fallita. Riprova.",
+      "retry": "Riprova",
+      "signOut": "Esci"
+    }
   }
 }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -156,6 +156,7 @@
       "title": "Impossibile caricare i tuoi permessi",
       "description": "Questo non significa che non hai accesso — la verifica dei permessi è fallita. Riprova.",
       "retry": "Riprova",
+      "retrying": "Nuovo tentativo…",
       "signOut": "Esci"
     }
   }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -166,6 +166,7 @@
       "title": "Não foi possível carregar suas permissões",
       "description": "Isso não significa que você não tem acesso — a verificação de permissões falhou. Tente novamente.",
       "retry": "Tentar novamente",
+      "retrying": "Tentando novamente…",
       "signOut": "Sair"
     }
   }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -160,5 +160,13 @@
   },
   "validation": {
     "required": "Este campo é obrigatório"
+  },
+  "permissions": {
+    "loadFailed": {
+      "title": "Não foi possível carregar suas permissões",
+      "description": "Isso não significa que você não tem acesso — a verificação de permissões falhou. Tente novamente.",
+      "retry": "Tentar novamente",
+      "signOut": "Sair"
+    }
   }
 }

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -150,5 +150,13 @@
   },
   "validation": {
     "required": "Este campo é obrigatório"
+  },
+  "permissions": {
+    "loadFailed": {
+      "title": "Não foi possível carregar suas permissões",
+      "description": "Isso não significa que você não tem acesso — a verificação de permissões falhou. Tente novamente.",
+      "retry": "Tentar novamente",
+      "signOut": "Sair"
+    }
   }
 }

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -156,6 +156,7 @@
       "title": "Não foi possível carregar suas permissões",
       "description": "Isso não significa que você não tem acesso — a verificação de permissões falhou. Tente novamente.",
       "retry": "Tentar novamente",
+      "retrying": "Tentando novamente…",
       "signOut": "Sair"
     }
   }

--- a/src/services/permissions.spec.ts
+++ b/src/services/permissions.spec.ts
@@ -2,11 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { permissionsService } from './permissions';
 import { apiAuth } from '@/services/core';
 
-// CRM-164. The context tests mock this service away, so without these examples
-// reverting the two `throw error` lines below back to `return []` restores the
-// original bug with every other test still green. The conditional is the whole
-// point: a failure serves the stale cache when there is one, and only fails
-// when there is nothing to serve.
+// CRM-164. The context tests mock this service away, so these are the only
+// examples guarding the two `throw error` lines — and the condition that
+// matters: fail only when there is no cache to serve.
 
 vi.mock('@/services/core', () => ({
   apiAuth: { get: vi.fn() },
@@ -64,9 +62,8 @@ describe('permissionsService — a failed fetch fails loudly (CRM-164)', () => {
     get.mockResolvedValueOnce({ data: { data: { permissions: ['contacts.read'] } } });
     await expect(permissionsService.getUserPermissions()).resolves.toEqual(['contacts.read']);
 
-    // 30min of cache + 1h of tolerance. Past that the list is too old to answer
-    // `can()` with: the failure has to surface instead of a revoked permission
-    // staying granted for as long as the tab is open.
+    // 30min of cache + 1h of tolerance: past that the list is too old to
+    // answer `can()` with, so the failure has to surface.
     vi.useFakeTimers();
     try {
       vi.setSystemTime(Date.now() + 100 * 60 * 1000);

--- a/src/services/permissions.spec.ts
+++ b/src/services/permissions.spec.ts
@@ -60,6 +60,24 @@ describe('permissionsService — a failed fetch fails loudly (CRM-164)', () => {
     ]);
   });
 
+  it('stops serving the stale cache once it is older than the tolerance window', async () => {
+    get.mockResolvedValueOnce({ data: { data: { permissions: ['contacts.read'] } } });
+    await expect(permissionsService.getUserPermissions()).resolves.toEqual(['contacts.read']);
+
+    // 30min of cache + 1h of tolerance. Past that the list is too old to answer
+    // `can()` with: the failure has to surface instead of a revoked permission
+    // staying granted for as long as the tab is open.
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.now() + 100 * 60 * 1000);
+      get.mockRejectedValue(new Error('network down'));
+
+      await expect(permissionsService.getUserPermissions(true)).rejects.toThrow('network down');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not strand a rejected promise in the dedup slot', async () => {
     get.mockRejectedValueOnce(new Error('network down'));
     await expect(permissionsService.getUserPermissions()).rejects.toThrow('network down');

--- a/src/services/permissions.spec.ts
+++ b/src/services/permissions.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { permissionsService } from './permissions';
+import { apiAuth } from '@/services/core';
+
+// CRM-164. The context tests mock this service away, so without these examples
+// reverting the two `throw error` lines below back to `return []` restores the
+// original bug with every other test still green. The conditional is the whole
+// point: a failure serves the stale cache when there is one, and only fails
+// when there is nothing to serve.
+
+vi.mock('@/services/core', () => ({
+  apiAuth: { get: vi.fn() },
+}));
+
+const get = vi.mocked(apiAuth.get);
+
+describe('permissionsService — a failed fetch fails loudly (CRM-164)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  let consoleWarn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    permissionsService.clearCache();
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  it('rejects instead of resolving to [] when the user fetch fails with no cache', async () => {
+    get.mockRejectedValue(new Error('network down'));
+
+    await expect(permissionsService.getUserPermissions()).rejects.toThrow('network down');
+  });
+
+  it('rejects instead of resolving to [] when the account fetch fails with no cache', async () => {
+    get.mockRejectedValue(new Error('network down'));
+
+    await expect(permissionsService.getAccountPermissions()).rejects.toThrow('network down');
+  });
+
+  it('serves the stale user cache instead of failing when a later fetch breaks', async () => {
+    get.mockResolvedValueOnce({ data: { data: { permissions: ['contacts.read'] } } });
+    await expect(permissionsService.getUserPermissions()).resolves.toEqual(['contacts.read']);
+
+    get.mockRejectedValue(new Error('network down'));
+    await expect(permissionsService.getUserPermissions(true)).resolves.toEqual(['contacts.read']);
+  });
+
+  it('serves the stale account cache instead of failing when a later fetch breaks', async () => {
+    get.mockResolvedValueOnce({ data: { data: { permissions: ['contacts.read'] } } });
+    await expect(permissionsService.getAccountPermissions()).resolves.toEqual(['contacts.read']);
+
+    get.mockRejectedValue(new Error('network down'));
+    await expect(permissionsService.getAccountPermissions(true)).resolves.toEqual([
+      'contacts.read',
+    ]);
+  });
+
+  it('does not strand a rejected promise in the dedup slot', async () => {
+    get.mockRejectedValueOnce(new Error('network down'));
+    await expect(permissionsService.getUserPermissions()).rejects.toThrow('network down');
+
+    // A retry must issue a fresh request rather than replay the failed one.
+    get.mockResolvedValueOnce({ data: { data: { permissions: ['contacts.read'] } } });
+    await expect(permissionsService.getUserPermissions()).resolves.toEqual(['contacts.read']);
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/permissions.ts
+++ b/src/services/permissions.ts
@@ -16,6 +16,13 @@ class PermissionsService {
   // ⚡ OTIMIZAÇÃO: Aumentado cache de 5min para 30min
   // Permissões mudam raramente, não é necessário revalidar a cada 5 minutos
   private readonly CACHE_DURATION = 30 * 60 * 1000; // 30 minutos (antes: 5 minutos)
+  // How long past expiry a cached list may still be served when the fetch
+  // fails. Unbounded, the fallback below would answer `can()` from a list of
+  // arbitrary age and `loadFailed` would never fire, so the "a failure is not a
+  // denial" guarantee (CRM-164) would only ever hold on the first fetch of a
+  // session — and a revoked permission would stay granted for as long as the
+  // tab is open.
+  private readonly MAX_STALE_DURATION = 60 * 60 * 1000; // 1h past expiry
 
   // Cache para permissões do usuário (global)
   private userPermissionsCache: string[] | null = null;
@@ -94,35 +101,40 @@ class PermissionsService {
     // caller fire yet another request — defeating the dedup entirely.
     const requestId = ++this.userPermissionsRequestId;
     const promise = (async () => {
-    try {
-      const response = await apiAuth.get('/permissions');
+      try {
+        const response = await apiAuth.get('/permissions');
 
-      const responseData = extractData<{ permissions: string[] }>(response);
-      this.userPermissionsCache = responseData.permissions || [];
-      this.permissionsCacheExpiry = now + this.CACHE_DURATION;
+        const responseData = extractData<{ permissions: string[] }>(response);
+        const permissions = responseData.permissions || [];
 
-        // Limpar Promise após sucesso
-        if (this.userPermissionsRequestId === requestId) this.userPermissionsPromise = null;
+        // Only the request that owns the slot writes: an older response
+        // settling after a newer forceRefresh would overwrite the fresh data.
+        if (this.userPermissionsRequestId === requestId) {
+          this.userPermissionsCache = permissions;
+          this.permissionsCacheExpiry = Date.now() + this.CACHE_DURATION;
+          this.userPermissionsPromise = null;
+        }
 
-      return this.userPermissionsCache || [];
-    } catch (error) {
+        return permissions;
+      } catch (error) {
         // Limpar Promise em caso de erro
         if (this.userPermissionsRequestId === requestId) this.userPermissionsPromise = null;
 
-      console.error('Erro ao buscar permissões do usuário:', error);
+        console.error('Erro ao buscar permissões do usuário:', error);
 
-      // Se tiver cache antigo, usar como fallback
-      if (this.userPermissionsCache) {
-        console.warn('Usando cache antigo de permissões do usuário');
-        return this.userPermissionsCache;
+        // Serve the previous list as a fallback while it is still inside the
+        // tolerance window
+        if (this.userPermissionsCache && Date.now() < this.permissionsCacheExpiry + this.MAX_STALE_DURATION) {
+          console.warn('Usando cache antigo de permissões do usuário');
+          return this.userPermissionsCache;
+        }
+
+        // CRM-164: sem cache para servir, a falha PRECISA propagar. Devolver []
+        // aqui fazia o PermissionsContext marcar isReady com lista vazia, e daí
+        // `can()` respondia false — falha de carga chegava ao usuário como
+        // negação de permissão.
+        throw error;
       }
-
-      // CRM-164: sem cache para servir, a falha PRECISA propagar. Devolver []
-      // aqui fazia o PermissionsContext marcar isReady com lista vazia, e daí
-      // `can()` respondia false — falha de carga chegava ao usuário como
-      // negação de permissão.
-      throw error;
-    }
     })();
 
     this.userPermissionsPromise = promise;
@@ -153,14 +165,15 @@ class PermissionsService {
 
         const responseData = extractData<{ permissions: string[] }>(response);
         const permissions = responseData.permissions || [];
-        this.accountPermissionsData = {
-          permissions,
-          expiry: now + this.CACHE_DURATION
-        };
 
-        // Limpar Promise após sucesso
-        // Ver getUserPermissions: só limpa o slot se esta ainda for a requisição dona.
-        if (this.accountPermissionsRequestId === requestId) this.accountPermissionsPromise = null;
+        // See getUserPermissions: only the owning request writes the cache.
+        if (this.accountPermissionsRequestId === requestId) {
+          this.accountPermissionsData = {
+            permissions,
+            expiry: Date.now() + this.CACHE_DURATION
+          };
+          this.accountPermissionsPromise = null;
+        }
 
         return permissions;
       } catch (error) {
@@ -169,8 +182,12 @@ class PermissionsService {
 
         console.error('Erro ao buscar permissões do account:', error);
 
-        // Se tiver cache antigo, usar como fallback
-        if (this.accountPermissionsData) {
+        // Serve the previous list as a fallback while it is still inside the
+        // tolerance window
+        if (
+          this.accountPermissionsData &&
+          Date.now() < this.accountPermissionsData.expiry + this.MAX_STALE_DURATION
+        ) {
           console.warn('Usando cache antigo de permissões do account');
           return this.accountPermissionsData.permissions;
         }

--- a/src/services/permissions.ts
+++ b/src/services/permissions.ts
@@ -16,12 +16,9 @@ class PermissionsService {
   // ⚡ OTIMIZAÇÃO: Aumentado cache de 5min para 30min
   // Permissões mudam raramente, não é necessário revalidar a cada 5 minutos
   private readonly CACHE_DURATION = 30 * 60 * 1000; // 30 minutos (antes: 5 minutos)
-  // How long past expiry a cached list may still be served when the fetch
-  // fails. Unbounded, the fallback below would answer `can()` from a list of
-  // arbitrary age and `loadFailed` would never fire, so the "a failure is not a
-  // denial" guarantee (CRM-164) would only ever hold on the first fetch of a
-  // session — and a revoked permission would stay granted for as long as the
-  // tab is open.
+  // Bounds the stale-cache fallback below. Unbounded, a revoked permission
+  // would stay granted for the life of the tab and `loadFailed` would never
+  // fire (CRM-164).
   private readonly MAX_STALE_DURATION = 60 * 60 * 1000; // 1h past expiry
 
   // Cache para permissões do usuário (global)
@@ -35,9 +32,9 @@ class PermissionsService {
   private userPermissionsPromise: Promise<string[]> | null = null;
   private accountPermissionsPromise: Promise<string[]> | null = null;
 
-  // Identifica a requisição dona do slot de dedup acima. Comparar contra a
-  // própria Promise seria mais direto, mas a auto-referência dentro da IIFE que
-  // a cria não compila (TS2454).
+  // Identifies the request that owns the dedup slot above. Comparing against
+  // the Promise itself would be simpler, but the self-reference inside the IIFE
+  // that creates it does not compile (TS2454).
   private userPermissionsRequestId = 0;
   private accountPermissionsRequestId = 0;
 
@@ -95,10 +92,8 @@ class PermissionsService {
     }
 
     // Criar nova Promise e armazenar
-    // `forceRefresh` bypasses the dedup guard above, so a retry can install a
-    // newer promise while this one is still in flight. Clearing the slot
-    // unconditionally would then discard the NEWER promise and let a third
-    // caller fire yet another request — defeating the dedup entirely.
+    // `forceRefresh` bypasses the dedup guard, so a newer promise can land in
+    // the slot mid-flight; only its owner may clear it.
     const requestId = ++this.userPermissionsRequestId;
     const promise = (async () => {
       try {
@@ -107,8 +102,7 @@ class PermissionsService {
         const responseData = extractData<{ permissions: string[] }>(response);
         const permissions = responseData.permissions || [];
 
-        // Only the request that owns the slot writes: an older response
-        // settling after a newer forceRefresh would overwrite the fresh data.
+        // Only the owner writes: an older response would overwrite fresh data.
         if (this.userPermissionsRequestId === requestId) {
           this.userPermissionsCache = permissions;
           this.permissionsCacheExpiry = Date.now() + this.CACHE_DURATION;
@@ -122,17 +116,14 @@ class PermissionsService {
 
         console.error('Erro ao buscar permissões do usuário:', error);
 
-        // Serve the previous list as a fallback while it is still inside the
-        // tolerance window
+        // Fall back to the previous list while it is inside the tolerance window
         if (this.userPermissionsCache && Date.now() < this.permissionsCacheExpiry + this.MAX_STALE_DURATION) {
           console.warn('Usando cache antigo de permissões do usuário');
           return this.userPermissionsCache;
         }
 
-        // CRM-164: sem cache para servir, a falha PRECISA propagar. Devolver []
-        // aqui fazia o PermissionsContext marcar isReady com lista vazia, e daí
-        // `can()` respondia false — falha de carga chegava ao usuário como
-        // negação de permissão.
+        // CRM-164: with no cache to serve, the failure MUST propagate.
+        // Returning [] here reached the user as a permission denial.
         throw error;
       }
     })();
@@ -182,8 +173,7 @@ class PermissionsService {
 
         console.error('Erro ao buscar permissões do account:', error);
 
-        // Serve the previous list as a fallback while it is still inside the
-        // tolerance window
+        // Fall back to the previous list while it is inside the tolerance window
         if (
           this.accountPermissionsData &&
           Date.now() < this.accountPermissionsData.expiry + this.MAX_STALE_DURATION
@@ -192,7 +182,7 @@ class PermissionsService {
           return this.accountPermissionsData.permissions;
         }
 
-        // CRM-164: ver getUserPermissions — falha sem cache propaga.
+        // CRM-164: see getUserPermissions — a failure with no cache propagates.
         throw error;
       }
     })();

--- a/src/services/permissions.ts
+++ b/src/services/permissions.ts
@@ -82,7 +82,11 @@ class PermissionsService {
     }
 
     // Criar nova Promise e armazenar
-    this.userPermissionsPromise = (async () => {
+    // `forceRefresh` bypasses the dedup guard above, so a retry can install a
+    // newer promise while this one is still in flight. Clearing the slot
+    // unconditionally would then discard the NEWER promise and let a third
+    // caller fire yet another request — defeating the dedup entirely.
+    const promise = (async () => {
     try {
       const response = await apiAuth.get('/permissions');
 
@@ -91,12 +95,12 @@ class PermissionsService {
       this.permissionsCacheExpiry = now + this.CACHE_DURATION;
 
         // Limpar Promise após sucesso
-        this.userPermissionsPromise = null;
+        if (this.userPermissionsPromise === promise) this.userPermissionsPromise = null;
 
       return this.userPermissionsCache || [];
     } catch (error) {
         // Limpar Promise em caso de erro
-        this.userPermissionsPromise = null;
+        if (this.userPermissionsPromise === promise) this.userPermissionsPromise = null;
 
       console.error('Erro ao buscar permissões do usuário:', error);
 
@@ -106,11 +110,16 @@ class PermissionsService {
         return this.userPermissionsCache;
       }
 
-      return [];
+      // CRM-164: sem cache para servir, a falha PRECISA propagar. Devolver []
+      // aqui fazia o PermissionsContext marcar isReady com lista vazia, e daí
+      // `can()` respondia false — falha de carga chegava ao usuário como
+      // negação de permissão.
+      throw error;
     }
     })();
 
-    return this.userPermissionsPromise;
+    this.userPermissionsPromise = promise;
+    return promise;
   }
 
   /**
@@ -142,12 +151,13 @@ class PermissionsService {
         };
 
         // Limpar Promise após sucesso
-        this.accountPermissionsPromise = null;
+        // Ver getUserPermissions: só limpa o slot se ele ainda for este promise.
+        if (this.accountPermissionsPromise === promise) this.accountPermissionsPromise = null;
 
         return permissions;
       } catch (error) {
         // Limpar Promise em caso de erro
-        this.accountPermissionsPromise = null;
+        if (this.accountPermissionsPromise === promise) this.accountPermissionsPromise = null;
 
         console.error('Erro ao buscar permissões do account:', error);
 
@@ -157,7 +167,8 @@ class PermissionsService {
           return this.accountPermissionsData.permissions;
         }
 
-        return [];
+        // CRM-164: ver getUserPermissions — falha sem cache propaga.
+        throw error;
       }
     })();
 

--- a/src/services/permissions.ts
+++ b/src/services/permissions.ts
@@ -28,6 +28,12 @@ class PermissionsService {
   private userPermissionsPromise: Promise<string[]> | null = null;
   private accountPermissionsPromise: Promise<string[]> | null = null;
 
+  // Identifica a requisição dona do slot de dedup acima. Comparar contra a
+  // própria Promise seria mais direto, mas a auto-referência dentro da IIFE que
+  // a cria não compila (TS2454).
+  private userPermissionsRequestId = 0;
+  private accountPermissionsRequestId = 0;
+
   /**
    * Busca todas as configurações de recursos e permissões do backend
    */
@@ -86,6 +92,7 @@ class PermissionsService {
     // newer promise while this one is still in flight. Clearing the slot
     // unconditionally would then discard the NEWER promise and let a third
     // caller fire yet another request — defeating the dedup entirely.
+    const requestId = ++this.userPermissionsRequestId;
     const promise = (async () => {
     try {
       const response = await apiAuth.get('/permissions');
@@ -95,12 +102,12 @@ class PermissionsService {
       this.permissionsCacheExpiry = now + this.CACHE_DURATION;
 
         // Limpar Promise após sucesso
-        if (this.userPermissionsPromise === promise) this.userPermissionsPromise = null;
+        if (this.userPermissionsRequestId === requestId) this.userPermissionsPromise = null;
 
       return this.userPermissionsCache || [];
     } catch (error) {
         // Limpar Promise em caso de erro
-        if (this.userPermissionsPromise === promise) this.userPermissionsPromise = null;
+        if (this.userPermissionsRequestId === requestId) this.userPermissionsPromise = null;
 
       console.error('Erro ao buscar permissões do usuário:', error);
 
@@ -139,6 +146,7 @@ class PermissionsService {
     }
 
     // Criar nova Promise e armazenar
+    const requestId = ++this.accountPermissionsRequestId;
     const promise = (async () => {
       try {
         const response = await apiAuth.get('/permissions');
@@ -151,13 +159,13 @@ class PermissionsService {
         };
 
         // Limpar Promise após sucesso
-        // Ver getUserPermissions: só limpa o slot se ele ainda for este promise.
-        if (this.accountPermissionsPromise === promise) this.accountPermissionsPromise = null;
+        // Ver getUserPermissions: só limpa o slot se esta ainda for a requisição dona.
+        if (this.accountPermissionsRequestId === requestId) this.accountPermissionsPromise = null;
 
         return permissions;
       } catch (error) {
         // Limpar Promise em caso de erro
-        if (this.accountPermissionsPromise === promise) this.accountPermissionsPromise = null;
+        if (this.accountPermissionsRequestId === requestId) this.accountPermissionsPromise = null;
 
         console.error('Erro ao buscar permissões do account:', error);
 


### PR DESCRIPTION
## Problema

`permissionsService.getUserPermissions()` / `getAccountPermissions()` engoliam qualquer erro e devolviam `[]`. O `PermissionsContext` então marcava `isReady = true` com a lista vazia, e `can()` respondia `false` — **indistinguível de uma negação real**.

Sintomas reportados no CRM-164:
- Recarregar com uma conversa aberta toastava *"Você não tem permissão para visualizar conversas"*.
- Trocar de conta (que o shell serve com um `window.location.reload()`) piscava `permissionDenied.read` em `/settings/ai-credentials` antes de listar as credenciais.

## Solução

- **`services/permissions.ts`** — os dois métodos **relançam** o erro quando não há cache antigo para servir. O fallback de cache continua intacto: erro *com* cache serve o cache e não falha.
- **`PermissionsContext.tsx`** — cada busca passa a ser rastreada como `pending | loaded | failed` em vez de um booleano "terminou". Uma lista vazia obtida com **sucesso** segue sendo negação legítima; uma vazia por **falha** não é. `isReady` exige as duas `loaded`.
- **`RouterGuard.tsx`** — como ele já bloqueava toda rota protegida em `!isReady`, o erro de carga aparece ali, no lugar do spinner que nunca terminaria. Uma superfície, cobertura global, **nenhum dos ~90 consumidores de `isReady` tocado**.
- **i18n** — `permissions.loadFailed.*` nas 6 locales.

O novo `loadFailed` só reporta depois que **ambas** as buscas assentaram: `loading` é uma flag compartilhada, então quem termina primeiro a limpa, e reportar na primeira rejeição fazia a tela de erro **piscar** no meio do boot — a mesma classe de bug que este PR existe para remover.

Uma falha determinística (403 do gate de membership, auth-service fora) retenta contra si mesma pra sempre, então o painel também oferece uma saída de logout.

`refreshPermissions` roda as duas buscas em `Promise.allSettled` — aguardá-las em sequência fazia uma rejeição da primeira **pular a segunda inteiramente**, de modo que o retry nunca atualizava uma lista de account velha. Os dois efeitos ganharam guarda de cancelamento: uma rejeição órfã chegando depois de um sucesso novo carimbava `failed` sobre um contexto já carregado.

## Testes

- `PermissionsContext.spec.tsx` — estendido: falha de account, falha de user, retry que recupera, e vazio-com-sucesso que **continua** negando.
- `permissions.spec.ts` (novo) — sem ele, reverter os dois `throw error` restaurava o bug com todos os outros testes verdes. Cobre a parte que importa: falhar **só** quando não há cache.
- `250 testes verdes` (contexto, service, i18n-parity, PermissionRoute, rbac-render-gates, AiCredentials) · `tsc --noEmit` limpo · `eslint` limpo.

Validado manualmente em dev local: boot limpo não exibe negação; com `*/permissions` bloqueado no DevTools aparece o painel de erro de carga; desbloqueando, o "Tentar novamente" recupera.

## Fora de escopo

- Backfill de `custom_attribute_definitions.read` no seed do auth (ex-AC2, recortado do card pelo PM).
- Gating do menu "Credenciais de IA" no shell (camada diferente).

## Pré-existentes, encontrados no review e não corrigidos aqui

- `/resource_actions` nunca é requisitado: o efeito de config tem deps `[]` e desiste se o auth ainda não hidratou, deixando `isValidPermission` inerte.
- `startImpersonation()` não limpa o cache de permissões, então `can()` responde com os grants do admin ao personificar um usuário restrito.
- `Chat.spec.tsx` falha 4 exemplos no `develop` (confirmado no baseline `e64c147`, sem estas mudanças).

Closes CRM-164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent permission-loading failures from being exposed as access denials by propagating unavailable permission state and providing recoverable error handling.

New Features:
- Add a user-facing permissions load failure state with retry and logout actions.

Bug Fixes:
- Ensure permission fetch failures are not interpreted as legitimate permission denials.
- Preserve valid stale permission caches during transient failures while surfacing failures when no usable cache exists.
- Prevent stale or orphaned requests from overwriting newer permission state and ensure retries refresh user and account permissions independently.

Enhancements:
- Track user and account permission loading outcomes separately so readiness requires both successful fetches, including successful empty permission lists.
- Display permission load failures through the provider or router guard without blocking public routes.

CI:
- Expand the targeted CI test suite to cover permission services, context behavior, and router guard failure handling.

Tests:
- Add coverage for failed permission loads, retries, empty successful responses, stale-cache fallback, cache expiry, request deduplication, and protected versus public routes.