### PR TITLE
fix(contacts): desembrulha o contato aninhado na criação

### DIFF
--- a/src/services/contacts/contactsService.createContact.spec.ts
+++ b/src/services/contacts/contactsService.createContact.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { contactsService } from './contactsService';
+import api from '@/services/core/api';
+
+vi.mock('@/services/core/api', () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// O POST /contacts responde `data: { contact, contact_inbox }`, enquanto GET e
+// PATCH respondem o contato na raiz. Sem desembrulhar, o create devolvia o
+// envelope e a tela navegava para /contacts/undefined.
+describe('contactsService.createContact', () => {
+  const postMock = vi.mocked(api.post);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('desembrulha o contato aninhado do POST', async () => {
+    postMock.mockResolvedValue({
+      data: { data: { contact: { id: 'c-1', name: 'Ana' }, contact_inbox: { id: 'ci-1' } } },
+    } as never);
+
+    const contact = await contactsService.createContact({ name: 'Ana' } as never);
+
+    expect(contact.id).toBe('c-1');
+    expect(contact.name).toBe('Ana');
+  });
+
+  it('desembrulha tambem no ramo com avatar (FormData)', async () => {
+    postMock.mockResolvedValue({
+      data: { data: { contact: { id: 'c-2', name: 'Bia' }, contact_inbox: null } },
+    } as never);
+
+    const contact = await contactsService.createContact({
+      name: 'Bia',
+      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+    } as never);
+
+    expect(contact.id).toBe('c-2');
+  });
+
+  it('aceita a forma plana caso o backend deixe de aninhar', async () => {
+    postMock.mockResolvedValue({
+      data: { data: { id: 'c-3', name: 'Caio' } },
+    } as never);
+
+    const contact = await contactsService.createContact({ name: 'Caio' } as never);
+
+    expect(contact.id).toBe('c-3');
+  });
+});

--- a/src/services/contacts/contactsService.createContact.spec.ts
+++ b/src/services/contacts/contactsService.createContact.spec.ts
@@ -46,6 +46,50 @@ describe('contactsService.createContact', () => {
     expect(contact.id).toBe('c-2');
   });
 
+  // O ramo com avatar precisa MANDAR o mesmo que o ramo JSON manda. O laco
+  // antigo testava `typeof value === 'object'` antes de `Array.isArray`, entao
+  // labels saiam como `labels[0]`; o Rails le isso como hash e o controller
+  // responde 422 'Invalid labels payload' — criar contato com avatar E labels
+  // falhava por inteiro.
+  it('serializa array como labels[] no ramo com avatar', async () => {
+    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-4' } } } } as never);
+
+    await contactsService.createContact({
+      name: 'Dina',
+      labels: ['vip', 'lead'],
+      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+    } as never);
+
+    const formData = postMock.mock.calls[0][1] as FormData;
+    expect(formData.getAll('labels[]')).toEqual(['vip', 'lead']);
+    expect(formData.get('labels[0]')).toBeNull();
+  });
+
+  it('desce nos atributos aninhados em vez de mandar [object Object]', async () => {
+    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-5' } } } } as never);
+
+    await contactsService.createContact({
+      name: 'Elis',
+      additional_attributes: { city: 'Recife', location: { city: 'Recife', timezone: 'America/Recife' } },
+      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+    } as never);
+
+    const formData = postMock.mock.calls[0][1] as FormData;
+    expect(formData.get('additional_attributes[city]')).toBe('Recife');
+    expect(formData.get('additional_attributes[location][timezone]')).toBe('America/Recife');
+    expect(formData.get('additional_attributes[location]')).toBeNull();
+  });
+
+  it('manda o avatar como arquivo, nao como String(value)', async () => {
+    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-6' } } } } as never);
+    const avatar = new File(['x'], 'a.png', { type: 'image/png' });
+
+    await contactsService.createContact({ name: 'Fabio', avatar } as never);
+
+    const formData = postMock.mock.calls[0][1] as FormData;
+    expect(formData.get('avatar')).toBeInstanceOf(File);
+  });
+
   it('aceita a forma plana caso o backend deixe de aninhar', async () => {
     postMock.mockResolvedValue({
       data: { data: { id: 'c-3', name: 'Caio' } },

--- a/src/services/contacts/contactsService.createContact.spec.ts
+++ b/src/services/contacts/contactsService.createContact.spec.ts
@@ -1,6 +1,8 @@
+import type { AxiosResponse } from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { contactsService } from './contactsService';
 import api from '@/services/core/api';
+import type { ContactFormData } from '@/types/contacts';
 
 vi.mock('@/services/core/api', () => ({
   default: {
@@ -12,20 +14,17 @@ vi.mock('@/services/core/api', () => ({
   },
 }));
 
-// O POST /contacts responde `data: { contact, contact_inbox }`, enquanto GET e
-// PATCH respondem o contato na raiz. Sem desembrulhar, o create devolvia o
-// envelope e a tela navegava para /contacts/undefined.
-// Achata um payload JSON nas mesmas chaves com colchete que o Rails espera,
-// para comparar ramo-a-ramo o que cada caminho de fato manda.
-function flattenForRails(value: unknown, key = ''): Array<[string, string]> {
-  if (value === undefined || value === null) return [];
-  if (Array.isArray(value)) return value.flatMap(item => flattenForRails(item, `${key}[]`));
-  if (typeof value === 'object') {
-    return Object.entries(value as Record<string, unknown>).flatMap(([subKey, subValue]) =>
-      flattenForRails(subValue, key ? `${key}[${subKey}]` : subKey),
-    );
-  }
-  return [[key, String(value)]];
+// Fixtures stay typed against ContactFormData so a rename in the type breaks the specs.
+function contactData(overrides: Partial<ContactFormData> = {}): ContactFormData {
+  return { name: 'Ana', type: 'person', ...overrides };
+}
+
+function apiResponse(data: unknown): AxiosResponse {
+  return { data } as AxiosResponse;
+}
+
+function avatarFile(): File {
+  return new File(['x'], 'a.png', { type: 'image/png' });
 }
 
 describe('contactsService.createContact', () => {
@@ -35,57 +34,51 @@ describe('contactsService.createContact', () => {
     vi.clearAllMocks();
   });
 
-  it('desembrulha o contato aninhado do POST', async () => {
-    postMock.mockResolvedValue({
-      data: { data: { contact: { id: 'c-1', name: 'Ana' }, contact_inbox: { id: 'ci-1' } } },
-    } as never);
+  it('unwraps the contact nested in the POST response', async () => {
+    postMock.mockResolvedValue(
+      apiResponse({ data: { contact: { id: 'c-1', name: 'Ana' }, contact_inbox: { id: 'ci-1' } } }),
+    );
 
-    const contact = await contactsService.createContact({ name: 'Ana' } as never);
+    const contact = await contactsService.createContact(contactData());
 
     expect(contact.id).toBe('c-1');
     expect(contact.name).toBe('Ana');
   });
 
-  it('desembrulha tambem no ramo com avatar (FormData)', async () => {
-    postMock.mockResolvedValue({
-      data: { data: { contact: { id: 'c-2', name: 'Bia' }, contact_inbox: null } },
-    } as never);
+  it('unwraps in the avatar branch too', async () => {
+    postMock.mockResolvedValue(
+      apiResponse({ data: { contact: { id: 'c-2', name: 'Bia' }, contact_inbox: null } }),
+    );
 
-    const contact = await contactsService.createContact({
-      name: 'Bia',
-      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-    } as never);
+    const contact = await contactsService.createContact(contactData({ name: 'Bia', avatar: avatarFile() }));
 
     expect(contact.id).toBe('c-2');
   });
 
-  // O ramo com avatar precisa MANDAR o mesmo que o ramo JSON manda. O laco
-  // antigo testava `typeof value === 'object'` antes de `Array.isArray`, entao
-  // labels saiam como `labels[0]`; o Rails le isso como hash e o controller
-  // responde 422 'Invalid labels payload' — criar contato com avatar E labels
-  // falhava por inteiro.
-  it('serializa array como labels[] no ramo com avatar', async () => {
-    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-4' } } } } as never);
+  // The old loop tested `typeof value === 'object'` before Array.isArray, so labels went
+  // out as `labels[0]`; Rails reads that as a hash and answers 422 Invalid labels payload.
+  it('serializes arrays as labels[] in the avatar branch', async () => {
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-4' } } }));
 
-    await contactsService.createContact({
-      name: 'Dina',
-      labels: ['vip', 'lead'],
-      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-    } as never);
+    await contactsService.createContact(
+      contactData({ name: 'Dina', labels: ['vip', 'lead'], avatar: avatarFile() }),
+    );
 
     const formData = postMock.mock.calls[0][1] as FormData;
     expect(formData.getAll('labels[]')).toEqual(['vip', 'lead']);
     expect(formData.get('labels[0]')).toBeNull();
   });
 
-  it('desce nos atributos aninhados em vez de mandar [object Object]', async () => {
-    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-5' } } } } as never);
+  it('descends into nested attributes instead of sending [object Object]', async () => {
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-5' } } }));
 
-    await contactsService.createContact({
-      name: 'Elis',
-      additional_attributes: { city: 'Recife', location: { city: 'Recife', timezone: 'America/Recife' } },
-      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-    } as never);
+    await contactsService.createContact(
+      contactData({
+        name: 'Elis',
+        additional_attributes: { city: 'Recife', location: { city: 'Recife', timezone: 'America/Recife' } },
+        avatar: avatarFile(),
+      }),
+    );
 
     const formData = postMock.mock.calls[0][1] as FormData;
     expect(formData.get('additional_attributes[city]')).toBe('Recife');
@@ -93,21 +86,19 @@ describe('contactsService.createContact', () => {
     expect(formData.get('additional_attributes[location]')).toBeNull();
   });
 
-  it('manda o avatar como arquivo, nao como String(value)', async () => {
-    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-6' } } } } as never);
-    const avatar = new File(['x'], 'a.png', { type: 'image/png' });
+  it('sends the avatar as a file, not as String(value)', async () => {
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-6' } } }));
 
-    await contactsService.createContact({ name: 'Fabio', avatar } as never);
+    await contactsService.createContact(contactData({ name: 'Fabio', avatar: avatarFile() }));
 
     const formData = postMock.mock.calls[0][1] as FormData;
     expect(formData.get('avatar')).toBeInstanceOf(File);
   });
 
-  // O AC do card e "criar COM avatar tem o MESMO comportamento". Os exemplos
-  // acima olham a forma do FormData isolada; este cobra a equivalencia, que e a
-  // invariante que quebrou.
-  it('manda pelos dois ramos o mesmo conjunto de campos', async () => {
-    const payload = {
+  // The card's acceptance criterion: creating WITH an avatar behaves the same. The
+  // expected keys are spelled out so the oracle does not restate the implementation.
+  it('sends the same fields through both branches', async () => {
+    const payload = contactData({
       name: 'Gal',
       email: 'gal@example.com',
       blocked: false,
@@ -115,76 +106,93 @@ describe('contactsService.createContact', () => {
       company_ids: ['co-1', 'co-2'],
       custom_attributes: { plano: 'gold' },
       additional_attributes: { city: 'Recife', location: { city: 'Recife', timezone: 'America/Recife' } },
-    };
+    });
+    const expectedFields: Array<[string, string]> = [
+      ['name', 'Gal'],
+      ['type', 'person'],
+      ['email', 'gal@example.com'],
+      ['blocked', 'false'],
+      ['labels[]', 'vip'],
+      ['labels[]', 'lead'],
+      ['company_ids[]', 'co-1'],
+      ['company_ids[]', 'co-2'],
+      ['custom_attributes[plano]', 'gold'],
+      ['additional_attributes[city]', 'Recife'],
+      ['additional_attributes[location][city]', 'Recife'],
+      ['additional_attributes[location][timezone]', 'America/Recife'],
+    ];
 
-    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-7' } } } } as never);
-    await contactsService.createContact({ ...payload } as never);
-    const jsonBody = postMock.mock.calls[0][1] as Record<string, unknown>;
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-7' } } }));
+    await contactsService.createContact({ ...payload });
+    expect(postMock.mock.calls[0][1]).toEqual(payload);
 
     postMock.mockClear();
-    await contactsService.createContact({
-      ...payload,
-      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-    } as never);
+    await contactsService.createContact({ ...payload, avatar: avatarFile() });
     const formData = postMock.mock.calls[0][1] as FormData;
-
-    const fromJson = flattenForRails(jsonBody).sort();
-    const fromForm = [...formData.entries()]
+    const sent = [...formData.entries()]
       .filter(([key]) => key !== 'avatar')
-      .map(([key, value]) => [key, String(value)] as [string, string])
-      .sort();
+      .map(([key, value]) => [key, String(value)] as [string, string]);
 
-    expect(fromForm).toEqual(fromJson);
+    expect(sent.sort()).toEqual(expectedFields.sort());
   });
 
-  it('omite array e objeto vazios, que o multipart nao consegue expressar', async () => {
-    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-8' } } } } as never);
+  it('drops empty arrays and objects, which multipart cannot express', async () => {
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-8' } } }));
 
-    await contactsService.createContact({
-      name: 'Hugo',
-      labels: [],
-      custom_attributes: {},
-      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-    } as never);
+    await contactsService.createContact(
+      contactData({ name: 'Hugo', labels: [], custom_attributes: {}, avatar: avatarFile() }),
+    );
 
     const formData = postMock.mock.calls[0][1] as FormData;
     expect(formData.getAll('labels[]')).toEqual([]);
-    expect([...formData.keys()]).toEqual(['name', 'avatar']);
+    expect([...formData.keys()]).toEqual(['name', 'type', 'avatar']);
   });
 
-  it('serializa Date como ISO em vez de apagar o valor', async () => {
-    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-9' } } } } as never);
+  it('serializes Date as ISO instead of dropping the value', async () => {
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-9' } } }));
     const when = new Date('2026-08-28T12:00:00.000Z');
 
-    await contactsService.createContact({
-      name: 'Iris',
-      additional_attributes: { seen_at: when },
-      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-    } as never);
+    await contactsService.createContact(
+      contactData({ name: 'Iris', custom_attributes: { seen_at: when }, avatar: avatarFile() }),
+    );
 
     const formData = postMock.mock.calls[0][1] as FormData;
-    expect(formData.get('additional_attributes[seen_at]')).toBe('2026-08-28T12:00:00.000Z');
+    expect(formData.get('custom_attributes[seen_at]')).toBe('2026-08-28T12:00:00.000Z');
   });
 
-  it('estoura com erro claro em dado ciclico em vez de travar a aba', async () => {
+  // MAX_FORM_DEPTH is 8, counted from the top-level key: a leaf seven levels below it is
+  // still serialized, one level deeper raises.
+  it('serializes up to the depth limit and raises past it', async () => {
+    const nest = (levels: number): Record<string, unknown> =>
+      levels === 1 ? { k: 'leaf' } : { k: nest(levels - 1) };
+    postMock.mockResolvedValue(apiResponse({ data: { contact: { id: 'c-10' } } }));
+
+    await contactsService.createContact(
+      contactData({ custom_attributes: nest(7), avatar: avatarFile() }),
+    );
+    const formData = postMock.mock.calls[0][1] as FormData;
+    expect(formData.get('custom_attributes[k][k][k][k][k][k][k]')).toBe('leaf');
+
+    await expect(
+      contactsService.createContact(contactData({ custom_attributes: nest(8), avatar: avatarFile() })),
+    ).rejects.toThrow(/max depth exceeded/);
+  });
+
+  it('raises a clear error on cyclic data instead of hanging the tab', async () => {
     const cyclic: Record<string, unknown> = { city: 'Recife' };
     cyclic.self = cyclic;
 
     await expect(
-      contactsService.createContact({
-        name: 'Joao',
-        additional_attributes: cyclic,
-        avatar: new File(['x'], 'a.png', { type: 'image/png' }),
-      } as never),
-    ).rejects.toThrow(/profundidade maxima excedida/);
+      contactsService.createContact(
+        contactData({ name: 'Joao', custom_attributes: cyclic, avatar: avatarFile() }),
+      ),
+    ).rejects.toThrow(/max depth exceeded/);
   });
 
-  it('aceita a forma plana caso o backend deixe de aninhar', async () => {
-    postMock.mockResolvedValue({
-      data: { data: { id: 'c-3', name: 'Caio' } },
-    } as never);
+  it('accepts the flat shape if the backend stops nesting', async () => {
+    postMock.mockResolvedValue(apiResponse({ data: { id: 'c-3', name: 'Caio' } }));
 
-    const contact = await contactsService.createContact({ name: 'Caio' } as never);
+    const contact = await contactsService.createContact(contactData({ name: 'Caio' }));
 
     expect(contact.id).toBe('c-3');
   });

--- a/src/services/contacts/contactsService.createContact.spec.ts
+++ b/src/services/contacts/contactsService.createContact.spec.ts
@@ -15,6 +15,19 @@ vi.mock('@/services/core/api', () => ({
 // O POST /contacts responde `data: { contact, contact_inbox }`, enquanto GET e
 // PATCH respondem o contato na raiz. Sem desembrulhar, o create devolvia o
 // envelope e a tela navegava para /contacts/undefined.
+// Achata um payload JSON nas mesmas chaves com colchete que o Rails espera,
+// para comparar ramo-a-ramo o que cada caminho de fato manda.
+function flattenForRails(value: unknown, key = ''): Array<[string, string]> {
+  if (value === undefined || value === null) return [];
+  if (Array.isArray(value)) return value.flatMap(item => flattenForRails(item, `${key}[]`));
+  if (typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>).flatMap(([subKey, subValue]) =>
+      flattenForRails(subValue, key ? `${key}[${subKey}]` : subKey),
+    );
+  }
+  return [[key, String(value)]];
+}
+
 describe('contactsService.createContact', () => {
   const postMock = vi.mocked(api.post);
 
@@ -88,6 +101,82 @@ describe('contactsService.createContact', () => {
 
     const formData = postMock.mock.calls[0][1] as FormData;
     expect(formData.get('avatar')).toBeInstanceOf(File);
+  });
+
+  // O AC do card e "criar COM avatar tem o MESMO comportamento". Os exemplos
+  // acima olham a forma do FormData isolada; este cobra a equivalencia, que e a
+  // invariante que quebrou.
+  it('manda pelos dois ramos o mesmo conjunto de campos', async () => {
+    const payload = {
+      name: 'Gal',
+      email: 'gal@example.com',
+      blocked: false,
+      labels: ['vip', 'lead'],
+      company_ids: ['co-1', 'co-2'],
+      custom_attributes: { plano: 'gold' },
+      additional_attributes: { city: 'Recife', location: { city: 'Recife', timezone: 'America/Recife' } },
+    };
+
+    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-7' } } } } as never);
+    await contactsService.createContact({ ...payload } as never);
+    const jsonBody = postMock.mock.calls[0][1] as Record<string, unknown>;
+
+    postMock.mockClear();
+    await contactsService.createContact({
+      ...payload,
+      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+    } as never);
+    const formData = postMock.mock.calls[0][1] as FormData;
+
+    const fromJson = flattenForRails(jsonBody).sort();
+    const fromForm = [...formData.entries()]
+      .filter(([key]) => key !== 'avatar')
+      .map(([key, value]) => [key, String(value)] as [string, string])
+      .sort();
+
+    expect(fromForm).toEqual(fromJson);
+  });
+
+  it('omite array e objeto vazios, que o multipart nao consegue expressar', async () => {
+    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-8' } } } } as never);
+
+    await contactsService.createContact({
+      name: 'Hugo',
+      labels: [],
+      custom_attributes: {},
+      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+    } as never);
+
+    const formData = postMock.mock.calls[0][1] as FormData;
+    expect(formData.getAll('labels[]')).toEqual([]);
+    expect([...formData.keys()]).toEqual(['name', 'avatar']);
+  });
+
+  it('serializa Date como ISO em vez de apagar o valor', async () => {
+    postMock.mockResolvedValue({ data: { data: { contact: { id: 'c-9' } } } } as never);
+    const when = new Date('2026-08-28T12:00:00.000Z');
+
+    await contactsService.createContact({
+      name: 'Iris',
+      additional_attributes: { seen_at: when },
+      avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+    } as never);
+
+    const formData = postMock.mock.calls[0][1] as FormData;
+    expect(formData.get('additional_attributes[seen_at]')).toBe('2026-08-28T12:00:00.000Z');
+  });
+
+  it('estoura com erro claro em dado ciclico em vez de travar a aba', async () => {
+    const cyclic: Record<string, unknown> = { city: 'Recife' };
+    cyclic.self = cyclic;
+
+    await expect(
+      contactsService.createContact({
+        name: 'Joao',
+        additional_attributes: cyclic,
+        avatar: new File(['x'], 'a.png', { type: 'image/png' }),
+      } as never),
+    ).rejects.toThrow(/profundidade maxima excedida/);
   });
 
   it('aceita a forma plana caso o backend deixe de aninhar', async () => {

--- a/src/services/contacts/contactsService.ts
+++ b/src/services/contacts/contactsService.ts
@@ -34,6 +34,36 @@ function unwrapCreatedContact(response: AxiosResponse): Contact {
   return nested ?? (payload as Contact);
 }
 
+// O Rails le `key[]` como array e `key[0]` como hash, e o controller de
+// contatos rejeita um `labels` nao-array com 422. O laco original testava
+// `typeof value === 'object'` ANTES de `Array.isArray`, e como array e objeto o
+// ramo de array nunca era alcancado; alem disso ele descia um nivel so, entao
+// atributo aninhado virava a string literal "[object Object]". Recursao sobre a
+// forma real faz o ramo com avatar enviar o mesmo que o ramo JSON envia.
+function appendFormValue(formData: FormData, key: string, value: unknown): void {
+  if (value === undefined || value === null) return;
+
+  // File herda de Blob; ambos vao crus, sem String().
+  if (value instanceof Blob) {
+    formData.append(key, value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(item => appendFormValue(formData, `${key}[]`, item));
+    return;
+  }
+
+  if (typeof value === 'object') {
+    Object.entries(value as Record<string, unknown>).forEach(([subKey, subValue]) =>
+      appendFormValue(formData, `${key}[${subKey}]`, subValue),
+    );
+    return;
+  }
+
+  formData.append(key, String(value));
+}
+
 class ContactsService {
   // List contacts with pagination and filters
   async getContacts(params?: ContactsListParams): Promise<ContactsResponse> {
@@ -94,23 +124,7 @@ class ContactsService {
       const formData = new FormData();
 
       // Add basic fields
-      Object.entries(data).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          if (typeof value === 'object') {
-            // Handle custom_attributes and additional_attributes
-            Object.entries(value).forEach(([subKey, subValue]) => {
-              if (subValue !== undefined && subValue !== null) {
-                formData.append(`${key}[${subKey}]`, String(subValue));
-              }
-            });
-          } else if (Array.isArray(value)) {
-            // Handle labels array
-            value.forEach(item => formData.append(`${key}[]`, String(item)));
-          } else {
-            formData.append(key, String(value));
-          }
-        }
-      });
+      Object.entries(data).forEach(([key, value]) => appendFormValue(formData, key, value));
 
       // Add avatar file
       formData.append('avatar', avatar);

--- a/src/services/contacts/contactsService.ts
+++ b/src/services/contacts/contactsService.ts
@@ -1,3 +1,5 @@
+import type { AxiosResponse } from 'axios';
+
 import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
 import type {
@@ -19,6 +21,18 @@ import type {
   ContactConversation,
   ContactableInboxes,
 } from '@/types/contacts';
+
+// O POST /contacts responde `data: { contact, contact_inbox }` — aninhado —
+// enquanto GET e PATCH respondem o contato na raiz de `data`. Como o
+// `extractData` desembrulha um nivel so, o create devolvia o envelope e o
+// chamador lia `.id` como undefined, navegando para /contacts/undefined.
+// O fallback mantem o create funcionando caso o backend passe a achatar a
+// resposta, sem precisar de deploy casado.
+function unwrapCreatedContact(response: AxiosResponse): Contact {
+  const payload = extractData<Contact | { contact?: Contact }>(response);
+  const nested = (payload as { contact?: Contact })?.contact;
+  return nested ?? (payload as Contact);
+}
 
 class ContactsService {
   // List contacts with pagination and filters
@@ -106,10 +120,10 @@ class ContactsService {
           'Content-Type': 'multipart/form-data',
         },
       });
-      return extractData<Contact>(response);
+      return unwrapCreatedContact(response);
     } else {
       const response = await api.post(`/contacts`, data);
-      return extractData<Contact>(response);
+      return unwrapCreatedContact(response);
     }
   }
 

--- a/src/services/contacts/contactsService.ts
+++ b/src/services/contacts/contactsService.ts
@@ -34,13 +34,36 @@ function unwrapCreatedContact(response: AxiosResponse): Contact {
   return nested ?? (payload as Contact);
 }
 
+// Profundidade maxima ao serializar um valor em FormData. Passar disso so
+// acontece com dado malformado ou ciclico — e um ciclo travaria a aba, entao
+// aqui e erro explicito em vez de recursao infinita.
+const MAX_FORM_DEPTH = 8;
+
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 // O Rails le `key[]` como array e `key[0]` como hash, e o controller de
-// contatos rejeita um `labels` nao-array com 422. O laco original testava
+// contatos recusa um `labels` nao-array com 422. O laco original testava
 // `typeof value === 'object'` ANTES de `Array.isArray`, e como array e objeto o
 // ramo de array nunca era alcancado; alem disso ele descia um nivel so, entao
 // atributo aninhado virava a string literal "[object Object]". Recursao sobre a
 // forma real faz o ramo com avatar enviar o mesmo que o ramo JSON envia.
-function appendFormValue(formData: FormData, key: string, value: unknown): void {
+//
+// Duas coisas que o multipart nao consegue expressar, e que por isso ficam
+// registradas aqui em vez de viverem como surpresa:
+//
+//  - ARRAY E OBJETO VAZIOS SAO OMITIDOS. Nao ha como mandar `[]`: `key[]=` vira
+//    `[""]`, que o controller recusa como label em branco. Em CREATE isso e
+//    inofensivo (ausente e vazio dao no mesmo). Em UPDATE nao seria: la, chave
+//    ausente significa "nao mexe" e `[]` significa "limpa tudo" — por isso o
+//    `updateContact` NAO reusa este helper.
+//  - TIPO ESCALAR SE PERDE. Multipart so carrega texto, entao `42`/`false`
+//    chegam como "42"/"false". Para coluna tipada o Rails converte de volta; em
+//    `custom_attributes` (jsonb livre) o valor fica string. Inerente ao ramo com
+//    avatar, nao ao helper.
+function appendFormValue(formData: FormData, key: string, value: unknown, depth = 0): void {
   if (value === undefined || value === null) return;
 
   // File herda de Blob; ambos vao crus, sem String().
@@ -49,14 +72,30 @@ function appendFormValue(formData: FormData, key: string, value: unknown): void 
     return;
   }
 
+  if (depth >= MAX_FORM_DEPTH) {
+    throw new Error(`appendFormValue: profundidade maxima excedida em "${key}" (dado ciclico ou malformado)`);
+  }
+
   if (Array.isArray(value)) {
-    value.forEach(item => appendFormValue(formData, `${key}[]`, item));
+    value.forEach(item => appendFormValue(formData, `${key}[]`, item, depth + 1));
+    return;
+  }
+
+  if (value instanceof Date) {
+    formData.append(key, value.toISOString());
     return;
   }
 
   if (typeof value === 'object') {
+    // Date/Map/Set e afins nao tem entries uteis: descer neles apagaria o valor
+    // em silencio, que era metade do bug original.
+    if (!isPlainObject(value as object)) {
+      formData.append(key, String(value));
+      return;
+    }
+
     Object.entries(value as Record<string, unknown>).forEach(([subKey, subValue]) =>
-      appendFormValue(formData, `${key}[${subKey}]`, subValue),
+      appendFormValue(formData, `${key}[${subKey}]`, subValue, depth + 1),
     );
     return;
   }

--- a/src/services/contacts/contactsService.ts
+++ b/src/services/contacts/contactsService.ts
@@ -22,21 +22,16 @@ import type {
   ContactableInboxes,
 } from '@/types/contacts';
 
-// O POST /contacts responde `data: { contact, contact_inbox }` — aninhado —
-// enquanto GET e PATCH respondem o contato na raiz de `data`. Como o
-// `extractData` desembrulha um nivel so, o create devolvia o envelope e o
-// chamador lia `.id` como undefined, navegando para /contacts/undefined.
-// O fallback mantem o create funcionando caso o backend passe a achatar a
-// resposta, sem precisar de deploy casado.
+// POST /contacts nests the contact under `data.contact`, while GET and PATCH put it at
+// the root of `data`. The flat fallback keeps a future backend change from needing a
+// coordinated deploy.
 function unwrapCreatedContact(response: AxiosResponse): Contact {
   const payload = extractData<Contact | { contact?: Contact }>(response);
   const nested = (payload as { contact?: Contact })?.contact;
   return nested ?? (payload as Contact);
 }
 
-// Profundidade maxima ao serializar um valor em FormData. Passar disso so
-// acontece com dado malformado ou ciclico — e um ciclo travaria a aba, entao
-// aqui e erro explicito em vez de recursao infinita.
+// Guards the recursion below: cyclic data would hang the tab instead of raising.
 const MAX_FORM_DEPTH = 8;
 
 function isPlainObject(value: object): boolean {
@@ -44,36 +39,21 @@ function isPlainObject(value: object): boolean {
   return proto === Object.prototype || proto === null;
 }
 
-// O Rails le `key[]` como array e `key[0]` como hash, e o controller de
-// contatos recusa um `labels` nao-array com 422. O laco original testava
-// `typeof value === 'object'` ANTES de `Array.isArray`, e como array e objeto o
-// ramo de array nunca era alcancado; alem disso ele descia um nivel so, entao
-// atributo aninhado virava a string literal "[object Object]". Recursao sobre a
-// forma real faz o ramo com avatar enviar o mesmo que o ramo JSON envia.
-//
-// Duas coisas que o multipart nao consegue expressar, e que por isso ficam
-// registradas aqui em vez de viverem como surpresa:
-//
-//  - ARRAY E OBJETO VAZIOS SAO OMITIDOS. Nao ha como mandar `[]`: `key[]=` vira
-//    `[""]`, que o controller recusa como label em branco. Em CREATE isso e
-//    inofensivo (ausente e vazio dao no mesmo). Em UPDATE nao seria: la, chave
-//    ausente significa "nao mexe" e `[]` significa "limpa tudo" — por isso o
-//    `updateContact` NAO reusa este helper.
-//  - TIPO ESCALAR SE PERDE. Multipart so carrega texto, entao `42`/`false`
-//    chegam como "42"/"false". Para coluna tipada o Rails converte de volta; em
-//    `custom_attributes` (jsonb livre) o valor fica string. Inerente ao ramo com
-//    avatar, nao ao helper.
+// Serializes a value into the bracket keys Rails parses back: `key[]` as an array,
+// `key[sub]` as a hash. Two limits the multipart body cannot express: empty arrays and
+// objects are dropped, and scalars arrive as text (`42` becomes "42", which persists as
+// a string in the free-form custom_attributes jsonb).
 function appendFormValue(formData: FormData, key: string, value: unknown, depth = 0): void {
   if (value === undefined || value === null) return;
 
-  // File herda de Blob; ambos vao crus, sem String().
+  // File extends Blob; both go raw, never through String().
   if (value instanceof Blob) {
     formData.append(key, value);
     return;
   }
 
   if (depth >= MAX_FORM_DEPTH) {
-    throw new Error(`appendFormValue: profundidade maxima excedida em "${key}" (dado ciclico ou malformado)`);
+    throw new Error(`appendFormValue: max depth exceeded at "${key}" (cyclic or malformed data)`);
   }
 
   if (Array.isArray(value)) {
@@ -87,8 +67,7 @@ function appendFormValue(formData: FormData, key: string, value: unknown, depth 
   }
 
   if (typeof value === 'object') {
-    // Date/Map/Set e afins nao tem entries uteis: descer neles apagaria o valor
-    // em silencio, que era metade do bug original.
+    // Date, Map and friends have no useful entries: descending would drop the value.
     if (!isPlainObject(value as object)) {
       formData.append(key, String(value));
       return;
@@ -187,7 +166,8 @@ class ContactsService {
     if (avatar) {
       const formData = new FormData();
 
-      // Add basic fields
+      // Left as-is, outside CRM-321's scope. Like appendFormValue it drops empty arrays,
+      // so a multipart update cannot clear labels while the JSON branch can.
       Object.entries(data).forEach(([key, value]) => {
         if (value !== undefined && value !== null) {
           if (typeof value === 'object' && !Array.isArray(value)) {


### PR DESCRIPTION
## O problema

São dois defeitos no mesmo `createContact`, e o segundo só apareceu no review do primeiro.

**1. A navegação depois de salvar.** O `POST /contacts` responde `data: { contact, contact_inbox }` — aninhado — enquanto `GET` e `PATCH` respondem o contato na raiz de `data` (`contacts_controller.rb:227` contra `:120` e `:252`). O `extractData` desembrulha um nível só, então o create devolvia o envelope, `created.id` era `undefined` e a tela navegava para `/contacts/undefined`. O contato era criado; só a navegação quebrava.

**2. O ramo com avatar não mandava o mesmo que o ramo JSON.** A montagem do `FormData` testava `typeof value === 'object'` antes de `Array.isArray`. Como array é objeto, o ramo de array nunca era alcançado e `labels: ['vip','lead']` saía como `labels[0]=vip`. O Rails lê isso como hash, e `invalid_contact_labels_payload?` (`contacts_controller.rb:501`) recusa um `labels` não-array com **422 `Invalid labels payload`** — criar contato com avatar E label falhava por inteiro, enquanto o mesmo create sem avatar passava. O mesmo laço descia um nível só, então o `additional_attributes.location` que o formulário monta em **todo** create (`ContactForm.tsx:328-336`) chegava como a string literal `[object Object]`.

## O que muda

`unwrapCreatedContact` tira o nível extra nos **dois** ramos, com fallback para a forma plana caso o backend passe a achatar — sem exigir deploy casado. O `updateContact` fica intocado: o PATCH já responde na raiz.

`appendFormValue` substitui o laço de montagem do FormData: recursa sobre a forma real do valor, testa array antes de objeto, e passa `File`/`Blob` crus em vez de `String(value)`.

Dois limites do multipart ficaram **documentados no helper** em vez de virarem surpresa: array e objeto vazios são omitidos (não há como mandar `[]` — `key[]=` chega como `[""]` e o controller recusa label em branco), e o tipo escalar se perde (`42` vira `"42"`, o que sobrevive no jsonb livre de `custom_attributes`). O primeiro é inofensivo em create. O `updateContact` fica de fora por escopo, não por risco: o laço dele omite array vazio do mesmo jeito, ou seja **já** não consegue limpar etiquetas num update com avatar, enquanto o ramo JSON consegue. Isso é um defeito à parte, registrado em comentário e fora deste card.

`Date` e outros objetos não-simples caíam no ramo de objeto e sumiam em silêncio, porque `Object.entries` neles não devolve nada. Agora `Date` vai em ISO e o resto por `String(value)`. A recursão ganhou limite de profundidade: dado cíclico travaria a aba em vez de dar erro.

## Verificação

11 specs em `contactsService.createContact.spec.ts`, incluindo um que passa o **mesmo payload pelos dois ramos** e cobra que o conjunto de campos enviado seja idêntico — que é literalmente o critério de aceite do card. Os fixtures são tipados contra `ContactFormData` (sem `as never`), o esperado do teste de equivalência é uma lista literal de campos em vez de uma reimplementação das regras do helper, e um exemplo fixa o limite de profundidade: sete níveis serializam, oito estouram.

Rodados contra a versão da `develop`: 8 dos 11 falham. Os 3 que passam são guardas — a forma plana, a omissão de vazio e o avatar seguir sendo `File`.

`tsc --noEmit` limpo e ESLint sem apontamento nos dois arquivos.

Conferido que o fix chega ao modelo: `permitted_params` (`contacts_controller.rb:454`) permite `additional_attributes: {}`, ou seja, nesting arbitrário. E descartar o `contact_inbox` da resposta é seguro: `createContact` tem um único call site (`Contacts.tsx:762`), que lê apenas o `.id`.

## Summary by Sourcery

Corrija a criação de contatos para processar corretamente respostas da API e payloads multipart com avatar.

Bug Fixes:
- Corrija a criação de contatos para desembrulhar respostas aninhadas e planas, garantindo que a navegação use o ID correto.
- Corrija a serialização multipart de arrays, atributos aninhados, datas e arquivos durante a criação de contatos.

Enhancements:
- Adicione limites de profundidade e tratamento para objetos não simples na serialização de dados multipart.

Tests:
- Adicione cobertura abrangente para respostas aninhadas, serialização consistente entre os fluxos JSON e multipart, arquivos, valores vazios, datas e dados cíclicos.
