### PR TITLE
feat(inbox): tela do canal Meta reflete o estado real da conexão

### DIFF
--- a/src/components/inbox/HubConnectButton.spec.tsx
+++ b/src/components/inbox/HubConnectButton.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import HubConnectButton from './HubConnectButton';
@@ -8,8 +8,11 @@ vi.mock('@/services/core', () => ({
   api: { post: vi.fn(), get: vi.fn() },
 }));
 
+// useGlobalConfig returns the config flat (GlobalConfigContextValue extends
+// GlobalConfig), so the mock has to be flat too — a nested { config } shape
+// leaves hubAllowExistingChannels undefined and silently enables the mode.
 vi.mock('@/contexts/GlobalConfigContext', () => ({
-  useGlobalConfig: () => ({ config: { hubAllowExistingChannels: false } }),
+  useGlobalConfig: () => ({ hubAllowExistingChannels: false, setupRequired: false, setupLoading: false }),
 }));
 
 const toastSuccess = vi.fn();
@@ -28,12 +31,14 @@ async function criarInbox() {
   await screen.findByTestId('hub-waiting');
 }
 
-function emitir(status: string, inboxId: string = INBOX_ID) {
-  window.dispatchEvent(
-    new CustomEvent('evolution:hubChannelConnection', {
-      detail: { inbox_id: inboxId, connection_status: status },
-    }),
-  );
+async function emitir(status: string, inboxId: string = INBOX_ID) {
+  await act(async () => {
+    window.dispatchEvent(
+      new CustomEvent('evolution:hubChannelConnection', {
+        detail: { inbox_id: inboxId, connection_status: status },
+      }),
+    );
+  });
 }
 
 describe('HubConnectButton — estado real da conexão', () => {
@@ -45,16 +50,17 @@ describe('HubConnectButton — estado real da conexão', () => {
   it('sai de "Aguardando" para conectado ao receber o evento do Hub', async () => {
     await criarInbox();
 
-    emitir('connected');
+    await emitir('connected');
 
     await waitFor(() => expect(screen.getByTestId('hub-connected')).toBeInTheDocument());
     expect(screen.queryByTestId('hub-waiting')).not.toBeInTheDocument();
+    expect(toastSuccess).toHaveBeenCalledWith('Canal conectado.');
   });
 
   it('ignora evento de outra inbox', async () => {
     await criarInbox();
 
-    emitir('connected', 'inbox-outra');
+    await emitir('connected', 'inbox-outra');
 
     await waitFor(() => expect(screen.getByTestId('hub-waiting')).toBeInTheDocument());
     expect(screen.queryByTestId('hub-connected')).not.toBeInTheDocument();
@@ -62,11 +68,43 @@ describe('HubConnectButton — estado real da conexão', () => {
 
   it('volta para aguardando quando o Hub desconecta o canal', async () => {
     await criarInbox();
-    emitir('connected');
+    await emitir('connected');
     await screen.findByTestId('hub-connected');
 
-    emitir('disconnected');
+    await emitir('disconnected');
 
     await waitFor(() => expect(screen.getByTestId('hub-waiting')).toBeInTheDocument());
+  });
+
+  // O broadcast se perde se o socket estava fora quando o Hub avisou; a volta
+  // para a aba tem que resolver o estado sem refresh manual.
+  it('reconcilia pelo GET da inbox quando o evento do ActionCable se perdeu', async () => {
+    await criarInbox();
+    vi.mocked(api.get).mockResolvedValue({
+      data: { data: { id: INBOX_ID, connection_state: 'connected', health_source: 'provider_event' } },
+    } as never);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('hub-connected')).toBeInTheDocument());
+    expect(api.get).toHaveBeenCalledWith(`/inboxes/${INBOX_ID}`);
+  });
+
+  // `stored_flag` é o resolver ASSUMINDO que um canal token-based configurado
+  // está vivo — não é confirmação do Hub, e não pode declarar conectado.
+  it('nao declara conectado quando o estado veio de stored_flag', async () => {
+    await criarInbox();
+    vi.mocked(api.get).mockResolvedValue({
+      data: { data: { id: INBOX_ID, connection_state: 'connected', health_source: 'stored_flag' } },
+    } as never);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(screen.getByTestId('hub-waiting')).toBeInTheDocument();
   });
 });

--- a/src/components/inbox/HubConnectButton.spec.tsx
+++ b/src/components/inbox/HubConnectButton.spec.tsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HubConnectButton from './HubConnectButton';
+import { api } from '@/services/core';
+
+vi.mock('@/services/core', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}));
+
+vi.mock('@/contexts/GlobalConfigContext', () => ({
+  useGlobalConfig: () => ({ config: { hubAllowExistingChannels: false } }),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({ toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) } }));
+
+const INBOX_ID = 'inbox-42';
+
+async function criarInbox() {
+  vi.mocked(api.post).mockResolvedValue({
+    data: { data: { id: INBOX_ID, evolution_hub: { public_link: 'http://localhost:8050/connect/tok' } } },
+  } as never);
+
+  render(<HubConnectButton channelType="whatsapp_cloud" name="Canal Teste" />);
+  await userEvent.click(screen.getByRole('button', { name: /conectar|criar/i }));
+  await screen.findByTestId('hub-waiting');
+}
+
+function emitir(status: string, inboxId: string = INBOX_ID) {
+  window.dispatchEvent(
+    new CustomEvent('evolution:hubChannelConnection', {
+      detail: { inbox_id: inboxId, connection_status: status },
+    }),
+  );
+}
+
+describe('HubConnectButton — estado real da conexão', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  it('sai de "Aguardando" para conectado ao receber o evento do Hub', async () => {
+    await criarInbox();
+
+    emitir('connected');
+
+    await waitFor(() => expect(screen.getByTestId('hub-connected')).toBeInTheDocument());
+    expect(screen.queryByTestId('hub-waiting')).not.toBeInTheDocument();
+  });
+
+  it('ignora evento de outra inbox', async () => {
+    await criarInbox();
+
+    emitir('connected', 'inbox-outra');
+
+    await waitFor(() => expect(screen.getByTestId('hub-waiting')).toBeInTheDocument());
+    expect(screen.queryByTestId('hub-connected')).not.toBeInTheDocument();
+  });
+
+  it('volta para aguardando quando o Hub desconecta o canal', async () => {
+    await criarInbox();
+    emitir('connected');
+    await screen.findByTestId('hub-connected');
+
+    emitir('disconnected');
+
+    await waitFor(() => expect(screen.getByTestId('hub-waiting')).toBeInTheDocument());
+  });
+});

--- a/src/components/inbox/HubConnectButton.tsx
+++ b/src/components/inbox/HubConnectButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@evoapi/design-system';
 import { toast } from 'sonner';
 import { Loader2, ExternalLink, CheckCircle2, Link2 } from 'lucide-react';
@@ -39,6 +39,14 @@ interface InboxCreateResponse {
       linked?: boolean;
       hub_channel_id?: string;
     };
+  };
+}
+
+interface InboxShowResponse {
+  data: {
+    id: number;
+    connection_state?: string;
+    health_source?: string;
   };
 }
 
@@ -112,9 +120,20 @@ export default function HubConnectButton({
     };
   }, [mode, channelType]);
 
-  // O Hub avisa o CRM por webhook quando o operador conclui o signup da Meta, e
-  // o backend reemite no ActionCable. Sem escutar aqui, a tela so descobria a
-  // conexao num refresh manual — a dor que originou o card.
+  // Guards the transition so the socket event and the reconciliation below
+  // cannot announce the same connection twice.
+  const alreadyConnected = useRef(false);
+
+  const markConnected = useCallback(() => {
+    if (alreadyConnected.current) return;
+    alreadyConnected.current = true;
+    setConnectionStatus('connected');
+    toast.success('Canal conectado.');
+  }, []);
+
+  // The Hub webhooks the CRM when the operator finishes the Meta signup and the
+  // backend re-emits it on ActionCable; without this the screen only learned
+  // about the connection on a manual refresh.
   useEffect(() => {
     if (inboxId === null) return;
 
@@ -123,21 +142,50 @@ export default function HubConnectButton({
         | { inbox_id?: string | number; connection_status?: string }
         | undefined;
       if (!detail) return;
-      // Comparacao frouxa de proposito: o id sai do backend como string e o
-      // estado local guarda number.
+      // Loose comparison on purpose: the id arrives as a string and the local
+      // state holds a number.
       if (String(detail.inbox_id) !== String(inboxId)) return;
 
       if (detail.connection_status === 'connected') {
-        setConnectionStatus('connected');
-        toast.success('Canal conectado.');
+        markConnected();
       } else if (detail.connection_status === 'disconnected') {
+        alreadyConnected.current = false;
         setConnectionStatus('waiting');
       }
     };
 
     window.addEventListener('evolution:hubChannelConnection', onConnection);
     return () => window.removeEventListener('evolution:hubChannelConnection', onConnection);
-  }, [inboxId]);
+  }, [inboxId, markConnected]);
+
+  // ActionCable has no replay: a transition broadcast while the socket was down
+  // is lost, and the socket is often still down while the operator sits in the
+  // Hub tab. Re-read the inbox when the tab comes back so the screen settles
+  // anyway. `provider_event` means the Hub actually confirmed the connection —
+  // `stored_flag` is the resolver assuming a configured token channel is live.
+  useEffect(() => {
+    if (inboxId === null || connectionStatus === 'connected') return;
+
+    const reconcile = async () => {
+      if (document.visibilityState !== 'visible') return;
+      try {
+        const response = await api.get<InboxShowResponse>(`/inboxes/${inboxId}`);
+        const inbox = response.data?.data;
+        if (inbox?.connection_state === 'connected' && inbox?.health_source === 'provider_event') {
+          markConnected();
+        }
+      } catch {
+        // Best effort — the ActionCable event stays the primary path.
+      }
+    };
+
+    document.addEventListener('visibilitychange', reconcile);
+    window.addEventListener('focus', reconcile);
+    return () => {
+      document.removeEventListener('visibilitychange', reconcile);
+      window.removeEventListener('focus', reconcile);
+    };
+  }, [inboxId, connectionStatus, markConnected]);
 
   const handleCreateNew = async () => {
     setSubmitting(true);
@@ -161,9 +209,8 @@ export default function HubConnectButton({
       toast.success('Inbox criada. Conclua a conexão na aba que foi aberta.');
       onCreated?.({ inboxId: inbox.id, publicLink: link });
     } catch (error: unknown) {
-      // O erro do Hub chega estruturado (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED) e
-      // o client ja traduz. Ler `data.message` cru descartava esse trabalho e
-      // devolvia o texto tecnico ao operador.
+      // Hub errors arrive structured (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED);
+      // reading `data.message` raw dropped the translated text.
       const message =
         apiErrorMessage(error) ??
         (error as { message?: string }).message ??

--- a/src/components/inbox/HubConnectButton.tsx
+++ b/src/components/inbox/HubConnectButton.tsx
@@ -3,6 +3,7 @@ import { Button } from '@evoapi/design-system';
 import { toast } from 'sonner';
 import { Loader2, ExternalLink, CheckCircle2, Link2 } from 'lucide-react';
 import { api } from '@/services/core';
+import { apiErrorMessage } from '@/utils/apiHelpers';
 import { useGlobalConfig } from '@/contexts/GlobalConfigContext';
 import {
   evolutionHubService,
@@ -70,6 +71,7 @@ export default function HubConnectButton({
   const [publicLink, setPublicLink] = useState<string | null>(null);
   const [inboxId, setInboxId] = useState<number | null>(null);
   const [linkedDone, setLinkedDone] = useState(false);
+  const [connectionStatus, setConnectionStatus] = useState<'waiting' | 'connected'>('waiting');
 
   const [availableChannels, setAvailableChannels] = useState<HubChannel[]>([]);
   const [loadingChannels, setLoadingChannels] = useState(false);
@@ -110,6 +112,33 @@ export default function HubConnectButton({
     };
   }, [mode, channelType]);
 
+  // O Hub avisa o CRM por webhook quando o operador conclui o signup da Meta, e
+  // o backend reemite no ActionCable. Sem escutar aqui, a tela so descobria a
+  // conexao num refresh manual — a dor que originou o card.
+  useEffect(() => {
+    if (inboxId === null) return;
+
+    const onConnection = (event: Event) => {
+      const detail = (event as CustomEvent).detail as
+        | { inbox_id?: string | number; connection_status?: string }
+        | undefined;
+      if (!detail) return;
+      // Comparacao frouxa de proposito: o id sai do backend como string e o
+      // estado local guarda number.
+      if (String(detail.inbox_id) !== String(inboxId)) return;
+
+      if (detail.connection_status === 'connected') {
+        setConnectionStatus('connected');
+        toast.success('Canal conectado.');
+      } else if (detail.connection_status === 'disconnected') {
+        setConnectionStatus('waiting');
+      }
+    };
+
+    window.addEventListener('evolution:hubChannelConnection', onConnection);
+    return () => window.removeEventListener('evolution:hubChannelConnection', onConnection);
+  }, [inboxId]);
+
   const handleCreateNew = async () => {
     setSubmitting(true);
     try {
@@ -132,8 +161,11 @@ export default function HubConnectButton({
       toast.success('Inbox criada. Conclua a conexão na aba que foi aberta.');
       onCreated?.({ inboxId: inbox.id, publicLink: link });
     } catch (error: unknown) {
+      // O erro do Hub chega estruturado (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED) e
+      // o client ja traduz. Ler `data.message` cru descartava esse trabalho e
+      // devolvia o texto tecnico ao operador.
       const message =
-        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        apiErrorMessage(error) ??
         (error as { message?: string }).message ??
         'Falha ao criar inbox via Evo Hub';
       toast.error(message);
@@ -162,7 +194,7 @@ export default function HubConnectButton({
       onCreated?.({ inboxId: inbox.id });
     } catch (error: unknown) {
       const message =
-        (error as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        apiErrorMessage(error) ??
         (error as { message?: string }).message ??
         'Falha ao linkar inbox ao canal Hub existente';
       toast.error(message);
@@ -186,10 +218,21 @@ export default function HubConnectButton({
   // Estado pós-sucesso: 'criar novo' mostra link pra reabrir aba OAuth;
   // 'linkar existente' só mostra confirmação (canal já está conectado).
   if (publicLink && inboxId !== null) {
+    if (connectionStatus === 'connected') {
+      return (
+        <div className="space-y-2 border rounded-md p-4 bg-muted/30" data-testid="hub-connected">
+          <div className="flex items-center gap-2 text-sm">
+            <CheckCircle2 className="h-5 w-5 text-green-500" />
+            <span>Canal conectado no Hub.</span>
+          </div>
+        </div>
+      );
+    }
+
     return (
-      <div className="space-y-3 border rounded-md p-4 bg-muted/30">
+      <div className="space-y-3 border rounded-md p-4 bg-muted/30" data-testid="hub-waiting">
         <div className="flex items-center gap-2 text-sm">
-          <CheckCircle2 className="h-5 w-5 text-green-500" />
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           <span>Inbox criada. Aguardando conexão Meta no Hub…</span>
         </div>
         <p className="text-xs text-muted-foreground">

--- a/src/services/core/websocket/actionCableService.spec.ts
+++ b/src/services/core/websocket/actionCableService.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Captures the subscription callbacks so the test can feed the exact frame the
+// Rails side broadcasts: `{ event, data }` (ActionCableBroadcastJob).
+const handlers: Record<string, (frame: unknown) => void> = {};
+
+vi.mock('@rails/actioncable', () => ({
+  createConsumer: () => ({
+    subscriptions: {
+      create: (_params: unknown, callbacks: Record<string, (frame: unknown) => void>) => {
+        Object.assign(handlers, callbacks);
+        return { unsubscribe: () => {} };
+      },
+    },
+    disconnect: () => {},
+  }),
+}));
+
+describe('actionCableService — contrato do frame do ActionCable', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('reemite hub_channel.connection_changed com o payload que veio em `data`', async () => {
+    const { actionCableService } = await import('./actionCableService');
+    actionCableService.init('tok', 'user-1');
+
+    let detail: unknown = null;
+    window.addEventListener('evolution:hubChannelConnection', (event) => {
+      detail = (event as CustomEvent).detail;
+    });
+
+    handlers.received({
+      event: 'hub_channel.connection_changed',
+      data: { inbox_id: 42, channel_type: 'Channel::Whatsapp', connection_status: 'connected' },
+    });
+
+    expect(detail).toEqual({
+      inbox_id: 42,
+      channel_type: 'Channel::Whatsapp',
+      connection_status: 'connected',
+    });
+  });
+
+  it('reemite os demais eventos pelo mesmo caminho', async () => {
+    const { actionCableService } = await import('./actionCableService');
+    actionCableService.init('tok', 'user-1');
+
+    let detail: unknown = null;
+    window.addEventListener('evolution:message', (event) => {
+      detail = (event as CustomEvent).detail;
+    });
+
+    handlers.received({ event: 'message.created', data: { id: 7 } });
+
+    expect(detail).toEqual({ id: 7 });
+  });
+});

--- a/src/services/core/websocket/actionCableService.ts
+++ b/src/services/core/websocket/actionCableService.ts
@@ -98,6 +98,12 @@ class ActionCableService {
         window.dispatchEvent(new CustomEvent('evolution:presence', { detail: payload }));
         break;
 
+      // Conexao de canal Meta via Evo Hub mudou de estado. A tela que abriu a
+      // aba do Hub escuta para sair do "Aguardando..." sem refresh manual.
+      case 'hub_channel.connection_changed':
+        window.dispatchEvent(new CustomEvent('evolution:hubChannelConnection', { detail: payload }));
+        break;
+
       default:
         window.dispatchEvent(new CustomEvent('evolution:event', { detail: { event, payload } }));
     }

--- a/src/services/core/websocket/actionCableService.ts
+++ b/src/services/core/websocket/actionCableService.ts
@@ -47,8 +47,8 @@ class ActionCableService {
           this.handleDisconnection();
         },
 
-        received: (data: any) => {
-          this.handleEventMessage(data);
+        received: (message: any) => {
+          this.handleEventMessage(message);
         },
       },
     );
@@ -66,8 +66,10 @@ class ActionCableService {
   //   // No separate PresenceChannel needed
   // }
 
-  private handleEventMessage(data: any) {
-    const { event, payload } = data;
+  // The Rails side puts `{ event, data }` on the wire (ActionCableBroadcastJob),
+  // so the payload has to be read from `data`, not from a `payload` key.
+  private handleEventMessage(message: any) {
+    const { event, data: payload } = message ?? {};
 
     // Dispatch events based on type
     switch (event) {
@@ -98,8 +100,7 @@ class ActionCableService {
         window.dispatchEvent(new CustomEvent('evolution:presence', { detail: payload }));
         break;
 
-      // Conexao de canal Meta via Evo Hub mudou de estado. A tela que abriu a
-      // aba do Hub escuta para sair do "Aguardando..." sem refresh manual.
+      // Meta channel relayed by the Evo Hub changed connection state.
       case 'hub_channel.connection_changed':
         window.dispatchEvent(new CustomEvent('evolution:hubChannelConnection', { detail: payload }));
         break;


### PR DESCRIPTION
## Problema

O operador abre a aba do Hub, conclui o signup da Meta e volta para uma tela parada em "Aguardando conexão Meta no Hub…" (`HubConnectButton.tsx:193`). O estado só mudava com refresh manual, sem sinal de sucesso nem de falha.

Par do PR de backend em `evo-ai-crm-community`, que passou a reemitir a transição no ActionCable como `hub_channel.connection_changed`.

## Mudança

O `actionCableService` ganha o case do evento e reemite como `evolution:hubChannelConnection`. O `default` do switch já reemitiria como `evolution:event`, mas um case nomeado é o que o arquivo faz para todos os outros eventos.

O `HubConnectButton` escuta enquanto está esperando e casa pelo id da inbox — comparação frouxa de propósito, porque o id sai do backend como string e o estado local guarda number. Conectado virou estado próprio; desconectado volta para a espera, já que o par de eventos do Hub é simétrico.

O erro do Hub passa pelo `apiErrorMessage`, que lê o envelope estruturado. Ler `data.message` cru descartava a tradução que o client já faz de `PLAN_FORBIDS_SHARED` e `QUOTA_EXCEEDED` e devolvia o texto técnico ao operador.

Um detalhe que estava enganando: a espera mostrava um `CheckCircle2` **verde** ao lado de "Aguardando conexão Meta no Hub…" — um check de sucesso enquanto nada tinha acontecido. Virou spinner.

## Como validar

```
npx vitest run src/components/inbox/HubConnectButton.spec.tsx
```

3 exemplos: sair da espera para conectado ao receber o evento, ignorar evento de outra inbox, e voltar para a espera quando o Hub desconecta. Com o componente revertido, os 3 falham. `tsc --noEmit` limpo.

O proxy do Vite já tem `ws: true` no `/crm-api`, então o ActionCable funciona em dev sem configuração extra.

## Fora de escopo

Embedded signup dentro do CRM (CRM-314). O modo "vincular canal existente do Hub" não foi tocado, e nada aqui mexe em `hubAllowExistingChannels`.

## Summary by Sourcery

Faça a tela de conexão Meta acompanhar o estado real do canal no Hub sem exigir atualização manual.

New Features:
- Atualize a tela de conexão Meta para refletir automaticamente conexões e desconexões reais do Hub, com reconciliação ao retornar à aba.

Bug Fixes:
- Corrija o processamento de eventos ActionCable e a exibição de mensagens de erro traduzidas nas operações do Hub.
- Substitua o indicador de sucesso incorreto durante a espera por um estado visual de carregamento.

Enhancements:
- Adicione filtragem de eventos por inbox e evite notificações duplicadas de conexão.

Tests:
- Adicione testes para transições de conexão, filtragem por inbox, reconciliação de estado e contrato dos eventos ActionCable.