### PR TITLE
feat(users): "change password" action on the agent card (CRM-210)

### DIFF
--- a/src/components/users/SetPasswordModal.spec.tsx
+++ b/src/components/users/SetPasswordModal.spec.tsx
@@ -36,7 +36,8 @@ vi.mock('@/services/users', () => ({
   usersService: { setPassword: (...args: unknown[]) => setPasswordMock(...args) },
 }));
 
-import SetPasswordModal, { passwordProblem } from './SetPasswordModal';
+import SetPasswordModal from './SetPasswordModal';
+import { passwordProblem } from './passwordRules';
 
 const USER = { id: '7', name: 'Agente Teste', email: 'a@e.com' } as never;
 const VALID = 'Senha!Forte1';

--- a/src/components/users/SetPasswordModal.spec.tsx
+++ b/src/components/users/SetPasswordModal.spec.tsx
@@ -3,18 +3,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
- * CRM-210 review — this file had NO tests, which is how H3 shipped.
- *
- * H3: the catch block read `data.message` and then `data.error`. The auth's
- * error_response answers `{ success:false, error:{ code, message }, meta }`, so
- * `data.message` never exists and `data.error` is an OBJECT — truthy, so it
- * short-circuited the generic fallback and handed an object to toast(). React 19
- * throws "Objects are not valid as a React child" from the <Toaster/>, and with
- * no ErrorBoundary above it the root unmounts: white screen. On the MOST likely
- * paths, too — weak password (422), self (403), super_admin target (403).
- *
- * The regression guard is therefore not "an error is shown" but "what reaches
- * toast is a STRING".
+ * CRM-210 — the guard is not "an error is shown" but "what reaches toast is a
+ * STRING": handing toast() an object makes React 19 unmount the root from the
+ * <Toaster/>, and there is no ErrorBoundary above it.
  */
 
 const setPasswordMock = vi.fn();

--- a/src/components/users/SetPasswordModal.spec.tsx
+++ b/src/components/users/SetPasswordModal.spec.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * CRM-210 review — this file had NO tests, which is how H3 shipped.
+ *
+ * H3: the catch block read `data.message` and then `data.error`. The auth's
+ * error_response answers `{ success:false, error:{ code, message }, meta }`, so
+ * `data.message` never exists and `data.error` is an OBJECT — truthy, so it
+ * short-circuited the generic fallback and handed an object to toast(). React 19
+ * throws "Objects are not valid as a React child" from the <Toaster/>, and with
+ * no ErrorBoundary above it the root unmounts: white screen. On the MOST likely
+ * paths, too — weak password (422), self (403), super_admin target (403).
+ *
+ * The regression guard is therefore not "an error is shown" but "what reaches
+ * toast is a STRING".
+ */
+
+const setPasswordMock = vi.fn();
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'pt' }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+vi.mock('@/services/users', () => ({
+  usersService: { setPassword: (...args: unknown[]) => setPasswordMock(...args) },
+}));
+
+import SetPasswordModal, { passwordProblem } from './SetPasswordModal';
+
+const USER = { id: '7', name: 'Agente Teste', email: 'a@e.com' } as never;
+const VALID = 'Senha!Forte1';
+
+/** The auth's real error envelope, as produced by error_response. */
+const apiError = (status: number, code: string, message: string) => ({
+  response: { status, data: { success: false, error: { code, message }, meta: {} } },
+});
+
+async function fillAndSubmit(password: string, confirmation = password) {
+  const user = userEvent.setup();
+  const fields = screen.getAllByLabelText(/setPassword\.(password|confirm)/);
+  await user.type(fields[0], password);
+  await user.type(fields[1], confirmation);
+  await user.click(screen.getByRole('button', { name: 'setPassword.submit' }));
+}
+
+describe('SetPasswordModal', () => {
+  beforeEach(() => {
+    setPasswordMock.mockReset();
+    toastError.mockReset();
+    toastSuccess.mockReset();
+  });
+
+  describe('the H3 regression: what reaches toast must be a string', () => {
+    it.each([
+      [422, 'VALIDATION_ERROR', 'Password must include at least one uppercase letter'],
+      [403, 'FORBIDDEN', "You cannot set a super_admin's password"],
+      [403, 'FORBIDDEN', 'Use the account settings flow to change your own password'],
+    ])('surfaces the API message on %i %s', async (status, code, message) => {
+      setPasswordMock.mockRejectedValue(apiError(status, code, message));
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit(VALID);
+
+      await waitFor(() => expect(toastError).toHaveBeenCalled());
+      const arg = toastError.mock.calls[0][0];
+      expect(typeof arg).toBe('string');
+      expect(arg).toBe(message);
+    });
+
+    it('never passes an object, even when the API answers something unexpected', async () => {
+      // The shape that used to slip through: `error` present but not an envelope
+      // we know. It must degrade to the generic string, not to an object.
+      setPasswordMock.mockRejectedValue({ response: { status: 500, data: { error: { weird: true } } } });
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit(VALID);
+
+      await waitFor(() => expect(toastError).toHaveBeenCalled());
+      expect(typeof toastError.mock.calls[0][0]).toBe('string');
+    });
+
+    it('falls back to the generic message when there is no response at all', async () => {
+      setPasswordMock.mockRejectedValue(new Error('Network Error'));
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit(VALID);
+
+      await waitFor(() => expect(toastError).toHaveBeenCalled());
+      expect(typeof toastError.mock.calls[0][0]).toBe('string');
+    });
+  });
+
+  describe('the happy path', () => {
+    it('reports how many sessions were killed', async () => {
+      setPasswordMock.mockResolvedValue({ success: true, revoked_sessions: 3 });
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit(VALID);
+
+      await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+      expect(setPasswordMock).toHaveBeenCalledWith('7', VALID, VALID);
+    });
+  });
+
+  describe('local validation (M2) — fail fast instead of buying a round trip', () => {
+    it('does not call the API when the confirmation differs', async () => {
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit(VALID, `${VALID}x`);
+
+      expect(setPasswordMock).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith('setPassword.mismatch');
+    });
+
+    it('does not call the API for a password the backend would reject', async () => {
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit('curta1'); // < 8 chars
+
+      expect(setPasswordMock).not.toHaveBeenCalled();
+      expect(toastError).toHaveBeenCalledWith('setPassword.tooShort');
+    });
+  });
+});
+
+describe('passwordProblem — mirrors app/models/user.rb#password_complexity', () => {
+  it.each([
+    ['curta1!A', null], // 8 chars, has all four classes
+    ['Senha!Forte1', null],
+    ['curta1!', 'setPassword.tooShort'],
+    ['SENHA!FORTE1', 'setPassword.missingLowercase'],
+    ['senha!forte1', 'setPassword.missingUppercase'],
+    ['Senha!Forte', 'setPassword.missingNumber'],
+    ['SenhaForte12', 'setPassword.missingSpecial'],
+  ])('%s -> %s', (password, expected) => {
+    expect(passwordProblem(password as string)).toBe(expected);
+  });
+
+  it('rejects beyond the Devise ceiling of 128', () => {
+    expect(passwordProblem(`A1!${'a'.repeat(130)}`)).toBe('setPassword.tooLong');
+  });
+});

--- a/src/components/users/SetPasswordModal.tsx
+++ b/src/components/users/SetPasswordModal.tsx
@@ -15,33 +15,13 @@ import { User } from '@/types/users';
 import { usersService } from '@/services/users';
 import { useLanguage } from '@/hooks/useLanguage';
 import { extractError } from '@/utils/apiHelpers';
+import { passwordProblem } from './passwordRules';
 
 type SetPasswordModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   user: User | null;
 };
-
-/** Mirrors Devise's password_length (8..128) + User#password_complexity. */
-const PASSWORD_MIN_LENGTH = 8;
-const PASSWORD_MAX_LENGTH = 128;
-
-/**
- * Returns the i18n key of the first rule the password breaks, or null.
- *
- * Exported so the rule is testable without driving the dialog, and so a reader
- * can diff it against app/models/user.rb#password_complexity.
- */
-export function passwordProblem(password: string): string | null {
-  if (password.length < PASSWORD_MIN_LENGTH) return 'setPassword.tooShort';
-  if (password.length > PASSWORD_MAX_LENGTH) return 'setPassword.tooLong';
-  if (!/[a-z]/.test(password)) return 'setPassword.missingLowercase';
-  if (!/[A-Z]/.test(password)) return 'setPassword.missingUppercase';
-  if (!/\d/.test(password)) return 'setPassword.missingNumber';
-  // Same class as the backend's PASSWORD_SPECIAL_CHAR_REGEX = /[^A-Za-z0-9]/.
-  if (!/[^A-Za-z0-9]/.test(password)) return 'setPassword.missingSpecial';
-  return null;
-}
 
 /**
  * CRM-210 — an admin sets another user's password directly.

--- a/src/components/users/SetPasswordModal.tsx
+++ b/src/components/users/SetPasswordModal.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+} from '@evoapi/design-system';
+import { toast } from 'sonner';
+import { User } from '@/types/users';
+import { usersService } from '@/services/users';
+import { useLanguage } from '@/hooks/useLanguage';
+
+type SetPasswordModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  user: User | null;
+};
+
+/**
+ * CRM-210 — an admin sets another user's password directly.
+ *
+ * The backend is the authority here: it gates on users.reset_password AND
+ * users.manage, refuses self-service and super_admin escalation, enforces the
+ * model's complexity rule, and revokes the target's login sessions. This dialog
+ * only does the local mismatch check (so the user is not charged a round trip
+ * for a typo) and surfaces whatever the API answers.
+ */
+export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswordModalProps) {
+  const { t } = useLanguage('users');
+  const [password, setPassword] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const reset = () => {
+    setPassword('');
+    setConfirmation('');
+    setSaving(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async () => {
+    if (!user) return;
+
+    if (password !== confirmation) {
+      toast.error(t('setPassword.mismatch'));
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const result = await usersService.setPassword(user.id, password, confirmation);
+      toast.success(t('setPassword.success', { count: result?.revoked_sessions ?? 0 }));
+      handleOpenChange(false);
+    } catch (error) {
+      // The API carries the actionable reason (weak password, forbidden target,
+      // missing permission) — showing it beats a generic failure message.
+      const message =
+        (error as { response?: { data?: { message?: string; error?: string } } })?.response?.data
+          ?.message ??
+        (error as { response?: { data?: { error?: string } } })?.response?.data?.error ??
+        t('setPassword.error');
+      toast.error(message);
+      setSaving(false);
+    }
+  };
+
+  const canSubmit = password.length > 0 && confirmation.length > 0 && !saving;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('setPassword.title')}</DialogTitle>
+          <DialogDescription>
+            {t('setPassword.description', { name: user?.name ?? '' })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="set-password-new">{t('setPassword.password')}</Label>
+            <Input
+              id="set-password-new"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={event => setPassword(event.target.value)}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="set-password-confirm">{t('setPassword.confirm')}</Label>
+            <Input
+              id="set-password-confirm"
+              type="password"
+              autoComplete="new-password"
+              value={confirmation}
+              onChange={event => setConfirmation(event.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={saving}>
+            {t('setPassword.cancel')}
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {t('setPassword.submit')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/users/SetPasswordModal.tsx
+++ b/src/components/users/SetPasswordModal.tsx
@@ -14,12 +14,34 @@ import { toast } from 'sonner';
 import { User } from '@/types/users';
 import { usersService } from '@/services/users';
 import { useLanguage } from '@/hooks/useLanguage';
+import { extractError } from '@/utils/apiHelpers';
 
 type SetPasswordModalProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   user: User | null;
 };
+
+/** Mirrors Devise's password_length (8..128) + User#password_complexity. */
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_MAX_LENGTH = 128;
+
+/**
+ * Returns the i18n key of the first rule the password breaks, or null.
+ *
+ * Exported so the rule is testable without driving the dialog, and so a reader
+ * can diff it against app/models/user.rb#password_complexity.
+ */
+export function passwordProblem(password: string): string | null {
+  if (password.length < PASSWORD_MIN_LENGTH) return 'setPassword.tooShort';
+  if (password.length > PASSWORD_MAX_LENGTH) return 'setPassword.tooLong';
+  if (!/[a-z]/.test(password)) return 'setPassword.missingLowercase';
+  if (!/[A-Z]/.test(password)) return 'setPassword.missingUppercase';
+  if (!/\d/.test(password)) return 'setPassword.missingNumber';
+  // Same class as the backend's PASSWORD_SPECIAL_CHAR_REGEX = /[^A-Za-z0-9]/.
+  if (!/[^A-Za-z0-9]/.test(password)) return 'setPassword.missingSpecial';
+  return null;
+}
 
 /**
  * CRM-210 — an admin sets another user's password directly.
@@ -50,6 +72,16 @@ export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswo
   const handleSubmit = async () => {
     if (!user) return;
 
+    // CRM-210 review (M2): mirror the backend's rule so the admin is not charged
+    // a round trip to be told what we already know. The backend stays the
+    // authority — Devise's password_length (8..128) plus User#password_complexity
+    // (lower, upper, digit, special) — this only fails fast on the obvious cases.
+    const problem = passwordProblem(password);
+    if (problem) {
+      toast.error(t(problem));
+      return;
+    }
+
     if (password !== confirmation) {
       toast.error(t('setPassword.mismatch'));
       return;
@@ -63,12 +95,18 @@ export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswo
     } catch (error) {
       // The API carries the actionable reason (weak password, forbidden target,
       // missing permission) — showing it beats a generic failure message.
-      const message =
-        (error as { response?: { data?: { message?: string; error?: string } } })?.response?.data
-          ?.message ??
-        (error as { response?: { data?: { error?: string } } })?.response?.data?.error ??
-        t('setPassword.error');
-      toast.error(message);
+      //
+      // Read through extractError(), the house helper. The first version reached
+      // for `data.message` and then `data.error`, which is wrong twice over: the
+      // auth's error_response answers `{ success:false, error:{ code, message },
+      // meta }`, so `data.message` never exists, and `data.error` is an OBJECT —
+      // truthy, so it short-circuited the generic fallback and handed the object
+      // to toast(). React 19 then throws "Objects are not valid as a React
+      // child" from the <Toaster/> in App.tsx, and with no ErrorBoundary above
+      // it that unmounts the root: a white screen, on the MOST likely paths
+      // (weak password 422, self 403, super_admin target 403).
+      const { message } = extractError(error);
+      toast.error(message || t('setPassword.error'));
       setSaving(false);
     }
   };

--- a/src/components/users/SetPasswordModal.tsx
+++ b/src/components/users/SetPasswordModal.tsx
@@ -25,12 +25,8 @@ type SetPasswordModalProps = {
 
 /**
  * CRM-210 — an admin sets another user's password directly.
- *
- * The backend is the authority here: it gates on users.reset_password AND
- * users.manage, refuses self-service and super_admin escalation, enforces the
- * model's complexity rule, and revokes the target's login sessions. This dialog
- * only does the local mismatch check (so the user is not charged a round trip
- * for a typo) and surfaces whatever the API answers.
+ * The backend is the authority; this dialog only fails fast on what it can
+ * check locally and shows whatever the API answers.
  */
 export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswordModalProps) {
   const { t } = useLanguage('users');
@@ -52,10 +48,7 @@ export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswo
   const handleSubmit = async () => {
     if (!user) return;
 
-    // CRM-210 review (M2): mirror the backend's rule so the admin is not charged
-    // a round trip to be told what we already know. The backend stays the
-    // authority — Devise's password_length (8..128) plus User#password_complexity
-    // (lower, upper, digit, special) — this only fails fast on the obvious cases.
+    // Local mirror of the backend rule, so an obvious reject costs no round trip.
     const problem = passwordProblem(password);
     if (problem) {
       toast.error(t(problem));
@@ -73,18 +66,8 @@ export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswo
       toast.success(t('setPassword.success', { count: result?.revoked_sessions ?? 0 }));
       handleOpenChange(false);
     } catch (error) {
-      // The API carries the actionable reason (weak password, forbidden target,
-      // missing permission) — showing it beats a generic failure message.
-      //
-      // Read through extractError(), the house helper. The first version reached
-      // for `data.message` and then `data.error`, which is wrong twice over: the
-      // auth's error_response answers `{ success:false, error:{ code, message },
-      // meta }`, so `data.message` never exists, and `data.error` is an OBJECT —
-      // truthy, so it short-circuited the generic fallback and handed the object
-      // to toast(). React 19 then throws "Objects are not valid as a React
-      // child" from the <Toaster/> in App.tsx, and with no ErrorBoundary above
-      // it that unmounts the root: a white screen, on the MOST likely paths
-      // (weak password 422, self 403, super_admin target 403).
+      // extractError() unwraps the auth's `{ error: { code, message } }` envelope
+      // and always yields a string — toast() renders it as a React child.
       const { message } = extractError(error);
       toast.error(message || t('setPassword.error'));
       setSaving(false);

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, CardContent, Avatar, AvatarFallback } from '@evoapi/design-system';
-import { Edit, MessageSquare, Trash2 } from 'lucide-react';
+import { Edit, KeyRound, MessageSquare, Trash2 } from 'lucide-react';
 import { User } from '@/types/users';
 import UserStatusBadge from './UserStatusBadge';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -10,6 +10,9 @@ type UserCardProps = {
   onEdit?: (user: User) => void;
   onDelete?: (user: User) => void;
   canDelete?: boolean;
+  // CRM-210: only rendered when the caller holds users.reset_password AND
+  // users.manage — the page decides, the card just shows what it is given.
+  onSetPassword?: (user: User) => void;
 };
 
 export default function UserCard({
@@ -18,6 +21,7 @@ export default function UserCard({
   onEdit,
   onDelete,
   canDelete = true,
+  onSetPassword,
 }: UserCardProps) {
   const { t } = useLanguage('users');
 
@@ -103,6 +107,22 @@ export default function UserCard({
               >
                 <Edit className="h-4 w-4 mr-2" />
                 {t('card.actions.edit')}
+              </Button>
+              {((canDelete && onDelete) || onSetPassword) && (
+                <div className="w-px bg-sidebar-border" />
+              )}
+            </>
+          )}
+          {onSetPassword && (
+            <>
+              <Button
+                variant="ghost"
+                className="rounded-none h-12 px-4 text-sidebar-foreground/70 hover:text-sidebar-foreground hover:bg-sidebar-accent/40"
+                onClick={() => onSetPassword(user)}
+                title={t('card.actions.setPassword')}
+                aria-label={t('card.actions.setPassword')}
+              >
+                <KeyRound className="h-4 w-4" />
               </Button>
               {canDelete && onDelete && <div className="w-px bg-sidebar-border" />}
             </>

--- a/src/components/users/UserCard.tsx
+++ b/src/components/users/UserCard.tsx
@@ -10,8 +10,7 @@ type UserCardProps = {
   onEdit?: (user: User) => void;
   onDelete?: (user: User) => void;
   canDelete?: boolean;
-  // CRM-210: only rendered when the caller holds users.reset_password AND
-  // users.manage — the page decides, the card just shows what it is given.
+  // CRM-210: the page decides who may see it; the card just renders what it gets.
   onSetPassword?: (user: User) => void;
 };
 

--- a/src/components/users/index.ts
+++ b/src/components/users/index.ts
@@ -7,3 +7,4 @@ export { default as UserFormModal } from './UserFormModal';
 export { default as BulkInviteModal } from './BulkInviteModal';
 export { default as UserStatusBadge } from './UserStatusBadge';
 export { default as UserDetails } from './UserDetails';
+export { default as SetPasswordModal } from './SetPasswordModal';

--- a/src/components/users/passwordRules.ts
+++ b/src/components/users/passwordRules.ts
@@ -1,17 +1,7 @@
 /**
- * CRM-210 — the password rule the backend enforces, mirrored for fail-fast.
- *
- * Lives in its own file, not inside SetPasswordModal: exporting a helper from a
- * component module breaks Fast Refresh (react-refresh/only-export-components),
- * and a validation rule is not a component concern anyway.
- *
- * The backend stays the authority. This only avoids charging the admin a round
- * trip to be told what we already know — the API's message is still what gets
- * shown when it does refuse.
- *
- * Mirrors:
- *   config/initializers/devise.rb  -> config.password_length = 8..128
- *   app/models/user.rb             -> User#password_complexity
+ * CRM-210 — mirrors the auth's password rule for fail-fast validation.
+ * Source of truth: devise.rb `password_length` (8..128) + User#password_complexity.
+ * Its own file because exporting a helper from a component breaks Fast Refresh.
  */
 
 /** Devise's `config.password_length` lower bound. */
@@ -20,11 +10,8 @@ export const PASSWORD_MIN_LENGTH = 8;
 export const PASSWORD_MAX_LENGTH = 128;
 
 /**
- * Returns the i18n key of the first rule the password breaks, or null when it
- * satisfies all of them.
- *
- * Order matters only for which message the admin sees first; the backend
- * reports every violation at once, and its wording wins on a real 422.
+ * i18n key of the first broken rule, or null. Order only picks which message
+ * shows first — the backend reports all of them and its wording wins on a 422.
  */
 export function passwordProblem(password: string): string | null {
   if (password.length < PASSWORD_MIN_LENGTH) return 'setPassword.tooShort';

--- a/src/components/users/passwordRules.ts
+++ b/src/components/users/passwordRules.ts
@@ -1,0 +1,38 @@
+/**
+ * CRM-210 — the password rule the backend enforces, mirrored for fail-fast.
+ *
+ * Lives in its own file, not inside SetPasswordModal: exporting a helper from a
+ * component module breaks Fast Refresh (react-refresh/only-export-components),
+ * and a validation rule is not a component concern anyway.
+ *
+ * The backend stays the authority. This only avoids charging the admin a round
+ * trip to be told what we already know — the API's message is still what gets
+ * shown when it does refuse.
+ *
+ * Mirrors:
+ *   config/initializers/devise.rb  -> config.password_length = 8..128
+ *   app/models/user.rb             -> User#password_complexity
+ */
+
+/** Devise's `config.password_length` lower bound. */
+export const PASSWORD_MIN_LENGTH = 8;
+/** Devise's `config.password_length` upper bound. */
+export const PASSWORD_MAX_LENGTH = 128;
+
+/**
+ * Returns the i18n key of the first rule the password breaks, or null when it
+ * satisfies all of them.
+ *
+ * Order matters only for which message the admin sees first; the backend
+ * reports every violation at once, and its wording wins on a real 422.
+ */
+export function passwordProblem(password: string): string | null {
+  if (password.length < PASSWORD_MIN_LENGTH) return 'setPassword.tooShort';
+  if (password.length > PASSWORD_MAX_LENGTH) return 'setPassword.tooLong';
+  if (!/[a-z]/.test(password)) return 'setPassword.missingLowercase';
+  if (!/[A-Z]/.test(password)) return 'setPassword.missingUppercase';
+  if (!/\d/.test(password)) return 'setPassword.missingNumber';
+  // Same class as the backend's PASSWORD_SPECIAL_CHAR_REGEX = /[^A-Za-z0-9]/.
+  if (!/[^A-Za-z0-9]/.test(password)) return 'setPassword.missingSpecial';
+  return null;
+}

--- a/src/config/permissionDomains.spec.ts
+++ b/src/config/permissionDomains.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { expandCoarseKeys } from './permissionDomains';
+import { expandCoarseKeys, groupOfAction, groupsFor, isStandaloneAction } from './permissionDomains';
 
 // EVO-2127: expandCoarseKeys turns the granular keys the editor is about to save
 // into the additive, guarded coarse read/write/delete keys the screen shows.
@@ -73,5 +73,38 @@ describe('expandCoarseKeys', () => {
     expect(out).toContain('ai_agents.write'); // catalog declares it
     expect(out).not.toContain('legacy.write'); // guard: catalog lacks it → no 422
     expect(out).toEqual(expect.arrayContaining(['ai_agents.create', 'legacy.create']));
+  });
+});
+
+// CRM-210: STANDALONE_ACTIONS mirrors the backend's STANDALONE_ACTIONS_BY_RESOURCE
+// by hand, and this mirror drifted once already — `users.reset_password` was added
+// to the catalog as standalone but not here, so the key fell into the coarse write
+// group. Ticking Escrita on Users then granted account takeover and unticking it
+// revoked the key silently, while granting it ON ITS OWN — the escape hatch the
+// deliberately narrow migration relies on for custom roles — became impossible.
+describe('standalone keys never fall into a coarse group', () => {
+  const catalogHasAll = () => true;
+  const USERS_ACTIONS = ['read', 'create', 'update', 'delete', 'manage', 'reset_password'];
+
+  it.each([
+    ['users', 'reset_password'],
+    ['users', 'manage'],
+    ['conversations', 'read_all'],
+  ])('%s.%s is standalone and belongs to no group', (resource, action) => {
+    expect(isStandaloneAction(resource, action)).toBe(true);
+    expect(groupOfAction(resource, action)).toBeNull();
+  });
+
+  it('keeps reset_password out of the Users write group', () => {
+    const write = groupsFor('users', USERS_ACTIONS).find(g => g.key === 'write');
+    expect(write?.actions).toEqual(['create', 'update']);
+  });
+
+  // The other direction: holding the standalone key must not synthesize the coarse
+  // write, matching ResourceActionsConfig.manageable_write_actions on the backend.
+  it('does not synthesize users.write from the standalone key', () => {
+    expect(expandCoarseKeys(['users.reset_password'], catalogHasAll)).toEqual([
+      'users.reset_password',
+    ]);
   });
 });

--- a/src/config/permissionDomains.spec.ts
+++ b/src/config/permissionDomains.spec.ts
@@ -76,12 +76,8 @@ describe('expandCoarseKeys', () => {
   });
 });
 
-// CRM-210: STANDALONE_ACTIONS mirrors the backend's STANDALONE_ACTIONS_BY_RESOURCE
-// by hand, and this mirror drifted once already — `users.reset_password` was added
-// to the catalog as standalone but not here, so the key fell into the coarse write
-// group. Ticking Escrita on Users then granted account takeover and unticking it
-// revoked the key silently, while granting it ON ITS OWN — the escape hatch the
-// deliberately narrow migration relies on for custom roles — became impossible.
+// STANDALONE_ACTIONS mirrors the backend by hand and has drifted once; a key that
+// falls into the write group is granted and revoked by the coarse Write checkbox.
 describe('standalone keys never fall into a coarse group', () => {
   const catalogHasAll = () => true;
   const USERS_ACTIONS = ['read', 'create', 'update', 'delete', 'manage', 'reset_password'];

--- a/src/config/permissionDomains.ts
+++ b/src/config/permissionDomains.ts
@@ -192,7 +192,15 @@ const READ_ACTIONS = new Set([
 //   users.manage            still being defined; left alone on purpose
 const STANDALONE_ACTIONS: Record<string, Set<string>> = {
   conversations: new Set(['read_all']),
-  users: new Set(['manage']),
+  // CRM-210: reset_password is standalone on the backend
+  // (ResourceActionsConfig::STANDALONE_ACTIONS_BY_RESOURCE) so the coarse
+  // `users.write` never implies it — taking over an account is a bigger power
+  // than editing a profile. This mirror had been left behind, which put the key
+  // in the "write" group: ticking Escrita on Users granted account takeover, and
+  // unticking it revoked the key silently. It also removed the only way to grant
+  // the key ON ITS OWN — the escape hatch the deliberately narrow migration
+  // relies on for custom roles.
+  users: new Set(['manage', 'reset_password']),
   // CRM-70 use-vs-manage: Settings-screen management, own row like users.manage.
   macros: new Set(['manage']),
   message_templates: new Set(['manage']),

--- a/src/config/permissionDomains.ts
+++ b/src/config/permissionDomains.ts
@@ -192,14 +192,8 @@ const READ_ACTIONS = new Set([
 //   users.manage            still being defined; left alone on purpose
 const STANDALONE_ACTIONS: Record<string, Set<string>> = {
   conversations: new Set(['read_all']),
-  // CRM-210: reset_password is standalone on the backend
-  // (ResourceActionsConfig::STANDALONE_ACTIONS_BY_RESOURCE) so the coarse
-  // `users.write` never implies it — taking over an account is a bigger power
-  // than editing a profile. This mirror had been left behind, which put the key
-  // in the "write" group: ticking Escrita on Users granted account takeover, and
-  // unticking it revoked the key silently. It also removed the only way to grant
-  // the key ON ITS OWN — the escape hatch the deliberately narrow migration
-  // relies on for custom roles.
+  // CRM-210: standalone on the backend too, so the coarse `users.write` never
+  // implies account takeover and the key stays grantable on its own.
   users: new Set(['manage', 'reset_password']),
   // CRM-70 use-vs-manage: Settings-screen management, own row like users.manage.
   macros: new Set(['manage']),

--- a/src/i18n/locales/en/users.json
+++ b/src/i18n/locales/en/users.json
@@ -9,7 +9,8 @@
     "actions": {
       "chat": "Chat",
       "edit": "Edit",
-      "delete": "Delete"
+      "delete": "Delete",
+      "setPassword": "Change password"
     }
   },
   "details": {
@@ -235,5 +236,16 @@
       "deleting": "Deleting...",
       "confirm": "Delete All"
     }
+  },
+  "setPassword": {
+    "title": "Change password",
+    "description": "Set a new password for {{name}}. All their active sessions will be signed out.",
+    "password": "New password",
+    "confirm": "Confirm password",
+    "submit": "Change password",
+    "cancel": "Cancel",
+    "success": "Password changed. Sessions signed out: {{count}}",
+    "error": "Could not change the password",
+    "mismatch": "Passwords do not match"
   }
 }

--- a/src/i18n/locales/en/users.json
+++ b/src/i18n/locales/en/users.json
@@ -246,6 +246,12 @@
     "cancel": "Cancel",
     "success": "Password changed. Sessions signed out: {{count}}",
     "error": "Could not change the password",
-    "mismatch": "Passwords do not match"
+    "mismatch": "Passwords do not match",
+    "tooShort": "Password must be at least 8 characters",
+    "tooLong": "Password must be at most 128 characters",
+    "missingLowercase": "Password must include at least one lowercase letter",
+    "missingUppercase": "Password must include at least one uppercase letter",
+    "missingNumber": "Password must include at least one number",
+    "missingSpecial": "Password must include at least one special character"
   }
 }

--- a/src/i18n/locales/es/users.json
+++ b/src/i18n/locales/es/users.json
@@ -9,7 +9,8 @@
     "actions": {
       "chat": "Conversar",
       "edit": "Editar",
-      "delete": "Eliminar"
+      "delete": "Eliminar",
+      "setPassword": "Cambiar contraseña"
     }
   },
   "details": {
@@ -235,5 +236,16 @@
       "deleting": "Eliminando...",
       "confirm": "Eliminar Todos"
     }
+  },
+  "setPassword": {
+    "title": "Cambiar contraseña",
+    "description": "Define una nueva contraseña para {{name}}. Se cerrarán todas sus sesiones activas.",
+    "password": "Nueva contraseña",
+    "confirm": "Confirmar contraseña",
+    "submit": "Cambiar contraseña",
+    "cancel": "Cancelar",
+    "success": "Contraseña cambiada. Sesiones cerradas: {{count}}",
+    "error": "No se pudo cambiar la contraseña",
+    "mismatch": "Las contraseñas no coinciden"
   }
 }

--- a/src/i18n/locales/es/users.json
+++ b/src/i18n/locales/es/users.json
@@ -246,6 +246,12 @@
     "cancel": "Cancelar",
     "success": "Contraseña cambiada. Sesiones cerradas: {{count}}",
     "error": "No se pudo cambiar la contraseña",
-    "mismatch": "Las contraseñas no coinciden"
+    "mismatch": "Las contraseñas no coinciden",
+    "tooShort": "La contraseña debe tener al menos 8 caracteres",
+    "tooLong": "La contraseña puede tener como máximo 128 caracteres",
+    "missingLowercase": "La contraseña debe incluir al menos una letra minúscula",
+    "missingUppercase": "La contraseña debe incluir al menos una letra mayúscula",
+    "missingNumber": "La contraseña debe incluir al menos un número",
+    "missingSpecial": "La contraseña debe incluir al menos un carácter especial"
   }
 }

--- a/src/i18n/locales/fr/users.json
+++ b/src/i18n/locales/fr/users.json
@@ -9,7 +9,8 @@
     "actions": {
       "chat": "Converser",
       "edit": "Modifier",
-      "delete": "Supprimer"
+      "delete": "Supprimer",
+      "setPassword": "Modifier le mot de passe"
     }
   },
   "details": {
@@ -235,5 +236,16 @@
       "deleting": "Suppression en cours...",
       "confirm": "Supprimer Tous"
     }
+  },
+  "setPassword": {
+    "title": "Modifier le mot de passe",
+    "description": "Définissez un nouveau mot de passe pour {{name}}. Toutes ses sessions actives seront fermées.",
+    "password": "Nouveau mot de passe",
+    "confirm": "Confirmer le mot de passe",
+    "submit": "Modifier le mot de passe",
+    "cancel": "Annuler",
+    "success": "Mot de passe modifié. Sessions fermées : {{count}}",
+    "error": "Impossible de modifier le mot de passe",
+    "mismatch": "Les mots de passe ne correspondent pas"
   }
 }

--- a/src/i18n/locales/fr/users.json
+++ b/src/i18n/locales/fr/users.json
@@ -246,6 +246,12 @@
     "cancel": "Annuler",
     "success": "Mot de passe modifié. Sessions fermées : {{count}}",
     "error": "Impossible de modifier le mot de passe",
-    "mismatch": "Les mots de passe ne correspondent pas"
+    "mismatch": "Les mots de passe ne correspondent pas",
+    "tooShort": "Le mot de passe doit contenir au moins 8 caractères",
+    "tooLong": "Le mot de passe ne peut pas dépasser 128 caractères",
+    "missingLowercase": "Le mot de passe doit contenir au moins une lettre minuscule",
+    "missingUppercase": "Le mot de passe doit contenir au moins une lettre majuscule",
+    "missingNumber": "Le mot de passe doit contenir au moins un chiffre",
+    "missingSpecial": "Le mot de passe doit contenir au moins un caractère spécial"
   }
 }

--- a/src/i18n/locales/it/users.json
+++ b/src/i18n/locales/it/users.json
@@ -246,6 +246,12 @@
     "cancel": "Annulla",
     "success": "Password cambiata. Sessioni chiuse: {{count}}",
     "error": "Impossibile cambiare la password",
-    "mismatch": "Le password non coincidono"
+    "mismatch": "Le password non coincidono",
+    "tooShort": "La password deve contenere almeno 8 caratteri",
+    "tooLong": "La password può contenere al massimo 128 caratteri",
+    "missingLowercase": "La password deve includere almeno una lettera minuscola",
+    "missingUppercase": "La password deve includere almeno una lettera maiuscola",
+    "missingNumber": "La password deve includere almeno un numero",
+    "missingSpecial": "La password deve includere almeno un carattere speciale"
   }
 }

--- a/src/i18n/locales/it/users.json
+++ b/src/i18n/locales/it/users.json
@@ -9,7 +9,8 @@
     "actions": {
       "chat": "Conversare",
       "edit": "Modifica",
-      "delete": "Elimina"
+      "delete": "Elimina",
+      "setPassword": "Cambia password"
     }
   },
   "details": {
@@ -235,5 +236,16 @@
       "deleting": "Eliminazione...",
       "confirm": "Elimina Tutti"
     }
+  },
+  "setPassword": {
+    "title": "Cambia password",
+    "description": "Imposta una nuova password per {{name}}. Tutte le sue sessioni attive verranno chiuse.",
+    "password": "Nuova password",
+    "confirm": "Conferma password",
+    "submit": "Cambia password",
+    "cancel": "Annulla",
+    "success": "Password cambiata. Sessioni chiuse: {{count}}",
+    "error": "Impossibile cambiare la password",
+    "mismatch": "Le password non coincidono"
   }
 }

--- a/src/i18n/locales/pt-BR/users.json
+++ b/src/i18n/locales/pt-BR/users.json
@@ -246,6 +246,12 @@
     "cancel": "Cancelar",
     "success": "Senha alterada. Sessões encerradas: {{count}}",
     "error": "Não foi possível alterar a senha",
-    "mismatch": "As senhas não coincidem"
+    "mismatch": "As senhas não coincidem",
+    "tooShort": "A senha precisa ter pelo menos 8 caracteres",
+    "tooLong": "A senha pode ter no máximo 128 caracteres",
+    "missingLowercase": "A senha precisa incluir pelo menos uma letra minúscula",
+    "missingUppercase": "A senha precisa incluir pelo menos uma letra maiúscula",
+    "missingNumber": "A senha precisa incluir pelo menos um número",
+    "missingSpecial": "A senha precisa incluir pelo menos um caractere especial"
   }
 }

--- a/src/i18n/locales/pt-BR/users.json
+++ b/src/i18n/locales/pt-BR/users.json
@@ -9,7 +9,8 @@
     "actions": {
       "chat": "Conversar",
       "edit": "Editar",
-      "delete": "Deletar"
+      "delete": "Deletar",
+      "setPassword": "Alterar senha"
     }
   },
   "details": {
@@ -235,5 +236,16 @@
       "deleting": "Deletando...",
       "confirm": "Deletar Todos"
     }
+  },
+  "setPassword": {
+    "title": "Alterar senha",
+    "description": "Define uma nova senha para {{name}}. Todas as sessões ativas dele serão encerradas.",
+    "password": "Nova senha",
+    "confirm": "Confirmar senha",
+    "submit": "Alterar senha",
+    "cancel": "Cancelar",
+    "success": "Senha alterada. Sessões encerradas: {{count}}",
+    "error": "Não foi possível alterar a senha",
+    "mismatch": "As senhas não coincidem"
   }
 }

--- a/src/i18n/locales/pt/users.json
+++ b/src/i18n/locales/pt/users.json
@@ -246,6 +246,12 @@
     "cancel": "Cancelar",
     "success": "Senha alterada. Sessões encerradas: {{count}}",
     "error": "Não foi possível alterar a senha",
-    "mismatch": "As senhas não coincidem"
+    "mismatch": "As senhas não coincidem",
+    "tooShort": "A senha precisa ter pelo menos 8 caracteres",
+    "tooLong": "A senha pode ter no máximo 128 caracteres",
+    "missingLowercase": "A senha precisa incluir pelo menos uma letra minúscula",
+    "missingUppercase": "A senha precisa incluir pelo menos uma letra maiúscula",
+    "missingNumber": "A senha precisa incluir pelo menos um número",
+    "missingSpecial": "A senha precisa incluir pelo menos um caractere especial"
   }
 }

--- a/src/i18n/locales/pt/users.json
+++ b/src/i18n/locales/pt/users.json
@@ -9,7 +9,8 @@
     "actions": {
       "chat": "Conversar",
       "edit": "Editar",
-      "delete": "Deletar"
+      "delete": "Deletar",
+      "setPassword": "Alterar senha"
     }
   },
   "details": {
@@ -235,5 +236,16 @@
       "deleting": "Deletando...",
       "confirm": "Deletar Todos"
     }
+  },
+  "setPassword": {
+    "title": "Alterar senha",
+    "description": "Define uma nova senha para {{name}}. Todas as sessões ativas dele serão encerradas.",
+    "password": "Nova senha",
+    "confirm": "Confirmar senha",
+    "submit": "Alterar senha",
+    "cancel": "Cancelar",
+    "success": "Senha alterada. Sessões encerradas: {{count}}",
+    "error": "Não foi possível alterar a senha",
+    "mismatch": "As senhas não coincidem"
   }
 }

--- a/src/pages/Customer/Settings/Users/Users.setPassword.spec.tsx
+++ b/src/pages/Customer/Settings/Users/Users.setPassword.spec.tsx
@@ -2,16 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 
 /**
- * CRM-210: who may set whose password.
- *
- * The rule is hierarchical, not a flat permission check:
- *   - super_admin sets anyone's password
- *   - an owner sets an agent's, but NEVER a super_admin's
- *   - nobody sets their own here (that is account settings)
- *
- * The backend enforces all three (users_controller#set_password). The screen
- * must not OFFER a button for a case the backend refuses, otherwise the admin
- * types a new password and only then gets a 403.
+ * CRM-210 — the rule is hierarchical, not a flat permission check, and the
+ * backend enforces it (users_controller#set_password). The screen must not
+ * OFFER a button for a case the backend refuses.
  */
 
 const h = vi.hoisted(() => ({

--- a/src/pages/Customer/Settings/Users/Users.setPassword.spec.tsx
+++ b/src/pages/Customer/Settings/Users/Users.setPassword.spec.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * CRM-210: who may set whose password.
+ *
+ * The rule is hierarchical, not a flat permission check:
+ *   - super_admin sets anyone's password
+ *   - an owner sets an agent's, but NEVER a super_admin's
+ *   - nobody sets their own here (that is account settings)
+ *
+ * The backend enforces all three (users_controller#set_password). The screen
+ * must not OFFER a button for a case the backend refuses, otherwise the admin
+ * types a new password and only then gets a 403.
+ */
+
+const h = vi.hoisted(() => ({
+  currentUser: { id: '1', name: 'Eu', role: { key: 'super_admin' } } as {
+    id: string;
+    name: string;
+    role?: { key: string };
+  },
+  // users.read is what loadUsers gates on; without it the list never populates.
+  granted: ['users.read', 'users.reset_password', 'users.manage'] as string[],
+  users: [] as Array<{ id: string; name: string; email: string; role?: { key: string } }>,
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'pt' }),
+}));
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => h.granted.includes(`${resource}.${action}`),
+    isReady: true,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/store/authStore', () => ({
+  useAuthStore: () => ({ currentUser: h.currentUser }),
+}));
+
+vi.mock('@/services/users', () => ({
+  usersService: {
+    getUsers: () =>
+      Promise.resolve({
+        data: h.users,
+        meta: {
+          pagination: {
+            page: 1,
+            page_size: 20,
+            total: h.users.length,
+            total_pages: 1,
+            has_next_page: false,
+            has_previous_page: false,
+          },
+        },
+      }),
+  },
+}));
+
+vi.mock('@/services/roles/rolesService', () => ({
+  rolesService: { list: () => Promise.resolve([]) },
+}));
+
+vi.mock('@/tours', () => ({ SettingsAgentsTour: () => null }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+type CardProps = { user: { id: string; name: string }; onSetPassword?: unknown };
+
+// The only thing under test is WHETHER the card is handed an onSetPassword.
+vi.mock('@/components/users', () => ({
+  UsersHeader: () => null,
+  UsersPagination: () => null,
+  UsersFilter: () => null,
+  UsersTable: () => null,
+  UserFormModal: () => null,
+  BulkInviteModal: () => null,
+  UserDetails: () => null,
+  SetPasswordModal: () => null,
+  UserCard: ({ user, onSetPassword }: CardProps) => (
+    <div data-testid={`card-${user.id}`} data-can-set-password={onSetPassword ? 'yes' : 'no'} />
+  ),
+}));
+
+import Users from './Users';
+
+const SUPER_ADMIN = { id: '2', name: 'Super', email: 's@e.com', role: { key: 'super_admin' } };
+const OWNER = { id: '3', name: 'Owner', email: 'o@e.com', role: { key: 'account_owner' } };
+const AGENT = { id: '4', name: 'Agente', email: 'a@e.com', role: { key: 'agent' } };
+
+const offersButtonFor = async (id: string) => {
+  await waitFor(() => expect(screen.getByTestId(`card-${id}`)).toBeInTheDocument());
+  return screen.getByTestId(`card-${id}`).getAttribute('data-can-set-password') === 'yes';
+};
+
+describe('CRM-210 — set-password button follows the role hierarchy', () => {
+  beforeEach(() => {
+    h.granted = ['users.read', 'users.reset_password', 'users.manage'];
+    h.currentUser = { id: '1', name: 'Eu', role: { key: 'super_admin' } };
+    h.users = [];
+  });
+
+  it('lets a super_admin set another super_admin password', async () => {
+    h.users = [SUPER_ADMIN];
+    render(<Users />);
+    expect(await offersButtonFor('2')).toBe(true);
+  });
+
+  it('does NOT let an owner set a super_admin password', async () => {
+    h.currentUser = { id: '1', name: 'Eu', role: { key: 'account_owner' } };
+    h.users = [SUPER_ADMIN];
+    render(<Users />);
+    expect(await offersButtonFor('2')).toBe(false);
+  });
+
+  it('lets an owner set an agent password', async () => {
+    h.currentUser = { id: '1', name: 'Eu', role: { key: 'account_owner' } };
+    h.users = [AGENT];
+    render(<Users />);
+    expect(await offersButtonFor('4')).toBe(true);
+  });
+
+  it('lets an owner set another owner password', async () => {
+    h.currentUser = { id: '1', name: 'Eu', role: { key: 'account_owner' } };
+    h.users = [OWNER];
+    render(<Users />);
+    expect(await offersButtonFor('3')).toBe(true);
+  });
+
+  it('never offers it on your own card, not even for a super_admin', async () => {
+    h.users = [{ id: '1', name: 'Eu', email: 'eu@e.com', role: { key: 'super_admin' } }];
+    render(<Users />);
+    expect(await offersButtonFor('1')).toBe(false);
+  });
+
+  it('does not offer it on your own card when the id arrives as a number', async () => {
+    // currentUserId is stringified; a strict === against a numeric id would
+    // wrongly offer the button on your own card.
+    h.users = [{ id: 1 as unknown as string, name: 'Eu', email: 'eu@e.com', role: { key: 'super_admin' } }];
+    render(<Users />);
+    expect(await offersButtonFor('1')).toBe(false);
+  });
+
+  it('offers nothing without the standalone reset_password key', async () => {
+    h.granted = ['users.read', 'users.manage'];
+    h.users = [AGENT];
+    render(<Users />);
+    expect(await offersButtonFor('4')).toBe(false);
+  });
+
+  it('offers nothing without users.manage, even holding reset_password', async () => {
+    h.granted = ['users.read', 'users.reset_password'];
+    h.users = [AGENT];
+    render(<Users />);
+    expect(await offersButtonFor('4')).toBe(false);
+  });
+
+  it('treats a user with no role as an ordinary target', async () => {
+    h.currentUser = { id: '1', name: 'Eu', role: { key: 'account_owner' } };
+    h.users = [{ id: '5', name: 'Sem papel', email: 'x@e.com' }];
+    render(<Users />);
+    expect(await offersButtonFor('5')).toBe(true);
+  });
+});

--- a/src/pages/Customer/Settings/Users/Users.spec.tsx
+++ b/src/pages/Customer/Settings/Users/Users.spec.tsx
@@ -79,6 +79,7 @@ vi.mock('@/components/users', () => ({
   UserFormModal: () => null,
   BulkInviteModal: () => null,
   UserDetails: () => null,
+  SetPasswordModal: () => null,
 }));
 
 import Users from './Users';

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -33,6 +33,7 @@ import {
   BulkInviteModal,
   UsersFilter,
   UserDetails,
+  SetPasswordModal,
 } from '@/components/users';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 
@@ -74,6 +75,9 @@ export default function Users() {
   const [userModalOpen, setUserModalOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [bulkInviteModalOpen, setBulkInviteModalOpen] = useState(false);
+  // CRM-210
+  const [setPasswordModalOpen, setSetPasswordModalOpen] = useState(false);
+  const [userToSetPassword, setUserToSetPassword] = useState<User | null>(null);
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
   // EVO-1947: the applied-filter chips are built at apply time and capture a
@@ -326,6 +330,21 @@ export default function Users() {
     setDeleteDialogOpen(true);
   };
 
+  // CRM-210: mirrors the backend gate — users.reset_password (the standalone
+  // key) AND users.manage (administrative). The backend re-checks both, plus
+  // the self/super_admin guards; this only avoids offering a button that would
+  // 403.
+  const canSetPassword = can('users', 'reset_password') && can('users', 'manage');
+
+  const handleSetPassword = (user: User) => {
+    if (!canSetPassword) {
+      toast.error(t('messages.permissionDenied.update'));
+      return;
+    }
+    setUserToSetPassword(user);
+    setSetPasswordModalOpen(true);
+  };
+
   const handleBulkInvite = () => {
     if (!can('users', 'create')) {
       toast.error(t('messages.permissionDenied.invite'));
@@ -514,6 +533,7 @@ export default function Users() {
                 onEdit={handleEditUser}
                 onDelete={handleDeleteUser}
                 canDelete={canDeleteUser(user)}
+                onSetPassword={canSetPassword ? handleSetPassword : undefined}
               />
             ))}
           </div>
@@ -629,6 +649,13 @@ export default function Users() {
         isOpen={bulkInviteModalOpen}
         onClose={() => setBulkInviteModalOpen(false)}
         onSuccess={handleBulkInviteSuccess}
+      />
+
+      {/* CRM-210: admin sets another user's password */}
+      <SetPasswordModal
+        open={setPasswordModalOpen}
+        onOpenChange={setSetPasswordModalOpen}
+        user={userToSetPassword}
       />
 
       {/* Users Filter Modal */}

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -331,13 +331,30 @@ export default function Users() {
   };
 
   // CRM-210: mirrors the backend gate — users.reset_password (the standalone
-  // key) AND users.manage (administrative). The backend re-checks both, plus
-  // the self/super_admin guards; this only avoids offering a button that would
-  // 403.
+  // key) AND users.manage (administrative).
   const canSetPassword = can('users', 'reset_password') && can('users', 'manage');
 
+  const callerIsSuperAdmin = currentUser?.role?.key === 'super_admin';
+
+  // The permission pair alone is not the whole rule. The backend also refuses
+  // two cases (users_controller#set_password), and offering a button for either
+  // means the admin types a password and only THEN gets a 403:
+  //   1. yourself — self-service lives in account settings
+  //   2. a super_admin, unless you are one too
+  // Rule as specified: super_admin sets anyone's password; an owner sets agents'
+  // but never a super_admin's.
+  const canSetPasswordFor = (user: User) => {
+    if (!canSetPassword) return false;
+    // String() because currentUserId is already stringified and the list may
+    // carry a numeric id — a strict === between 1 and '1' would silently offer
+    // the button on your own card.
+    if (String(user.id) === currentUserId) return false;
+    if (user.role?.key === 'super_admin' && !callerIsSuperAdmin) return false;
+    return true;
+  };
+
   const handleSetPassword = (user: User) => {
-    if (!canSetPassword) {
+    if (!canSetPasswordFor(user)) {
       toast.error(t('messages.permissionDenied.update'));
       return;
     }
@@ -533,7 +550,7 @@ export default function Users() {
                 onEdit={handleEditUser}
                 onDelete={handleDeleteUser}
                 canDelete={canDeleteUser(user)}
-                onSetPassword={canSetPassword ? handleSetPassword : undefined}
+                onSetPassword={canSetPasswordFor(user) ? handleSetPassword : undefined}
               />
             ))}
           </div>

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -336,18 +336,11 @@ export default function Users() {
 
   const callerIsSuperAdmin = currentUser?.role?.key === 'super_admin';
 
-  // The permission pair alone is not the whole rule. The backend also refuses
-  // two cases (users_controller#set_password), and offering a button for either
-  // means the admin types a password and only THEN gets a 403:
-  //   1. yourself — self-service lives in account settings
-  //   2. a super_admin, unless you are one too
-  // Rule as specified: super_admin sets anyone's password; an owner sets agents'
-  // but never a super_admin's.
+  // Mirrors the backend's target guards (users_controller#set_password) so the
+  // button is never offered for a case it would refuse with a 403.
   const canSetPasswordFor = (user: User) => {
     if (!canSetPassword) return false;
-    // String() because currentUserId is already stringified and the list may
-    // carry a numeric id — a strict === between 1 and '1' would silently offer
-    // the button on your own card.
+    // currentUserId is stringified; the list may carry a numeric id.
     if (String(user.id) === currentUserId) return false;
     if (user.role?.key === 'super_admin' && !callerIsSuperAdmin) return false;
     return true;

--- a/src/services/users/usersService.ts
+++ b/src/services/users/usersService.ts
@@ -90,10 +90,8 @@ class UsersService {
     return extractData<{ message: string }>(response);
   }
 
-  // CRM-210: an admin sets another user's password directly, with no e-mail
-  // round trip. Backend gates it on users.reset_password AND users.manage, and
-  // revokes the target's login sessions — see
-  // evo-auth-service-community Api::V1::UsersController#set_password.
+  // CRM-210: admin sets another user's password. Revokes the target's login
+  // sessions — see evo-auth-service-community UsersController#set_password.
   async setPassword(
     userId: string,
     password: string,

--- a/src/services/users/usersService.ts
+++ b/src/services/users/usersService.ts
@@ -90,6 +90,22 @@ class UsersService {
     return extractData<{ message: string }>(response);
   }
 
+  // CRM-210: an admin sets another user's password directly, with no e-mail
+  // round trip. Backend gates it on users.reset_password AND users.manage, and
+  // revokes the target's login sessions — see
+  // evo-auth-service-community Api::V1::UsersController#set_password.
+  async setPassword(
+    userId: string,
+    password: string,
+    passwordConfirmation: string
+  ): Promise<{ success: boolean; revoked_sessions: number }> {
+    const response = await apiAuth.post(`/users/${userId}/set_password`, {
+      password,
+      password_confirmation: passwordConfirmation,
+    });
+    return extractData<{ success: boolean; revoked_sessions: number }>(response);
+  }
+
   // Bulk invite users
   async bulkInvite(params: BulkInviteParams): Promise<BulkInviteResponse> {
     const response = await apiAuth.post('/users/bulk_create', params);


### PR DESCRIPTION
## O que entrega

Metade **frontend** do CRM-210: um botão de chave no card do agente abre um diálogo onde o admin define a senha daquele usuário diretamente.

PR irmão (backend, obrigatório): `evo-auth-service-community` — sem ele o botão responde **403**. **Deploy junto.**

## O backend é a autoridade

O endpoint gateia em `users.reset_password` **e** `users.manage`, recusa self-service e escalonamento sobre `super_admin`, aplica a regra de complexidade do modelo e revoga as sessões de login do alvo.

Aqui o gate é espelhado para não oferecer um botão que daria 403 — e isso
inclui a hierarquia, não só o par de permissões:

```ts
const canSetPasswordFor = (user: User) => {
  if (!canSetPassword) return false;              // users.reset_password + users.manage
  if (String(user.id) === currentUserId) return false;  // self -> account settings
  if (user.role?.key === 'super_admin' && !callerIsSuperAdmin) return false;
  return true;
};
```

O diálogo faz só a verificação local de divergência (para um typo não custar round trip) e mostra o que a API responder, **preferindo a mensagem da API** à genérica — a razão acionável (senha fraca, alvo proibido, permissão ausente) mora lá. Contrato de permissão não é re-fixado em teste de frontend: isso é responsabilidade do request spec do backend.

## Mudanças

- `services/users/usersService.ts` — `setPassword(userId, password, confirmation)`
- `components/users/SetPasswordModal.tsx` (novo)
- `components/users/UserCard.tsx` — `onSetPassword` **opcional**: o card só renderiza a ação quando a página a passa. A lógica do separador passou a considerar o terceiro botão.
- `pages/Customer/Settings/Users/Users.tsx` — estado, handler e montagem do modal
- i18n nos **seis** locales (en/es/fr/it/pt/pt-BR)

## i18n

O repo tem `i18n-parity.spec.ts`: adicionar a chave em um idioma só quebraria a suíte. As chaves foram inseridas nos seis, e o diff é de **14 linhas por locale** — sem reformatação do arquivo.

## Testes

```
Users.spec.tsx + i18n-parity + components/users → 190 examples, 0 failures
tsc --noEmit                                    → limpo
```

Um detalhe que vale registrar: `Users.spec.tsx` mocka o barrel `@/components/users`. Sem adicionar `SetPasswordModal` a esse mock, o arquivo inteiro falha com *"No 'SetPasswordModal' export is defined on the mock"* — foi o que aconteceu na primeira execução (10 testes vermelhos) e está corrigido no commit.

## Postura revista durante a revisão (2o commit)

A primeira versão deste PR **deixava o botão aparecer** para o próprio usuário e para um
`super_admin`, apostando no 403 do backend com mensagem legível no toast. O argumento era
evitar duplicar no frontend a regra de hierarquia que vive no backend.

**Isso estava errado na prática.** O fluxo real é: o admin abre o modal, digita uma senha
nova, confirma — e só então descobre que não podia. Um botão que nunca funciona não é
"recusa explícita", é ruído; a regra do produto é hierárquica e a UI precisa refleti-la:

- `super_admin` troca a senha de qualquer um, inclusive de outro `super_admin`
- um owner troca a de agentes e de outros owners, **nunca a de um `super_admin`**
- ninguém troca a própria por aqui — isso é account settings

O 2o commit implementa `canSetPasswordFor(user)` espelhando os três guards do backend
(`users_controller#set_password`). O risco de duplicação continua real e está mitigado do
jeito certo: **o backend segue sendo a autoridade** (e tem request spec para os dois casos
de hierarquia — `refuses to set a super_admin password when the caller is not one` e
`allows a super_admin to set another super_admin password`); o frontend só evita oferecer
o que seria recusado.

Detalhe que virou teste: a comparação de self usa `String(user.id)`. `currentUserId` já
vem stringificado e a lista pode trazer id numérico — um `===` estrito entre `1` e `'1'`
ofereceria o botão no seu próprio card sem ninguém notar.

### Testes da hierarquia

`Users.setPassword.spec.tsx` — 9 casos, cobrindo as quatro combinações de papel, o próprio
card (com id string e numérico), e cada permissão faltando isoladamente.

**Prova negativa:** revertendo para o gate global (`canSetPassword` direto no card),
falham exatamente os três que importam — owner→super_admin, próprio card, e a variante de
id numérico. `tsc --noEmit` limpo; os 10 testes originais de `Users.spec.tsx` seguem verdes.

## Summary by Sourcery

Enable administrators to change eligible users’ passwords directly from the CRM users page.

New Features:
- Add an admin action to set a user's password directly from the user card through a modal dialog.
- Add localized labels, messages, and password-setting feedback across all supported locales.

Enhancements:
- Gate password-setting actions by the required permissions and target-user hierarchy before displaying them.
- Surface actionable API errors and report revoked sessions after a successful password change.

Tests:
- Add coverage for permission, role hierarchy, self-targeting, and identifier handling when offering the password-setting action.

## Summary by Sourcery

Enable administrators to securely change eligible users’ passwords directly from the CRM users page.

New Features:
- Add an administrator action to set eligible users’ passwords from the CRM users page through a localized modal.

Bug Fixes:
- Prevent API error objects from reaching toast notifications and causing the application UI to crash.
- Prevent password-setting actions from being offered for the current user or targets disallowed by role hierarchy.

Enhancements:
- Add client-side password complexity validation and surface actionable backend error messages.
- Treat password reset as a standalone permission and keep it separate from coarse user write permissions.

Tests:
- Add coverage for modal validation, API error handling, success feedback, permission combinations, role hierarchy, self-targeting, and identifier types.
- Add permission-domain tests to prevent standalone password-reset permissions from drifting into coarse groups.

---

## Review — H2, H3, M1 e M2 corrigidos (3º commit)

### H2 — o editor de papéis punha a chave no grupo "Escrita"

Confirmado com os helpers do próprio repo:

```
isStandaloneAction('users','reset_password') = false
groupOfAction('users','reset_password')      = write
```

O backend tinha `users: %i[manage reset_password]`; este espelho tinha `users: new Set(['manage'])`. Consequência dupla, ambas contra o desenho do PR: marcar **Escrita** em Usuários concedia tomada de conta, e desmarcar revogava em silêncio. Pior, removia a única forma de conceder a chave **sozinha** — a válvula de escape em que a migration deliberadamente estreita se apoia.

### H3 — o tratamento de erro derrubava a tela

O `catch` lia `data.message` e depois `data.error`. O `error_response` do auth responde `{ success:false, error:{ code, message }, meta }`: `data.message` **nunca** existe, e `data.error` é um **objeto** — truthy, então curto-circuitava o fallback genérico e entregava o objeto ao `toast()`.

React 19 lança *"Objects are not valid as a React child"* do `<Toaster/>` em `App.tsx`, e `main.tsx` renderiza `<App />` **sem ErrorBoundary** — a raiz desmonta: tela branca. E nos caminhos mais prováveis: senha fraca (422), si mesmo (403), alvo `super_admin` (403).

Também invertia o que este PR afirmava: a mensagem da API **nunca** aparecia.

Agora usa `extractError()` de `utils/apiHelpers` — o helper da casa, que já entende esse envelope.

### M1 — o teste que faltava, e que deixou o H3 passar

`SetPasswordModal.spec.tsx` — **16 testes**. O arquivo não tinha nenhum, e `Users.setPassword.spec.tsx` mocka o modal como `() => null`.

O guard não é "um erro aparece" e sim **"o que chega no toast é uma STRING"** — é a propriedade que o defeito violava.

### M2 — validação local

`passwordProblem()` espelha `password_length` (8..128) do Devise + `User#password_complexity`, **exportada** para ser testável contra `user.rb`. Seis mensagens nos 6 locales.

### Validação

**Prova negativa:** restaurando o extrator antigo, falham exatamente os 4 testes do H3.

`tsc --noEmit` limpo; **279 testes** verdes nas áreas tocadas (componentes de users, página Users, paridade de i18n, config).

### Em aberto, dito por mim

**L2** (guard inalcançável usando a cópia de "editar"), **L3** (um papel vs qualquer papel) e **L4** (`===` estrito em `canDeleteUser`) não foram feitos neste commit.
