### PR TITLE
fix(macros): lista de execuções vazia deixa de virar toast verde (CRM-152)

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -245,7 +245,7 @@
   },
   "src/components/chat/message-input/MacrosButton.tsx": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 6
+      "count": 3
     }
   },
   "src/components/chat/messages/MessageAudio.tsx": {

--- a/src/components/chat/message-input/MacrosButton.spec.tsx
+++ b/src/components/chat/message-input/MacrosButton.spec.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    // Echo the key plus the interpolated ids so an assertion can tell the toasts apart.
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars?.ids ? `${key}:${String(vars.ids)}` : key,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/services/macros/macrosService', () => ({
+  macrosService: { getMacros: vi.fn(), executeMacro: vi.fn() },
+}));
+
+import MacrosButton from './MacrosButton';
+import { macrosService } from '@/services/macros/macrosService';
+import { toast } from 'sonner';
+
+const MACRO = { id: 'macro-1', name: 'Boas-vindas', actions: [{ action_name: 'add_label' }] };
+
+// Walks the real flow: open the popover, pick the macro, confirm the dialog.
+async function runMacro() {
+  render(<MacrosButton conversationId="conv-1" />);
+
+  fireEvent.click(screen.getByTitle('messageInput.macros.tooltip'));
+  fireEvent.click(await screen.findByText(MACRO.name));
+  fireEvent.click(await screen.findByText('contactSidebar.macros.dialog.execute'));
+
+  await waitFor(() => expect(macrosService.executeMacro).toHaveBeenCalled());
+}
+
+describe('MacrosButton — CRM-152 execution feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(macrosService.getMacros).mockResolvedValue({ data: [MACRO] } as never);
+  });
+
+  // The bug: `executions.some(...)` over [] is false for both failure and pending, so
+  // an empty list fell through to the success branch and painted the toast green.
+  it('never shows the success toast when nothing executed', async () => {
+    vi.mocked(macrosService.executeMacro).mockResolvedValue({
+      data: { macro_id: 'macro-1', executions: [] },
+    } as never);
+
+    await runMacro();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  // The backend answers 404 for that case, which axios rejects — same outcome required.
+  it('shows the error toast when the request rejects', async () => {
+    vi.mocked(macrosService.executeMacro).mockRejectedValue(new Error('Request failed'));
+
+    await runMacro();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('warns instead of celebrating when part of the conversations did not resolve', async () => {
+    vi.mocked(macrosService.executeMacro).mockResolvedValue({
+      data: {
+        executions: [{ id: 'e1', conversation_id: 'conv-1', status: 'completed' }],
+        unresolved_conversation_ids: ['404-a', '404-b'],
+      },
+    } as never);
+
+    await runMacro();
+
+    await waitFor(() =>
+      expect(toast.warning).toHaveBeenCalledWith(
+        'contactSidebar.macros.executeUnresolved:404-a, 404-b',
+      ),
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  // A failure and an unresolved id are independent facts: an exclusive chain would
+  // report one and swallow the other.
+  it('reports the failure AND the unresolved ids together', async () => {
+    vi.mocked(macrosService.executeMacro).mockResolvedValue({
+      data: {
+        executions: [{ id: 'e1', conversation_id: 'conv-1', status: 'failed', actions_result: [] }],
+        unresolved_conversation_ids: ['404-a'],
+      },
+    } as never);
+
+    await runMacro();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.warning).toHaveBeenCalledWith('contactSidebar.macros.executeUnresolved:404-a');
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('still celebrates a clean run', async () => {
+    vi.mocked(macrosService.executeMacro).mockResolvedValue({
+      data: {
+        executions: [{ id: 'e1', conversation_id: 'conv-1', status: 'completed' }],
+        unresolved_conversation_ids: [],
+      },
+    } as never);
+
+    await runMacro();
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/message-input/MacrosButton.spec.tsx
+++ b/src/components/chat/message-input/MacrosButton.spec.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({
-    // Echo the key plus the interpolated ids so an assertion can tell the toasts apart.
+    // Echo the key plus the count so assertions can tell the toasts apart.
     t: (key: string, vars?: Record<string, unknown>) =>
-      vars?.ids ? `${key}:${String(vars.ids)}` : key,
+      vars?.count === undefined ? key : `${key}:${String(vars.count)}`,
   }),
 }));
 
@@ -41,8 +41,6 @@ describe('MacrosButton — CRM-152 execution feedback', () => {
     vi.mocked(macrosService.getMacros).mockResolvedValue({ data: [MACRO] } as never);
   });
 
-  // The bug: `executions.some(...)` over [] is false for both failure and pending, so
-  // an empty list fell through to the success branch and painted the toast green.
   it('never shows the success toast when nothing executed', async () => {
     vi.mocked(macrosService.executeMacro).mockResolvedValue({
       data: { macro_id: 'macro-1', executions: [] },
@@ -55,7 +53,6 @@ describe('MacrosButton — CRM-152 execution feedback', () => {
     expect(toast.warning).not.toHaveBeenCalled();
   });
 
-  // The backend answers 404 for that case, which axios rejects — same outcome required.
   it('shows the error toast when the request rejects', async () => {
     vi.mocked(macrosService.executeMacro).mockRejectedValue(new Error('Request failed'));
 
@@ -69,34 +66,42 @@ describe('MacrosButton — CRM-152 execution feedback', () => {
     vi.mocked(macrosService.executeMacro).mockResolvedValue({
       data: {
         executions: [{ id: 'e1', conversation_id: 'conv-1', status: 'completed' }],
-        unresolved_conversation_ids: ['404-a', '404-b'],
+        unresolved_conversation_count: 2,
       },
     } as never);
 
     await runMacro();
 
     await waitFor(() =>
-      expect(toast.warning).toHaveBeenCalledWith(
-        'contactSidebar.macros.executeUnresolved:404-a, 404-b',
-      ),
+      expect(toast.warning).toHaveBeenCalledWith('contactSidebar.macros.executeUnresolved:2'),
     );
     expect(toast.success).not.toHaveBeenCalled();
   });
 
-  // A failure and an unresolved id are independent facts: an exclusive chain would
-  // report one and swallow the other.
-  it('reports the failure AND the unresolved ids together', async () => {
+  it('reports the failure AND the unresolved count together', async () => {
     vi.mocked(macrosService.executeMacro).mockResolvedValue({
       data: {
         executions: [{ id: 'e1', conversation_id: 'conv-1', status: 'failed', actions_result: [] }],
-        unresolved_conversation_ids: ['404-a'],
+        unresolved_conversation_count: 1,
       },
     } as never);
 
     await runMacro();
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
-    expect(toast.warning).toHaveBeenCalledWith('contactSidebar.macros.executeUnresolved:404-a');
+    expect(toast.warning).toHaveBeenCalledWith('contactSidebar.macros.executeUnresolved:1');
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('warns about the unresolved count even when nothing executed', async () => {
+    vi.mocked(macrosService.executeMacro).mockResolvedValue({
+      data: { executions: [], unresolved_conversation_count: 3 },
+    } as never);
+
+    await runMacro();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.warning).toHaveBeenCalledWith('contactSidebar.macros.executeUnresolved:3');
     expect(toast.success).not.toHaveBeenCalled();
   });
 
@@ -104,7 +109,7 @@ describe('MacrosButton — CRM-152 execution feedback', () => {
     vi.mocked(macrosService.executeMacro).mockResolvedValue({
       data: {
         executions: [{ id: 'e1', conversation_id: 'conv-1', status: 'completed' }],
-        unresolved_conversation_ids: [],
+        unresolved_conversation_count: 0,
       },
     } as never);
 

--- a/src/components/chat/message-input/MacrosButton.tsx
+++ b/src/components/chat/message-input/MacrosButton.tsx
@@ -86,50 +86,39 @@ const MacrosButton: React.FC<MacrosButtonProps> = ({
       });
 
       const executions = response?.data?.executions || (response as any)?.executions || [];
-      const unresolvedIds: string[] =
-        response?.data?.unresolved_conversation_ids ||
-        (response as unknown as { unresolved_conversation_ids?: string[] })
-          ?.unresolved_conversation_ids ||
-        [];
+      const unresolvedCount: number =
+        response?.data?.unresolved_conversation_count ??
+        (response as unknown as { unresolved_conversation_count?: number })
+          ?.unresolved_conversation_count ??
+        0;
       const hasFailure = executions.some((exec: any) => exec.status === 'failed');
       const hasPending = executions.some((exec: any) => exec.status === 'pending');
 
-      // CRM-152: zero executions is not success. The backend now answers 404 here, so
-      // this branch is the belt to that suspenders — an empty list must never reach
-      // the green toast, whatever the status code says.
+      // Emitted before the early return and outside the chain below: a run can both
+      // fail on one conversation and not find another.
+      if (unresolvedCount > 0) {
+        toast.warning(
+          t('contactSidebar.macros.executeUnresolved', {
+            name: selectedMacro.name,
+            count: unresolvedCount,
+          }),
+        );
+      }
+
+      // Zero executions is not success. The backend answers 404 here; this is the
+      // guard for any response that still gets through with an empty list.
       if (executions.length === 0) {
         toast.error(t('contactSidebar.macros.executeError', { name: selectedMacro.name }));
         return;
       }
 
-      // Emitted on its own rather than as a branch: a run can BOTH fail on one
-      // conversation and not find another, and an exclusive chain would hide one of them.
-      if (unresolvedIds.length > 0) {
-        toast.warning(
-          t('contactSidebar.macros.executeUnresolved', {
-            name: selectedMacro.name,
-            ids: unresolvedIds.join(', '),
-          }),
-        );
-      }
-
       if (hasFailure) {
-        const failedExec = executions.find((exec: any) => exec.status === 'failed');
-        const failedActions = failedExec?.actions_result
-          ?.filter((a: any) => a.status === 'failed')
-          ?.map((a: any) => a.action)
-          ?.join(', ');
-        toast.error(
-          t('contactSidebar.macros.executePartialError', { name: selectedMacro.name }) ||
-            `Macro "${selectedMacro.name}" executada com falhas${failedActions ? `: ${failedActions}` : ''}`,
-        );
+        toast.error(t('contactSidebar.macros.executePartialError', { name: selectedMacro.name }));
       } else if (hasPending) {
         // Webhook actions are async — wait for macro.execution.completed
         // WebSocket event before confirming success/failure to the user.
         toast.info(t('contactSidebar.macros.executeQueued', { name: selectedMacro.name }));
-      } else if (unresolvedIds.length === 0) {
-        // A partial run already got its warning above; green would overwrite it with a
-        // claim of a clean run.
+      } else if (unresolvedCount === 0) {
         toast.success(t('contactSidebar.macros.executeSuccess', { name: selectedMacro.name }));
       }
       onMacroExecuted?.();

--- a/src/components/chat/message-input/MacrosButton.tsx
+++ b/src/components/chat/message-input/MacrosButton.tsx
@@ -86,8 +86,32 @@ const MacrosButton: React.FC<MacrosButtonProps> = ({
       });
 
       const executions = response?.data?.executions || (response as any)?.executions || [];
+      const unresolvedIds: string[] =
+        response?.data?.unresolved_conversation_ids ||
+        (response as unknown as { unresolved_conversation_ids?: string[] })
+          ?.unresolved_conversation_ids ||
+        [];
       const hasFailure = executions.some((exec: any) => exec.status === 'failed');
       const hasPending = executions.some((exec: any) => exec.status === 'pending');
+
+      // CRM-152: zero executions is not success. The backend now answers 404 here, so
+      // this branch is the belt to that suspenders — an empty list must never reach
+      // the green toast, whatever the status code says.
+      if (executions.length === 0) {
+        toast.error(t('contactSidebar.macros.executeError', { name: selectedMacro.name }));
+        return;
+      }
+
+      // Emitted on its own rather than as a branch: a run can BOTH fail on one
+      // conversation and not find another, and an exclusive chain would hide one of them.
+      if (unresolvedIds.length > 0) {
+        toast.warning(
+          t('contactSidebar.macros.executeUnresolved', {
+            name: selectedMacro.name,
+            ids: unresolvedIds.join(', '),
+          }),
+        );
+      }
 
       if (hasFailure) {
         const failedExec = executions.find((exec: any) => exec.status === 'failed');
@@ -103,7 +127,9 @@ const MacrosButton: React.FC<MacrosButtonProps> = ({
         // Webhook actions are async — wait for macro.execution.completed
         // WebSocket event before confirming success/failure to the user.
         toast.info(t('contactSidebar.macros.executeQueued', { name: selectedMacro.name }));
-      } else {
+      } else if (unresolvedIds.length === 0) {
+        // A partial run already got its warning above; green would overwrite it with a
+        // claim of a clean run.
         toast.success(t('contactSidebar.macros.executeSuccess', { name: selectedMacro.name }));
       }
       onMacroExecuted?.();

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -513,6 +513,7 @@
       "executeError": "Error executing macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" completed with failures",
       "executeQueued": "Macro \"{{name}}\" queued — waiting for webhook",
+      "executeUnresolved": "Macro \"{{name}}\" executed, but these conversations were not found: {{ids}}",
       "dialog": {
         "title": "Execute Macro",
         "description": "Are you sure you want to execute the macro {{name}}? This action will apply {{count}} {{actionLabel}} to this conversation.",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -513,7 +513,8 @@
       "executeError": "Error executing macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" completed with failures",
       "executeQueued": "Macro \"{{name}}\" queued — waiting for webhook",
-      "executeUnresolved": "Macro \"{{name}}\" executed, but these conversations were not found: {{ids}}",
+      "executeUnresolved_one": "Macro \"{{name}}\" executed, but 1 conversation was not found",
+      "executeUnresolved_other": "Macro \"{{name}}\" executed, but {{count}} conversations were not found",
       "dialog": {
         "title": "Execute Macro",
         "description": "Are you sure you want to execute the macro {{name}}? This action will apply {{count}} {{actionLabel}} to this conversation.",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -498,6 +498,9 @@
       "actions": "acciones",
       "executeSuccess": "Macro \"{{name}}\" ejecutada con éxito",
       "executeError": "Error al ejecutar macro \"{{name}}\"",
+      "executePartialError": "Macro \"{{name}}\" ejecutada con fallos",
+      "executeQueued": "Macro \"{{name}}\" en cola — esperando el webhook",
+      "executeUnresolved": "Macro \"{{name}}\" ejecutada, pero estas conversaciones no fueron encontradas: {{ids}}",
       "dialog": {
         "title": "Ejecutar Macro",
         "description": "¿Está seguro de que desea ejecutar la macro {{name}}? Esta acción aplicará {{count}} {{actionLabel}} en esta conversación.",

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -500,7 +500,8 @@
       "executeError": "Error al ejecutar macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" ejecutada con fallos",
       "executeQueued": "Macro \"{{name}}\" en cola — esperando el webhook",
-      "executeUnresolved": "Macro \"{{name}}\" ejecutada, pero estas conversaciones no fueron encontradas: {{ids}}",
+      "executeUnresolved_one": "Macro \"{{name}}\" ejecutada, pero 1 conversación no fue encontrada",
+      "executeUnresolved_other": "Macro \"{{name}}\" ejecutada, pero {{count}} conversaciones no fueron encontradas",
       "dialog": {
         "title": "Ejecutar Macro",
         "description": "¿Está seguro de que desea ejecutar la macro {{name}}? Esta acción aplicará {{count}} {{actionLabel}} en esta conversación.",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -500,7 +500,8 @@
       "executeError": "Erreur lors de l'exécution de la macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" exécutée avec des échecs",
       "executeQueued": "Macro \"{{name}}\" en file d'attente — en attente du webhook",
-      "executeUnresolved": "Macro \"{{name}}\" exécutée, mais ces conversations sont introuvables : {{ids}}",
+      "executeUnresolved_one": "Macro \"{{name}}\" exécutée, mais 1 conversation est introuvable",
+      "executeUnresolved_other": "Macro \"{{name}}\" exécutée, mais {{count}} conversations sont introuvables",
       "dialog": {
         "title": "Exécuter la Macro",
         "description": "Êtes-vous sûr de vouloir exécuter la macro {{name}} ? Cette action appliquera {{count}} {{actionLabel}} à cette conversation.",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -498,6 +498,9 @@
       "actions": "actions",
       "executeSuccess": "Macro \"{{name}}\" exécutée avec succès",
       "executeError": "Erreur lors de l'exécution de la macro \"{{name}}\"",
+      "executePartialError": "Macro \"{{name}}\" exécutée avec des échecs",
+      "executeQueued": "Macro \"{{name}}\" en file d'attente — en attente du webhook",
+      "executeUnresolved": "Macro \"{{name}}\" exécutée, mais ces conversations sont introuvables : {{ids}}",
       "dialog": {
         "title": "Exécuter la Macro",
         "description": "Êtes-vous sûr de vouloir exécuter la macro {{name}} ? Cette action appliquera {{count}} {{actionLabel}} à cette conversation.",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -498,6 +498,9 @@
       "actions": "azioni",
       "executeSuccess": "Macro \"{{name}}\" eseguita con successo",
       "executeError": "Errore nell'esecuzione della macro \"{{name}}\"",
+      "executePartialError": "Macro \"{{name}}\" eseguita con errori",
+      "executeQueued": "Macro \"{{name}}\" in coda — in attesa del webhook",
+      "executeUnresolved": "Macro \"{{name}}\" eseguita, ma queste conversazioni non sono state trovate: {{ids}}",
       "dialog": {
         "title": "Eseguire Macro",
         "description": "Sei sicuro di voler eseguire la macro {{name}}? Questa azione applicherà {{count}} {{actionLabel}} a questa conversazione.",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -500,7 +500,8 @@
       "executeError": "Errore nell'esecuzione della macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" eseguita con errori",
       "executeQueued": "Macro \"{{name}}\" in coda — in attesa del webhook",
-      "executeUnresolved": "Macro \"{{name}}\" eseguita, ma queste conversazioni non sono state trovate: {{ids}}",
+      "executeUnresolved_one": "Macro \"{{name}}\" eseguita, ma 1 conversazione non è stata trovata",
+      "executeUnresolved_other": "Macro \"{{name}}\" eseguita, ma {{count}} conversazioni non sono state trovate",
       "dialog": {
         "title": "Eseguire Macro",
         "description": "Sei sicuro di voler eseguire la macro {{name}}? Questa azione applicherà {{count}} {{actionLabel}} a questa conversazione.",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -513,6 +513,7 @@
       "executeError": "Erro ao executar macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" executada com falhas",
       "executeQueued": "Macro \"{{name}}\" enfileirada — aguardando webhook",
+      "executeUnresolved": "Macro \"{{name}}\" executada, mas estas conversas não foram encontradas: {{ids}}",
       "dialog": {
         "title": "Executar Macro",
         "description": "Você tem certeza que deseja executar a macro {{name}}? Esta ação aplicará {{count}} {{actionLabel}} nesta conversa.",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -513,7 +513,8 @@
       "executeError": "Erro ao executar macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" executada com falhas",
       "executeQueued": "Macro \"{{name}}\" enfileirada — aguardando webhook",
-      "executeUnresolved": "Macro \"{{name}}\" executada, mas estas conversas não foram encontradas: {{ids}}",
+      "executeUnresolved_one": "Macro \"{{name}}\" executada, mas 1 conversa não foi encontrada",
+      "executeUnresolved_other": "Macro \"{{name}}\" executada, mas {{count}} conversas não foram encontradas",
       "dialog": {
         "title": "Executar Macro",
         "description": "Você tem certeza que deseja executar a macro {{name}}? Esta ação aplicará {{count}} {{actionLabel}} nesta conversa.",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -500,7 +500,8 @@
       "executeError": "Erro ao executar macro \"{{name}}\"",
       "executePartialError": "Macro \"{{name}}\" executada com falhas",
       "executeQueued": "Macro \"{{name}}\" enfileirada — aguardando webhook",
-      "executeUnresolved": "Macro \"{{name}}\" executada, mas estas conversas não foram encontradas: {{ids}}",
+      "executeUnresolved_one": "Macro \"{{name}}\" executada, mas 1 conversa não foi encontrada",
+      "executeUnresolved_other": "Macro \"{{name}}\" executada, mas {{count}} conversas não foram encontradas",
       "dialog": {
         "title": "Executar Macro",
         "description": "Você tem certeza que deseja executar a macro {{name}}? Esta ação aplicará {{count}} {{actionLabel}} nesta conversa.",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -498,6 +498,9 @@
       "actions": "ações",
       "executeSuccess": "Macro \"{{name}}\" executada com sucesso",
       "executeError": "Erro ao executar macro \"{{name}}\"",
+      "executePartialError": "Macro \"{{name}}\" executada com falhas",
+      "executeQueued": "Macro \"{{name}}\" enfileirada — aguardando webhook",
+      "executeUnresolved": "Macro \"{{name}}\" executada, mas estas conversas não foram encontradas: {{ids}}",
       "dialog": {
         "title": "Executar Macro",
         "description": "Você tem certeza que deseja executar a macro {{name}}? Esta ação aplicará {{count}} {{actionLabel}} nesta conversa.",

--- a/src/services/macros/macrosService.ts
+++ b/src/services/macros/macrosService.ts
@@ -67,7 +67,7 @@ class MacrosService {
   }
 
   // Execute macro — returns execution results with status per action
-  async executeMacro(data: MacroExecuteData): Promise<{ data?: { executions?: Array<{ id: string; status: string; error_message?: string; actions_result?: Array<{ action: string; status: string; error?: string }> }> } }> {
+  async executeMacro(data: MacroExecuteData): Promise<{ data?: { executions?: Array<{ id: string; status: string; error_message?: string; actions_result?: Array<{ action: string; status: string; error?: string }> }>; unresolved_conversation_ids?: string[] } }> {
     const response = await api.post(`/macros/${data.macroId}/execute`, {
       conversation_ids: data.conversationIds,
     });

--- a/src/services/macros/macrosService.ts
+++ b/src/services/macros/macrosService.ts
@@ -67,7 +67,7 @@ class MacrosService {
   }
 
   // Execute macro — returns execution results with status per action
-  async executeMacro(data: MacroExecuteData): Promise<{ data?: { executions?: Array<{ id: string; status: string; error_message?: string; actions_result?: Array<{ action: string; status: string; error?: string }> }>; unresolved_conversation_ids?: string[] } }> {
+  async executeMacro(data: MacroExecuteData): Promise<{ data?: { executions?: Array<{ id: string; status: string; error_message?: string; actions_result?: Array<{ action: string; status: string; error?: string }> }>; unresolved_conversation_count?: number } }> {
     const response = await api.post(`/macros/${data.macroId}/execute`, {
       conversation_ids: data.conversationIds,
     });


### PR DESCRIPTION
## O problema

`MacrosButton.tsx` decidia o toast assim:

```ts
const hasFailure = executions.some((e) => e.status === 'failed');
const hasPending = executions.some((e) => e.status === 'pending');
```

Sobre um array **vazio**, `.some()` dá `false` nos dois. Resultado: caía no `else` e mostrava **toast verde de sucesso** quando nada tinha executado. Mesmo padrão de mentira verde do CRM-54, numa camada diferente.

## O que mudou

- **Execuções vazias mostram toast de erro.** O backend agora responde 404 nesse caso (o `catch` pega), mas o guard fica como defesa em profundidade: lista vazia nunca mais chega no caminho verde, qualquer que seja o status.
- **Resolução parcial mostra toast de aviso** com a **quantidade** de conversas que não resolveram. Execução parcial é sucesso parcial — mentir de verde é o bug deste card, mentir de vermelho descarta trabalho que de fato aconteceu. O backend devolve `unresolved_conversation_count`, não os ids: a lista era um oráculo de existência, e de quebra o toast despejava UUID cru na cara do atendente.
- **O aviso é emitido por fora da cadeia `if/else` e antes do early return de lista vazia.** Uma execução pode falhar **e** outra conversa não ser encontrada; um ramo exclusivo — ou o `return` embaixo dele — reportaria uma e engoliria a outra.
- **O toast verde passa a exigir zero não-resolvidos**, senão sobrescreveria o aviso com uma alegação de execução limpa.

## i18n

Chave nova `executeUnresolved` nas 6 locales, com plural real (`_one`/`_other`) — o padrão que o próprio `chat.json` já usa em `selectedCount` e `menuAriaLabel`, e que o i18next v25 resolve por `Intl.PluralRules` (sem `compatibilityJSON` no init). De quebra, `executePartialError` e `executeQueued` **faltavam em `es`, `fr`, `it` e `pt`** — nessas línguas o toast de falha renderizava a chave crua, e o fallback `t(...) || 'texto'` nunca dispara porque o i18next devolve a própria chave (truthy), não `undefined`. Como o nó já estava sendo editado, foram preenchidas. O `i18n-parity.spec.ts` não pegava porque só compara `en ↔ pt-BR`.

## Testes

`MacrosButton` não tinha spec. Agora tem 6 casos: lista vazia, promise rejeitada (o 404 do backend), parcial, falha + parcial juntos, aviso de não-resolvidas quando **nada** executou (o caso que o early return engolia), e caminho feliz.

```
i18n-parity.spec.ts ......... 178 passed
MacrosButton.spec.tsx .......   6 passed
tsc -b ...................... ok
eslint ...................... ok (sem dívida nova)
```

Validado por mutação: removendo o guard de lista vazia, 1 exemplo quebra; tornando o aviso um ramo exclusivo de novo, 2 quebram.

Também verificado manualmente no ecossistema local, ciclo completo **verde → vermelho → verde** — a terceira medição importa: garante que a correção não trocou uma mentira por outra, isto é, que o toast não virou "sempre erro".

**Ressalva:** essa validação manual é da primeira rodada. A segunda — que trocou os ids pela contagem e mexeu na ordem dos toasts — foi validada só pelos automatizados (239 verdes, `tsc -b`, eslint). O caminho feliz não mudou, mas o toast de aviso mudou de texto e de gatilho e **não foi reconferido na tela**.

## Par

Backend: evolution-foundation/evo-ai-crm-community#293 — é ele que passa a devolver 404 e o campo `unresolved_conversation_count`.

Card: CRM-152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct macro execution feedback so empty, failed, queued, and partially unresolved runs are reported accurately while clean executions retain success feedback.

Bug Fixes:
- Prevent empty macro execution results from displaying a misleading success toast.
- Report partially unresolved conversations with a warning while preserving simultaneous execution failure feedback.

Enhancements:
- Require a fully resolved execution with no failures or pending work before showing success feedback.
- Add localized messages for unresolved and previously missing macro execution states across all supported locales.

Tests:
- Add MacrosButton coverage for empty results, rejected requests, partial resolution, combined failure and resolution issues, and successful execution.
