### PR TITLE
fix(setup): warn instead of congratulating on degraded provisioning (CRM-262)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,11 @@ jobs:
       #     there is an agent list to pick from — a reopened modal refetching over
       #     the previous one included — and never on the other select actions.
       #     Also guards the aria wiring from the select to the warning.
+      #   - Setup wizard (CRM-262): a degraded provisioning answer warns instead of
+      #     congratulating, and an ok one still congratulates without warning. The
+      #     paired direction is what keeps it honest — a warning ADDED next to the
+      #     success toast would look right on screen and still tell the operator
+      #     the install is fine.
       #   - i18n-parity (CRM-162): en and pt-BR keep the same key set, catalog-wide.
       #   - macros-parity (CRM-162): es, fr, it and pt are covered nowhere else, so
       #     macros.json is checked against en across all six. A key added to one
@@ -137,6 +142,7 @@ jobs:
             src/components/customAttributes/CustomAttributesForm.spec.tsx \
             src/components/layout/config/menuItems.spec.ts \
             src/components/macros/MacroActionRow.spec.tsx \
+            src/pages/Setup/Setup.spec.tsx \
             src/i18n/locales/i18n-parity.spec.ts \
             src/i18n/locales/macros-parity.spec.ts
 

--- a/src/i18n/locales/en/setup.json
+++ b/src/i18n/locales/en/setup.json
@@ -57,6 +57,10 @@
     "title": "Setup complete!",
     "description": "You can now sign in with your credentials."
   },
+  "degraded": {
+    "title": "Setup complete, with one pending step",
+    "description": "The install finished, but provisioning the account did not complete. It retries automatically within ~10 minutes."
+  },
   "error": {
     "generic": "An error occurred during setup. Please try again.",
     "alreadySetup": "This instance has already been set up."

--- a/src/i18n/locales/es/setup.json
+++ b/src/i18n/locales/es/setup.json
@@ -57,6 +57,10 @@
     "title": "¡Configuración completa!",
     "description": "Ahora puede iniciar sesión con sus credenciales."
   },
+  "degraded": {
+    "title": "Configuración completada, con un pendiente",
+    "description": "La instalación terminó, pero el aprovisionamiento de la cuenta no se completó. Se reintenta automáticamente en ~10 minutos."
+  },
   "error": {
     "generic": "Ocurrió un error durante la configuración. Por favor, inténtelo de nuevo.",
     "alreadySetup": "Esta instancia ya ha sido configurada."

--- a/src/i18n/locales/fr/setup.json
+++ b/src/i18n/locales/fr/setup.json
@@ -57,6 +57,10 @@
     "title": "Configuration terminée !",
     "description": "Vous pouvez maintenant vous connecter avec vos identifiants."
   },
+  "degraded": {
+    "title": "Configuration terminée, avec un point en attente",
+    "description": "L'installation est terminée, mais le provisionnement du compte n'a pas abouti. Il est relancé automatiquement sous ~10 minutes."
+  },
   "error": {
     "generic": "Une erreur s'est produite lors de la configuration. Veuillez réessayer.",
     "alreadySetup": "Cette instance a déjà été configurée."

--- a/src/i18n/locales/it/setup.json
+++ b/src/i18n/locales/it/setup.json
@@ -57,6 +57,10 @@
     "title": "Configurazione completata!",
     "description": "Ora puoi accedere con le tue credenziali."
   },
+  "degraded": {
+    "title": "Configurazione completata, con un elemento in sospeso",
+    "description": "L'installazione è terminata, ma il provisioning dell'account non è stato completato. Riprova automaticamente entro ~10 minuti."
+  },
   "error": {
     "generic": "Si è verificato un errore durante la configurazione. Riprova.",
     "alreadySetup": "Questa istanza è già stata configurata."

--- a/src/i18n/locales/pt-BR/setup.json
+++ b/src/i18n/locales/pt-BR/setup.json
@@ -57,6 +57,10 @@
     "title": "Configuração concluída!",
     "description": "Agora você pode entrar com suas credenciais."
   },
+  "degraded": {
+    "title": "Configuração concluída, com uma pendência",
+    "description": "A instalação terminou, mas o provisionamento da conta não completou. Ele repete sozinho em até ~10 minutos."
+  },
   "error": {
     "generic": "Ocorreu um erro durante a configuração. Tente novamente.",
     "alreadySetup": "Esta instância já foi configurada."

--- a/src/i18n/locales/pt/setup.json
+++ b/src/i18n/locales/pt/setup.json
@@ -57,6 +57,10 @@
     "title": "Configuração concluída!",
     "description": "Agora pode entrar com as suas credenciais."
   },
+  "degraded": {
+    "title": "Configuração concluída, com uma pendência",
+    "description": "A instalação terminou, mas o aprovisionamento da conta não completou. Repete automaticamente em até ~10 minutos."
+  },
   "error": {
     "generic": "Ocorreu um erro durante a configuração. Tente novamente.",
     "alreadySetup": "Esta instância já foi configurada."

--- a/src/pages/Setup/Setup.spec.tsx
+++ b/src/pages/Setup/Setup.spec.tsx
@@ -252,7 +252,7 @@ describe('Setup wizard', () => {
   // is that "Configuração concluída!" no longer covers a box left without
   // membership, without its first account and without roles.
   describe('when the server reports degraded provisioning (CRM-262)', () => {
-    const degraded = (message: string | null) => {
+    const degraded = (message: string | null, survey_token: string | null = null) => {
       vi.mocked(setupService.getStatus).mockResolvedValue({
         status: 'inactive',
         instance_id: null,
@@ -261,7 +261,7 @@ describe('Setup wizard', () => {
       vi.mocked(setupService.bootstrap).mockResolvedValue({
         status: 'degraded',
         message,
-        survey_token: null,
+        survey_token,
       });
     };
 
@@ -316,6 +316,19 @@ describe('Setup wizard', () => {
       await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }));
       // The error alert belongs to a failed install; this one succeeded.
       expect(screen.queryByText('error.generic')).not.toBeInTheDocument();
+    });
+
+    // The path a real box takes: the server returns the survey_token on the
+    // degraded response too, so the wizard goes to the survey, not to /login.
+    it('still hands off to the survey when the server sends a token', async () => {
+      degraded('anything', 'tok-123');
+      await submit();
+
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith('/setup/onboarding', { replace: true }),
+      );
+      expect(sessionStorage.getItem('survey_token')).toBe('tok-123');
+      expect(toast.warning).toHaveBeenCalled();
     });
   });
 

--- a/src/pages/Setup/Setup.spec.tsx
+++ b/src/pages/Setup/Setup.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { toast } from 'sonner';
 import Setup from './Setup';
 import { setupService } from '@/services/setup/setupService';
 import {
@@ -34,8 +35,10 @@ vi.mock('@/components/AppLogo', () => ({
   AppLogo: () => <div data-testid="app-logo">Logo</div>,
 }));
 
+// `warning` is part of this mock, not decoration: without it the degraded path
+// calls undefined and the branch cannot be tested at all.
 vi.mock('sonner', () => ({
-  toast: { success: vi.fn(), info: vi.fn() },
+  toast: { success: vi.fn(), info: vi.fn(), warning: vi.fn() },
 }));
 
 const mockNavigate = vi.fn();
@@ -242,5 +245,94 @@ describe('Setup wizard', () => {
 
     await waitFor(() => expect(setupService.bootstrap).toHaveBeenCalledWith(ACCOUNT));
     expect(screen.queryByTestId('fake-setup-step')).not.toBeInTheDocument();
+  });
+
+  // CRM-262 — the install finished and the admin exists, so this stays on the
+  // success path: 201, no error alert, and the wizard still leaves. What changes
+  // is that "Configuração concluída!" no longer covers a box left without
+  // membership, without its first account and without roles.
+  describe('when the server reports degraded provisioning (CRM-262)', () => {
+    const degraded = (message: string | null) => {
+      vi.mocked(setupService.getStatus).mockResolvedValue({
+        status: 'inactive',
+        instance_id: null,
+        extra_setup_steps: false,
+      });
+      vi.mocked(setupService.bootstrap).mockResolvedValue({
+        status: 'degraded',
+        message,
+        survey_token: null,
+      });
+    };
+
+    const submit = async () => {
+      renderSetup();
+      await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+      fillAccount();
+      fireEvent.click(screen.getByRole('button', { name: 'form.submit.idle' }));
+    };
+
+    it('warns instead of congratulating', async () => {
+      degraded('provisioning did not finish — retries within ~10 minutes');
+      await submit();
+
+      await waitFor(() => expect(toast.warning).toHaveBeenCalled());
+      // The half that actually matters: a warning ADDED next to the success
+      // toast would look right on screen and still tell the operator the
+      // install is fine.
+      expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it("relays the server's message, which is what says how to recover", async () => {
+      degraded('provisioning did not finish — retries within ~10 minutes');
+      await submit();
+
+      await waitFor(() =>
+        expect(toast.warning).toHaveBeenCalledWith(
+          'degraded.title',
+          expect.objectContaining({
+            description: 'provisioning did not finish — retries within ~10 minutes',
+          }),
+        ),
+      );
+    });
+
+    it('falls back to the local copy when the server sends no message', async () => {
+      degraded(null);
+      await submit();
+
+      await waitFor(() =>
+        expect(toast.warning).toHaveBeenCalledWith(
+          'degraded.title',
+          expect.objectContaining({ description: 'degraded.description' }),
+        ),
+      );
+    });
+
+    it('still finishes the wizard — degraded is not an error', async () => {
+      degraded('anything');
+      await submit();
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true }));
+      // The error alert belongs to a failed install; this one succeeded.
+      expect(screen.queryByText('error.generic')).not.toBeInTheDocument();
+    });
+  });
+
+  // The guard for the other direction: a healthy install must not start warning.
+  it('congratulates and does not warn when the server reports ok', async () => {
+    vi.mocked(setupService.getStatus).mockResolvedValue({
+      status: 'inactive',
+      instance_id: null,
+      extra_setup_steps: false,
+    });
+
+    renderSetup();
+    await waitFor(() => expect(setupService.getStatus).toHaveBeenCalled());
+    fillAccount();
+    fireEvent.click(screen.getByRole('button', { name: 'form.submit.idle' }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(toast.warning).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/Setup/Setup.tsx
+++ b/src/pages/Setup/Setup.tsx
@@ -152,9 +152,23 @@ const Setup: React.FC = () => {
         }
       }
 
-      toast.success(t('success.title'), {
-        description: t('success.description'),
-      });
+      // CRM-262: o install terminou e o admin existe — por isso segue no fluxo de
+      // sucesso nos dois casos. Mas quando o provisionamento da conta não completa,
+      // o backend responde `degraded`, e dizer "Configuração concluída!" esconderia
+      // do operador que ainda falta algo (o box fica sem membership, sem a primeira
+      // conta e sem papéis até o job de rede completar). A descrição vem do
+      // servidor, que sabe o que ficou pendente e o que conferir — mesmo padrão já
+      // usado no catch abaixo, que prefere `data.error` à mensagem genérica.
+      if (result.status === 'degraded') {
+        toast.warning(t('degraded.title'), {
+          description: result.message || t('degraded.description'),
+          duration: 12000,
+        });
+      } else {
+        toast.success(t('success.title'), {
+          description: t('success.description'),
+        });
+      }
 
       if (result.survey_token) {
         sessionStorage.setItem('survey_token', result.survey_token);

--- a/src/pages/Setup/Setup.tsx
+++ b/src/pages/Setup/Setup.tsx
@@ -152,13 +152,9 @@ const Setup: React.FC = () => {
         }
       }
 
-      // CRM-262: o install terminou e o admin existe — por isso segue no fluxo de
-      // sucesso nos dois casos. Mas quando o provisionamento da conta não completa,
-      // o backend responde `degraded`, e dizer "Configuração concluída!" esconderia
-      // do operador que ainda falta algo (o box fica sem membership, sem a primeira
-      // conta e sem papéis até o job de rede completar). A descrição vem do
-      // servidor, que sabe o que ficou pendente e o que conferir — mesmo padrão já
-      // usado no catch abaixo, que prefere `data.error` à mensagem genérica.
+      // Both paths stay on the success flow: the install finished and the admin
+      // exists. The description comes from the server, which is the side that knows
+      // what is pending and what to check — same preference as the catch below.
       if (result.status === 'degraded') {
         toast.warning(t('degraded.title'), {
           description: result.message || t('degraded.description'),

--- a/src/services/setup/setupService.ts
+++ b/src/services/setup/setupService.ts
@@ -32,8 +32,13 @@ export interface BootstrapPayload {
 }
 
 export interface BootstrapResponse {
+  /** 'ok' | 'degraded' (CRM-262) — widened, since the wizard runs pre-login and
+   *  cannot assume which version of the auth service answered it. */
   status: string;
-  message: string;
+  /** Nullable on purpose: this is the server-authored copy the degraded warning
+   *  shows, and a warning with an empty body is the exact failure this card is
+   *  about. The caller falls back to local copy rather than trusting it. */
+  message: string | null;
   survey_token: string | null;
 }
 


### PR DESCRIPTION
## O defeito

O wizard mostrava **"Configuração concluída!"** independente do que o servidor respondesse:

```tsx
toast.success(t('success.title'), { description: t('success.description') });
```

Numa box onde o provisionamento da conta não completou, isso parabeniza o operador sobre um install sem membership, sem a primeira conta e sem papéis. E como o admin **existe**, o wizard não roda de novo — não há segunda chance de o operador descobrir. As rotas `/enterprise/v1/admin/*` passam a devolver `403 AGENCY_REQUIRED` e *Meu Time* abre com "Funções (0)", sem ninguém saber por quê.

## A mudança

O backend passou a responder `status: "degraded"` (contrato `AfterBootstrap` **1.1.0**, PR em `evo-auth-service-community`). Esta PR lê isso:

```tsx
if (result.status === 'degraded') {
  toast.warning(t('degraded.title'), {
    description: result.message || t('degraded.description'),
    duration: 12000,
  });
} else {
  toast.success(...);
}
```

**A descrição vem do servidor**, que é quem sabe o que ficou pendente e o que conferir — mesmo padrão que o `catch` logo abaixo já usa ao preferir `data.error` à mensagem genérica.

**Tudo o mais no caminho fica igual**: o install terminou e o admin existe, então continua navegando para fora e continua **sem** alerta de erro. `degraded` não é falha — é sucesso com pendência, e o `duration: 12000` existe para o aviso não sumir antes de ser lido.

`degraded.title` e `degraded.description` entraram nos **6 locales** (en, pt-BR, pt, es, fr, it), traduzidos de verdade, não inglês copiado. Paridade de chaves conferida: **40/40 em todos**, sem faltando e sem sobrando.

## Testes — 5 novos, 10 no arquivo

| Exemplo | O que trava |
|---|---|
| avisa em vez de parabenizar | **o bug** — e checa que `toast.success` **não** foi chamado |
| repassa a mensagem do servidor | que o texto acionável chega na tela |
| cai na cópia local quando o servidor não manda mensagem | que o aviso nunca fica com corpo vazio |
| ainda termina o wizard e não mostra alerta de erro | que `degraded` não virou falha |
| com `ok`, parabeniza e **não** avisa | a direção contrária — install saudável não pode passar a avisar |

O primeiro tem duas metades de propósito: um `toast.warning` **acrescentado ao lado** do `toast.success` pareceria certo na tela e ainda diria que está tudo bem. Por isso o `expect(toast.success).not.toHaveBeenCalled()`.

**Prova negativa:** removendo só o ramo `degraded` do `Setup.tsx`, falham **3 de 5**. Os outros dois passam nos dois lados por construção — são guardas do que não pode mudar (que segue navegando; que `ok` continua parabenizando), não prova do bug.

## Dois achados no caminho

**O mock de `sonner` não tinha `warning`.** Era `{ success, info }`. Meu `toast.warning` cairia em `undefined` — o ramo era **impossível de testar** antes de corrigir o mock. A suíte existente passava (5/5) porque todos os testes atuais caem no ramo `ok`.

**`BootstrapResponse.message` estava tipado `string`.** Isso tornava o fallback `result.message || t('degraded.description')` **código morto pelo tipo** e obrigava um cast no teste para exercitá-lo. Tipei `string | null` e mantive o fallback — decisão consciente, porque um aviso de degradação com corpo vazio é exatamente o que este card combate, e o idioma já é da casa (`useChannelSubmission.ts:236`). O campo só é consumido em `setupService.ts` e `Setup.tsx`, então a mudança não tem alcance além disso.

## Verificação

- `tsc --noEmit` — **limpo** (`rc=0`)
- Raio de impacto medido nos dois lados. Os únicos consumidores de `setupService` são `Setup`, `OnboardingPage` e `GlobalConfigContext`; o namespace i18n `setup` não é usado fora de `pages/Setup`:

| | Arquivos | Testes |
|---|---|---|
| `develop` | 3 | **13 passed** |
| com o fix | 3 | **18 passed** (+5 meus) |

⚠️ **A suíte completa não foi baselineada nos dois lados** — cada passada leva mais de uma hora nesta máquina. O que sustento é o raio de impacto acima, medido com `git stash`, mais o lane do CI abaixo. Nenhum arquivo fora de `pages/Setup` importa `setupService`, o namespace i18n `setup` não é usado em outro lugar, e o `tsc` cobre a mudança de tipo em todo o projeto.

## Achado no CI — o check `Vitest` não rodaria este teste

O job `Vitest` **não roda a suíte inteira**: é uma allowlist explícita de arquivos, e o próprio workflow documenta por quê (160 arquivos jsdom levam ~30min no runner e flakeiam por OOM de worker; follow-up **EVO-2062**).

`src/pages/Setup/Setup.spec.tsx` **não estava na lista**. Os 5 exemplos deste card nunca teriam rodado no CI, e o check verde não diria nada sobre eles. Adicionei o arquivo à allowlist, com a entrada no bloco de comentário no mesmo formato dos outros. O lane passa de 40 para **41 arquivos / 469 testes**.

## Achado lateral — `RoleDetail.spec.tsx` é flaky, e já era

Rodando o lane localmente, ele cai de forma intermitente **em um teste diferente quase toda vez**. Seis rodadas alternando o lane com e sem o meu arquivo:

| Escopo | Passou | Falhou | Testes que caíram |
|---|---|---|---|
| 40 arquivos (`develop` de hoje) | 1 | **2** | *"the Read group ignores a locked member when toggled"*, *"the top checkbox grants everything on screen"* |
| 41 arquivos (com este PR) | 1 | **3** | *"classifies the live inbox template sync as a write"*, *"keeps an implied permission editable"*, *"the top checkbox grants everything"* ×2 |

Flakeia **dos dois lados**, inclusive no lane que já está em `develop` — não é regressão deste PR. Sozinho, `RoleDetail.spec.tsx` passa **32/32**.

Não mexi nele: está fora do escopo deste card e merece um próprio, porque hoje derruba o `Vitest` do CI de forma intermitente e isso treina o time a ignorar vermelho. Fica registrado aqui em vez de virar surpresa na primeira re-run.

## Deploy

3 repos, uma PR em cada, **junto**:

- `evo-auth-service-community` — contrato 1.1.0 + a resposta (**dependência dura desta PR**)
- `evo-enterprise-docker` — o overlay que produz o `degraded`
- esta (`evo-ai-frontend-community`) — o wizard

Sozinha, esta PR é inerte: sem o backend novo, `status` nunca é `degraded` e o caminho é byte a byte o de hoje.

## Summary by Sourcery

Handle degraded account provisioning transparently by warning operators without treating the completed setup as a failed install.

Bug Fixes:
- Show a warning instead of a success notification when provisioning completes in a degraded state, while preserving the existing navigation flow.
- Use the server-provided degradation message with a localized fallback when no message is available.

Enhancements:
- Support nullable bootstrap response messages and keep healthy provisioning on the success notification path.
- Add localized degraded-provisioning messages across all supported locales.

CI:
- Add the Setup wizard test suite to the targeted CI test run.

Tests:
- Add coverage for degraded provisioning warnings, server-message and fallback handling, continued navigation, and the unchanged healthy provisioning behavior.

---

### As três PRs do CRM-262

| Repo | PR | Papel |
|---|---|---|
| `evo-auth-service-community` | [#95](https://github.com/evolution-foundation/evo-auth-service-community/pull/95) | contrato 1.1.0 + resposta `degraded` |
| `evo-enterprise-docker` | [#51](https://github.com/evolution-foundation/evo-enterprise-docker/pull/51) | overlay + guia do operador + guarda no CI |
| `evo-ai-frontend-community` | **esta** | wizard mostra o aviso + 6 locales |

Ordem de merge: **auth primeiro** (as outras duas dependem do contrato 1.1.0), depois overlay e front em qualquer ordem.

## Summary by Sourcery

Handle degraded provisioning responses transparently in the setup wizard without treating them as failed installations.

Bug Fixes:
- Show a warning instead of a success notification when account provisioning completes in a degraded state, while preserving the existing setup completion flow.
- Display the server-provided degradation guidance with a localized fallback when no message is available.

Enhancements:
- Support nullable bootstrap messages and add localized degraded-provisioning copy across all supported locales.

CI:
- Include the Setup wizard tests in the targeted Vitest CI allowlist.

Tests:
- Add coverage for degraded and healthy provisioning notifications, fallback messaging, navigation, and survey handoff.