### PR TITLE
fix(chat): status da mensagem mostra o motivo devolvido pelo provedor (CRM-365)

### DIFF
--- a/src/components/chat/messages/MessageStatus.spec.tsx
+++ b/src/components/chat/messages/MessageStatus.spec.tsx
@@ -2,16 +2,18 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MessageStatus from './MessageStatus';
-import { Message } from '@/types/chat/api';
+import { MESSAGE_TYPE, Message } from '@/types/chat/api';
+
+type ToastOptions = { description?: string; action?: { label: string; onClick: () => void } };
 
 const toastError = vi.fn();
 const toastWarning = vi.fn();
 const toastInfo = vi.fn();
 vi.mock('sonner', () => ({
   toast: {
-    error: (title: string, opts?: { description?: string }) => toastError(title, opts),
-    warning: (title: string, opts?: { description?: string }) => toastWarning(title, opts),
-    info: (title: string, opts?: { description?: string }) => toastInfo(title, opts),
+    error: (title: string, opts?: ToastOptions) => toastError(title, opts),
+    warning: (title: string, opts?: ToastOptions) => toastWarning(title, opts),
+    info: (title: string, opts?: ToastOptions) => toastInfo(title, opts),
   },
 }));
 
@@ -19,61 +21,104 @@ vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
 }));
 
-const ERRO_DA_META = '131042: Business eligibility payment issue';
+const META_ERROR = '131042: Business eligibility payment issue';
 
-function mensagemFalhada(externalError?: string): Message {
+function failedMessage(externalError?: string): Message {
   return {
     id: 'msg-1',
-    content: 'oi',
-    content_attributes: externalError ? { external_error: externalError } : {},
+    content: 'hi',
+    content_attributes: externalError === undefined ? {} : { external_error: externalError },
     content_type: 'text',
     conversation_id: 'conv-1',
-    created_at: '2026-08-27T21:00:00Z',
+    created_at: 1_756_330_000,
     external_source_ids: {},
-    message_type: 1,
+    message_type: MESSAGE_TYPE.OUTGOING,
     private: false,
-    sender: { id: 'user-1', name: 'Agente', type: 'user' },
+    sender: { id: 'user-1', name: 'Agent', type: 'user' },
     source_id: 'wamid.HBgMNTU3NDk5ODc5NDA5',
     status: 'failed',
     attachments: [],
-  } as unknown as Message;
+  };
 }
 
-async function clicarNoIndicador(message: Message) {
-  render(<MessageStatus message={message} isOwn />);
+async function clickIndicator(message: Message, onRetry?: () => void) {
+  render(<MessageStatus message={message} isOwn onRetry={onRetry} />);
   await userEvent.click(screen.getByRole('button'));
 }
 
-describe('MessageStatus — mensagem pública que falhou', () => {
+describe('MessageStatus — failed public message', () => {
   beforeEach(() => {
     toastError.mockClear();
     toastWarning.mockClear();
     toastInfo.mockClear();
   });
 
-  it('mostra o motivo devolvido pelo provedor quando ele existe', async () => {
-    await clicarNoIndicador(mensagemFalhada(ERRO_DA_META));
+  it('shows the reason the backend stored, without the generic guidance', async () => {
+    await clickIndicator(failedMessage(META_ERROR));
 
     expect(toastError).toHaveBeenCalledWith(
-      'messages.messageStatus.providerRejected',
-      expect.objectContaining({ description: ERRO_DA_META }),
+      'messages.messageStatus.messageNotSent',
+      expect.objectContaining({ description: META_ERROR }),
     );
     expect(toastWarning).not.toHaveBeenCalled();
     expect(toastInfo).not.toHaveBeenCalled();
   });
 
-  it('cai no texto genérico quando o provedor não devolveu motivo', async () => {
-    await clicarNoIndicador(mensagemFalhada());
+  it('labels the indicator as a send failure when the reason is known', async () => {
+    render(<MessageStatus message={failedMessage(META_ERROR)} isOwn />);
+
+    const indicator = screen.getByRole('button');
+    expect(indicator).toHaveTextContent('messages.messageStatus.sendFailedText');
+    expect(indicator).toHaveAttribute('title', 'messages.messageStatus.sendFailed');
+  });
+
+  it('keeps the generic guidance and its label when there is no reason', async () => {
+    render(<MessageStatus message={failedMessage()} isOwn />);
+
+    const indicator = screen.getByRole('button');
+    expect(indicator).toHaveTextContent('messages.messageStatus.statusUnavailableText');
+    await userEvent.click(indicator);
 
     expect(toastWarning).toHaveBeenCalled();
     expect(toastInfo).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
   });
 
-  it('ignora external_error em branco e trata como sem motivo', async () => {
-    await clicarNoIndicador(mensagemFalhada('   '));
+  it.each([
+    ['empty', ''],
+    ['whitespace only', '   '],
+  ])('treats a %s external_error as missing', async (_label, externalError) => {
+    await clickIndicator(failedMessage(externalError));
 
     expect(toastWarning).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('caps a long reason so the toast stays readable', async () => {
+    await clickIndicator(failedMessage('x'.repeat(1000)));
+
+    const description = toastError.mock.calls[0][1].description;
+    expect(description).toHaveLength(241);
+    expect(description.endsWith('…')).toBe(true);
+  });
+
+  it('does not resend on click and offers the retry as an explicit action', async () => {
+    const onRetry = vi.fn();
+    await clickIndicator(failedMessage(META_ERROR), onRetry);
+
+    expect(onRetry).not.toHaveBeenCalled();
+
+    toastError.mock.calls[0][1].action.onClick();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers the retry action on the generic path too', async () => {
+    const onRetry = vi.fn();
+    await clickIndicator(failedMessage(), onRetry);
+
+    expect(onRetry).not.toHaveBeenCalled();
+
+    toastWarning.mock.calls[0][1].action.onClick();
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/chat/messages/MessageStatus.spec.tsx
+++ b/src/components/chat/messages/MessageStatus.spec.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import MessageStatus from './MessageStatus';
+import { Message } from '@/types/chat/api';
+
+const toastError = vi.fn();
+const toastWarning = vi.fn();
+const toastInfo = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (title: string, opts?: { description?: string }) => toastError(title, opts),
+    warning: (title: string, opts?: { description?: string }) => toastWarning(title, opts),
+    info: (title: string, opts?: { description?: string }) => toastInfo(title, opts),
+  },
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+const ERRO_DA_META = '131042: Business eligibility payment issue';
+
+function mensagemFalhada(externalError?: string): Message {
+  return {
+    id: 'msg-1',
+    content: 'oi',
+    content_attributes: externalError ? { external_error: externalError } : {},
+    content_type: 'text',
+    conversation_id: 'conv-1',
+    created_at: '2026-08-27T21:00:00Z',
+    external_source_ids: {},
+    message_type: 1,
+    private: false,
+    sender: { id: 'user-1', name: 'Agente', type: 'user' },
+    source_id: 'wamid.HBgMNTU3NDk5ODc5NDA5',
+    status: 'failed',
+    attachments: [],
+  } as unknown as Message;
+}
+
+async function clicarNoIndicador(message: Message) {
+  render(<MessageStatus message={message} isOwn />);
+  await userEvent.click(screen.getByRole('button'));
+}
+
+describe('MessageStatus — mensagem pública que falhou', () => {
+  beforeEach(() => {
+    toastError.mockClear();
+    toastWarning.mockClear();
+    toastInfo.mockClear();
+  });
+
+  it('mostra o motivo devolvido pelo provedor quando ele existe', async () => {
+    await clicarNoIndicador(mensagemFalhada(ERRO_DA_META));
+
+    expect(toastError).toHaveBeenCalledWith(
+      'messages.messageStatus.providerRejected',
+      expect.objectContaining({ description: ERRO_DA_META }),
+    );
+    expect(toastWarning).not.toHaveBeenCalled();
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it('cai no texto genérico quando o provedor não devolveu motivo', async () => {
+    await clicarNoIndicador(mensagemFalhada());
+
+    expect(toastWarning).toHaveBeenCalled();
+    expect(toastInfo).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('ignora external_error em branco e trata como sem motivo', async () => {
+    await clicarNoIndicador(mensagemFalhada('   '));
+
+    expect(toastWarning).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/messages/MessageStatus.tsx
+++ b/src/components/chat/messages/MessageStatus.tsx
@@ -25,6 +25,9 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
   const isOnColoredBubble = isOwn && !message.private;
   const timeTextClass = isOnColoredBubble ? 'text-white/70' : 'text-muted-foreground';
 
+  const rawExternalError = message.content_attributes?.external_error;
+  const externalError = typeof rawExternalError === 'string' ? rawExternalError.trim() : '';
+
   const getStatusIcon = () => {
     if (!isOwn) return null;
 
@@ -34,8 +37,6 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
       return <Check className="h-3 w-3 text-muted-foreground" />;
     }
 
-    // CORREÇÃO: Em ambiente de desenvolvimento, canais podem não estar configurados
-    // Se for uma mensagem pública com status 'failed', pode ser problema de configuração
     if (message.status === 'failed' && !message.private) {
       return (
         <Button
@@ -46,13 +47,18 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
             e.preventDefault();
             e.stopPropagation();
 
-            // Mostrar toast explicativo sobre o problema do webhook
-            toast.warning(t('messages.messageStatus.statusUnavailable'), {
-              description: t('messages.messageStatus.statusUnavailableDescription'),
-            });
-            toast.info(t('messages.messageStatus.checkChannelConfig'), {
-              description: t('messages.messageStatus.webhookIssue'),
-            });
+            if (externalError) {
+              toast.error(t('messages.messageStatus.providerRejected'), {
+                description: externalError,
+              });
+            } else {
+              toast.warning(t('messages.messageStatus.statusUnavailable'), {
+                description: t('messages.messageStatus.statusUnavailableDescription'),
+              });
+              toast.info(t('messages.messageStatus.checkChannelConfig'), {
+                description: t('messages.messageStatus.webhookIssue'),
+              });
+            }
 
             // Se existe função onRetry, também executar (para tentar reenviar)
             if (onRetry) {

--- a/src/components/chat/messages/MessageStatus.tsx
+++ b/src/components/chat/messages/MessageStatus.tsx
@@ -16,6 +16,9 @@ interface MessageStatusProps {
   variant?: 'default' | 'tuck';
 }
 
+// SendReplyJob truncates its generic rescue to 1000 chars, which is unreadable in a toast.
+const MAX_FAILURE_REASON_CHARS = 240;
+
 const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, variant = 'default' }) => {
   const { t } = useLanguage('chat');
 
@@ -25,8 +28,14 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
   const isOnColoredBubble = isOwn && !message.private;
   const timeTextClass = isOnColoredBubble ? 'text-white/70' : 'text-muted-foreground';
 
+  // Every channel service writes external_error, and so does SendReplyJob's generic rescue —
+  // the text may be a provider rejection or an internal exception. Show it, never name a source.
   const rawExternalError = message.content_attributes?.external_error;
-  const externalError = typeof rawExternalError === 'string' ? rawExternalError.trim() : '';
+  const trimmedError = typeof rawExternalError === 'string' ? rawExternalError.trim() : '';
+  const failureReason =
+    trimmedError.length > MAX_FAILURE_REASON_CHARS
+      ? `${trimmedError.slice(0, MAX_FAILURE_REASON_CHARS)}…`
+      : trimmedError;
 
   const getStatusIcon = () => {
     if (!isOwn) return null;
@@ -38,6 +47,11 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
     }
 
     if (message.status === 'failed' && !message.private) {
+      // Resending is an explicit choice: clicking the indicator only explains the failure.
+      const retryAction = onRetry
+        ? { label: t('messages.messageStatus.tryAgain'), onClick: () => onRetry() }
+        : undefined;
+
       return (
         <Button
           size="sm"
@@ -47,30 +61,34 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
             e.preventDefault();
             e.stopPropagation();
 
-            if (externalError) {
-              toast.error(t('messages.messageStatus.providerRejected'), {
-                description: externalError,
+            if (failureReason) {
+              toast.error(t('messages.messageStatus.messageNotSent'), {
+                description: failureReason,
+                action: retryAction,
               });
-            } else {
-              toast.warning(t('messages.messageStatus.statusUnavailable'), {
-                description: t('messages.messageStatus.statusUnavailableDescription'),
-              });
-              toast.info(t('messages.messageStatus.checkChannelConfig'), {
-                description: t('messages.messageStatus.webhookIssue'),
-              });
+              return;
             }
 
-            // Se existe função onRetry, também executar (para tentar reenviar)
-            if (onRetry) {
-              setTimeout(() => {
-                onRetry();
-              }, 1000); // Delay para que o usuário veja o toast primeiro
-            }
+            toast.warning(t('messages.messageStatus.statusUnavailable'), {
+              description: t('messages.messageStatus.statusUnavailableDescription'),
+              action: retryAction,
+            });
+            toast.info(t('messages.messageStatus.checkChannelConfig'), {
+              description: t('messages.messageStatus.webhookIssue'),
+            });
           }}
-          title={t('messages.messageStatus.deliveryStatusUnavailable')}
+          title={
+            failureReason
+              ? t('messages.messageStatus.sendFailed')
+              : t('messages.messageStatus.deliveryStatusUnavailable')
+          }
         >
           <AlertCircle className="h-3 w-3" />
-          <span className="ml-1 text-xs">{t('messages.messageStatus.statusUnavailableText')}</span>
+          <span className="ml-1 text-xs">
+            {failureReason
+              ? t('messages.messageStatus.sendFailedText')
+              : t('messages.messageStatus.statusUnavailableText')}
+          </span>
         </Button>
       );
     }
@@ -86,25 +104,8 @@ const MessageStatus: React.FC<MessageStatusProps> = ({ message, isOwn, onRetry, 
         return <CheckCheck className="h-3 w-3 text-primary" />;
       case 'progress':
         return <Loader2 className="h-3 w-3 text-blue-500 animate-spin" />;
-      case 'failed':
-        return (
-          <Button
-            size="sm"
-            variant="ghost"
-            className="h-auto p-0 text-destructive hover:text-destructive/80"
-            onClick={() => {
-              if (onRetry) {
-                onRetry();
-              } else {
-                toast.error(t('messages.messageStatus.retryInDevelopment'));
-              }
-            }}
-            title={t('messages.messageStatus.sendFailed')}
-          >
-            <AlertCircle className="h-3 w-3" />
-            <span className="ml-1 text-xs">{t('messages.messageStatus.tryAgain')}</span>
-          </Button>
-        );
+      // 'failed' never reaches here: private messages return above, public ones are
+      // handled by the branch before the switch.
       default:
         return <Clock className="h-3 w-3 text-muted-foreground animate-pulse" />;
     }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -92,6 +92,7 @@
       "statusUnavailableDescription": "The message was sent, but we could not confirm the delivery status.",
       "checkChannelConfig": "Check channel configuration",
       "webhookIssue": "The webhook may be outdated or inactive.",
+      "providerRejected": "The channel provider rejected this message",
       "deliveryStatusUnavailable": "Delivery status unavailable - Click for more details",
       "statusUnavailableText": "Status unavailable",
       "retryInDevelopment": "Retry functionality in development",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -92,11 +92,11 @@
       "statusUnavailableDescription": "The message was sent, but we could not confirm the delivery status.",
       "checkChannelConfig": "Check channel configuration",
       "webhookIssue": "The webhook may be outdated or inactive.",
-      "providerRejected": "The channel provider rejected this message",
+      "messageNotSent": "The message was not sent",
       "deliveryStatusUnavailable": "Delivery status unavailable - Click for more details",
       "statusUnavailableText": "Status unavailable",
-      "retryInDevelopment": "Retry functionality in development",
-      "sendFailed": "Send failed - Click to try again",
+      "sendFailedText": "Send failed",
+      "sendFailed": "Send failed - Click to see the reason",
       "tryAgain": "Try again"
     },
     "replyPreview": {

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -91,11 +91,11 @@
       "statusUnavailableDescription": "El mensaje fue enviado, pero no pudimos confirmar el estado de entrega.",
       "checkChannelConfig": "Verifique la configuración del canal",
       "webhookIssue": "El webhook puede estar desactualizado o inactivo.",
-      "providerRejected": "El proveedor del canal rechazó este mensaje",
+      "messageNotSent": "El mensaje no fue enviado",
       "deliveryStatusUnavailable": "Estado de entrega no disponible - Haga clic para más detalles",
       "statusUnavailableText": "Estado no disponible",
-      "retryInDevelopment": "Funcionalidad de reintento en desarrollo",
-      "sendFailed": "Envío fallido - Haga clic para intentar de nuevo",
+      "sendFailedText": "Envío fallido",
+      "sendFailed": "Envío fallido - Haga clic para ver el motivo",
       "tryAgain": "Intentar de nuevo"
     },
     "replyPreview": {

--- a/src/i18n/locales/es/chat.json
+++ b/src/i18n/locales/es/chat.json
@@ -91,6 +91,7 @@
       "statusUnavailableDescription": "El mensaje fue enviado, pero no pudimos confirmar el estado de entrega.",
       "checkChannelConfig": "Verifique la configuración del canal",
       "webhookIssue": "El webhook puede estar desactualizado o inactivo.",
+      "providerRejected": "El proveedor del canal rechazó este mensaje",
       "deliveryStatusUnavailable": "Estado de entrega no disponible - Haga clic para más detalles",
       "statusUnavailableText": "Estado no disponible",
       "retryInDevelopment": "Funcionalidad de reintento en desarrollo",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -91,11 +91,11 @@
       "statusUnavailableDescription": "Le message a été envoyé, mais nous n'avons pas pu confirmer le statut de livraison.",
       "checkChannelConfig": "Vérifiez la configuration du canal",
       "webhookIssue": "Le webhook peut être obsolète ou inactif.",
-      "providerRejected": "Le fournisseur du canal a rejeté ce message",
+      "messageNotSent": "Le message n'a pas été envoyé",
       "deliveryStatusUnavailable": "Statut de livraison indisponible - Cliquez pour plus de détails",
       "statusUnavailableText": "Statut indisponible",
-      "retryInDevelopment": "Fonctionnalité de nouvelle tentative en développement",
-      "sendFailed": "Échec de l'envoi - Cliquez pour réessayer",
+      "sendFailedText": "Échec de l'envoi",
+      "sendFailed": "Échec de l'envoi - Cliquez pour voir la raison",
       "tryAgain": "Réessayer"
     },
     "replyPreview": {

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -91,6 +91,7 @@
       "statusUnavailableDescription": "Le message a été envoyé, mais nous n'avons pas pu confirmer le statut de livraison.",
       "checkChannelConfig": "Vérifiez la configuration du canal",
       "webhookIssue": "Le webhook peut être obsolète ou inactif.",
+      "providerRejected": "Le fournisseur du canal a rejeté ce message",
       "deliveryStatusUnavailable": "Statut de livraison indisponible - Cliquez pour plus de détails",
       "statusUnavailableText": "Statut indisponible",
       "retryInDevelopment": "Fonctionnalité de nouvelle tentative en développement",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -91,11 +91,11 @@
       "statusUnavailableDescription": "Il messaggio è stato inviato, ma non siamo riusciti a confermare lo stato di consegna.",
       "checkChannelConfig": "Verifica la configurazione del canale",
       "webhookIssue": "Il webhook potrebbe essere obsoleto o inattivo.",
-      "providerRejected": "Il fornitore del canale ha rifiutato questo messaggio",
+      "messageNotSent": "Il messaggio non è stato inviato",
       "deliveryStatusUnavailable": "Stato di consegna non disponibile - Clicca per maggiori dettagli",
       "statusUnavailableText": "Stato non disponibile",
-      "retryInDevelopment": "Funzionalità di nuovo tentativo in sviluppo",
-      "sendFailed": "Invio fallito - Clicca per riprovare",
+      "sendFailedText": "Invio fallito",
+      "sendFailed": "Invio fallito - Clicca per vedere il motivo",
       "tryAgain": "Riprova"
     },
     "replyPreview": {

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -91,6 +91,7 @@
       "statusUnavailableDescription": "Il messaggio è stato inviato, ma non siamo riusciti a confermare lo stato di consegna.",
       "checkChannelConfig": "Verifica la configurazione del canale",
       "webhookIssue": "Il webhook potrebbe essere obsoleto o inattivo.",
+      "providerRejected": "Il fornitore del canale ha rifiutato questo messaggio",
       "deliveryStatusUnavailable": "Stato di consegna non disponibile - Clicca per maggiori dettagli",
       "statusUnavailableText": "Stato non disponibile",
       "retryInDevelopment": "Funzionalità di nuovo tentativo in sviluppo",

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -92,11 +92,11 @@
       "statusUnavailableDescription": "A mensagem foi enviada, mas não conseguimos confirmar o status de entrega.",
       "checkChannelConfig": "Verifique a configuração do canal",
       "webhookIssue": "O webhook pode estar desatualizado ou inativo.",
-      "providerRejected": "O provedor do canal recusou esta mensagem",
+      "messageNotSent": "A mensagem não foi enviada",
       "deliveryStatusUnavailable": "Status de entrega indisponível - Clique para mais detalhes",
       "statusUnavailableText": "Status indisponível",
-      "retryInDevelopment": "Funcionalidade de reenvio em desenvolvimento",
-      "sendFailed": "Falha no envio - Clique para tentar novamente",
+      "sendFailedText": "Falha no envio",
+      "sendFailed": "Falha no envio - Clique para ver o motivo",
       "tryAgain": "Tentar novamente"
     },
     "replyPreview": {

--- a/src/i18n/locales/pt-BR/chat.json
+++ b/src/i18n/locales/pt-BR/chat.json
@@ -92,6 +92,7 @@
       "statusUnavailableDescription": "A mensagem foi enviada, mas não conseguimos confirmar o status de entrega.",
       "checkChannelConfig": "Verifique a configuração do canal",
       "webhookIssue": "O webhook pode estar desatualizado ou inativo.",
+      "providerRejected": "O provedor do canal recusou esta mensagem",
       "deliveryStatusUnavailable": "Status de entrega indisponível - Clique para mais detalhes",
       "statusUnavailableText": "Status indisponível",
       "retryInDevelopment": "Funcionalidade de reenvio em desenvolvimento",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -91,6 +91,7 @@
       "statusUnavailableDescription": "A mensagem foi enviada, mas não conseguimos confirmar o status de entrega.",
       "checkChannelConfig": "Verifique a configuração do canal",
       "webhookIssue": "O webhook pode estar desatualizado ou inativo.",
+      "providerRejected": "O provedor do canal recusou esta mensagem",
       "deliveryStatusUnavailable": "Status de entrega indisponível - Clique para mais detalhes",
       "statusUnavailableText": "Status indisponível",
       "retryInDevelopment": "Funcionalidade de reenvio em desenvolvimento",

--- a/src/i18n/locales/pt/chat.json
+++ b/src/i18n/locales/pt/chat.json
@@ -91,11 +91,11 @@
       "statusUnavailableDescription": "A mensagem foi enviada, mas não conseguimos confirmar o status de entrega.",
       "checkChannelConfig": "Verifique a configuração do canal",
       "webhookIssue": "O webhook pode estar desatualizado ou inativo.",
-      "providerRejected": "O provedor do canal recusou esta mensagem",
+      "messageNotSent": "A mensagem não foi enviada",
       "deliveryStatusUnavailable": "Status de entrega indisponível - Clique para mais detalhes",
       "statusUnavailableText": "Status indisponível",
-      "retryInDevelopment": "Funcionalidade de reenvio em desenvolvimento",
-      "sendFailed": "Falha no envio - Clique para tentar novamente",
+      "sendFailedText": "Falha no envio",
+      "sendFailed": "Falha no envio - Clique para ver o motivo",
       "tryAgain": "Tentar novamente"
     },
     "replyPreview": {

--- a/src/types/chat/api.ts
+++ b/src/types/chat/api.ts
@@ -201,6 +201,7 @@ export interface MessageContentAttributes extends Record<string, unknown> {
   is_unsupported?: boolean;
   deleted?: boolean;
   external_created_at?: number;
+  external_error?: string;
 }
 
 // ===== MESSAGE =====


### PR DESCRIPTION
## O que muda

Mensagem pública com `status: failed` passa a mostrar o motivo que o provedor do canal devolveu, quando ele existe. O texto genérico sobre webhook fica só para o caso em que não há motivo nenhum.

## Por quê

`MessageStatus.tsx` disparava dois toasts com texto fixo — "Verifique a configuração do canal" e "O webhook pode estar desatualizado ou inativo" — para qualquer falha de envio, sem olhar o `content_attributes.external_error` que o backend já grava. O comentário no código mostrava a origem: o texto foi escrito para o cenário de canal não configurado em ambiente de desenvolvimento, e acabou valendo para todos os casos.

Num envio real por canal WhatsApp Cloud via Evo Hub, a mensagem falhou com `external_error: "131042: Business eligibility payment issue"` — elegibilidade/pagamento da conta Meta. O `source_id` trazia um `wamid`, ou seja, a Meta respondeu e o webhook estava íntegro. A tela mandou investigar canal e webhook, e a causa estava a um campo de distância.

## Como validar

`npx vitest run src/components/chat/messages/MessageStatus.spec.tsx` — três casos: motivo presente (mostra o do provedor e não mostra o genérico), motivo ausente (mostra o genérico) e `external_error` em branco (tratado como ausente).

## Summary by Sourcery

Improve failed public message status feedback by showing the provider’s reason when available and making retries explicit.

New Features:
- Display the channel provider’s failure reason for failed public messages when available.
- Offer retry as an explicit toast action instead of retrying automatically when the status indicator is clicked.

Bug Fixes:
- Use generic channel and webhook guidance only when no meaningful failure reason is available.
- Treat blank failure reasons as missing and keep long provider messages readable.

Enhancements:
- Add localized labels for failure states and provider-error feedback.
- Extend message content attributes to support external error details.

Tests:
- Add coverage for provider reasons, fallback guidance, blank values, truncation, and explicit retry behavior.