### PR TITLE
fix(users): read the set-password error with apiErrorMessage (CRM-251)

### DIFF
--- a/src/components/users/SetPasswordModal.spec.tsx
+++ b/src/components/users/SetPasswordModal.spec.tsx
@@ -70,6 +70,20 @@ describe('SetPasswordModal', () => {
       expect(arg).toBe(message);
     });
 
+    // A 5xx body is written for whoever operates the API. apiErrorMessage() drops
+    // it; extractError() surfaced the driver's own words to the admin on screen.
+    it('keeps a 5xx operator message off the screen', async () => {
+      setPasswordMock.mockRejectedValue(
+        apiError(500, 'ERR_UNDEFINED_COLUMN', 'PG::UndefinedColumn: column users.foo does not exist')
+      );
+      render(<SetPasswordModal open user={USER} onOpenChange={() => {}} />);
+
+      await fillAndSubmit(VALID);
+
+      await waitFor(() => expect(toastError).toHaveBeenCalled());
+      expect(toastError).toHaveBeenCalledWith('setPassword.error');
+    });
+
     it('never passes an object, even when the API answers something unexpected', async () => {
       // The shape that used to slip through: `error` present but not an envelope
       // we know. It must degrade to the generic string, not to an object.

--- a/src/components/users/SetPasswordModal.tsx
+++ b/src/components/users/SetPasswordModal.tsx
@@ -14,7 +14,7 @@ import { toast } from 'sonner';
 import { User } from '@/types/users';
 import { usersService } from '@/services/users';
 import { useLanguage } from '@/hooks/useLanguage';
-import { extractError } from '@/utils/apiHelpers';
+import { apiErrorMessage } from '@/utils/apiHelpers';
 import { passwordProblem } from './passwordRules';
 
 type SetPasswordModalProps = {
@@ -66,10 +66,9 @@ export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswo
       toast.success(t('setPassword.success', { count: result?.revoked_sessions ?? 0 }));
       handleOpenChange(false);
     } catch (error) {
-      // extractError() unwraps the auth's `{ error: { code, message } }` envelope
-      // and always yields a string — toast() renders it as a React child.
-      const { message } = extractError(error);
-      toast.error(message || t('setPassword.error'));
+      // apiErrorMessage() yields the backend's own message, or undefined for a 5xx
+      // and for anything off-envelope — those fall back to the localized string.
+      toast.error(apiErrorMessage(error) || t('setPassword.error'));
       setSaving(false);
     }
   };

--- a/src/components/users/SetPasswordModal.tsx
+++ b/src/components/users/SetPasswordModal.tsx
@@ -26,7 +26,7 @@ type SetPasswordModalProps = {
 /**
  * CRM-210 — an admin sets another user's password directly.
  * The backend is the authority; this dialog only fails fast on what it can
- * check locally and shows whatever the API answers.
+ * check locally.
  */
 export default function SetPasswordModal({ open, onOpenChange, user }: SetPasswordModalProps) {
   const { t } = useLanguage('users');


### PR DESCRIPTION
Primeiro item do **CRM-251** (follow-ups do code review do CRM-210).

## O problema

O `SetPasswordModal` lia o erro da API por `extractError()`. Esse helper substitui defaults em inglês por conta própria e devolve corpo de 5xx tal e qual:

| entrada | `extractError().message` | `apiErrorMessage()` |
|---|---|---|
| 500 com corpo do auth | `"PG::UndefinedColumn: column users.foo"` | `undefined` |
| 502 HTML do proxy | `"Bad Gateway"` | `undefined` |
| envelope com `code` e sem `message` | `"An error occurred"` | `undefined` |

Nos três casos a mensagem localizada era inalcançável, porque as duas primeiras colunas são truthy e curto-circuitam o `|| t('setPassword.error')`. Na prática: o admin via as palavras do driver do Postgres, ou inglês cru numa UI de seis locales.

## A troca

`apiErrorMessage()` foi escrito exatamente para isso — devolve a mensagem do backend num envelope 4xx e `undefined` para 5xx ou qualquer coisa fora do envelope. O comentário do próprio helper diz por que não passa pelo `extractError`: *"5xx bodies are skipped: those messages are written for whoever operates the API, not for the person on screen"*.

Uma linha no `catch`, mais o import.

## O que não regride

O defeito que a correção anterior fechou (objeto chegando no `toast()`, React 19 desmontando a raiz a partir do `<Toaster/>`) continua fechado: `undefined` não é objeto, e só string chega no toast. Os 16 casos existentes seguem verdes sem alteração.

## Teste

Um exemplo novo: um 500 cujo corpo carrega mensagem de operador tem que mostrar a string localizada.

**Prova negativa:** restaurando o `extractError()`, falha exatamente esse, e só ele —

```
× keeps a 5xx operator message off the screen
  → expected "spy" to be called with arguments: [ 'setPassword.error' ]
Tests  1 failed | 16 passed (17)
```

`52 examples, 0 failures` nas áreas tocadas · `tsc --noEmit` e `eslint` limpos.

## Procedência

Foi indicação errada do review de reprovação do CRM-210: o comentário apontou `extractError()` e a implementação seguiu o que estava escrito. O defeito é do apontamento, não de quem implementou.

## Summary by Sourcery

Ensure set-password failures display safe, localized messages while preserving backend messages for supported client errors.

Bug Fixes:
- Use localized fallback messaging for 5xx and malformed API errors in the set-password modal instead of exposing operator-facing backend details.

Tests:
- Add coverage confirming operator messages from 5xx responses are not shown to administrators.