### PR TITLE
fix(custom-attributes): falha ao carregar deixa de ser exibida como "não há atributos" (CRM-166)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,11 @@ jobs:
       #     so these are the only examples guarding it.
       #   - RouterGuard (CRM-164): the load-failure panel, and the path split
       #     that keeps public pages reachable for a logged-in visitor.
+      #   - CustomAttributesForm (CRM-166): a definitions fetch that fails is
+      #     reported as a failure with a retry, not as "no attributes". The two
+      #     modes are asserted against their genuine empty states, which is what
+      #     keeps the failure assertions honest — a panel rendered
+      #     unconditionally would satisfy them too.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -119,7 +124,8 @@ jobs:
             src/components/chat/messages/MessageList.spec.tsx \
             src/contexts/chat/eventLabels.spec.ts \
             src/components/contacts/ContactNotesCard.spec.tsx \
-            src/components/rbac-render-gates.spec.tsx
+            src/components/rbac-render-gates.spec.tsx \
+            src/components/customAttributes/CustomAttributesForm.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,9 @@ jobs:
       #   - CustomAttributesForm (CRM-166): a failed definitions fetch is reported
       #     as a failure with a retry, not as "no attributes". Asserted against the
       #     genuine empty state, which is what keeps the failure cases honest.
+      #   - menuItems (CRM-166): the Settings entries gated on an administrative
+      #     key stay gated on it — Atributos Personalizados above all, whose read
+      #     the agent now holds. Also covers the EVO-1938/CRM-70 gates already there.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -123,7 +126,8 @@ jobs:
             src/contexts/chat/eventLabels.spec.ts \
             src/components/contacts/ContactNotesCard.spec.tsx \
             src/components/rbac-render-gates.spec.tsx \
-            src/components/customAttributes/CustomAttributesForm.spec.tsx
+            src/components/customAttributes/CustomAttributesForm.spec.tsx \
+            src/components/layout/config/menuItems.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,11 +74,9 @@ jobs:
       #     so these are the only examples guarding it.
       #   - RouterGuard (CRM-164): the load-failure panel, and the path split
       #     that keeps public pages reachable for a logged-in visitor.
-      #   - CustomAttributesForm (CRM-166): a definitions fetch that fails is
-      #     reported as a failure with a retry, not as "no attributes". The two
-      #     modes are asserted against their genuine empty states, which is what
-      #     keeps the failure assertions honest — a panel rendered
-      #     unconditionally would satisfy them too.
+      #   - CustomAttributesForm (CRM-166): a failed definitions fetch is reported
+      #     as a failure with a retry, not as "no attributes". Asserted against the
+      #     genuine empty state, which is what keeps the failure cases honest.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in

--- a/src/components/base/PrimaryActionButton.tsx
+++ b/src/components/base/PrimaryActionButton.tsx
@@ -47,8 +47,13 @@ export default function PrimaryActionButton({
     return <span className="mr-2">{icon}</span>;
   };
 
+  // The design-system Button sets no `type`, so the HTML default (submit) applies:
+  // inside a <form> this fires onClick AND submits. The prop contract here is
+  // onClick-only, and `action.onClick` in EmptyState is typed `() => void`, so the
+  // event never surfaces for a caller to preventDefault — the tsc cannot catch it.
   const button = (
     <Button
+      type="button"
       variant={variant}
       size={size}
       onClick={onClick}

--- a/src/components/chat/contact-sidebar/EditableContactCustomAttributes.tsx
+++ b/src/components/chat/contact-sidebar/EditableContactCustomAttributes.tsx
@@ -33,7 +33,6 @@ export default function EditableContactCustomAttributes({
       onUpdateSuccess={onContactUpdate}
       translationNamespace="chat"
       translationKeys={{
-        loadError: 'contactSidebar.customAttributes.loadError',
         updateSuccess: 'contactSidebar.customAttributes.updateSuccess',
         updateError: 'contactSidebar.customAttributes.updateError',
         noAttributes: 'contactSidebar.customAttributes.noAttributes',

--- a/src/components/chat/contact-sidebar/EditableConversationCustomAttributes.tsx
+++ b/src/components/chat/contact-sidebar/EditableConversationCustomAttributes.tsx
@@ -31,7 +31,6 @@ export default function EditableConversationCustomAttributes({
       onUpdateSuccess={onConversationUpdate}
       translationNamespace="chat"
       translationKeys={{
-        loadError: 'contactSidebar.conversationAttributes.loadError',
         updateSuccess: 'contactSidebar.conversationAttributes.updateSuccess',
         updateError: 'contactSidebar.conversationAttributes.updateError',
         noAttributes: 'contactSidebar.conversationAttributes.noAttributes',

--- a/src/components/customAttributes/CustomAttributesForm.spec.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.spec.tsx
@@ -218,5 +218,83 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       expect(onSubmit).not.toHaveBeenCalled();
       expect(mockGetCustomAttributes).toHaveBeenCalledTimes(2);
     });
+
+    // The remaining ad-hoc controls, same reason as the two cases above: each is a
+    // design-system Button inside ContactForm's <form>. Remove is icon-only, so it is
+    // located by having no accessible name.
+    it('does not submit the surrounding form from the remove, cancel or add controls', async () => {
+      mockGetCustomAttributes.mockResolvedValue(definitions([]));
+      const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+
+      render(
+        <form onSubmit={onSubmit}>
+          <CustomAttributesForm
+            attributeModel="contact_attribute"
+            attributes={{ plano_contratado: 'Pro' }}
+            mode="form"
+            onAttributesChange={vi.fn()}
+          />
+        </form>,
+      );
+
+      await screen.findByText('plano_contratado');
+      const remove = screen.getAllByRole('button').find(button => button.textContent === '');
+      await userEvent.click(remove as HTMLElement);
+
+      await userEvent.click(screen.getByRole('button', { name: /actions.addAttribute/ }));
+      await userEvent.click(screen.getByRole('button', { name: /actions.cancel/ }));
+
+      await userEvent.click(screen.getByRole('button', { name: /actions.addAttribute/ }));
+      await userEvent.type(screen.getByPlaceholderText('fields.attributeKey.placeholder'), 'plano');
+      const values = screen.getAllByPlaceholderText('fields.attributeValue.placeholder');
+      await userEvent.type(values[values.length - 1], 'Pro');
+      await userEvent.click(screen.getByRole('button', { name: /^actions.add$/ }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  // The design-system Button sets no `type`, so the HTML default (submit) applies and
+  // no `<form>` in the test tree is needed to catch a regression. Asserted per mode
+  // because each renders a disjoint set of controls.
+  describe('every button opts out of submit', () => {
+    it('form mode, ad-hoc section and add form', async () => {
+      mockGetCustomAttributes.mockResolvedValue(definitions([]));
+
+      render(
+        <CustomAttributesForm
+          attributeModel="contact_attribute"
+          attributes={{ plano_contratado: 'Pro' }}
+          mode="form"
+          onAttributesChange={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(await screen.findByRole('button', { name: /actions.addAttribute/ }));
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBeGreaterThan(2);
+      buttons.forEach(button => expect(button).toHaveAttribute('type', 'button'));
+    });
+
+    it('editable mode, including the inline edit controls', async () => {
+      mockGetCustomAttributes.mockResolvedValue(definitions([definition]));
+
+      render(
+        <CustomAttributesForm
+          attributeModel="contact_attribute"
+          attributes={{ plano_contratado: 'Pro' }}
+          mode="editable"
+          onUpdateAttributes={vi.fn()}
+        />,
+      );
+
+      await screen.findByText('Plano contratado');
+      await userEvent.click(screen.getAllByRole('button')[0]);
+
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.length).toBeGreaterThan(1);
+      buttons.forEach(button => expect(button).toHaveAttribute('type', 'button'));
+    });
   });
 });

--- a/src/components/customAttributes/CustomAttributesForm.spec.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CustomAttributesForm from './CustomAttributesForm';
@@ -61,6 +61,19 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       ).not.toBeInTheDocument();
     });
 
+    it('asks for the three loadFailed keys', async () => {
+      mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
+
+      renderEditable();
+
+      const panel = await screen.findByTestId('custom-attributes-load-failed');
+      expect(within(panel).getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      expect(within(panel).getByText('customAttributes.loadFailed.description')).toBeInTheDocument();
+      expect(
+        within(panel).getByRole('button', { name: 'customAttributes.loadFailed.retry' }),
+      ).toBeInTheDocument();
+    });
+
     it('still reports a genuinely empty catalog as the empty state', async () => {
       mockGetCustomAttributes.mockResolvedValue(definitions([]));
 
@@ -117,6 +130,19 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       expect(screen.queryByText('empty.title')).not.toBeInTheDocument();
     });
 
+    it('asks for the three loadFailed keys', async () => {
+      mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
+
+      renderForm();
+
+      const panel = await screen.findByTestId('custom-attributes-load-failed');
+      expect(within(panel).getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      expect(within(panel).getByText('customAttributes.loadFailed.description')).toBeInTheDocument();
+      expect(
+        within(panel).getByRole('button', { name: 'customAttributes.loadFailed.retry' }),
+      ).toBeInTheDocument();
+    });
+
     it('still shows the empty state when the catalog really is empty', async () => {
       mockGetCustomAttributes.mockResolvedValue(definitions([]));
 
@@ -140,6 +166,30 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       });
       expect(screen.getByText('plano_contratado')).toBeInTheDocument();
       expect(screen.getByDisplayValue('Pro')).toBeInTheDocument();
+    });
+
+    // Every control here renders inside ContactForm's <form>, and the design-system
+    // Button sets no `type` — the HTML default is submit. Reached via the empty state,
+    // the one path where the definitions loaded fine, so it is not a failure-mode case.
+    it('does not submit the surrounding form when opening the add-attribute form', async () => {
+      mockGetCustomAttributes.mockResolvedValue(definitions([]));
+      const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+
+      render(
+        <form onSubmit={onSubmit}>
+          <CustomAttributesForm
+            attributeModel="contact_attribute"
+            attributes={{}}
+            mode="form"
+            onAttributesChange={vi.fn()}
+          />
+        </form>,
+      );
+
+      await userEvent.click(await screen.findByRole('button', { name: /actions.addAttribute/ }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(screen.getByText('sections.newAttribute')).toBeInTheDocument();
     });
 
     // Needs the surrounding <form>: rendered standalone the component satisfies every

--- a/src/components/customAttributes/CustomAttributesForm.spec.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.spec.tsx
@@ -54,7 +54,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       renderEditable();
 
       await waitFor(() => {
-        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+        expect(screen.getByTestId('custom-attributes-load-failed')).toBeInTheDocument();
       });
       expect(
         screen.queryByText('contactSidebar.customAttributes.noAttributes'),
@@ -71,7 +71,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
           screen.getByText('contactSidebar.customAttributes.noAttributes'),
         ).toBeInTheDocument();
       });
-      expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('custom-attributes-load-failed')).not.toBeInTheDocument();
     });
 
     it('retries the load and renders the attributes once the request succeeds', async () => {
@@ -82,7 +82,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       renderEditable();
 
       await waitFor(() => {
-        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+        expect(screen.getByTestId('custom-attributes-load-failed')).toBeInTheDocument();
       });
 
       await userEvent.click(screen.getByRole('button', { name: 'customAttributes.loadFailed.retry' }));
@@ -90,7 +90,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       await waitFor(() => {
         expect(screen.getByText('Plano contratado')).toBeInTheDocument();
       });
-      expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('custom-attributes-load-failed')).not.toBeInTheDocument();
       expect(mockGetCustomAttributes).toHaveBeenCalledTimes(2);
     });
   });
@@ -112,7 +112,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       renderForm();
 
       await waitFor(() => {
-        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+        expect(screen.getByTestId('custom-attributes-load-failed')).toBeInTheDocument();
       });
       expect(screen.queryByText('empty.title')).not.toBeInTheDocument();
     });
@@ -125,7 +125,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       await waitFor(() => {
         expect(screen.getByText('empty.title')).toBeInTheDocument();
       });
-      expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('custom-attributes-load-failed')).not.toBeInTheDocument();
     });
 
     // The edit form kept working through the bug because values with no definition
@@ -136,7 +136,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       renderForm({ plano_contratado: 'Pro' });
 
       await waitFor(() => {
-        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+        expect(screen.getByTestId('custom-attributes-load-failed')).toBeInTheDocument();
       });
       expect(screen.getByText('plano_contratado')).toBeInTheDocument();
       expect(screen.getByDisplayValue('Pro')).toBeInTheDocument();
@@ -160,7 +160,7 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       );
 
       await waitFor(() => {
-        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+        expect(screen.getByTestId('custom-attributes-load-failed')).toBeInTheDocument();
       });
 
       await userEvent.click(screen.getByRole('button', { name: 'customAttributes.loadFailed.retry' }));

--- a/src/components/customAttributes/CustomAttributesForm.spec.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.spec.tsx
@@ -18,15 +18,9 @@ vi.mock('@/services/customAttributes/customAttributesService', () => ({
   },
 }));
 
-// CRM-166. `GET /custom_attribute_definitions` is gated on
-// `custom_attribute_definitions.read`, which the default agent role did not hold,
-// so the request 403'd. The component swallowed the rejection, left
-// `definedAttributes` at [], and every read-only surface rendered "no attributes"
-// — the user reported "my custom attributes disappeared outside the edit form".
-//
-// The paired positive cases below are what keep the negative ones honest: a
-// component that rendered the failure panel unconditionally would satisfy the
-// failure assertions too.
+// CRM-166: a 403 on the definitions endpoint was swallowed and rendered as "no
+// attributes". The paired empty-catalog cases keep the failure assertions honest —
+// a panel rendered unconditionally would satisfy them too.
 describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)', () => {
   const definition = {
     id: 'def-1',
@@ -134,9 +128,8 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
     });
 
-    // The edit form is the one surface that kept working through the bug: values
-    // with no matching definition fall through to the ad-hoc section. The failure
-    // panel must not take that away — it replaces the "Defined" section only.
+    // The edit form kept working through the bug because values with no definition
+    // fall through to the ad-hoc section, which the failure panel must not replace.
     it('keeps rendering the ad-hoc values while the definitions are unavailable', async () => {
       mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
 
@@ -147,6 +140,33 @@ describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)
       });
       expect(screen.getByText('plano_contratado')).toBeInTheDocument();
       expect(screen.getByDisplayValue('Pro')).toBeInTheDocument();
+    });
+
+    // Needs the surrounding <form>: rendered standalone the component satisfies every
+    // case above even while the retry is submitting ContactForm instead of refetching.
+    it('does not submit the surrounding form when retrying', async () => {
+      mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
+      const onSubmit = vi.fn((event: React.FormEvent) => event.preventDefault());
+
+      render(
+        <form onSubmit={onSubmit}>
+          <CustomAttributesForm
+            attributeModel="contact_attribute"
+            attributes={{}}
+            mode="form"
+            onAttributesChange={vi.fn()}
+          />
+        </form>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'customAttributes.loadFailed.retry' }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(mockGetCustomAttributes).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/components/customAttributes/CustomAttributesForm.spec.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.spec.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CustomAttributesForm from './CustomAttributesForm';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockGetCustomAttributes = vi.fn();
+vi.mock('@/services/customAttributes/customAttributesService', () => ({
+  customAttributesService: {
+    getCustomAttributes: (...args: unknown[]) => mockGetCustomAttributes(...args),
+  },
+}));
+
+// CRM-166. `GET /custom_attribute_definitions` is gated on
+// `custom_attribute_definitions.read`, which the default agent role did not hold,
+// so the request 403'd. The component swallowed the rejection, left
+// `definedAttributes` at [], and every read-only surface rendered "no attributes"
+// — the user reported "my custom attributes disappeared outside the edit form".
+//
+// The paired positive cases below are what keep the negative ones honest: a
+// component that rendered the failure panel unconditionally would satisfy the
+// failure assertions too.
+describe('CustomAttributesForm — load failure is not "no attributes" (CRM-166)', () => {
+  const definition = {
+    id: 'def-1',
+    attribute_display_name: 'Plano contratado',
+    attribute_key: 'plano_contratado',
+    attribute_display_type: 'text',
+    attribute_model: 'contact_attribute',
+    attribute_description: null,
+  };
+
+  const definitions = (data: unknown[]) => ({ data, meta: {} });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('editable mode (contact sidebar)', () => {
+    const renderEditable = () =>
+      render(
+        <CustomAttributesForm
+          attributeModel="contact_attribute"
+          attributes={{ plano_contratado: 'Pro' }}
+          mode="editable"
+          onUpdateAttributes={vi.fn()}
+        />,
+      );
+
+    it('reports the failure instead of the empty state when the definitions do not load', async () => {
+      mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
+
+      renderEditable();
+
+      await waitFor(() => {
+        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText('contactSidebar.customAttributes.noAttributes'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('still reports a genuinely empty catalog as the empty state', async () => {
+      mockGetCustomAttributes.mockResolvedValue(definitions([]));
+
+      renderEditable();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('contactSidebar.customAttributes.noAttributes'),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
+    });
+
+    it('retries the load and renders the attributes once the request succeeds', async () => {
+      mockGetCustomAttributes
+        .mockRejectedValueOnce(new Error('Request failed with status code 403'))
+        .mockResolvedValueOnce(definitions([definition]));
+
+      renderEditable();
+
+      await waitFor(() => {
+        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'customAttributes.loadFailed.retry' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Plano contratado')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
+      expect(mockGetCustomAttributes).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('form mode (contact edit form)', () => {
+    const renderForm = (attributes: Record<string, unknown> = {}) =>
+      render(
+        <CustomAttributesForm
+          attributeModel="contact_attribute"
+          attributes={attributes}
+          mode="form"
+          onAttributesChange={vi.fn()}
+        />,
+      );
+
+    it('reports the failure instead of the "no attributes registered" empty state', async () => {
+      mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
+
+      renderForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('empty.title')).not.toBeInTheDocument();
+    });
+
+    it('still shows the empty state when the catalog really is empty', async () => {
+      mockGetCustomAttributes.mockResolvedValue(definitions([]));
+
+      renderForm();
+
+      await waitFor(() => {
+        expect(screen.getByText('empty.title')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('customAttributes.loadFailed.title')).not.toBeInTheDocument();
+    });
+
+    // The edit form is the one surface that kept working through the bug: values
+    // with no matching definition fall through to the ad-hoc section. The failure
+    // panel must not take that away — it replaces the "Defined" section only.
+    it('keeps rendering the ad-hoc values while the definitions are unavailable', async () => {
+      mockGetCustomAttributes.mockRejectedValue(new Error('Request failed with status code 403'));
+
+      renderForm({ plano_contratado: 'Pro' });
+
+      await waitFor(() => {
+        expect(screen.getByText('customAttributes.loadFailed.title')).toBeInTheDocument();
+      });
+      expect(screen.getByText('plano_contratado')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Pro')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/customAttributes/CustomAttributesForm.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.tsx
@@ -136,9 +136,10 @@ export default function CustomAttributesForm({
   };
 
   // CRM-166: the catch only toasted and left `definedAttributes` at [], so a failed
-  // load was indistinguishable from an empty catalog. `cancelled` is for StrictMode's
-  // double-mount: without it the first mount's rejection lands after the second
-  // mount's success and paints the failure panel over loaded attributes.
+  // load was indistinguishable from an empty catalog. Nothing aborts the request, so
+  // `cancelled` is what keeps a late response from writing state the component has
+  // moved on from — unmount (collapsing the sidebar section mid-flight) above all.
+  // Not StrictMode: main.tsx renders <App /> unwrapped, on purpose.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -777,6 +778,7 @@ export default function CustomAttributesForm({
                       </div>
                       {!disabled && (
                         <Button
+                          type="button"
                           variant="ghost"
                           size="sm"
                           onClick={() => handleRemoveAttribute(key)}
@@ -823,6 +825,7 @@ export default function CustomAttributesForm({
                 </div>
                 <div className="flex gap-2">
                   <Button
+                    type="button"
                     size="sm"
                     onClick={handleAddAttribute}
                     disabled={!newAttributeKey.trim() || !newAttributeValue.trim()}
@@ -830,6 +833,7 @@ export default function CustomAttributesForm({
                     {t('actions.add')}
                   </Button>
                   <Button
+                    type="button"
                     variant="outline"
                     size="sm"
                     onClick={() => {
@@ -845,6 +849,7 @@ export default function CustomAttributesForm({
             </Card>
           ) : (
             <Button
+              type="button"
               variant="outline"
               size="sm"
               onClick={() => setShowAddForm(true)}

--- a/src/components/customAttributes/CustomAttributesForm.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.tsx
@@ -93,14 +93,9 @@ export default function CustomAttributesForm({
     return value;
   };
 
-  // CRM-166: a failed load used to leave `definedAttributes` at [] and only
-  // toast, so every read-only surface rendered "no attributes" — indistinguishable
-  // from a real empty catalog. The failure is tracked so the render paths below can
-  // say what happened and offer a retry.
-  //
-  // `cancelled` guards the ordering: on a model switch (or a retry landing before
-  // the request it replaced) a stale rejection must not stamp failed over a newer
-  // success.
+  // CRM-166: the catch only toasted and left `definedAttributes` at [], so a failed
+  // load was indistinguishable from an empty catalog. `cancelled` keeps a stale
+  // rejection from overwriting a newer success on a model switch or overlapping retry.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -127,7 +122,12 @@ export default function CustomAttributesForm({
     };
   }, [attributeModel, reloadToken]);
 
-  const retryLoadDefinedAttributes = () => setReloadToken(token => token + 1);
+  // The design-system Button sets no `type`, and in `form` mode this renders inside
+  // ContactForm's <form>: without preventDefault the retry submits it instead.
+  const retryLoadDefinedAttributes = (event?: React.MouseEvent<HTMLButtonElement>) => {
+    event?.preventDefault();
+    setReloadToken(token => token + 1);
+  };
 
   // Form mode handlers
   const handleAddAttribute = () => {

--- a/src/components/customAttributes/CustomAttributesForm.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.tsx
@@ -24,6 +24,49 @@ import { toast } from 'sonner';
 
 export type CustomAttributesMode = 'form' | 'editable';
 
+/**
+ * CRM-166: both modes report a failed definitions load with the same three strings
+ * and the same retry. `compact` is the sidebar shape; the default is the full-width
+ * EmptyState used inside the contact edit form.
+ */
+function LoadFailurePanel({ compact, onRetry }: { compact?: boolean; onRetry: () => void }) {
+  const { t: tCommon } = useLanguage('common');
+  const title = tCommon('customAttributes.loadFailed.title');
+  const description = tCommon('customAttributes.loadFailed.description');
+  const retryLabel = tCommon('customAttributes.loadFailed.retry');
+
+  if (compact) {
+    return (
+      <div className="space-y-2 py-4 text-center" data-testid="custom-attributes-load-failed">
+        <AlertTriangle className="mx-auto h-4 w-4 text-muted-foreground" />
+        <p className="text-xs font-medium text-foreground">{title}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={onRetry}
+          className="h-6 px-2 text-xs"
+        >
+          {retryLabel}
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="custom-attributes-load-failed">
+      <EmptyState
+        icon={AlertTriangle}
+        title={title}
+        description={description}
+        action={{ label: retryLabel, onClick: onRetry, variant: 'outline' }}
+        className="py-8"
+      />
+    </div>
+  );
+}
+
 export interface CustomAttributesFormProps {
   /** The attribute model type (e.g., 'pipeline_item_attribute', 'contact_attribute') */
   attributeModel: AttributeModel;
@@ -70,7 +113,6 @@ export default function CustomAttributesForm({
 }: CustomAttributesFormProps) {
   const defaultTranslationNamespace = mode === 'editable' ? 'chat' : 'customAttributes';
   const { t } = useLanguage(translationNamespace || defaultTranslationNamespace);
-  const { t: tCommon } = useLanguage('common');
   const [definedAttributes, setDefinedAttributes] = useState<CustomAttributeDefinition[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -94,8 +136,9 @@ export default function CustomAttributesForm({
   };
 
   // CRM-166: the catch only toasted and left `definedAttributes` at [], so a failed
-  // load was indistinguishable from an empty catalog. `cancelled` keeps a stale
-  // rejection from overwriting a newer success on a model switch or overlapping retry.
+  // load was indistinguishable from an empty catalog. `cancelled` is for StrictMode's
+  // double-mount: without it the first mount's rejection lands after the second
+  // mount's success and paints the failure panel over loaded attributes.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -122,10 +165,7 @@ export default function CustomAttributesForm({
     };
   }, [attributeModel, reloadToken]);
 
-  // The design-system Button sets no `type`, and in `form` mode this renders inside
-  // ContactForm's <form>: without preventDefault the retry submits it instead.
-  const retryLoadDefinedAttributes = (event?: React.MouseEvent<HTMLButtonElement>) => {
-    event?.preventDefault();
+  const retryLoadDefinedAttributes = () => {
     setReloadToken(token => token + 1);
   };
 
@@ -617,26 +657,7 @@ export default function CustomAttributesForm({
     }
 
     if (loadFailed) {
-      return (
-        <div className="space-y-2 py-4 text-center" data-testid="custom-attributes-load-failed">
-          <AlertTriangle className="mx-auto h-4 w-4 text-muted-foreground" />
-          <p className="text-xs font-medium text-foreground">
-            {tCommon('customAttributes.loadFailed.title')}
-          </p>
-          <p className="text-xs text-muted-foreground">
-            {tCommon('customAttributes.loadFailed.description')}
-          </p>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={retryLoadDefinedAttributes}
-            disabled={loading}
-            className="h-6 px-2 text-xs"
-          >
-            {tCommon('customAttributes.loadFailed.retry')}
-          </Button>
-        </div>
-      );
+      return <LoadFailurePanel compact onRetry={retryLoadDefinedAttributes} />;
     }
 
     if (definedAttributes.length === 0) {
@@ -672,18 +693,7 @@ export default function CustomAttributesForm({
       )}
 
       {loadFailed && !loading && (
-        <EmptyState
-          icon={AlertTriangle}
-          title={tCommon('customAttributes.loadFailed.title')}
-          description={tCommon('customAttributes.loadFailed.description')}
-          action={{
-            label: tCommon('customAttributes.loadFailed.retry'),
-            onClick: retryLoadDefinedAttributes,
-            variant: 'outline',
-            disabled: loading,
-          }}
-          className="py-8"
-        />
+        <LoadFailurePanel onRetry={retryLoadDefinedAttributes} />
       )}
 
       {/* Defined Custom Attributes */}

--- a/src/components/customAttributes/CustomAttributesForm.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.tsx
@@ -16,9 +16,10 @@ import {
   Textarea,
   Switch,
 } from '@evoapi/design-system';
-import { Plus, X, Settings, Pencil, Check, Loader2 } from 'lucide-react';
+import { Plus, X, Settings, Pencil, Check, Loader2, AlertTriangle } from 'lucide-react';
 import { customAttributesService } from '@/services/customAttributes/customAttributesService';
 import { CustomAttributeDefinition, AttributeModel } from '@/types/settings';
+import EmptyState from '@/components/base/EmptyState';
 import { toast } from 'sonner';
 
 export type CustomAttributesMode = 'form' | 'editable';
@@ -42,7 +43,6 @@ export interface CustomAttributesFormProps {
   translationNamespace?: string;
   /** Translation keys for messages (used in 'editable' mode) */
   translationKeys?: {
-    loadError?: string;
     updateSuccess?: string;
     updateError?: string;
     noAttributes?: string;
@@ -70,8 +70,11 @@ export default function CustomAttributesForm({
 }: CustomAttributesFormProps) {
   const defaultTranslationNamespace = mode === 'editable' ? 'chat' : 'customAttributes';
   const { t } = useLanguage(translationNamespace || defaultTranslationNamespace);
+  const { t: tCommon } = useLanguage('common');
   const [definedAttributes, setDefinedAttributes] = useState<CustomAttributeDefinition[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [reloadToken, setReloadToken] = useState(0);
   const [newAttributeKey, setNewAttributeKey] = useState('');
   const [newAttributeValue, setNewAttributeValue] = useState('');
   const [showAddForm, setShowAddForm] = useState(false);
@@ -90,27 +93,41 @@ export default function CustomAttributesForm({
     return value;
   };
 
-  // Load defined custom attributes for the specified model
+  // CRM-166: a failed load used to leave `definedAttributes` at [] and only
+  // toast, so every read-only surface rendered "no attributes" — indistinguishable
+  // from a real empty catalog. The failure is tracked so the render paths below can
+  // say what happened and offer a retry.
+  //
+  // `cancelled` guards the ordering: on a model switch (or a retry landing before
+  // the request it replaced) a stale rejection must not stamp failed over a newer
+  // success.
   useEffect(() => {
-    const loadDefinedAttributes = async () => {
-      setLoading(true);
-      try {
-        const response = await customAttributesService.getCustomAttributes(attributeModel);
-        setDefinedAttributes(response.data);
-      } catch (error) {
-        if (mode === 'editable') {
-          const errorKey = translationKeys.loadError || 'contactSidebar.customAttributes.loadError';
-          toast.error(t(errorKey));
-        } else {
-          console.error('Error loading custom attributes:', error);
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
+    let cancelled = false;
+    setLoading(true);
 
-    loadDefinedAttributes();
-  }, [attributeModel, mode, t, translationKeys.loadError]);
+    customAttributesService
+      .getCustomAttributes(attributeModel)
+      .then(response => {
+        if (cancelled) return;
+        setDefinedAttributes(response.data);
+        setLoadFailed(false);
+      })
+      .catch(error => {
+        if (cancelled) return;
+        console.error('Error loading custom attributes:', error);
+        setLoadFailed(true);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attributeModel, reloadToken]);
+
+  const retryLoadDefinedAttributes = () => setReloadToken(token => token + 1);
 
   // Form mode handlers
   const handleAddAttribute = () => {
@@ -599,6 +616,29 @@ export default function CustomAttributesForm({
       );
     }
 
+    if (loadFailed) {
+      return (
+        <div className="space-y-2 py-4 text-center" data-testid="custom-attributes-load-failed">
+          <AlertTriangle className="mx-auto h-4 w-4 text-muted-foreground" />
+          <p className="text-xs font-medium text-foreground">
+            {tCommon('customAttributes.loadFailed.title')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {tCommon('customAttributes.loadFailed.description')}
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={retryLoadDefinedAttributes}
+            disabled={loading}
+            className="h-6 px-2 text-xs"
+          >
+            {tCommon('customAttributes.loadFailed.retry')}
+          </Button>
+        </div>
+      );
+    }
+
     if (definedAttributes.length === 0) {
       const noAttributesKey = translationKeys.noAttributes || 'contactSidebar.customAttributes.noAttributes';
       return (
@@ -629,6 +669,21 @@ export default function CustomAttributesForm({
         <div className="text-center py-4">
           <div className="text-sm text-muted-foreground">{t('loading')}</div>
         </div>
+      )}
+
+      {loadFailed && !loading && (
+        <EmptyState
+          icon={AlertTriangle}
+          title={tCommon('customAttributes.loadFailed.title')}
+          description={tCommon('customAttributes.loadFailed.description')}
+          action={{
+            label: tCommon('customAttributes.loadFailed.retry'),
+            onClick: retryLoadDefinedAttributes,
+            variant: 'outline',
+            disabled: loading,
+          }}
+          className="py-8"
+        />
       )}
 
       {/* Defined Custom Attributes */}
@@ -796,7 +851,8 @@ export default function CustomAttributesForm({
       {definedAttributes.length === 0 &&
         attributeEntries.length === 0 &&
         !showAddForm &&
-        !loading && (
+        !loading &&
+        !loadFailed && (
           <div className="text-center py-6 text-muted-foreground">
             <Settings className="h-8 w-8 mx-auto mb-2 opacity-50" />
             <p className="text-sm">{t('empty.title')}</p>

--- a/src/components/customAttributes/CustomAttributesForm.tsx
+++ b/src/components/customAttributes/CustomAttributesForm.tsx
@@ -465,6 +465,7 @@ export default function CustomAttributesForm({
                 disabled={saving}
               />
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleSave}
@@ -478,6 +479,7 @@ export default function CustomAttributesForm({
                 )}
               </Button>
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleCancelEdit}
@@ -505,6 +507,7 @@ export default function CustomAttributesForm({
                 disabled={saving}
               />
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleSave}
@@ -518,6 +521,7 @@ export default function CustomAttributesForm({
                 )}
               </Button>
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleCancelEdit}
@@ -545,6 +549,7 @@ export default function CustomAttributesForm({
                 </SelectContent>
               </Select>
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleSave}
@@ -558,6 +563,7 @@ export default function CustomAttributesForm({
                 )}
               </Button>
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleCancelEdit}
@@ -580,6 +586,7 @@ export default function CustomAttributesForm({
                 disabled={saving}
               />
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleSave}
@@ -593,6 +600,7 @@ export default function CustomAttributesForm({
                 )}
               </Button>
               <Button
+                type="button"
                 size="sm"
                 variant="ghost"
                 onClick={handleCancelEdit}
@@ -631,6 +639,7 @@ export default function CustomAttributesForm({
           {value || <span className="text-muted-foreground">--</span>}
         </span>
         <Button
+          type="button"
           size="sm"
           variant="ghost"
           onClick={() => handleStartEdit(key, rawValue)}

--- a/src/components/layout/config/menuItems.spec.ts
+++ b/src/components/layout/config/menuItems.spec.ts
@@ -138,3 +138,35 @@ describe('menuItems — EVO-1938 admin Settings gating for the default agent', (
     expect(isVisible(findSubItem('/settings/segments'), adminGranted)).toBe(true);
   });
 });
+
+// CRM-166: the agent now holds `custom_attribute_definitions.read` so a contact's
+// attributes render in the read-only screens. The Settings screen must not come
+// with it — it is gated on the administrative keys instead. Any of the three, not
+// `create` alone: create/update come as one group in the role editor, but delete is
+// its own, and deleting a definition is only offered from this screen.
+describe('menuItems — Settings > Atributos Personalizados gating (CRM-166)', () => {
+  const item = () => findSubItem('/settings/attributes');
+  const isVisible = (granted: string[]) =>
+    shouldShowMenuItem(item(), canFrom(granted), canAnyFrom(granted), canAllFrom(granted));
+
+  it('gates on the administrative keys, never on read', () => {
+    expect(item().action).toBeUndefined();
+    expect(item().permissions).toEqual([
+      'custom_attribute_definitions.create',
+      'custom_attribute_definitions.update',
+      'custom_attribute_definitions.delete',
+    ]);
+  });
+
+  it('hides the item from an agent holding only the definitions read', () => {
+    expect(isVisible(['conversations.read', 'custom_attribute_definitions.read'])).toBe(false);
+  });
+
+  it.each([
+    'custom_attribute_definitions.create',
+    'custom_attribute_definitions.update',
+    'custom_attribute_definitions.delete',
+  ])('shows the item to a role holding %s', key => {
+    expect(isVisible(['custom_attribute_definitions.read', key])).toBe(true);
+  });
+});

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -230,7 +230,7 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         href: '/settings/attributes',
         icon: Code,
         resource: 'custom_attribute_definitions',
-        action: 'read',
+        action: 'create',
       },
       {
         name: t('menu.settings.segments'),

--- a/src/components/layout/config/menuItems.ts
+++ b/src/components/layout/config/menuItems.ts
@@ -229,8 +229,13 @@ export const getCustomerMenuItems = (t: (key: string) => string): MenuItem[] => 
         name: t('menu.settings.customAttributes'),
         href: '/settings/attributes',
         icon: Code,
-        resource: 'custom_attribute_definitions',
-        action: 'create',
+        // CRM-166: administrative gate, not `read` — the agent holds the read to
+        // render a contact's attributes and must not reach this Settings screen.
+        permissions: [
+          'custom_attribute_definitions.create',
+          'custom_attribute_definitions.update',
+          'custom_attribute_definitions.delete',
+        ],
       },
       {
         name: t('menu.settings.segments'),

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -169,5 +169,12 @@
       "retrying": "Trying again…",
       "signOut": "Sign out"
     }
+  },
+  "customAttributes": {
+    "loadFailed": {
+      "title": "Could not load the custom attributes",
+      "description": "This does not mean there are none — loading the definitions failed. Try again.",
+      "retry": "Try again"
+    }
   }
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -159,5 +159,12 @@
       "retrying": "Intentando de nuevo…",
       "signOut": "Cerrar sesión"
     }
+  },
+  "customAttributes": {
+    "loadFailed": {
+      "title": "No se pudieron cargar los atributos personalizados",
+      "description": "Esto no significa que no haya ninguno: falló la carga de las definiciones. Inténtalo de nuevo.",
+      "retry": "Intentar de nuevo"
+    }
   }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -159,5 +159,12 @@
       "retrying": "Nouvel essai…",
       "signOut": "Se déconnecter"
     }
+  },
+  "customAttributes": {
+    "loadFailed": {
+      "title": "Impossible de charger les attributs personnalisés",
+      "description": "Cela ne signifie pas qu'il n'y en a aucun — le chargement des définitions a échoué. Réessayez.",
+      "retry": "Réessayer"
+    }
   }
 }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -159,5 +159,12 @@
       "retrying": "Nuovo tentativo…",
       "signOut": "Esci"
     }
+  },
+  "customAttributes": {
+    "loadFailed": {
+      "title": "Non è stato possibile caricare gli attributi personalizzati",
+      "description": "Questo non significa che non ce ne siano: il caricamento delle definizioni è fallito. Riprova.",
+      "retry": "Riprova"
+    }
   }
 }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -169,5 +169,12 @@
       "retrying": "Tentando novamente…",
       "signOut": "Sair"
     }
+  },
+  "customAttributes": {
+    "loadFailed": {
+      "title": "Não foi possível carregar os atributos personalizados",
+      "description": "Isso não significa que não existem — a carga das definições falhou. Tente novamente.",
+      "retry": "Tentar novamente"
+    }
   }
 }

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -159,5 +159,12 @@
       "retrying": "Tentando novamente…",
       "signOut": "Sair"
     }
+  },
+  "customAttributes": {
+    "loadFailed": {
+      "title": "Não foi possível carregar os atributos personalizados",
+      "description": "Isso não significa que não existem — a carga das definições falhou. Tente novamente.",
+      "retry": "Tentar novamente"
+    }
   }
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -755,7 +755,13 @@ const AppRouter = () => {
               <PrivateRoute>
                 <CustomerRoute>
                   <MainLayout>
-                    <PermissionRoute resource="custom_attribute_definitions" action="create">
+                    <PermissionRoute
+                      permissions={[
+                        'custom_attribute_definitions.create',
+                        'custom_attribute_definitions.update',
+                        'custom_attribute_definitions.delete',
+                      ]}
+                    >
                       <CustomAttributes />
                     </PermissionRoute>
                   </MainLayout>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -755,7 +755,7 @@ const AppRouter = () => {
               <PrivateRoute>
                 <CustomerRoute>
                   <MainLayout>
-                    <PermissionRoute resource="custom_attribute_definitions" action="read">
+                    <PermissionRoute resource="custom_attribute_definitions" action="create">
                       <CustomAttributes />
                     </PermissionRoute>
                   </MainLayout>


### PR DESCRIPTION
Card: [CRM-166](https://plane.evosetup.com/evolution/browse/CRM-166/) — **AC1**.

## Problema

`CustomAttributesForm` engolia a rejeição do `GET /custom_attribute_definitions`: `definedAttributes` ficava `[]` e o `catch` só toastava. Toda superfície de leitura renderizava então *"nenhum atributo cadastrado"* — **indistinguível de catálogo realmente vazio**.

Como o modo `form` joga as chaves sem definição no bloco "Adicionais", os atributos personalizados de um contato só apareciam dentro do formulário de edição. Esse é o sintoma reportado.

A causa da falha era o **403** (o papel `agent` não tinha `custom_attribute_definitions.read` — AC2, PR separado no auth). Mesmo com a permissão concedida, um endpoint fora do ar volta a produzir o mesmo texto mentiroso; por isso a distinção mora aqui.

## O que muda

- **`loadFailed` rastreado** e renderizado como estado próprio, com **retry** (bump de token que redispara o effect).
- **Estado de erro DENTRO do componente**, não num guard de rota. O shell **não monta o `RouterGuard`** (só `src/routes/index.tsx` o importa; o shell tem roteador próprio), então a tela do CRM-164 não renderiza nas duas hospedagens — esta renderiza.
- **Flag de cancelamento no effect**: numa troca de `attributeModel` (ou num retry que aterrissa antes da request que substituiu) uma rejeição órfã estampava `failed` sobre um sucesso mais novo.
- **Modo `form`**: o painel de erro substitui só a seção "Definidos" e suprime o empty state enganoso. A lista ad-hoc e o "adicionar atributo" continuam funcionando — é a tela de edição, e ela já funcionava sem as definições.
- **`translationKeys.loadError` removido**: a chave não existia em **nenhuma** das 6 locales, então o toast exibia a chave crua. Removida da interface e dos 2 wrappers que a passavam.
- **i18n nas 6 locales** (`en`, `es`, `fr`, `it`, `pt`, `pt-BR`) em `common.json`. Ficam em `common` porque o componente é montado sob `chat`, `customAttributes` e namespaces do chamador — duplicar em cada um seria pior.

## Testes

`src/components/customAttributes/CustomAttributesForm.spec.tsx` (novo, 6 exemplos), **registrado na allowlist do `.github/workflows/test.yml`** — senão não rodaria em lane nenhuma (mordeu no CRM-177 e no CRM-164).

Cada modo tem o par positivo/negativo: a falha é asserida contra o empty state **genuíno** do mesmo modo. Um painel renderizado incondicionalmente satisfaria só metade.

```
npx tsc -b                                    # limpo
npx eslint <arquivos tocados>                 # limpo
lista completa do test.yml: 34 files, 201 tests passed
i18n-parity + contacts-parity: 192 tests passed
```

## Par deste PR

**AC2** em `evo-auth-service-community` (concede `custom_attribute_definitions.read` ao `agent`) — evolution-foundation/evo-auth-service-community#89.

## Fora de escopo (registrado no card)

`ContactDetailsCard.tsx` (página de Contatos, modo leitura) não renderiza atributos personalizados em cenário nenhum — campos fixos. Defeito distinto; vira card próprio se virar prioridade.

**AC3** do card é condicional e não entra agora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Distinguish custom-attribute definition load failures from empty catalogs while preserving editing behavior and retrying failed loads.

New Features:
- Display a dedicated, localized custom-attribute definition load-failure state with retry support in editable and form views.

Bug Fixes:
- Prevent failed definition requests from being presented as genuinely empty attribute catalogs.
- Prevent custom-attribute controls from unintentionally submitting surrounding forms.
- Keep stale requests from overwriting newer custom-attribute load state.

Enhancements:
- Restrict Custom Attributes settings access to administrative create, update, or delete permissions rather than read access.

CI:
- Register CustomAttributesForm and menu permission tests in the CI test allowlist.

Tests:
- Add coverage for load failures, genuine empty states, retries, ad-hoc values, form submission behavior, and permission gating.

Chores:
- Remove the obsolete custom-attribute load-error translation key and wrapper configuration.