### PR TITLE
fix(pipelines): limita a descrição da etapa no formulário de criação (CRM-254)

### DIFF
--- a/src/components/pipelines/CreateStageModal.tsx
+++ b/src/components/pipelines/CreateStageModal.tsx
@@ -110,8 +110,15 @@ export default function CreateStageModal({
                 })}
                 placeholder={t('createStage.descriptionPlaceholder')}
                 rows={3}
+                maxLength={500}
                 disabled={loading}
               />
+              <p className="text-xs text-muted-foreground">
+                {t('createStage.characterCount', {
+                  current: (formData.automation_rules?.description || '').length,
+                  max: 500,
+                })}
+              </p>
             </div>
 
             {/* Color */}

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -203,6 +203,7 @@
     "namePlaceholder": "Ex: Leads Qualified",
     "descriptionLabel": "Description",
     "descriptionPlaceholder": "Describe the purpose of this stage...",
+    "characterCount": "{{current}}/{{max}} characters",
     "color": "Stage Color",
     "colorSelected": "Selected Color",
     "stageType": "Stage Type",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -170,6 +170,7 @@
     "namePlaceholder": "Ej: Leads Calificados",
     "descriptionLabel": "Descripción",
     "descriptionPlaceholder": "Describa el propósito de esta etapa...",
+    "characterCount": "{{current}}/{{max}} caracteres",
     "color": "Color de la Etapa",
     "colorSelected": "Color seleccionado",
     "stageType": "Tipo de Etapa",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -170,6 +170,7 @@
     "namePlaceholder": "Ex : Leads Qualifiés",
     "descriptionLabel": "Description",
     "descriptionPlaceholder": "Décrivez le but de cette étape...",
+    "characterCount": "{{current}}/{{max}} caractères",
     "color": "Couleur de l'Étape",
     "colorSelected": "Couleur sélectionnée",
     "stageType": "Type d'Étape",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -170,6 +170,7 @@
     "namePlaceholder": "Es: Lead Qualificati",
     "descriptionLabel": "Descrizione",
     "descriptionPlaceholder": "Descrivi lo scopo di questa fase...",
+    "characterCount": "{{current}}/{{max}} caratteri",
     "color": "Colore della Fase",
     "colorSelected": "Colore selezionato",
     "stageType": "Tipo di Fase",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -203,6 +203,7 @@
     "namePlaceholder": "Ex: Leads Qualificados",
     "descriptionLabel": "Descrição",
     "descriptionPlaceholder": "Descreva o propósito desta etapa...",
+    "characterCount": "{{current}}/{{max}} caracteres",
     "color": "Cor da Etapa",
     "colorSelected": "Cor selecionada",
     "stageType": "Tipo de Etapa",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -197,6 +197,7 @@
     "namePlaceholder": "Ex: Leads Qualificados",
     "descriptionLabel": "Descrição",
     "descriptionPlaceholder": "Descreva o propósito desta etapa...",
+    "characterCount": "{{current}}/{{max}} caracteres",
     "color": "Cor da Etapa",
     "colorSelected": "Cor selecionada",
     "stageType": "Tipo de Etapa",


### PR DESCRIPTION
A API passou a **recusar com 422** uma descrição de etapa acima de 500 caracteres, no lugar de truncar em silêncio (evolution-foundation/evo-ai-crm-community#298).

O formulário de **edição** já tinha `maxLength={500}` e contador. O de **criação** não tinha nenhum dos dois: o usuário digitava além do limite e a criação falhava com `kanban.messages.stageCreateError`, um toast genérico que não diz o motivo. Antes da mudança da API isso passava, porque o backend truncava e criava a etapa.

O campo agora para em 500 e mostra o mesmo contador da edição, com `createStage.characterCount` nos três locales.

Depois disto, os outros 422 novos do #298 ficam inalcançáveis pela tela: gatilho, ação e `stage_type` vêm todos de `Select`.

## Testes

`npx tsc -b` e `npx eslint` limpos nos arquivos tocados.

## Summary by Sourcery

Prevent stage creation failures by enforcing the API description limit in the creation form.

New Features:
- Limit stage descriptions in the creation form to 500 characters and display a live character counter across supported locales.

Bug Fixes:
- Prevent stage creation requests from failing because of overlong descriptions rejected by the API.