### PR TITLE
feat(channels): habilita o salvar do rodapé na aba de agente de IA (CRM-344)

### DIFF
--- a/src/components/channels/settings/AgentBotConfigurationForm.spec.tsx
+++ b/src/components/channels/settings/AgentBotConfigurationForm.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import AgentBotConfigurationForm from './AgentBotConfigurationForm';
 
 vi.mock('@/hooks/useLanguage', () => ({
@@ -121,6 +121,34 @@ describe('AgentBotConfigurationForm', () => {
         allowed_conversation_statuses: ['pending'],
       }),
     );
+  });
+
+  it('blocks the footer save while the bot is being disconnected', async () => {
+    vi.mocked(AgentBotsService.getInboxAgentBot).mockResolvedValue(bot as never);
+    let releaseDisconnect = () => {};
+    vi.mocked(AgentBotsService.disconnectInboxBot).mockReturnValue(
+      new Promise<boolean>(resolve => {
+        releaseDisconnect = () => resolve(true);
+      }) as never,
+    );
+    const registerSave = vi.fn();
+    render(<AgentBotConfigurationForm {...defaultProps} registerSave={registerSave} />);
+
+    await waitFor(() => expect(lastHandle(registerSave)?.canSave).toBe(true));
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /settings\.agentBotConfiguration\.buttons\.disconnect$/,
+      }),
+    );
+
+    // setInboxAgentBot and disconnectInboxBot write the same agent_bot_inbox
+    // row, so the footer must stay locked until the disconnect settles.
+    await waitFor(() => expect(lastHandle(registerSave)?.canSave).toBe(false));
+
+    await act(async () => {
+      releaseDisconnect();
+    });
+    expect(AgentBotsService.setInboxAgentBot).not.toHaveBeenCalled();
   });
 
   it('unregisters the handle on unmount', async () => {

--- a/src/components/channels/settings/AgentBotConfigurationForm.spec.tsx
+++ b/src/components/channels/settings/AgentBotConfigurationForm.spec.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, waitFor } from '@testing-library/react';
+import AgentBotConfigurationForm from './AgentBotConfigurationForm';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/channels/agentBotsService', () => ({
+  default: {
+    getAll: vi.fn(),
+    getInboxAgentBot: vi.fn(),
+    getInboxAgentBotConfiguration: vi.fn(),
+    setInboxAgentBot: vi.fn(),
+    removeInboxAgentBot: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/contacts/labelsService', () => ({
+  labelsService: {
+    getLabels: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/channels/inboxesService', () => ({
+  default: {
+    getById: vi.fn(),
+    getFacebookPosts: vi.fn(),
+  },
+}));
+
+import AgentBotsService from '@/services/channels/agentBotsService';
+import { labelsService } from '@/services/contacts/labelsService';
+import InboxesService from '@/services/channels/inboxesService';
+
+const bot = { id: 'bot-1', name: 'Bot One', description: '', outgoing_url: '' };
+const savedConfiguration = {
+  allowed_conversation_statuses: ['pending'],
+  allowed_label_ids: ['lbl-1'],
+  ignored_label_ids: ['lbl-2'],
+};
+
+describe('AgentBotConfigurationForm', () => {
+  const defaultProps = { inboxId: 'inbox-1' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(InboxesService.getById).mockResolvedValue({
+      data: { channel_type: 'Channel::WebWidget' },
+    } as never);
+    vi.mocked(AgentBotsService.getAll).mockResolvedValue([bot] as never);
+    vi.mocked(AgentBotsService.getInboxAgentBot).mockResolvedValue(null as never);
+    vi.mocked(AgentBotsService.getInboxAgentBotConfiguration).mockResolvedValue(null as never);
+    vi.mocked(AgentBotsService.setInboxAgentBot).mockResolvedValue(undefined as never);
+    vi.mocked(labelsService.getLabels).mockResolvedValue({
+      data: [
+        { id: 'lbl-1', title: 'VIP', color: '#111111' },
+        { id: 'lbl-2', title: 'Spam', color: '#222222' },
+      ],
+    } as never);
+  });
+
+  // The save is driven by the ChannelSettings sticky footer through the
+  // registerSave registry, mirroring the other snapshot tabs.
+  const lastHandle = (mock: ReturnType<typeof vi.fn>) => {
+    const handles = mock.mock.calls
+      .map(call => call[0])
+      .filter(arg => arg && typeof arg === 'object');
+    return handles[handles.length - 1];
+  };
+
+  it('registers a non-savable handle when no bot is selected', async () => {
+    const registerSave = vi.fn();
+    render(<AgentBotConfigurationForm {...defaultProps} registerSave={registerSave} />);
+
+    await waitFor(() => expect(lastHandle(registerSave)).toBeTruthy());
+    const handle = lastHandle(registerSave);
+    expect(handle.canSave).toBe(false);
+    expect(typeof handle.save).toBe('function');
+  });
+
+  it('registers a savable handle once a bot is connected and data is loaded', async () => {
+    vi.mocked(AgentBotsService.getInboxAgentBot).mockResolvedValue(bot as never);
+    const registerSave = vi.fn();
+    render(<AgentBotConfigurationForm {...defaultProps} registerSave={registerSave} />);
+
+    await waitFor(() => expect(lastHandle(registerSave)?.canSave).toBe(true));
+  });
+
+  it('save() sends the full configuration including label scoping', async () => {
+    vi.mocked(AgentBotsService.getInboxAgentBot).mockResolvedValue(bot as never);
+    vi.mocked(AgentBotsService.getInboxAgentBotConfiguration).mockResolvedValue(
+      savedConfiguration as never,
+    );
+    const registerSave = vi.fn();
+    render(<AgentBotConfigurationForm {...defaultProps} registerSave={registerSave} />);
+
+    await waitFor(() => expect(lastHandle(registerSave)?.canSave).toBe(true));
+    await act(() => lastHandle(registerSave).save());
+
+    expect(AgentBotsService.setInboxAgentBot).toHaveBeenCalledWith(
+      'inbox-1',
+      'bot-1',
+      expect.objectContaining({
+        allowed_label_ids: ['lbl-1'],
+        ignored_label_ids: ['lbl-2'],
+        allowed_conversation_statuses: ['pending'],
+      }),
+    );
+  });
+
+  it('unregisters the handle on unmount', async () => {
+    const registerSave = vi.fn();
+    const { unmount } = render(
+      <AgentBotConfigurationForm {...defaultProps} registerSave={registerSave} />,
+    );
+    await waitFor(() => expect(lastHandle(registerSave)).toBeTruthy());
+
+    unmount();
+    expect(registerSave).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/src/components/channels/settings/AgentBotConfigurationForm.spec.tsx
+++ b/src/components/channels/settings/AgentBotConfigurationForm.spec.tsx
@@ -21,7 +21,7 @@ vi.mock('@/services/channels/agentBotsService', () => ({
     getInboxAgentBot: vi.fn(),
     getInboxAgentBotConfiguration: vi.fn(),
     setInboxAgentBot: vi.fn(),
-    removeInboxAgentBot: vi.fn(),
+    disconnectInboxBot: vi.fn(),
   },
 }));
 
@@ -78,12 +78,17 @@ describe('AgentBotConfigurationForm', () => {
     return handles[handles.length - 1];
   };
 
-  it('registers a non-savable handle when no bot is selected', async () => {
+  it('registers a non-savable handle when no bot is selected, even after loading', async () => {
     const registerSave = vi.fn();
     render(<AgentBotConfigurationForm {...defaultProps} registerSave={registerSave} />);
 
-    await waitFor(() => expect(lastHandle(registerSave)).toBeTruthy());
+    // Let the initial load settle so the assertion covers the post-load state,
+    // not just the synchronous mount registration.
+    await waitFor(() => expect(labelsService.getLabels).toHaveBeenCalled());
+    await act(async () => {});
+
     const handle = lastHandle(registerSave);
+    expect(handle).toBeTruthy();
     expect(handle.canSave).toBe(false);
     expect(typeof handle.save).toBe('function');
   });

--- a/src/components/channels/settings/AgentBotConfigurationForm.tsx
+++ b/src/components/channels/settings/AgentBotConfigurationForm.tsx
@@ -405,7 +405,7 @@ export default function AgentBotConfigurationForm({
   const hasAvailableBots = agentBots.length > 0;
 
   // Expose the save to the settings sticky footer registry.
-  const canSave = hasSelectedBot && !isUpdating && !isLoading;
+  const canSave = hasSelectedBot && !isUpdating && !isLoading && !isDisconnecting;
   const registerSaveRef = useRef(registerSave);
   registerSaveRef.current = registerSave;
   const handleUpdateRef = useRef(handleUpdateAgentBot);

--- a/src/components/channels/settings/AgentBotConfigurationForm.tsx
+++ b/src/components/channels/settings/AgentBotConfigurationForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import {
   Card,
   CardContent,
@@ -33,14 +33,17 @@ import InboxesService from '@/services/channels/inboxesService';
 import { Label as LabelType } from '@/types/settings';
 import { AgentBot, isBotConnectedToInbox, getBotStatusColor } from './helpers/agentBotHelpers';
 import { AgentBotInboxConfiguration, FacebookPost } from '@/types';
+import type { TabSaveHandle } from './tabSave';
 
 interface AgentBotConfigurationFormProps {
   inboxId: string;
+  registerSave?: (handle: TabSaveHandle | null) => void;
   onUpdate?: (success: boolean) => void;
 }
 
 export default function AgentBotConfigurationForm({
   inboxId,
+  registerSave,
   onUpdate,
 }: AgentBotConfigurationFormProps) {
   const { t } = useLanguage('channels');
@@ -400,6 +403,17 @@ export default function AgentBotConfigurationForm({
   const isConnected = isBotConnectedToInbox(agentBots, activeAgentBot?.id);
   const hasSelectedBot = selectedAgentBotId !== null;
   const hasAvailableBots = agentBots.length > 0;
+
+  // Expose the save to the settings sticky footer registry.
+  const canSave = hasSelectedBot && !isUpdating && !isLoading;
+  const registerSaveRef = useRef(registerSave);
+  registerSaveRef.current = registerSave;
+  const handleUpdateRef = useRef(handleUpdateAgentBot);
+  handleUpdateRef.current = handleUpdateAgentBot;
+  useLayoutEffect(() => {
+    registerSaveRef.current?.({ save: () => handleUpdateRef.current(), canSave });
+    return () => registerSaveRef.current?.(null);
+  }, [canSave]);
 
   return (
     <div className="space-y-6">

--- a/src/pages/Customer/Channels/ChannelSettings.spec.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.spec.tsx
@@ -1,7 +1,9 @@
+import { useLayoutEffect, useRef } from 'react';
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ChannelSettings from './ChannelSettings';
+import type { TabSaveHandle } from '@/components/channels/settings/tabSave';
 
 // Router: provide the inbox id and a no-op navigate.
 vi.mock('react-router-dom', () => ({
@@ -45,6 +47,10 @@ vi.mock('@/services/channels/inboxesService', () => ({
   },
 }));
 
+// The AI agent tab registers its save with the footer like the other snapshot
+// tabs; the spy stands in for that tab's save.
+const { agentBotSave } = vi.hoisted(() => ({ agentBotSave: vi.fn() }));
+
 // Stub the channel component barrel so the page renders without pulling every
 // heavy settings form into the test.
 vi.mock('@/components/channels', () => {
@@ -62,7 +68,19 @@ vi.mock('@/components/channels', () => {
     CSATForm: stub('CSATForm'),
     PreChatForm: stub('PreChatForm'),
     WidgetBuilderForm: stub('WidgetBuilderForm'),
-    AgentBotConfigurationForm: stub('AgentBotConfigurationForm'),
+    AgentBotConfigurationForm: ({
+      registerSave,
+    }: {
+      registerSave?: (handle: TabSaveHandle | null) => void;
+    }) => {
+      const registerSaveRef = useRef(registerSave);
+      registerSaveRef.current = registerSave;
+      useLayoutEffect(() => {
+        registerSaveRef.current?.({ save: agentBotSave, canSave: true });
+        return () => registerSaveRef.current?.(null);
+      }, []);
+      return <div data-testid="AgentBotConfigurationForm" />;
+    },
     ConfigurationForm: stub('ConfigurationForm'),
     ModerationDashboard: stub('ModerationDashboard'),
   };
@@ -114,6 +132,19 @@ describe('ChannelSettings redesign', () => {
 
     await userEvent.click(saveButton);
     await waitFor(() => expect(update).toHaveBeenCalled());
+  });
+
+  it('saves the agent bot tab from the sticky footer', async () => {
+    await renderPage();
+    await userEvent.click(screen.getByRole('tab', { name: /settings\.tabs\.botConfiguration/i }));
+    await screen.findByTestId('AgentBotConfigurationForm');
+
+    expect(screen.queryByText('settings.info.tabSpecificSave')).toBeNull();
+    const saveButton = screen.getByRole('button', { name: /settings\.updateConfig/i });
+    expect(saveButton).toBeEnabled();
+
+    await userEvent.click(saveButton);
+    await waitFor(() => expect(agentBotSave).toHaveBeenCalled());
   });
 
   it('disables the footer with a hint on imperative tabs', async () => {

--- a/src/pages/Customer/Channels/ChannelSettings.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.tsx
@@ -926,6 +926,7 @@ export default function ChannelSettings({ inboxId: inboxIdProp, onExit }: Channe
             <TabsContent value="botConfiguration">
               {activeTab === 'botConfiguration' && <AgentBotConfigurationForm
                 inboxId={inboxId}
+                registerSave={handle => registerTabSave('botConfiguration', handle)}
                 onUpdate={success => {
                   if (success) {
                     // Optionally refresh inbox data or show success feedback


### PR DESCRIPTION
## Summary
- A aba **Agente de IA** das configurações de canal era a única aba snapshot que não registrava seu `TabSaveHandle` no rodapé sticky do `ChannelSettings` — o botão "✓ Atualizar Configurações" ficava permanentemente desabilitado nela, impedindo salvar o escopo por etiquetas (Etiquetas/Etiquetas Ignoradas) por esse caminho.
- Agora a aba registra `save`/`canSave` no mesmo padrão das irmãs (`BusinessHoursForm` etc.): o rodapé habilita com bot selecionado e salva o snapshot completo da aba, incluindo `allowed_label_ids`/`ignored_label_ids`.
- `canSave = hasSelectedBot && !isUpdating && !isLoading && !isDisconnecting` — o guard de desconexão evita corrida entre `setInboxAgentBot` e `disconnectInboxBot`.
- Botões internos da aba (Configurar / Desconectar) intactos — o fluxo de conectar não muda.

## Security
- Sem mudança de superfície de API: o rodapé chama o mesmo `AgentBotsService.setInboxAgentBot` do botão interno.
- Bônus: o caminho do rodapé passa pelo `footerCanSave`, que respeita o `canUpdate` (RBAC) da página.

## Test plan
- `npx vitest run src/components/channels/settings/AgentBotConfigurationForm.spec.tsx` (4 specs novos: registro sem bot / com bot, payload completo com label ids no save, unregister no unmount)
- `npx tsc --noEmit` e `npx vite build` limpos
- Manual: Configurações → Canais → aba Agente de IA → alterar etiquetas → salvar pelo rodapé → recarregar e conferir persistência; sem bot selecionado o rodapé fica desabilitado

## Changed Files
- `src/components/channels/settings/AgentBotConfigurationForm.tsx`
- `src/components/channels/settings/AgentBotConfigurationForm.spec.tsx` (novo)
- `src/pages/Customer/Channels/ChannelSettings.tsx`

## Linked Issue
- CRM-344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuywNCXrqa9inPWWjb1htN

## Summary by Sourcery

Enable the AI Agent channel settings tab to save its configuration through the shared sticky footer.

New Features:
- Enable saving the AI Agent channel settings tab through the shared sticky footer.
- Persist the tab’s complete agent bot configuration, including allowed and ignored label scopes, when saved from the footer.

Bug Fixes:
- Allow the sticky footer save action to become available only when an agent bot is selected and channel updates are not in progress.

Enhancements:
- Prevent footer saves during bot disconnection to avoid conflicting updates and integrate the tab with the existing save-handle lifecycle.

Tests:
- Add coverage for save-handle registration, complete configuration payloads, disconnection safeguards, cleanup, and sticky-footer integration.