### PR TITLE
fix(macros): avisa que atribuir agente só vale nos inboxes dele (CRM-162)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,13 @@ jobs:
       #   - menuItems (CRM-166): the Settings entries gated on an administrative
       #     key stay gated on it — Atributos Personalizados above all, whose read
       #     the agent now holds. Also covers the EVO-1938/CRM-70 gates already there.
+      #   - MacroActionRow (CRM-162): the assign_agent warning renders whenever
+      #     there is an agent list to pick from — a reopened modal refetching over
+      #     the previous one included — and never on the other select actions.
+      #     Also guards the aria wiring from the select to the warning.
+      #   - i18n-parity (CRM-162): every locale keeps the same key set. A key added
+      #     to one locale only is invisible until someone on another locale reads
+      #     the raw key on screen.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -127,7 +134,9 @@ jobs:
             src/components/contacts/ContactNotesCard.spec.tsx \
             src/components/rbac-render-gates.spec.tsx \
             src/components/customAttributes/CustomAttributesForm.spec.tsx \
-            src/components/layout/config/menuItems.spec.ts
+            src/components/layout/config/menuItems.spec.ts \
+            src/components/macros/MacroActionRow.spec.tsx \
+            src/i18n/locales/i18n-parity.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,9 +84,10 @@ jobs:
       #     there is an agent list to pick from — a reopened modal refetching over
       #     the previous one included — and never on the other select actions.
       #     Also guards the aria wiring from the select to the warning.
-      #   - i18n-parity (CRM-162): every locale keeps the same key set. A key added
-      #     to one locale only is invisible until someone on another locale reads
-      #     the raw key on screen.
+      #   - i18n-parity (CRM-162): en and pt-BR keep the same key set, catalog-wide.
+      #   - macros-parity (CRM-162): es, fr, it and pt are covered nowhere else, so
+      #     macros.json is checked against en across all six. A key added to one
+      #     locale only is invisible until someone on another reads the raw key.
       # The whole list runs in ~30s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -136,7 +137,8 @@ jobs:
             src/components/customAttributes/CustomAttributesForm.spec.tsx \
             src/components/layout/config/menuItems.spec.ts \
             src/components/macros/MacroActionRow.spec.tsx \
-            src/i18n/locales/i18n-parity.spec.ts
+            src/i18n/locales/i18n-parity.spec.ts \
+            src/i18n/locales/macros-parity.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/macros/MacroActionRow.spec.tsx
+++ b/src/components/macros/MacroActionRow.spec.tsx
@@ -169,10 +169,60 @@ describe('MacroActionRow', () => {
   });
 
   describe('assign_agent (select)', () => {
+    const AGENT = { id: '7c9e1a2b-3d4f-4a56-b7c8-9d0e1f2a3b4c', name: 'Ana' };
+    const WARNING = 'actionRow.assignAgentInboxWarning';
+    const LOADED_AGENT = { ...EMPTY_OPTIONS, agents: [AGENT] };
+
     it('says "no agents registered" when the list is empty and not loading', () => {
       renderRow({ actionName: 'assign_agent' });
 
       expect(screen.getByText('actionRow.emptyAgents')).toBeTruthy();
+    });
+
+    it('warns that the assignment only lands on inboxes the agent belongs to', () => {
+      renderRow({ actionName: 'assign_agent', options: LOADED_AGENT });
+
+      expect(screen.getByText(WARNING)).toBeTruthy();
+    });
+
+    // The list stays complete on purpose, so the warning is the only thing
+    // keeping the form from promising an assignment the execution rejects.
+    it('warns without filtering the agent list', () => {
+      renderRow({ actionName: 'assign_agent', options: LOADED_AGENT });
+
+      expect(screen.getByRole('option', { name: AGENT.name })).toBeTruthy();
+    });
+
+    // Naming "this agent" while the select says "loading" / "none registered" /
+    // "failed to load" describes a choice the user cannot have made yet. Each of
+    // these three renders the warning if the guard is reduced to the action name.
+    it.each([
+      ['the list is still loading', { optionsLoading: true, options: LOADED_AGENT }],
+      ['no agent is registered', { options: EMPTY_OPTIONS }],
+      ['the agents source failed', { options: EMPTY_OPTIONS, failedSources: ['agents' as const] }],
+    ])('does not warn while %s', (_label, extra) => {
+      renderRow({ actionName: 'assign_agent', ...extra });
+
+      expect(screen.queryByText(WARNING)).toBeNull();
+    });
+
+    it('points the select at the warning so a screen reader reaches it', () => {
+      renderRow({ actionName: 'assign_agent', options: LOADED_AGENT });
+
+      const warning = screen.getByText(WARNING);
+      expect(warning.getAttribute('id')).toBeTruthy();
+    });
+
+    // change_status shares the `select` branch and carries no source, which is
+    // where a refactor of the switch would most likely leak the warning.
+    it.each([
+      ['assign_team', { ...EMPTY_OPTIONS, teams: [TEAM_DIGIT] }],
+      ['change_status', EMPTY_OPTIONS],
+      ['change_priority', EMPTY_OPTIONS],
+    ])('does not warn on %s', (actionName, options) => {
+      renderRow({ actionName, options });
+
+      expect(screen.queryByText(WARNING)).toBeNull();
     });
   });
 

--- a/src/components/macros/MacroActionRow.spec.tsx
+++ b/src/components/macros/MacroActionRow.spec.tsx
@@ -29,7 +29,15 @@ vi.mock('@evoapi/design-system', () => ({
       {children}
     </select>
   ),
-  SelectTrigger: () => null,
+  // An <option>: the only element a test can read the trigger's aria wiring
+  // from while the Select above is a native <select>.
+  SelectTrigger: (props: Record<string, unknown>) => (
+    // Empty children on purpose: <SelectValue /> renders null, and React cannot
+    // infer an option value from a complex child.
+    <option data-testid="select-trigger" {...props}>
+      {null}
+    </option>
+  ),
   SelectValue: () => null,
   SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
   // Text children only: the action-type items wrap their label in a <div>,
@@ -197,7 +205,7 @@ describe('MacroActionRow', () => {
     // "failed to load" describes a choice the user cannot have made yet. Each of
     // these three renders the warning if the guard is reduced to the action name.
     it.each([
-      ['the list is still loading', { optionsLoading: true, options: LOADED_AGENT }],
+      ['the list is still loading', { optionsLoading: true, options: EMPTY_OPTIONS }],
       ['no agent is registered', { options: EMPTY_OPTIONS }],
       ['the agents source failed', { options: EMPTY_OPTIONS, failedSources: ['agents' as const] }],
     ])('does not warn while %s', (_label, extra) => {
@@ -206,11 +214,21 @@ describe('MacroActionRow', () => {
       expect(screen.queryByText(WARNING)).toBeNull();
     });
 
+    // Reopening the modal refetches over the agents already in state: the
+    // select keeps listing them and stays pickable, so no placeholder is on
+    // screen to carry the message in its place.
+    it('keeps warning while a refetch runs over an already loaded list', () => {
+      renderRow({ actionName: 'assign_agent', options: LOADED_AGENT, optionsLoading: true });
+
+      expect(screen.getByText(WARNING)).toBeTruthy();
+    });
+
     it('points the select at the warning so a screen reader reaches it', () => {
       renderRow({ actionName: 'assign_agent', options: LOADED_AGENT });
 
       const warning = screen.getByText(WARNING);
-      expect(warning.getAttribute('id')).toBeTruthy();
+      const [, configTrigger] = screen.getAllByTestId('select-trigger');
+      expect(configTrigger.getAttribute('aria-describedby')).toBe(warning.getAttribute('id'));
     });
 
     // change_status shares the `select` branch and carries no source, which is

--- a/src/components/macros/MacroActionRow.spec.tsx
+++ b/src/components/macros/MacroActionRow.spec.tsx
@@ -228,15 +228,20 @@ describe('MacroActionRow', () => {
 
       const warning = screen.getByText(WARNING);
       const [, configTrigger] = screen.getAllByTestId('select-trigger');
-      expect(configTrigger.getAttribute('aria-describedby')).toBe(warning.getAttribute('id'));
+      // Both sides asserted present: dropping the id and the attribute together
+      // would otherwise leave this comparing an absent value to an absent one.
+      expect(warning.id).toBeTruthy();
+      expect(configTrigger.getAttribute('aria-describedby')).toBe(warning.id);
     });
 
     // change_status shares the `select` branch and carries no source, which is
-    // where a refactor of the switch would most likely leak the warning.
+    // where a refactor of the switch would most likely leak the warning. The
+    // agent list is loaded on purpose: with it empty these pass on the list
+    // guard alone and say nothing about the action name.
     it.each([
-      ['assign_team', { ...EMPTY_OPTIONS, teams: [TEAM_DIGIT] }],
-      ['change_status', EMPTY_OPTIONS],
-      ['change_priority', EMPTY_OPTIONS],
+      ['assign_team', { ...LOADED_AGENT, teams: [TEAM_DIGIT] }],
+      ['change_status', LOADED_AGENT],
+      ['change_priority', LOADED_AGENT],
     ])('does not warn on %s', (actionName, options) => {
       renderRow({ actionName, options });
 

--- a/src/components/macros/MacroActionRow.tsx
+++ b/src/components/macros/MacroActionRow.tsx
@@ -45,6 +45,14 @@ export default function MacroActionRow({
 
   const selectedActionConfig = MACRO_ACTION_TYPES.find(a => a.key === action.action_name);
 
+  // The list is deliberately unfiltered: no inbox exists at form time, and one
+  // macro runs over conversations from several inboxes. Warning about an agent
+  // is only truthful once there is a loaded list to pick one from — while it is
+  // loading, empty or failed, the placeholder already owns the message.
+  const assignAgentWarningId = `macro-action-${index}-assign-agent-warning`;
+  const showAssignAgentWarning =
+    action.action_name === 'assign_agent' && !optionsLoading && options.agents.length > 0;
+
   const handleFieldChange = (field: keyof MacroAction, value: string) => {
     const updated = { ...action, [field]: value };
 
@@ -135,7 +143,10 @@ export default function MacroActionRow({
             onValueChange={value => handleParamsChange([value])}
             disabled={disabled}
           >
-            <SelectTrigger className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground">
+            <SelectTrigger
+              className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
+              aria-describedby={showAssignAgentWarning ? assignAgentWarningId : undefined}
+            >
               <SelectValue placeholder={t('actionRow.selectPlaceholder')} />
             </SelectTrigger>
             <SelectContent className="bg-sidebar border-sidebar-border">
@@ -399,6 +410,14 @@ export default function MacroActionRow({
           </div>
         )}
       </div>
+
+      {/* Outside the row: inside it, the extra height would push the bottom
+          aligned column off the baseline the other column keeps. */}
+      {showAssignAgentWarning && (
+        <p id={assignAgentWarningId} className="mt-3 text-sm text-sidebar-foreground/70">
+          {t('actionRow.assignAgentInboxWarning')}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/macros/MacroActionRow.tsx
+++ b/src/components/macros/MacroActionRow.tsx
@@ -45,12 +45,8 @@ export default function MacroActionRow({
 
   const selectedActionConfig = MACRO_ACTION_TYPES.find(a => a.key === action.action_name);
 
-  // The list is deliberately unfiltered: no inbox exists at form time, and one
-  // macro runs over conversations from several inboxes. Warning about an agent
-  // is only truthful once there is a list to pick one from: an empty one
-  // renders the placeholder, which owns the message instead. A reopened modal
-  // refetches with the previous agents still listed and pickable, so
-  // `optionsLoading` is not what hides the warning.
+  // An empty list renders the placeholder, which owns the message instead. Not
+  // `optionsLoading`: a reopened modal refetches with the old agents pickable.
   const assignAgentWarningId = `macro-action-${index}-assign-agent-warning`;
   const showAssignAgentWarning = action.action_name === 'assign_agent' && options.agents.length > 0;
 

--- a/src/components/macros/MacroActionRow.tsx
+++ b/src/components/macros/MacroActionRow.tsx
@@ -47,11 +47,12 @@ export default function MacroActionRow({
 
   // The list is deliberately unfiltered: no inbox exists at form time, and one
   // macro runs over conversations from several inboxes. Warning about an agent
-  // is only truthful once there is a loaded list to pick one from — while it is
-  // loading, empty or failed, the placeholder already owns the message.
+  // is only truthful once there is a list to pick one from: an empty one
+  // renders the placeholder, which owns the message instead. A reopened modal
+  // refetches with the previous agents still listed and pickable, so
+  // `optionsLoading` is not what hides the warning.
   const assignAgentWarningId = `macro-action-${index}-assign-agent-warning`;
-  const showAssignAgentWarning =
-    action.action_name === 'assign_agent' && !optionsLoading && options.agents.length > 0;
+  const showAssignAgentWarning = action.action_name === 'assign_agent' && options.agents.length > 0;
 
   const handleFieldChange = (field: keyof MacroAction, value: string) => {
     const updated = { ...action, [field]: value };

--- a/src/i18n/locales/en/macros.json
+++ b/src/i18n/locales/en/macros.json
@@ -62,6 +62,7 @@
   "actionRow": {
     "selectPlaceholder": "Select an option",
     "multiSelectPlaceholder": "Select options",
+    "assignAgentInboxWarning": "This assignment only applies to conversations whose inbox has this agent as a member. In the others the action fails, and a failed action marks the whole execution as failed.",
     "loadingOptions": "Loading options...",
     "loadFailed": "Could not load the options",
     "emptyTeams": "No teams registered",

--- a/src/i18n/locales/es/macros.json
+++ b/src/i18n/locales/es/macros.json
@@ -62,6 +62,7 @@
   "actionRow": {
     "selectPlaceholder": "Seleccione una opción",
     "multiSelectPlaceholder": "Seleccione opciones",
+    "assignAgentInboxWarning": "Esta asignación solo se aplica a las conversaciones cuya bandeja de entrada tiene a este agente como miembro. En las demás la acción falla, y una acción fallida marca toda la ejecución como fallida.",
     "loadingOptions": "Cargando opciones...",
     "loadFailed": "No fue posible cargar las opciones",
     "emptyTeams": "Ningún equipo registrado",

--- a/src/i18n/locales/fr/macros.json
+++ b/src/i18n/locales/fr/macros.json
@@ -62,6 +62,7 @@
   "actionRow": {
     "selectPlaceholder": "Sélectionnez une option",
     "multiSelectPlaceholder": "Sélectionnez des options",
+    "assignAgentInboxWarning": "Cette attribution ne s'applique qu'aux conversations dont la boîte de réception a cet agent comme membre. Dans les autres l'action échoue, et une action en échec marque toute l'exécution comme échouée.",
     "loadingOptions": "Chargement des options...",
     "loadFailed": "Impossible de charger les options",
     "emptyTeams": "Aucune équipe enregistrée",

--- a/src/i18n/locales/it/macros.json
+++ b/src/i18n/locales/it/macros.json
@@ -62,6 +62,7 @@
   "actionRow": {
     "selectPlaceholder": "Seleziona un'opzione",
     "multiSelectPlaceholder": "Seleziona opzioni",
+    "assignAgentInboxWarning": "Questa assegnazione si applica solo alle conversazioni la cui casella di posta ha questo agente come membro. Nelle altre l'azione fallisce, e un'azione fallita segna l'intera esecuzione come fallita.",
     "loadingOptions": "Caricamento opzioni...",
     "loadFailed": "Non è stato possibile caricare le opzioni",
     "emptyTeams": "Nessun team registrato",

--- a/src/i18n/locales/macros-parity.spec.ts
+++ b/src/i18n/locales/macros-parity.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { emptyValueKeys, missingKeys } from './_lib/parity';
+import en from './en/macros.json';
+import ptBR from './pt-BR/macros.json';
+import pt from './pt/macros.json';
+import es from './es/macros.json';
+import fr from './fr/macros.json';
+// Renamed to avoid shadowing vitest's `it` block helper.
+import itLocale from './it/macros.json';
+
+/**
+ * macros.json parity across the six shipped locales (CRM-162).
+ *
+ * i18n-parity.spec.ts globs en ↔ pt-BR only, so a key added to one locale and
+ * forgotten in es/fr/it/pt reaches the user as the raw key on screen with CI
+ * green. macros.json carries no drift, so the whole file is enforced instead
+ * of a per-card key subset.
+ *
+ * Orphan keys (in every locale, absent from EN) are left alone: clearing them
+ * means editing EN, which the catalog-wide spec also declines to do.
+ */
+
+const TRANSLATIONS: [string, Record<string, unknown>][] = [
+  ['pt-BR', ptBR],
+  ['pt', pt],
+  ['es', es],
+  ['fr', fr],
+  ['it', itLocale],
+];
+
+describe('macros i18n parity (CRM-162)', () => {
+  it.each(TRANSLATIONS)('%s contains every EN key', (_name, locale) => {
+    expect(missingKeys(en, locale)).toEqual([]);
+  });
+
+  it.each([['en', en] as [string, Record<string, unknown>], ...TRANSLATIONS])(
+    '%s has no empty string values',
+    (_name, locale) => {
+      expect(emptyValueKeys(locale)).toEqual([]);
+    },
+  );
+});

--- a/src/i18n/locales/pt-BR/macros.json
+++ b/src/i18n/locales/pt-BR/macros.json
@@ -62,6 +62,7 @@
   "actionRow": {
     "selectPlaceholder": "Selecione uma opção",
     "multiSelectPlaceholder": "Selecione opções",
+    "assignAgentInboxWarning": "Esta atribuição só se aplica às conversas cuja caixa de entrada tem este agente como membro. Nas demais a ação falha, e uma ação que falha marca a execução inteira como falha.",
     "loadingOptions": "Carregando opções...",
     "loadFailed": "Não foi possível carregar as opções",
     "emptyTeams": "Nenhuma equipe cadastrada",

--- a/src/i18n/locales/pt/macros.json
+++ b/src/i18n/locales/pt/macros.json
@@ -62,6 +62,7 @@
   "actionRow": {
     "selectPlaceholder": "Selecione uma opção",
     "multiSelectPlaceholder": "Selecione opções",
+    "assignAgentInboxWarning": "Esta atribuição só se aplica às conversas cuja caixa de entrada tem este agente como membro. Nas demais a ação falha, e uma ação que falha marca a execução inteira como falha.",
     "loadingOptions": "Carregando opções...",
     "loadFailed": "Não foi possível carregar as opções",
     "emptyTeams": "Nenhuma equipe cadastrada",


### PR DESCRIPTION
## Problema

Na ação **"Atribuir agente"** do formulário de macro, o seletor lista todos os usuários da conta. Mas a execução só aceita o agente se ele for membro do inbox daquela conversa (ou SuperAdmin) — `conversation_action_handlers.rb#agent_belongs_to_inbox?`.

Antes do CRM-54, escolher qualquer outro virava um no-op que ainda reportava `success`. O CRM-54 matou esse falso-verde: agora a ação vira `failed` com `"uuid" is not a member of inbox uuid` e a execução inteira é marcada como falha. O CRM-54 fez a coisa certa; ao fazê-la, expôs que o formulário oferece opções que não têm como funcionar.

## Por que não é só "filtrar a lista"

Uma macro não é presa a um inbox — o `MacrosExecutionJob` roda a mesma macro sobre N conversas, cada uma com o seu. Nenhuma ação do `MACRO_ACTION_TYPES` coloca um inbox no contexto do formulário, então no momento da escolha não existe inbox contra o qual filtrar. E mesmo uma escolha correta para o inbox A falharia nas conversas do inbox B — um seletor filtrado diria "esses funcionam" e continuaria mentindo.

Decisão de produto (Guilherme, 21/08): **saída 3** — avisar no formulário, mantendo a lista completa.

## O que muda

- `MacroActionRow.tsx`: texto de apoio abaixo da linha de ação, só em `assign_agent`.
- `src/i18n/locales/{en,es,fr,it,pt,pt-BR}/macros.json`: chave `actionRow.assignAgentInboxWarning`.
- `.github/workflows/test.yml`: os dois specs que provam este card entram na lista do job Vitest.

Duas decisões que valem o olhar do revisor:

**O aviso só aparece quando há lista para escolher** (`options.agents.length > 0`). Com a lista vazia — carregando, nada cadastrado ou fonte que falhou — quem fala é o `renderPlaceholderItem`: nomear "este agente" aí descreveria uma escolha que o usuário ainda não pôde fazer, e no caso de erro competiria com a mensagem de falha.

A guarda **não** olha `optionsLoading`, de propósito. O `MacroFormModal` fica montado o tempo todo e reabrir dispara `loadFormData` sem limpar as opções: durante todo o refetch o select lista os agentes da abertura anterior e continua clicável. Condicionar o aviso ao loading o faria sumir exatamente na tela de "editar macro". O que importa é haver lista, e `agents.length > 0` já é essa condição.

**O `<p>` fica fora do `flex items-end`**, no rodapé da row. Dentro da coluna, a altura extra do texto empurraria o Label + select de configuração para cima do baseline que a coluna de ação mantém.

Acessibilidade: o `SelectTrigger` recebe `aria-describedby` apontando para o aviso, seguindo o padrão de `ConditionalPanel.tsx`.

## Fora do escopo

- **Backend: nenhuma mudança.** `conversation_action_handlers.rb` é o mesmo guarda-corpo de automation rules, jornadas e pipelines — não se toca.
- **Nenhum filtro em `options.agents`** — a lista completa é intencional.
- Mensagem de falha legível por conversa: follow-up pós-CRM-152, card próprio.
- Opção `self` no seletor: feature nova, card próprio.

## Testes

`MacroActionRow.spec.tsx`, bloco `assign_agent (select)`: 23 testes (era 15).

Tudo validado por mutação:

- reduzindo a guarda a só `action.action_name === 'assign_agent'`, os três testes de lista vazia/carregando/erro falham;
- devolvendo o `!optionsLoading` à guarda, falha o teste do refetch por cima da lista já carregada;
- apagando o `aria-describedby` do `SelectTrigger`, falha o teste de acessibilidade.

`MacroActionRow.spec.tsx` e `i18n-parity.spec.ts` entraram na lista do `test.yml`. Nenhum dos dois rodava no CI antes — o "Vitest pass" não tocava neste card, e a parity dos 6 locales não reprovava nada.

```
vitest src/components/macros src/i18n/locales  →  256 passed
tsc -b                                          →  clean
eslint                                          →  clean
```

Validado na UI: aviso renderiza em largura total, alinhamento das colunas preservado, some ao trocar para "Atribuir equipe".

## Summary by Sourcery

Warn users about inbox membership constraints when selecting an agent for a macro action.

New Features:
- Add an inline warning to macro agent assignment actions explaining that assignments only apply when the agent belongs to the conversation’s inbox.

Enhancements:
- Preserve the complete agent list while associating the warning with the agent selector for screen-reader users.

CI:
- Run MacroActionRow and macro translation parity tests in the CI Vitest job.

Tests:
- Expand MacroActionRow coverage for warning visibility, refetch behavior, list preservation, action isolation, and accessibility wiring.
- Add parity coverage for macro translation keys across all six supported locales.
