### PR TITLE
fix(inbox): achados do code review do CRM-318

### DIFF
--- a/src/components/inbox/HubConnectButton.spec.tsx
+++ b/src/components/inbox/HubConnectButton.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import HubConnectButton from './HubConnectButton';
@@ -8,8 +8,11 @@ vi.mock('@/services/core', () => ({
   api: { post: vi.fn(), get: vi.fn() },
 }));
 
+// useGlobalConfig returns the config flat (GlobalConfigContextValue extends
+// GlobalConfig), so the mock has to be flat too — a nested { config } shape
+// leaves hubAllowExistingChannels undefined and silently enables the mode.
 vi.mock('@/contexts/GlobalConfigContext', () => ({
-  useGlobalConfig: () => ({ config: { hubAllowExistingChannels: false } }),
+  useGlobalConfig: () => ({ hubAllowExistingChannels: false, setupRequired: false, setupLoading: false }),
 }));
 
 const toastSuccess = vi.fn();
@@ -28,12 +31,14 @@ async function criarInbox() {
   await screen.findByTestId('hub-waiting');
 }
 
-function emitir(status: string, inboxId: string = INBOX_ID) {
-  window.dispatchEvent(
-    new CustomEvent('evolution:hubChannelConnection', {
-      detail: { inbox_id: inboxId, connection_status: status },
-    }),
-  );
+async function emitir(status: string, inboxId: string = INBOX_ID) {
+  await act(async () => {
+    window.dispatchEvent(
+      new CustomEvent('evolution:hubChannelConnection', {
+        detail: { inbox_id: inboxId, connection_status: status },
+      }),
+    );
+  });
 }
 
 describe('HubConnectButton — estado real da conexão', () => {
@@ -45,16 +50,17 @@ describe('HubConnectButton — estado real da conexão', () => {
   it('sai de "Aguardando" para conectado ao receber o evento do Hub', async () => {
     await criarInbox();
 
-    emitir('connected');
+    await emitir('connected');
 
     await waitFor(() => expect(screen.getByTestId('hub-connected')).toBeInTheDocument());
     expect(screen.queryByTestId('hub-waiting')).not.toBeInTheDocument();
+    expect(toastSuccess).toHaveBeenCalledWith('Canal conectado.');
   });
 
   it('ignora evento de outra inbox', async () => {
     await criarInbox();
 
-    emitir('connected', 'inbox-outra');
+    await emitir('connected', 'inbox-outra');
 
     await waitFor(() => expect(screen.getByTestId('hub-waiting')).toBeInTheDocument());
     expect(screen.queryByTestId('hub-connected')).not.toBeInTheDocument();
@@ -62,11 +68,43 @@ describe('HubConnectButton — estado real da conexão', () => {
 
   it('volta para aguardando quando o Hub desconecta o canal', async () => {
     await criarInbox();
-    emitir('connected');
+    await emitir('connected');
     await screen.findByTestId('hub-connected');
 
-    emitir('disconnected');
+    await emitir('disconnected');
 
     await waitFor(() => expect(screen.getByTestId('hub-waiting')).toBeInTheDocument());
+  });
+
+  // O broadcast se perde se o socket estava fora quando o Hub avisou; a volta
+  // para a aba tem que resolver o estado sem refresh manual.
+  it('reconcilia pelo GET da inbox quando o evento do ActionCable se perdeu', async () => {
+    await criarInbox();
+    vi.mocked(api.get).mockResolvedValue({
+      data: { data: { id: INBOX_ID, connection_state: 'connected', health_source: 'provider_event' } },
+    } as never);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => expect(screen.getByTestId('hub-connected')).toBeInTheDocument());
+    expect(api.get).toHaveBeenCalledWith(`/inboxes/${INBOX_ID}`);
+  });
+
+  // `stored_flag` é o resolver ASSUMINDO que um canal token-based configurado
+  // está vivo — não é confirmação do Hub, e não pode declarar conectado.
+  it('nao declara conectado quando o estado veio de stored_flag', async () => {
+    await criarInbox();
+    vi.mocked(api.get).mockResolvedValue({
+      data: { data: { id: INBOX_ID, connection_state: 'connected', health_source: 'stored_flag' } },
+    } as never);
+
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalled());
+    expect(screen.getByTestId('hub-waiting')).toBeInTheDocument();
   });
 });

--- a/src/components/inbox/HubConnectButton.tsx
+++ b/src/components/inbox/HubConnectButton.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@evoapi/design-system';
 import { toast } from 'sonner';
 import { Loader2, ExternalLink, CheckCircle2, Link2 } from 'lucide-react';
@@ -39,6 +39,14 @@ interface InboxCreateResponse {
       linked?: boolean;
       hub_channel_id?: string;
     };
+  };
+}
+
+interface InboxShowResponse {
+  data: {
+    id: number;
+    connection_state?: string;
+    health_source?: string;
   };
 }
 
@@ -112,9 +120,20 @@ export default function HubConnectButton({
     };
   }, [mode, channelType]);
 
-  // O Hub avisa o CRM por webhook quando o operador conclui o signup da Meta, e
-  // o backend reemite no ActionCable. Sem escutar aqui, a tela so descobria a
-  // conexao num refresh manual — a dor que originou o card.
+  // Guards the transition so the socket event and the reconciliation below
+  // cannot announce the same connection twice.
+  const alreadyConnected = useRef(false);
+
+  const markConnected = useCallback(() => {
+    if (alreadyConnected.current) return;
+    alreadyConnected.current = true;
+    setConnectionStatus('connected');
+    toast.success('Canal conectado.');
+  }, []);
+
+  // The Hub webhooks the CRM when the operator finishes the Meta signup and the
+  // backend re-emits it on ActionCable; without this the screen only learned
+  // about the connection on a manual refresh.
   useEffect(() => {
     if (inboxId === null) return;
 
@@ -123,21 +142,50 @@ export default function HubConnectButton({
         | { inbox_id?: string | number; connection_status?: string }
         | undefined;
       if (!detail) return;
-      // Comparacao frouxa de proposito: o id sai do backend como string e o
-      // estado local guarda number.
+      // Loose comparison on purpose: the id arrives as a string and the local
+      // state holds a number.
       if (String(detail.inbox_id) !== String(inboxId)) return;
 
       if (detail.connection_status === 'connected') {
-        setConnectionStatus('connected');
-        toast.success('Canal conectado.');
+        markConnected();
       } else if (detail.connection_status === 'disconnected') {
+        alreadyConnected.current = false;
         setConnectionStatus('waiting');
       }
     };
 
     window.addEventListener('evolution:hubChannelConnection', onConnection);
     return () => window.removeEventListener('evolution:hubChannelConnection', onConnection);
-  }, [inboxId]);
+  }, [inboxId, markConnected]);
+
+  // ActionCable has no replay: a transition broadcast while the socket was down
+  // is lost, and the socket is often still down while the operator sits in the
+  // Hub tab. Re-read the inbox when the tab comes back so the screen settles
+  // anyway. `provider_event` means the Hub actually confirmed the connection —
+  // `stored_flag` is the resolver assuming a configured token channel is live.
+  useEffect(() => {
+    if (inboxId === null || connectionStatus === 'connected') return;
+
+    const reconcile = async () => {
+      if (document.visibilityState !== 'visible') return;
+      try {
+        const response = await api.get<InboxShowResponse>(`/inboxes/${inboxId}`);
+        const inbox = response.data?.data;
+        if (inbox?.connection_state === 'connected' && inbox?.health_source === 'provider_event') {
+          markConnected();
+        }
+      } catch {
+        // Best effort — the ActionCable event stays the primary path.
+      }
+    };
+
+    document.addEventListener('visibilitychange', reconcile);
+    window.addEventListener('focus', reconcile);
+    return () => {
+      document.removeEventListener('visibilitychange', reconcile);
+      window.removeEventListener('focus', reconcile);
+    };
+  }, [inboxId, connectionStatus, markConnected]);
 
   const handleCreateNew = async () => {
     setSubmitting(true);
@@ -161,9 +209,8 @@ export default function HubConnectButton({
       toast.success('Inbox criada. Conclua a conexão na aba que foi aberta.');
       onCreated?.({ inboxId: inbox.id, publicLink: link });
     } catch (error: unknown) {
-      // O erro do Hub chega estruturado (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED) e
-      // o client ja traduz. Ler `data.message` cru descartava esse trabalho e
-      // devolvia o texto tecnico ao operador.
+      // Hub errors arrive structured (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED);
+      // reading `data.message` raw dropped the translated text.
       const message =
         apiErrorMessage(error) ??
         (error as { message?: string }).message ??

--- a/src/services/core/websocket/actionCableService.spec.ts
+++ b/src/services/core/websocket/actionCableService.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Captures the subscription callbacks so the test can feed the exact frame the
+// Rails side broadcasts: `{ event, data }` (ActionCableBroadcastJob).
+const handlers: Record<string, (frame: unknown) => void> = {};
+
+vi.mock('@rails/actioncable', () => ({
+  createConsumer: () => ({
+    subscriptions: {
+      create: (_params: unknown, callbacks: Record<string, (frame: unknown) => void>) => {
+        Object.assign(handlers, callbacks);
+        return { unsubscribe: () => {} };
+      },
+    },
+    disconnect: () => {},
+  }),
+}));
+
+describe('actionCableService — contrato do frame do ActionCable', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('reemite hub_channel.connection_changed com o payload que veio em `data`', async () => {
+    const { actionCableService } = await import('./actionCableService');
+    actionCableService.init('tok', 'user-1');
+
+    let detail: unknown = null;
+    window.addEventListener('evolution:hubChannelConnection', (event) => {
+      detail = (event as CustomEvent).detail;
+    });
+
+    handlers.received({
+      event: 'hub_channel.connection_changed',
+      data: { inbox_id: 42, channel_type: 'Channel::Whatsapp', connection_status: 'connected' },
+    });
+
+    expect(detail).toEqual({
+      inbox_id: 42,
+      channel_type: 'Channel::Whatsapp',
+      connection_status: 'connected',
+    });
+  });
+
+  it('reemite os demais eventos pelo mesmo caminho', async () => {
+    const { actionCableService } = await import('./actionCableService');
+    actionCableService.init('tok', 'user-1');
+
+    let detail: unknown = null;
+    window.addEventListener('evolution:message', (event) => {
+      detail = (event as CustomEvent).detail;
+    });
+
+    handlers.received({ event: 'message.created', data: { id: 7 } });
+
+    expect(detail).toEqual({ id: 7 });
+  });
+});

--- a/src/services/core/websocket/actionCableService.ts
+++ b/src/services/core/websocket/actionCableService.ts
@@ -47,8 +47,8 @@ class ActionCableService {
           this.handleDisconnection();
         },
 
-        received: (data: any) => {
-          this.handleEventMessage(data);
+        received: (message: any) => {
+          this.handleEventMessage(message);
         },
       },
     );
@@ -66,8 +66,10 @@ class ActionCableService {
   //   // No separate PresenceChannel needed
   // }
 
-  private handleEventMessage(data: any) {
-    const { event, payload } = data;
+  // The Rails side puts `{ event, data }` on the wire (ActionCableBroadcastJob),
+  // so the payload has to be read from `data`, not from a `payload` key.
+  private handleEventMessage(message: any) {
+    const { event, data: payload } = message ?? {};
 
     // Dispatch events based on type
     switch (event) {
@@ -98,8 +100,7 @@ class ActionCableService {
         window.dispatchEvent(new CustomEvent('evolution:presence', { detail: payload }));
         break;
 
-      // Conexao de canal Meta via Evo Hub mudou de estado. A tela que abriu a
-      // aba do Hub escuta para sair do "Aguardando..." sem refresh manual.
+      // Meta channel relayed by the Evo Hub changed connection state.
       case 'hub_channel.connection_changed':
         window.dispatchEvent(new CustomEvent('evolution:hubChannelConnection', { detail: payload }));
         break;


### PR DESCRIPTION
Correções dos achados do code review do **CRM-318**. Alvo é o branch do card (`danilocarneiro/crm-313-demo-live-frente1`), não a `develop` — o PR original (#326) segue como está e este entra por baixo.

Par do PR de backend `evo-ai-crm-community#309`.

## O achado crítico: a tela nunca sairia de "Aguardando"

`handleEventMessage` desestruturava `const { event, payload } = data`, mas o Rails põe no fio `{ event, data }` (`ActionCableBroadcastJob#broadcast_to_members`). O `payload` era **sempre `undefined`**, o `CustomEvent` saía com `detail: null`, e o `if (!detail) return` do `HubConnectButton` abortava. A tela continuava em "Aguardando conexão Meta no Hub…" indefinidamente — exatamente a dor que o card existe para matar.

O bug era latente e pré-existente: ninguém escuta `evolution:conversation`, `:message` nem `:presence`, então o case do Hub é o primeiro consumidor vivo daquele switch e herdou o defeito inteiro. O contrato certo está no próprio repo — `BaseActionCableConnector.onReceived` desestrutura `{ event, data }`, e `useNotificationWebSocket` lê `message.data`.

A validação do #326 parou no `ActionCable broadcast done` do backend, e o teste despacha o `CustomEvent` direto na janela — os dois ficam a montante do ponto quebrado. O spec novo (`actionCableService.spec.ts`) alimenta o `received` com o frame real.

## Reconciliação quando o broadcast se perde

ActionCable não tem replay. E o socket costuma estar fora justo na hora: o `actionCableService` só é iniciado pelo `ReconnectService`, cujo tick de 60s e o `checkAndReconnect` saem cedo enquanto a aba está oculta — que é o estado dela durante todo o signup no Hub. Perdido o broadcast, a tela voltava a travar.

O componente relê a inbox no `visibilitychange`/`focus` enquanto espera. Só declara conectado com `connection_state === 'connected'` **e** `health_source === 'provider_event'`: `stored_flag` é o `ConnectionStateResolver` supondo que um canal token-based configurado está vivo, não confirmação do Hub. Zero superfície nova de API — o `InboxSerializer` já devolve os dois campos.

## O mock que mentia

`useGlobalConfig` era mockado como `{ config: { hubAllowExistingChannels: false } }`, mas o hook devolve a config **plana** (`GlobalConfigContextValue extends GlobalConfig`). `hubAllowExistingChannels` ficava `undefined`, `!== false` dava `true`, e o componente renderizava com o modo "vincular canal existente" HABILITADO — o oposto do que o mock declarava, e justo o modo do critério de aceite 4. Também o `act()` que faltava no helper de despacho.

## Como validar

```
npx vitest run src/components/inbox/HubConnectButton.spec.tsx src/services/core/websocket/actionCableService.spec.ts
```

**7 exemplos** (antes: 3). Mutação: revertendo o destructure, os 2 do `actionCableService` ficam vermelhos; removendo a reconciliação, o exemplo dela fica vermelho.

`tsc --noEmit` limpo. Suíte completa: 2306 testes, 49 falhas — **as mesmas 49 da `develop`**, medidas nos mesmos 9 arquivos num worktree limpo da base. Zero regressão.

## Fora de escopo

Nada aqui mexe em `hubAllowExistingChannels`, no modo "vincular canal existente" nem no embedded signup (CRM-314).

## Summary by Sourcery

Corrija o fluxo de confirmação da conexão do Hub para refletir eventos ActionCable reais e recuperar estados perdidos sem exigir atualização manual.

Bug Fixes:
- Corrija o processamento de frames do ActionCable para repassar corretamente os eventos de conexão e permitir que a tela saia do estado de espera.
- Reconcilie o estado da inbox ao retornar à aba ou receber foco, reconhecendo a conexão apenas quando confirmada pelo evento do provedor.
- Evite notificações duplicadas e preserve o estado de espera quando a API reportar apenas um estado inferido por `stored_flag`.

Enhancements:
- Atualize os testes do Hub para refletir o formato correto do mock de configuração e valide eventos, reconciliação e estados de conexão.

Tests:
- Adicione testes do serviço ActionCable cobrindo o contrato real dos frames e o repasse dos eventos para a janela.