### PR TITLE
fix(pipelines): send the emptied stage description instead of omitting it (CRM-254)

### DIFF
--- a/src/components/pipelines/EditStageModal.tsx
+++ b/src/components/pipelines/EditStageModal.tsx
@@ -32,6 +32,7 @@ import type { AgentBotOption, MessageTemplateOption } from './StageAutomationRul
 import { LocalAttributeDefinition, LocalAttributeDefinitionPayload } from '@/types/pipelines/localAttributeDefinition';
 import PipelineStageCustomAttributes from './PipelineStageCustomAttributes';
 import StageAutomationRules, { type PipelineWithStages } from './StageAutomationRules';
+import { buildAutomationRulesPayload } from './stageAutomationPayload';
 
 // Cores predefinidas para as etapas
 const getStageColors = (t: (key: string) => string) => [
@@ -60,7 +61,7 @@ interface EditStageModalProps {
     name: string;
     color: string;
     stage_type: string;
-    automation_rules?: { description?: string; rules?: StageAutomationRule[] };
+    automation_rules: { description: string; rules: StageAutomationRule[] };
     custom_fields?: Record<string, unknown> & {
       attributes?: string[];
     };
@@ -230,11 +231,9 @@ export default function EditStageModal({
 
   const handleSubmit = () => {
     if (!name.trim() || !stage) return;
-    
-    const automationRulesPayload: { description?: string; rules?: StageAutomationRule[] } = {};
-    if (description) automationRulesPayload.description = description;
-    if (automationRules.length > 0) automationRulesPayload.rules = automationRules;
-    
+
+    const automationRulesPayload = buildAutomationRulesPayload(description, automationRules);
+
     const attributeKeys = Object.keys(customAttributes);
     const attributeDefinitions = Object.entries(customAttributes).reduce(
       (acc, [key, value]) => {
@@ -261,7 +260,7 @@ export default function EditStageModal({
       name: name.trim(),
       color,
       stage_type: stageType,
-      automation_rules: Object.keys(automationRulesPayload).length > 0 ? automationRulesPayload : undefined,
+      automation_rules: automationRulesPayload,
       custom_fields: attributeKeys.length > 0
         ? {
             ...existingCustomFields,

--- a/src/components/pipelines/stageAutomationPayload.spec.ts
+++ b/src/components/pipelines/stageAutomationPayload.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildAutomationRulesPayload } from './stageAutomationPayload';
+import type { StageAutomationRule } from '@/types/analytics';
+
+const rule: StageAutomationRule = {
+  trigger: 'label_added',
+  trigger_value: 'lead qualificado',
+  action: 'apply_label',
+  action_value: 'em negociacao',
+};
+
+describe('buildAutomationRulesPayload', () => {
+  // The API merges what arrives over what is stored: a key left out is preserved, not
+  // cleared. Omitting the emptied field is how the form silently lost the ability to erase.
+  it('sends the empty description instead of omitting it', () => {
+    expect(buildAutomationRulesPayload('', [rule])).toEqual({ description: '', rules: [rule] });
+  });
+
+  it('sends the empty rule list instead of omitting it', () => {
+    expect(buildAutomationRulesPayload('Primeiro contato', [])).toEqual({
+      description: 'Primeiro contato',
+      rules: [],
+    });
+  });
+
+  it('sends both keys when both are empty', () => {
+    expect(buildAutomationRulesPayload('   ', [])).toEqual({ description: '', rules: [] });
+  });
+
+  it('keeps both when both are filled', () => {
+    expect(buildAutomationRulesPayload('Primeiro contato', [rule])).toEqual({
+      description: 'Primeiro contato',
+      rules: [rule],
+    });
+  });
+});

--- a/src/components/pipelines/stageAutomationPayload.ts
+++ b/src/components/pipelines/stageAutomationPayload.ts
@@ -1,0 +1,11 @@
+import type { StageAutomationRule } from '@/types/analytics';
+
+// The backend merges automation_rules over what is already stored, so a key left out of the
+// payload is PRESERVED, not cleared. Clearing has to be explicit — always send both keys,
+// empty when the user emptied them, or the description can never be erased from the form.
+export function buildAutomationRulesPayload(
+  description: string,
+  rules: StageAutomationRule[],
+): { description: string; rules: StageAutomationRule[] } {
+  return { description: description.trim(), rules };
+}

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -50,6 +50,7 @@ import {
   PipelineItem,
   UpdatePipelineData,
   CreateStageData,
+  StageAutomationRule,
 } from '@/types/analytics';
 import EditPipelineModal from '@/components/pipelines/EditPipelineModal';
 import CreateStageModal from '@/components/pipelines/CreateStageModal';
@@ -707,7 +708,7 @@ export default function PipelineKanban() {
     name: string;
     color: string;
     stage_type: string;
-    automation_rules?: { description?: string };
+    automation_rules: { description: string; rules: StageAutomationRule[] };
     custom_fields?: Record<string, unknown>;
   }) => {
     if (!stageToEdit || !pipelineId) return;

--- a/src/services/pipelines/pipelinesService.ts
+++ b/src/services/pipelines/pipelinesService.ts
@@ -19,6 +19,7 @@ import type {
   AvailableContactsResponse,
   PipelineItemResponse,
   ConversationForModal,
+  StageAutomationRule,
 } from '@/types/analytics';
 import { Contact } from '@/types';
 
@@ -120,7 +121,9 @@ class PipelinesService {
       position?: number;
       color?: string;
       stage_type?: string;
-      automation_rules?: { description?: string };
+      // Sent whole: the API merges what arrives over what is stored, so an omitted key is
+      // kept, not cleared. To erase, send the empty value.
+      automation_rules?: { description?: string; rules?: StageAutomationRule[] };
       custom_fields?: Record<string, unknown>;
     },
   ): Promise<PipelineStage> {


### PR DESCRIPTION
O formulário de edição de estágio limpava **por omissão**: descrição vazia ou lista de regras vazia simplesmente não iam no payload. Isso só funcionava porque a API substituía o objeto `automation_rules` inteiro a cada chamada.

A API passou a mesclar o payload sobre o que está gravado (para o copiloto conseguir atualizar uma chave sem apagar a outra). Com isso, limpar por omissão vira o oposto do que o usuário pediu: apagar a descrição no formulário restauraria a antiga, e remover a última regra restauraria as antigas.

O payload agora sai de uma função pura que manda sempre as duas chaves, vazias quando o usuário esvaziou. Os tipos ao longo da cadeia (`EditStageModal` → `PipelineKanban` → `pipelinesService`) passaram a dizer que `rules` viaja junto com `description` — o tipo do serviço declarava só `{ description?: string }`.

## Ordem de merge

Este PR precisa entrar **antes** de evolution-foundation/evo-ai-crm-community#298, que é o que muda a API para mesclar. Se o #298 entrar sozinho, a regressão de limpeza fica em produção até este aqui subir.

## Testes

`src/components/pipelines/stageAutomationPayload.spec.ts` cobre os quatro casos (descrição vazia, lista vazia, ambas vazias, ambas preenchidas). `npx tsc -b` e `npx eslint` limpos nos arquivos tocados.

## Summary by Sourcery

Send complete stage automation values so clearing descriptions or rules remains effective when the API merges updates.

Bug Fixes:
- Ensure empty stage descriptions and automation rule lists are sent explicitly so users can clear previously saved values.

Enhancements:
- Use a shared payload builder and update pipeline types to carry both automation description and rules through the update flow.

Tests:
- Add coverage for empty, populated, and mixed stage automation payloads.