### PR TITLE
fix(agents): surface the core-service's error message, not axios's (CRM-116 F2)

### DIFF
--- a/src/utils/agentUtils.spec.ts
+++ b/src/utils/agentUtils.spec.ts
@@ -2,29 +2,22 @@ import { describe, it, expect } from 'vitest';
 import { extractBackendErrorMessage } from './agentUtils';
 
 /**
- * CRM-116 — o motivo da recusa nunca chegava ao usuário.
+ * CRM-116 — the reason for a refusal never reached the user.
  *
- * O core-service (Go) responde `{ success:false, error:{ code, message } }`.
- * `extractBackendErrorMessage` lia `data.detail` (shape do FastAPI) e
- * `data.message`, e nenhum dos dois existe nesse envelope — então TUDO que o core
- * recusa caía no `error.message` do axios.
- *
- * Na prática: quem estourava a cota de agentes do plano via
- * "Request failed with status code 422", sem uma palavra sobre plano ou limite.
- * A recusa funcionava; a explicação se perdia no caminho.
- *
- * O mesmo bug já tinha sido corrigido neste SPA em customToolsService.ts, com o
- * comentário dizendo que antes "callers only ever saw axios's generic message".
+ * The core-service answers `{ success:false, error:{ code, message } }`, which
+ * matches neither the FastAPI `detail` branch nor `data.message` — so every core
+ * refusal fell through to axios's generic message. A tenant over its plan limit
+ * read "Request failed with status code 422", with no mention of a limit.
  */
 describe('extractBackendErrorMessage', () => {
-  /** O envelope real do core-service. */
+  /** The core-service's real envelope. */
   const coreError = (status: number, code: string, message: string) => ({
-    message: `Request failed with status code ${status}`, // o que o axios põe
+    message: `Request failed with status code ${status}`, // what axios puts there
     response: { status, data: { success: false, error: { code, message }, meta: {} } },
   });
 
-  describe('o envelope do core-service (a regressão)', () => {
-    it('mostra o motivo da cota estourada, não a mensagem do axios', () => {
+  describe("the core-service's envelope (the regression)", () => {
+    it('shows why the quota refused, not axios\'s message', () => {
       const error = coreError(422, 'QUOTA_EXCEEDED', 'agents limit reached (2/2, requested 500)');
 
       const result = extractBackendErrorMessage(error);
@@ -37,13 +30,13 @@ describe('extractBackendErrorMessage', () => {
       [403, 'FORBIDDEN', 'You do not have permission to create agents'],
       [400, 'BAD_REQUEST', 'Invalid agent configuration'],
       [500, 'INTERNAL_ERROR', 'Something went wrong'],
-    ])('vale para qualquer status do core (%i %s)', (status, code, message) => {
+    ])('holds for any core status (%i %s)', (status, code, message) => {
       expect(extractBackendErrorMessage(coreError(status, code, message))).toBe(message);
     });
   });
 
-  describe('os shapes que já funcionavam continuam funcionando', () => {
-    it('mantém a personalização do 422 do processor (FastAPI, data.detail)', () => {
+  describe('the shapes that already worked still work', () => {
+    it("keeps the processor's 422 wording (FastAPI, data.detail)", () => {
       const error = {
         response: {
           status: 422,
@@ -54,31 +47,31 @@ describe('extractBackendErrorMessage', () => {
       expect(extractBackendErrorMessage(error)).toContain('não pode conter espaços');
     });
 
-    it('mantém o ramo data.message', () => {
+    it('keeps the data.message branch', () => {
       const error = { response: { status: 400, data: { message: 'plain message shape' } } };
 
       expect(extractBackendErrorMessage(error)).toBe('plain message shape');
     });
 
-    it('cai no erro do axios quando não há resposta (rede)', () => {
+    it("falls back to axios's error when there is no response (network)", () => {
       expect(extractBackendErrorMessage({ message: 'Network Error' })).toBe('Network Error');
     });
 
-    it('tem um último recurso quando não há nada', () => {
+    it('has a last resort when there is nothing at all', () => {
       expect(extractBackendErrorMessage({})).toBe('Erro desconhecido ao salvar agente');
     });
   });
 
-  describe('precedência', () => {
-    it('o detail do FastAPI ganha do envelope do core no mesmo 422', () => {
-      // Um 422 com `detail` vem do processor e já tinha tratamento amigável;
-      // o envelope do core não deve atropelá-lo.
+  describe('precedence', () => {
+    it("the FastAPI detail wins over the core envelope on the same 422", () => {
+      // A 422 carrying `detail` comes from the processor and already has friendly
+      // wording; the core envelope must not override it.
       const error = {
         response: {
           status: 422,
           data: {
             detail: [{ msg: 'Input should be a valid UUID' }],
-            error: { code: 'X', message: 'nao deve aparecer' },
+            error: { code: 'X', message: 'must not surface' },
           },
         },
       };
@@ -86,7 +79,7 @@ describe('extractBackendErrorMessage', () => {
       expect(extractBackendErrorMessage(error)).toContain('UUID');
     });
 
-    it('o envelope do core ganha do error.message do axios', () => {
+    it("the core envelope wins over axios's error.message", () => {
       const error = coreError(422, 'QUOTA_EXCEEDED', 'agents limit reached (2/2)');
 
       expect(extractBackendErrorMessage(error)).not.toBe(error.message);

--- a/src/utils/agentUtils.spec.ts
+++ b/src/utils/agentUtils.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { extractBackendErrorMessage } from './agentUtils';
+
+/**
+ * CRM-116 — o motivo da recusa nunca chegava ao usuário.
+ *
+ * O core-service (Go) responde `{ success:false, error:{ code, message } }`.
+ * `extractBackendErrorMessage` lia `data.detail` (shape do FastAPI) e
+ * `data.message`, e nenhum dos dois existe nesse envelope — então TUDO que o core
+ * recusa caía no `error.message` do axios.
+ *
+ * Na prática: quem estourava a cota de agentes do plano via
+ * "Request failed with status code 422", sem uma palavra sobre plano ou limite.
+ * A recusa funcionava; a explicação se perdia no caminho.
+ *
+ * O mesmo bug já tinha sido corrigido neste SPA em customToolsService.ts, com o
+ * comentário dizendo que antes "callers only ever saw axios's generic message".
+ */
+describe('extractBackendErrorMessage', () => {
+  /** O envelope real do core-service. */
+  const coreError = (status: number, code: string, message: string) => ({
+    message: `Request failed with status code ${status}`, // o que o axios põe
+    response: { status, data: { success: false, error: { code, message }, meta: {} } },
+  });
+
+  describe('o envelope do core-service (a regressão)', () => {
+    it('mostra o motivo da cota estourada, não a mensagem do axios', () => {
+      const error = coreError(422, 'QUOTA_EXCEEDED', 'agents limit reached (2/2, requested 500)');
+
+      const result = extractBackendErrorMessage(error);
+
+      expect(result).toBe('agents limit reached (2/2, requested 500)');
+      expect(result).not.toContain('Request failed with status code');
+    });
+
+    it.each([
+      [403, 'FORBIDDEN', 'You do not have permission to create agents'],
+      [400, 'BAD_REQUEST', 'Invalid agent configuration'],
+      [500, 'INTERNAL_ERROR', 'Something went wrong'],
+    ])('vale para qualquer status do core (%i %s)', (status, code, message) => {
+      expect(extractBackendErrorMessage(coreError(status, code, message))).toBe(message);
+    });
+  });
+
+  describe('os shapes que já funcionavam continuam funcionando', () => {
+    it('mantém a personalização do 422 do processor (FastAPI, data.detail)', () => {
+      const error = {
+        response: {
+          status: 422,
+          data: { detail: [{ msg: 'Agent name cannot contain spaces or special characters' }] },
+        },
+      };
+
+      expect(extractBackendErrorMessage(error)).toContain('não pode conter espaços');
+    });
+
+    it('mantém o ramo data.message', () => {
+      const error = { response: { status: 400, data: { message: 'plain message shape' } } };
+
+      expect(extractBackendErrorMessage(error)).toBe('plain message shape');
+    });
+
+    it('cai no erro do axios quando não há resposta (rede)', () => {
+      expect(extractBackendErrorMessage({ message: 'Network Error' })).toBe('Network Error');
+    });
+
+    it('tem um último recurso quando não há nada', () => {
+      expect(extractBackendErrorMessage({})).toBe('Erro desconhecido ao salvar agente');
+    });
+  });
+
+  describe('precedência', () => {
+    it('o detail do FastAPI ganha do envelope do core no mesmo 422', () => {
+      // Um 422 com `detail` vem do processor e já tinha tratamento amigável;
+      // o envelope do core não deve atropelá-lo.
+      const error = {
+        response: {
+          status: 422,
+          data: {
+            detail: [{ msg: 'Input should be a valid UUID' }],
+            error: { code: 'X', message: 'nao deve aparecer' },
+          },
+        },
+      };
+
+      expect(extractBackendErrorMessage(error)).toContain('UUID');
+    });
+
+    it('o envelope do core ganha do error.message do axios', () => {
+      const error = coreError(422, 'QUOTA_EXCEEDED', 'agents limit reached (2/2)');
+
+      expect(extractBackendErrorMessage(error)).not.toBe(error.message);
+    });
+  });
+});

--- a/src/utils/agentUtils.ts
+++ b/src/utils/agentUtils.ts
@@ -58,14 +58,10 @@ export const extractBackendErrorMessage = (error: any): string => {
     }
   }
 
-  // CRM-116: o core-service (Go) responde `{ success:false, error:{ code, message } }`.
-  // Nenhum dos dois ramos acima casa com esse envelope: `detail` é shape do FastAPI e
-  // `data.message` não existe ali. Sem esta linha, tudo que o core recusa cai no
-  // `error.message` do axios — quem estourava a cota do plano via
-  // "Request failed with status code 422", sem uma palavra sobre plano ou limite.
-  //
-  // Mesmo bug já corrigido neste SPA em services/agents/customToolsService.ts
-  // (getErrorMessage), com a mesma leitura de `data.error.message`.
+  // CRM-116: the core-service (Go) answers `{ success:false, error:{ code, message } }`,
+  // which neither branch above matches — so every core refusal fell through to
+  // axios's generic "Request failed with status code N". Same read as
+  // services/agents/customToolsService.ts.
   if (error?.response?.data?.error?.message) {
     return error.response.data.error.message;
   }

--- a/src/utils/agentUtils.ts
+++ b/src/utils/agentUtils.ts
@@ -58,6 +58,18 @@ export const extractBackendErrorMessage = (error: any): string => {
     }
   }
 
+  // CRM-116: o core-service (Go) responde `{ success:false, error:{ code, message } }`.
+  // Nenhum dos dois ramos acima casa com esse envelope: `detail` é shape do FastAPI e
+  // `data.message` não existe ali. Sem esta linha, tudo que o core recusa cai no
+  // `error.message` do axios — quem estourava a cota do plano via
+  // "Request failed with status code 422", sem uma palavra sobre plano ou limite.
+  //
+  // Mesmo bug já corrigido neste SPA em services/agents/customToolsService.ts
+  // (getErrorMessage), com a mesma leitura de `data.error.message`.
+  if (error?.response?.data?.error?.message) {
+    return error.response.data.error.message;
+  }
+
   // Fallback para outros tipos de erro
   if (error?.response?.data?.message) {
     return error.response.data.message;


### PR DESCRIPTION
A recusa funcionava; **a explicação se perdia no caminho**.

## O que acontecia

`extractBackendErrorMessage` (`src/utils/agentUtils.ts`) lia `data.detail` — shape do **FastAPI** — e `data.message`. O core-service responde:

```json
{ "success": false, "error": { "code": "QUOTA_EXCEEDED", "message": "agents limit reached (2/2, requested 500)" } }
```

Nenhum dos dois ramos casa com esse envelope, então **tudo** que o core recusa caía no `error.message` do axios. Quem estourava a cota de agentes do plano via:

> **"Erro ao salvar agente / Request failed with status code 422"**

Sem uma palavra sobre plano ou limite. O enforcement de cota do CRM-116 seria **invisível para a pessoa a quem ele se aplica**.

## O fix

Ler `data.error.message` — a mesma linha que `services/agents/customToolsService.ts` já carrega, e cujo comentário registra o bug idêntico: antes dela, *"callers only ever saw axios's generic message"*.

### Precedência é deliberada

O ramo `detail` do FastAPI **continua ganhando** no 422: esses vêm do processor e já têm tratamento amigável (nome de agente com espaços, UUID inválido). O envelope do core entra **à frente do fallback do axios**, que é o único lugar onde ele estava perdendo.

### Não falta chave de i18n

A nota anterior da review supôs que faltava uma key `quota.*` aqui. As `quota.resource.*` vivem no **shell SaaS**, outro app — este SPA não tem tratamento de `QUOTA_EXCEEDED` nenhum. O conserto é mostrar o que o backend já diz.

## Escopo

PR próprio porque é outro repositório e porque **se sustenta sozinho**: qualquer recusa do core-service que chegasse a essas telas era igualmente muda, não só a de cota.

O enforcement em si está em [evo-ai-core-service-community#26](https://github.com/evolution-foundation/evo-ai-core-service-community/pull/26). Os dois são independentes — este melhora toda mensagem de erro vinda do core, com ou sem aquele.

## Testes

**10 casos** em `agentUtils.spec.ts`, cobrindo o envelope do core em 4 status, os três shapes que já funcionavam e as duas regras de precedência.

**Prova negativa:** removendo o ramo, **5 falham** — incluindo o da cota. Os **5 que cobrem os shapes pré-existentes continuam passando**, e é isso que prova que o fix não os deslocou.

`tsc --noEmit` e `eslint` limpos.

## Summary by Sourcery

Display actionable backend refusal messages when agent operations fail, including quota-related errors.

Bug Fixes:
- Surface core-service error messages instead of Axios's generic status error when saving agents.
- Preserve existing FastAPI validation and plain-message error handling precedence.

Tests:
- Add coverage for core-service errors across statuses, existing error shapes, fallbacks, and precedence rules.