### PR TITLE
fix(segments): condição de Etiqueta salva o id da label, não o título (CRM-215)

### DIFF
--- a/src/components/segments/SegmentConditionEditor.label.spec.tsx
+++ b/src/components/segments/SegmentConditionEditor.label.spec.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18n from '@/i18n/config';
+import type { LabelNode } from '@/types/analytics';
+import SegmentConditionEditor from './SegmentConditionEditor';
+
+// Radix Select jsdom polyfills (same as SegmentConditionEditor.performed.spec.tsx).
+class ResizeObserverPolyfill {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = globalThis.ResizeObserver ?? (ResizeObserverPolyfill as never);
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+
+// hoisted: vi.mock factories run before module-level consts are initialized.
+const VIP = vi.hoisted(() => ({
+  id: '3f1c9a20-0000-4000-8000-000000000001',
+  title: 'VIP',
+  color: '#ff0000',
+}));
+
+vi.mock('@/services/contacts/labelsService', () => ({
+  labelsService: { getLabels: vi.fn().mockResolvedValue({ data: [VIP] }) },
+}));
+vi.mock('@/services/customAttributes/customAttributesService', () => ({
+  customAttributesService: { getCustomAttributes: vi.fn().mockResolvedValue({ data: [] }) },
+}));
+
+function renderLabel(condition: LabelNode) {
+  const onUpdate = vi.fn();
+  render(<SegmentConditionEditor condition={condition} index={0} onUpdate={onUpdate} onRemove={vi.fn()} />);
+  return { onUpdate };
+}
+
+// The Label block has two comboboxes (label, has/not_has) plus the condition-type
+// selector; the label one is the only one showing the placeholder. It only settles
+// after loadLabels() resolves, so wait for it.
+async function labelCombobox(): Promise<HTMLElement> {
+  let el: HTMLElement | undefined;
+  await waitFor(() => {
+    el = screen.getAllByRole('combobox').find((c) => c.textContent?.includes('Select a label'));
+    expect(el).toBeDefined();
+  });
+  return el as HTMLElement;
+}
+
+// CRM-215: the CRM emits the Label UUID in `contact.label.*` traits and evo-flow
+// matches on it, so the editor must store the id — it used to store the title.
+describe('SegmentConditionEditor — Label condition (CRM-215)', () => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('stores the label id, not its title, when one is picked', async () => {
+    const { onUpdate } = renderLabel({ id: 'n1', type: 'Label', labelId: '', condition: 'has' } as LabelNode);
+    const user = userEvent.setup();
+
+    await user.click(await labelCombobox());
+    await user.click(within(await screen.findByRole('listbox')).getByText('VIP'));
+
+    expect(onUpdate).toHaveBeenCalledWith(0, expect.objectContaining({ labelId: VIP.id }));
+    expect(onUpdate).not.toHaveBeenCalledWith(0, expect.objectContaining({ labelId: 'VIP' }));
+  });
+
+  // A definition saved by the old editor carries the title; it migrates to the id
+  // once the labels load, so it starts matching on the next save.
+  it('migrates a legacy definition that holds the label title', async () => {
+    const { onUpdate } = renderLabel({ id: 'n1', type: 'Label', labelId: 'VIP', condition: 'has' } as LabelNode);
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith(0, expect.objectContaining({ labelId: VIP.id })),
+    );
+  });
+
+  it('leaves a definition that already holds the id alone', async () => {
+    const { onUpdate } = renderLabel({ id: 'n1', type: 'Label', labelId: VIP.id, condition: 'has' } as LabelNode);
+
+    await screen.findByText('VIP');
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/segments/SegmentConditionEditor.tsx
+++ b/src/components/segments/SegmentConditionEditor.tsx
@@ -225,18 +225,7 @@ export default function SegmentConditionEditor({
       }
       case 'Label': {
         const node = condition as LabelNode;
-        // Para manter compatibilidade, verificar se labelId é um UUID (formato antigo) ou nome (formato novo)
-        const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-          node.labelId,
-        );
-        if (isUUID) {
-          // Formato antigo com UUID - precisamos encontrar o nome da label
-          // Por enquanto, usar o UUID e converter depois que as labels carregarem
-          setSelectedLabelId(node.labelId);
-        } else {
-          // Formato novo com nome da label
-          setSelectedLabelId(node.labelId);
-        }
+        setSelectedLabelId(node.labelId);
         setLabelConditionType(node.condition);
         loadLabels(); // Load labels when editing
         break;
@@ -254,25 +243,18 @@ export default function SegmentConditionEditor({
     setInitialized(true);
   }, [condition, initialized, loadCustomAttributes, loadLabels]);
 
-  // Convert UUID labelId to label name after labels are loaded (for backward compatibility)
+  // labelId is the Label UUID — the CRM emits it in `contact.label.*` traits and evo-flow
+  // matches on it (CRM-215). Definitions saved by the old editor carry the label TITLE;
+  // migrate them to the id once labels load, so they start matching on the next save.
   useEffect(() => {
-    if (selectedConditionType === 'Label' && selectedLabelId && availableLabels.length > 0) {
-      const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-        selectedLabelId,
-      );
-      if (isUUID) {
-        // Find label by ID and update to use name instead
-        const label = availableLabels.find(l => l.id === selectedLabelId);
-        if (label) {
-          setSelectedLabelId(label.title);
-          // Update the condition to use the label name
-          const node = localCondition as LabelNode;
-          const updatedCondition = { ...node, labelId: label.title };
-          setLocalCondition(updatedCondition);
-          onUpdate(index, updatedCondition);
-        }
-      }
-    }
+    if (selectedConditionType !== 'Label' || !selectedLabelId || availableLabels.length === 0) return;
+    if (availableLabels.some(l => l.id === selectedLabelId)) return;
+    const label = availableLabels.find(l => l.title === selectedLabelId);
+    if (!label) return;
+    setSelectedLabelId(label.id);
+    const updatedCondition = { ...(localCondition as LabelNode), labelId: label.id };
+    setLocalCondition(updatedCondition);
+    onUpdate(index, updatedCondition);
   }, [selectedConditionType, selectedLabelId, availableLabels, localCondition, index, onUpdate]);
 
   const handleConditionTypeChange = (value: string) => {

--- a/src/components/segments/editors/LabelConditionEditor.tsx
+++ b/src/components/segments/editors/LabelConditionEditor.tsx
@@ -77,7 +77,7 @@ export default function LabelConditionEditor({
               </div>
             )}
             {availableLabels.map((label) => (
-              <SelectItem key={label.id} value={label.title}>
+              <SelectItem key={label.id} value={label.id}>
                 {label.title}
               </SelectItem>
             ))}


### PR DESCRIPTION
## Summary
- O editor de condição de Etiqueta do segmento enviava o **título** da label como `labelId`; o evento `contact.label.added/removed` carrega o **id** da label. O segmento por etiqueta nunca casava um evento e computava 0 membros.
- `LabelConditionEditor`: o item do select passa a valer `label.id` (exibe o título).
- `SegmentConditionEditor`: inverte a compatibilidade — o estado guarda o id; uma definição antiga com título é migrada para o id assim que as labels carregam, e persiste na próxima gravação.

## Security
- Sem superfície nova: mesmo endpoint de labels, mesmo payload de segmento (só o valor do campo muda para o id).

## Test plan
- `npx tsc --noEmit` · `npx eslint` nos 2 arquivos · `npx vitest run src/components/segments` — 11/11.
- Runtime (dev, contra o evo-flow com a PR irmã): editar um segmento antigo (`labelId: "vip"`) e salvar → definição persiste com o UUID; "Tem VIP" passa de 0 para 1.

## Notas
- Definições antigas só migram ao serem **editadas** (não há backfill no front).
- Chave i18n `labelEditor.noLabels` não existe no locale (`noLabelsFound`) — pré-existente, fora do escopo.

## Related PRs
- evo-flow: builder/cache com os nomes canônicos de evento (link no card).

## Changed Files
- `src/components/segments/editors/LabelConditionEditor.tsx`
- `src/components/segments/SegmentConditionEditor.tsx`

## Linked Issue
- CRM-215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYhKfFRYqqdNnFTL7FSVpS

## Summary by Sourcery

Fix segment label conditions to persist and match labels by ID instead of title.

Bug Fixes:
- Store label UUIDs in segment label conditions so contact label events match correctly.
- Migrate legacy label conditions that contain a label title to the corresponding UUID when edited.

Enhancements:
- Keep label titles as the user-facing values while using IDs for condition state and persistence.

Tests:
- Add coverage for storing label IDs, migrating legacy title-based conditions, and preserving already-correct IDs.