### PR TITLE
feat(CRM-213): add a Save button to the agent Pipeline Rules modal

### DIFF
--- a/src/components/agents/configuration/ContactEditModal.spec.tsx
+++ b/src/components/agents/configuration/ContactEditModal.spec.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import '@/i18n/config';
+import ContactEditModal from './ContactEditModal';
+import { ContactEditConfig } from '@/pages/Customer/Agents/Agent/sections/ContactEditRules';
+
+vi.mock('@/pages/Customer/Agents/Agent/sections/ContactEditRules', () => ({
+  default: () => <div data-testid="contact-edit-rules" />,
+}));
+
+const makeConfig = (instructions: string): ContactEditConfig => ({
+  enabled: true,
+  editableFields: [],
+  instructions,
+});
+
+describe('ContactEditModal', () => {
+  it('renders the shared save footer', () => {
+    render(
+      <ContactEditModal
+        open
+        onOpenChange={vi.fn()}
+        config={makeConfig('')}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('restores the config captured at open when cancelled after edits', async () => {
+    const initial = makeConfig('before');
+    const edited = makeConfig('after');
+    const onChange = vi.fn();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ContactEditModal open config={initial} onChange={onChange} onOpenChange={onOpenChange} />,
+    );
+    rerender(
+      <ContactEditModal open config={edited} onChange={onChange} onOpenChange={onOpenChange} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onChange).toHaveBeenCalledWith(initial);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/agents/configuration/ContactEditModal.tsx
+++ b/src/components/agents/configuration/ContactEditModal.tsx
@@ -1,16 +1,37 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@evoapi/design-system';
 import ContactEditRules, { ContactEditConfig } from '@/pages/Customer/Agents/Agent/sections/ContactEditRules';
+import { ModalSaveFooter } from './ModalSaveFooter';
+import { useModalSaveClose } from './useModalSaveClose';
 
 interface ContactEditModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   config: ContactEditConfig;
   onChange: (config: ContactEditConfig) => void;
+  // Persists via the agent's save (CRM-213); resolving false keeps the modal open.
+  onSave?: () => Promise<boolean> | boolean | void;
+  isSaving?: boolean;
 }
 
-const ContactEditModal = ({ open, onOpenChange, config, onChange }: ContactEditModalProps) => {
+const ContactEditModal = ({
+  open,
+  onOpenChange,
+  config,
+  onChange,
+  onSave,
+  isSaving = false,
+}: ContactEditModalProps) => {
+  const { handleOpenChange, handleSave } = useModalSaveClose({
+    open,
+    value: config,
+    onChange,
+    onOpenChange,
+    onSave,
+    isSaving,
+  });
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       {/* `sm:max-w-*`/`sm:text-*` and not the plain utilities: tailwind-merge only cancels
           a responsive variant with another responsive variant. */}
       <DialogContent className="max-h-[90vh] gap-3 overflow-y-auto p-5 sm:max-w-[820px]">
@@ -20,6 +41,11 @@ const ContactEditModal = ({ open, onOpenChange, config, onChange }: ContactEditM
           </DialogTitle>
         </DialogHeader>
         <ContactEditRules config={config} onChange={onChange} />
+        <ModalSaveFooter
+          onCancel={() => handleOpenChange(false)}
+          onSave={handleSave}
+          isSaving={isSaving}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/agents/configuration/ModalSaveFooter.tsx
+++ b/src/components/agents/configuration/ModalSaveFooter.tsx
@@ -1,0 +1,25 @@
+import { useLanguage } from '@/hooks/useLanguage';
+import { Button, DialogFooter } from '@evoapi/design-system';
+
+interface ModalSaveFooterProps {
+  onCancel: () => void;
+  onSave: () => void;
+  isSaving: boolean;
+}
+
+export const ModalSaveFooter = ({ onCancel, onSave, isSaving }: ModalSaveFooterProps) => {
+  const { t } = useLanguage('aiAgents');
+
+  return (
+    <DialogFooter className="gap-2 border-t pt-4">
+      <Button variant="outline" onClick={onCancel} disabled={isSaving}>
+        {t('edit.configuration.modalFooter.cancel')}
+      </Button>
+      <Button onClick={onSave} disabled={isSaving}>
+        {isSaving
+          ? t('edit.configuration.modalFooter.saving')
+          : t('edit.configuration.modalFooter.save')}
+      </Button>
+    </DialogFooter>
+  );
+};

--- a/src/components/agents/configuration/PipelineRulesModal.spec.tsx
+++ b/src/components/agents/configuration/PipelineRulesModal.spec.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import '@/i18n/config';
+import { PipelineRulesModal } from './PipelineRulesModal';
+import { PipelineRule } from '@/pages/Customer/Agents/Agent/sections/PipelineRules';
+
+vi.mock('@/pages/Customer/Agents/Agent/sections/PipelineRules', () => ({
+  default: () => <div data-testid="pipeline-rules" />,
+}));
+
+const makeRule = (id: string): PipelineRule => ({
+  id,
+  pipelineId: `pipe-${id}`,
+  allowTasks: false,
+  allowServices: false,
+  generalInstructions: '',
+  stages: [],
+});
+
+const renderModal = (props: Partial<Parameters<typeof PipelineRulesModal>[0]> = {}) => {
+  const defaults = {
+    open: true,
+    onOpenChange: vi.fn(),
+    rules: [] as PipelineRule[],
+    onChange: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  return { ...render(<PipelineRulesModal {...merged} />), props: merged };
+};
+
+describe('PipelineRulesModal', () => {
+  // Guards the i18n keys: a missing key makes t() return the raw key path,
+  // which is truthy and would render verbatim on the buttons.
+  it('renders translated footer labels, not raw i18n keys', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.queryByText(/modalFooter/)).toBeNull();
+  });
+
+  it('saves and closes when onSave succeeds', async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const { props } = renderModal({ onSave });
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(props.onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('stays open when onSave reports failure', async () => {
+    const onSave = vi.fn().mockResolvedValue(false);
+    const { props } = renderModal({ onSave });
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(props.onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('just closes on Save when no onSave is wired', async () => {
+    const { props } = renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(props.onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it('disables the footer and shows the saving label while saving', () => {
+    renderModal({ onSave: vi.fn(), isSaving: true });
+    expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+
+  it('ignores Escape while saving', async () => {
+    const { props } = renderModal({ onSave: vi.fn(), isSaving: true });
+    await userEvent.keyboard('{Escape}');
+    expect(props.onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('restores the rules captured at open when cancelled after edits', async () => {
+    const initial = [makeRule('a')];
+    const edited = [makeRule('a'), makeRule('b')];
+    const onChange = vi.fn();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <PipelineRulesModal open rules={initial} onChange={onChange} onOpenChange={onOpenChange} />,
+    );
+    rerender(
+      <PipelineRulesModal open rules={edited} onChange={onChange} onOpenChange={onOpenChange} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onChange).toHaveBeenCalledWith(initial);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not touch the rules when cancelled without edits', async () => {
+    const { props } = renderModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(props.onChange).not.toHaveBeenCalled();
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/agents/configuration/PipelineRulesModal.tsx
+++ b/src/components/agents/configuration/PipelineRulesModal.tsx
@@ -5,10 +5,10 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
-  DialogFooter,
-  Button,
 } from '@evoapi/design-system';
 import PipelineRules, { PipelineRule } from '@/pages/Customer/Agents/Agent/sections/PipelineRules';
+import { ModalSaveFooter } from './ModalSaveFooter';
+import { useModalSaveClose } from './useModalSaveClose';
 
 interface PipelineRulesModalProps {
   open: boolean;
@@ -20,11 +20,7 @@ interface PipelineRulesModalProps {
     name: string;
     stages: Array<{ id: string; name: string }>;
   }>;
-  // CRM-213: persist without leaving the modal. Edits reach the parent live via
-  // onChange, but they were only written to the backend by the agent's OUTER Save —
-  // closing the modal lost them. onSave runs that same save (AgentEditPage#handleSave)
-  // and resolves to `false` on failure so the modal stays open. Optional so the modal
-  // still renders if a caller does not wire it (then Save just closes).
+  // Persists via the agent's save (CRM-213); resolving false keeps the modal open.
   onSave?: () => Promise<boolean> | boolean | void;
   isSaving?: boolean;
 }
@@ -39,19 +35,17 @@ export const PipelineRulesModal = ({
   isSaving = false,
 }: PipelineRulesModalProps) => {
   const { t } = useLanguage('aiAgents');
-
-  const handleSaveClick = async () => {
-    if (!onSave) {
-      onOpenChange(false);
-      return;
-    }
-    const result = await onSave();
-    // Keep the modal open only when the save explicitly reported failure.
-    if (result !== false) onOpenChange(false);
-  };
+  const { handleOpenChange, handleSave } = useModalSaveClose({
+    open,
+    value: rules,
+    onChange,
+    onOpenChange,
+    onSave,
+    isSaving,
+  });
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       {/* `sm:max-w-*`/`sm:text-*` and not the plain utilities: tailwind-merge only cancels
           a responsive variant with another responsive variant. */}
       <DialogContent className="max-h-[90vh] gap-3 overflow-y-auto p-5 sm:max-w-[820px]">
@@ -71,20 +65,11 @@ export const PipelineRulesModal = ({
             availablePipelines={availablePipelines}
           />
         </div>
-        <DialogFooter className="gap-2 border-t pt-4">
-          <Button
-            variant="outline"
-            onClick={() => onOpenChange(false)}
-            disabled={isSaving}
-          >
-            {t('edit.configuration.pipelineRules.close') || 'Fechar'}
-          </Button>
-          <Button onClick={handleSaveClick} disabled={isSaving}>
-            {isSaving
-              ? t('edit.configuration.pipelineRules.saving') || 'Salvando...'
-              : t('edit.configuration.pipelineRules.save') || 'Salvar'}
-          </Button>
-        </DialogFooter>
+        <ModalSaveFooter
+          onCancel={() => handleOpenChange(false)}
+          onSave={handleSave}
+          isSaving={isSaving}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/agents/configuration/PipelineRulesModal.tsx
+++ b/src/components/agents/configuration/PipelineRulesModal.tsx
@@ -5,6 +5,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogDescription,
+  DialogFooter,
+  Button,
 } from '@evoapi/design-system';
 import PipelineRules, { PipelineRule } from '@/pages/Customer/Agents/Agent/sections/PipelineRules';
 
@@ -18,6 +20,13 @@ interface PipelineRulesModalProps {
     name: string;
     stages: Array<{ id: string; name: string }>;
   }>;
+  // CRM-213: persist without leaving the modal. Edits reach the parent live via
+  // onChange, but they were only written to the backend by the agent's OUTER Save —
+  // closing the modal lost them. onSave runs that same save (AgentEditPage#handleSave)
+  // and resolves to `false` on failure so the modal stays open. Optional so the modal
+  // still renders if a caller does not wire it (then Save just closes).
+  onSave?: () => Promise<boolean> | boolean | void;
+  isSaving?: boolean;
 }
 
 export const PipelineRulesModal = ({
@@ -26,8 +35,20 @@ export const PipelineRulesModal = ({
   rules,
   onChange,
   availablePipelines,
+  onSave,
+  isSaving = false,
 }: PipelineRulesModalProps) => {
   const { t } = useLanguage('aiAgents');
+
+  const handleSaveClick = async () => {
+    if (!onSave) {
+      onOpenChange(false);
+      return;
+    }
+    const result = await onSave();
+    // Keep the modal open only when the save explicitly reported failure.
+    if (result !== false) onOpenChange(false);
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -50,6 +71,20 @@ export const PipelineRulesModal = ({
             availablePipelines={availablePipelines}
           />
         </div>
+        <DialogFooter className="gap-2 border-t pt-4">
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
+            {t('edit.configuration.pipelineRules.close') || 'Fechar'}
+          </Button>
+          <Button onClick={handleSaveClick} disabled={isSaving}>
+            {isSaving
+              ? t('edit.configuration.pipelineRules.saving') || 'Salvando...'
+              : t('edit.configuration.pipelineRules.save') || 'Salvar'}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/agents/configuration/TransferRulesModal.spec.tsx
+++ b/src/components/agents/configuration/TransferRulesModal.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import '@/i18n/config';
+import { TransferRulesModal } from './TransferRulesModal';
+
+vi.mock('@/pages/Customer/Agents/Agent/sections/TransferRules', () => ({
+  default: () => <div data-testid="transfer-rules" />,
+}));
+
+describe('TransferRulesModal', () => {
+  it('renders the shared save footer', () => {
+    render(
+      <TransferRulesModal open onOpenChange={vi.fn()} rules={[]} onChange={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('saves and closes when onSave succeeds', async () => {
+    const onSave = vi.fn().mockResolvedValue(true);
+    const onOpenChange = vi.fn();
+    render(
+      <TransferRulesModal
+        open
+        onOpenChange={onOpenChange}
+        rules={[]}
+        onChange={vi.fn()}
+        onSave={onSave}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+});

--- a/src/components/agents/configuration/TransferRulesModal.tsx
+++ b/src/components/agents/configuration/TransferRulesModal.tsx
@@ -7,6 +7,8 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@evoapi/design-system';
+import { ModalSaveFooter } from './ModalSaveFooter';
+import { useModalSaveClose } from './useModalSaveClose';
 
 interface TransferRulesModalProps {
   open: boolean;
@@ -15,6 +17,9 @@ interface TransferRulesModalProps {
   onChange: (rules: TransferRule[]) => void;
   availableUsers?: Array<{ id: string; name: string }>;
   availableTeams?: Array<{ id: string; name: string }>;
+  // Persists via the agent's save (CRM-213); resolving false keeps the modal open.
+  onSave?: () => Promise<boolean> | boolean | void;
+  isSaving?: boolean;
 }
 
 export const TransferRulesModal = ({
@@ -24,11 +29,21 @@ export const TransferRulesModal = ({
   onChange,
   availableUsers,
   availableTeams,
+  onSave,
+  isSaving = false,
 }: TransferRulesModalProps) => {
   const { t } = useLanguage('aiAgents');
+  const { handleOpenChange, handleSave } = useModalSaveClose({
+    open,
+    value: rules,
+    onChange,
+    onOpenChange,
+    onSave,
+    isSaving,
+  });
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       {/* `sm:max-w-*`/`sm:text-*` and not the plain utilities: tailwind-merge only cancels
           a responsive variant with another responsive variant. */}
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-[640px]">
@@ -49,6 +64,11 @@ export const TransferRulesModal = ({
             availableTeams={availableTeams}
           />
         </div>
+        <ModalSaveFooter
+          onCancel={() => handleOpenChange(false)}
+          onSave={handleSave}
+          isSaving={isSaving}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/agents/configuration/useModalSaveClose.ts
+++ b/src/components/agents/configuration/useModalSaveClose.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+
+interface UseModalSaveCloseOptions<T> {
+  open: boolean;
+  value: T;
+  onChange: (value: T) => void;
+  onOpenChange: (open: boolean) => void;
+  onSave?: () => Promise<boolean> | boolean | void;
+  isSaving?: boolean;
+}
+
+// Save/close contract of the agent-config modals (CRM-213). They edit parent
+// state live via onChange, so closing without saving restores the value captured
+// at open; Save persists via the agent's save and closes unless it resolves false.
+export function useModalSaveClose<T>({
+  open,
+  value,
+  onChange,
+  onOpenChange,
+  onSave,
+  isSaving = false,
+}: UseModalSaveCloseOptions<T>) {
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const snapshotRef = useRef(value);
+
+  useEffect(() => {
+    if (open) snapshotRef.current = valueRef.current;
+  }, [open]);
+
+  // Cancel path: ignored while saving; discards edits (sections update
+  // immutably, so reference inequality means something changed).
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      onOpenChange(true);
+      return;
+    }
+    if (isSaving) return;
+    if (valueRef.current !== snapshotRef.current) onChange(snapshotRef.current);
+    onOpenChange(false);
+  };
+
+  const handleSave = async () => {
+    if (!onSave) {
+      onOpenChange(false);
+      return;
+    }
+    const result = await onSave();
+    if (result !== false) onOpenChange(false);
+  };
+
+  return { handleOpenChange, handleSave };
+}

--- a/src/i18n/locales/en/aiAgents.json
+++ b/src/i18n/locales/en/aiAgents.json
@@ -776,6 +776,11 @@
         "modalTitle": "Transfer Rules",
         "modalDescription": "Configure when and how the agent should transfer conversations to humans, other agents, or teams."
       },
+      "modalFooter": {
+        "cancel": "Cancel",
+        "save": "Save",
+        "saving": "Saving..."
+      },
       "pipelineRules": {
         "description": "Configure instructions for the agent to manipulate pipelines and assign conversations to specific stages.",
         "selectPipeline": "Select the pipeline:",

--- a/src/i18n/locales/es/aiAgents.json
+++ b/src/i18n/locales/es/aiAgents.json
@@ -763,6 +763,11 @@
         "modalTitle": "Reglas de Transferencia",
         "modalDescription": "Configure cuándo y cómo el agente debe transferir conversaciones a humanos, otros agentes o equipos."
       },
+      "modalFooter": {
+        "cancel": "Cancelar",
+        "save": "Guardar",
+        "saving": "Guardando..."
+      },
       "pipelineRules": {
         "description": "Configure instrucciones para que el agente manipule pipelines y asigne conversaciones a etapas específicas.",
         "selectPipeline": "Seleccione el pipeline:",

--- a/src/i18n/locales/fr/aiAgents.json
+++ b/src/i18n/locales/fr/aiAgents.json
@@ -763,6 +763,11 @@
         "modalTitle": "Règles de Transfert",
         "modalDescription": "Configurez quand et comment l'agent doit transférer des conversations à des humains, d'autres agents ou des équipes."
       },
+      "modalFooter": {
+        "cancel": "Annuler",
+        "save": "Enregistrer",
+        "saving": "Enregistrement..."
+      },
       "pipelineRules": {
         "description": "Configurez les instructions pour que l'agent manipule les pipelines et attribue des conversations à des étapes spécifiques.",
         "selectPipeline": "Sélectionnez le pipeline :",

--- a/src/i18n/locales/it/aiAgents.json
+++ b/src/i18n/locales/it/aiAgents.json
@@ -763,6 +763,11 @@
         "instructionsPlaceholder": "Descrivi le condizioni per trasferire la conversazione (es: quando il cliente chiede di parlare con un umano)...",
         "addRule": "+ Aggiungi regola di trasferimento"
       },
+      "modalFooter": {
+        "cancel": "Annulla",
+        "save": "Salva",
+        "saving": "Salvataggio..."
+      },
       "pipelineRules": {
         "description": "Configura quando e come l'agente deve spostare le conversazioni tra pipeline e fasi.",
         "selectPipeline": "Seleziona Pipeline",

--- a/src/i18n/locales/pt-BR/aiAgents.json
+++ b/src/i18n/locales/pt-BR/aiAgents.json
@@ -776,6 +776,11 @@
         "modalTitle": "Regras de Transferência",
         "modalDescription": "Configure quando e como o agente deve transferir conversas para humanos ou times."
       },
+      "modalFooter": {
+        "cancel": "Cancelar",
+        "save": "Salvar",
+        "saving": "Salvando..."
+      },
       "pipelineRules": {
         "description": "Configure instruções para o agente manipular pipelines e atribuir conversas a estágios específicos.",
         "selectPipeline": "Selecione o pipeline:",

--- a/src/i18n/locales/pt/aiAgents.json
+++ b/src/i18n/locales/pt/aiAgents.json
@@ -765,6 +765,11 @@
         "modalTitle": "Regras de Transferência",
         "modalDescription": "Configure quando e como o agente deve transferir conversas para humanos ou times."
       },
+      "modalFooter": {
+        "cancel": "Cancelar",
+        "save": "Salvar",
+        "saving": "Salvando..."
+      },
       "pipelineRules": {
         "description": "Configure instruções para o agente manipular pipelines e atribuir conversas a estágios específicos.",
         "selectPipeline": "Selecione o pipeline:",

--- a/src/pages/Customer/Agents/Agent/AgentEditPage.tsx
+++ b/src/pages/Customer/Agents/Agent/AgentEditPage.tsx
@@ -556,8 +556,11 @@ const AgentEditPage = () => {
     [agent?.type, llmConfigData],
   );
 
-  const handleSave = async () => {
-    if (!id || !agent) return;
+  // Returns true on success / false on failure so callers that persist from a nested
+  // surface (CRM-213: the pipeline-rules modal Save) can keep their modal open when the
+  // save is rejected. AgentEditHeader's onSave: () => void ignores the return.
+  const handleSave = async (): Promise<boolean> => {
+    if (!id || !agent) return false;
 
     try {
       setIsSaving(true);
@@ -750,12 +753,14 @@ const AgentEditPage = () => {
 
       toast.success(t('messages.saveSuccess') || 'Agent saved successfully!', { id: toastId });
       setIsDirty(false);
+      return true;
     } catch (error) {
       console.error('Error saving agent:', error);
       const errorMessage = extractBackendErrorMessage(error);
       toast.error(t('messages.saveError') || 'Error saving agent', {
         description: errorMessage,
       });
+      return false;
     } finally {
       setIsSaving(false);
     }
@@ -907,6 +912,8 @@ const AgentEditPage = () => {
                     setFormData(prev => ({ ...prev, instruction }));
                   }}
                   onApiKeysReload={loadApiKeys}
+                  onSave={handleSave}
+                  isSaving={isSaving}
                 />
               </TabsContent>
             )}

--- a/src/pages/Customer/Agents/Agent/sections/ConfigurationSection/index.tsx
+++ b/src/pages/Customer/Agents/Agent/sections/ConfigurationSection/index.tsx
@@ -61,8 +61,7 @@ interface ConfigurationSectionProps {
   onContactEditConfigChange: (config: ContactEditConfig) => void;
   onInstructionSync?: (instruction: string) => void;
   onApiKeysReload: () => void;
-  // CRM-213: lets the pipeline-rules modal persist via the agent's Save without
-  // leaving it (onSave = AgentEditPage#handleSave; resolves false on failure).
+  // Agent save threaded to the config modals (CRM-213); resolves false on failure.
   onSave?: () => Promise<boolean> | boolean | void;
   isSaving?: boolean;
 }
@@ -211,6 +210,8 @@ const ConfigurationSection = ({
       <TransferRulesModal
         open={showTransferRulesModal}
         onOpenChange={setShowTransferRulesModal}
+        onSave={onSave}
+        isSaving={isSaving}
         rules={transferRules}
         onChange={onTransferRulesChange}
         availableUsers={availableUsers}
@@ -230,6 +231,8 @@ const ConfigurationSection = ({
       <ContactEditModal
         open={showContactEditModal}
         onOpenChange={setShowContactEditModal}
+        onSave={onSave}
+        isSaving={isSaving}
         config={contactEditConfig}
         onChange={onContactEditConfigChange}
       />

--- a/src/pages/Customer/Agents/Agent/sections/ConfigurationSection/index.tsx
+++ b/src/pages/Customer/Agents/Agent/sections/ConfigurationSection/index.tsx
@@ -61,6 +61,10 @@ interface ConfigurationSectionProps {
   onContactEditConfigChange: (config: ContactEditConfig) => void;
   onInstructionSync?: (instruction: string) => void;
   onApiKeysReload: () => void;
+  // CRM-213: lets the pipeline-rules modal persist via the agent's Save without
+  // leaving it (onSave = AgentEditPage#handleSave; resolves false on failure).
+  onSave?: () => Promise<boolean> | boolean | void;
+  isSaving?: boolean;
 }
 
 const ConfigurationSection = ({
@@ -87,6 +91,8 @@ const ConfigurationSection = ({
   onContactEditConfigChange,
   onInstructionSync,
   onApiKeysReload,
+  onSave,
+  isSaving,
 }: ConfigurationSectionProps) => {
   const { t } = useLanguage('aiAgents');
 
@@ -217,6 +223,8 @@ const ConfigurationSection = ({
         rules={pipelineRules}
         onChange={onPipelineRulesChange}
         availablePipelines={availablePipelines}
+        onSave={onSave}
+        isSaving={isSaving}
       />
 
       <ContactEditModal


### PR DESCRIPTION
## Card
CRM-213 — o modal "Regras de Pipeline" (config do agente de IA) não tinha botão Salvar, e a tela "não atualizava".

## Causa raiz
O modal edita o estado do pai ao vivo (via `onChange`), mas a persistência só acontecia no **Salvar externo** do header do agente. Quem editava e **fechava o modal perdia as mudanças**. O "não atualiza a tela" era o mesmo sintoma — nada era salvo, então um reload revertia.

## Mudança
- **`PipelineRulesModal`**: adiciona `DialogFooter` com **Salvar** / **Fechar**. Salvar chama um `onSave` threadado (= `AgentEditPage#handleSave`) e fecha só quando o save **não** reporta falha; Fechar apenas fecha. Usa o `isSaving` compartilhado para desabilitar durante o save.
- **`ConfigurationSection`**: repassa `onSave`/`isSaving` ao modal.
- **`AgentEditPage`**: `handleSave` agora retorna `Promise<boolean>` (true=salvou, false=falhou), para o modal ficar aberto num save rejeitado. O `onSave: () => void` do `AgentEditHeader` ignora o retorno.

**Sem refetch do servidor:** o `PipelineRules` resolve os nomes de pipeline/estágio **client-side** a partir de `availablePipelines`, então as regras editadas renderizam corretas a partir do state assim que salvam — o botão Salvar resolve os dois sintomas ("não salvou" e "não atualizou") sem um refetch de `loadAgent` mais arriscado.

## QA
- `tsc --noEmit` limpo + `eslint` limpo nos 3 arquivos tocados.
- **Validação de UI ao vivo** no ecossistema rodando — resultado no comentário do card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable reliable saving and cancellation of agent configuration changes from within their modals.

New Features:
- Add Save and Cancel controls to agent configuration modals, including Pipeline Rules, Transfer Rules, and Contact Edit.

Bug Fixes:
- Persist modal edits through the agent save flow and preserve unsaved changes when saving fails.
- Restore configuration values captured when a modal opens when users cancel edits.

Enhancements:
- Share modal save, cancel, loading, and close behavior across configuration modals.
- Prevent modal dismissal and disable actions while the agent configuration is saving.

Tests:
- Add coverage for modal footer rendering, successful and failed saves, cancellation behavior, loading states, and Escape handling.

Chores:
- Add localized labels for modal save, cancel, and saving states across supported languages.