### PR TITLE
feat(inbox): conclui a conexão do canal Meta sem sair do CRM (CRM-314)

### DIFF
--- a/src/components/inbox/HubConnectButton.embeddedSignup.spec.tsx
+++ b/src/components/inbox/HubConnectButton.embeddedSignup.spec.tsx
@@ -1,0 +1,131 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HubConnectButton from './HubConnectButton';
+import { api } from '@/services/core';
+import { evolutionHubService } from '@/services/integrations';
+
+vi.mock('@/services/core', () => ({
+  api: { post: vi.fn(), get: vi.fn() },
+}));
+
+vi.mock('@/services/integrations', () => ({
+  evolutionHubService: {
+    getConnectInfo: vi.fn(),
+    connectWhatsapp: vi.fn(),
+    getAvailableChannels: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@/contexts/GlobalConfigContext', () => ({
+  useGlobalConfig: () => ({ hubAllowExistingChannels: false, setupRequired: false, setupLoading: false }),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: { success: (m: string) => toastSuccess(m), error: (m: string) => toastError(m) },
+}));
+
+const INBOX_ID = 7;
+const PUBLIC_LINK = 'http://localhost:8050/connect/tok';
+
+let fbLogin: ReturnType<typeof vi.fn>;
+let openSpy: ReturnType<typeof vi.fn>;
+
+function comAppEConfig() {
+  vi.mocked(evolutionHubService.getConnectInfo).mockResolvedValue({
+    meta_app_id: 'app-123',
+    meta_config_id: 'cfg-456',
+    can_connect: true,
+  });
+}
+
+async function criarInbox() {
+  vi.mocked(api.post).mockResolvedValue({
+    data: { data: { id: INBOX_ID, evolution_hub: { public_link: PUBLIC_LINK } } },
+  } as never);
+
+  render(<HubConnectButton channelType="whatsapp_cloud" name="Canal Teste" />);
+  await userEvent.click(screen.getByRole('button', { name: /conectar/i }));
+  await screen.findByTestId('hub-waiting');
+}
+
+async function concluirNaMeta(payload: Record<string, unknown>) {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://www.facebook.com',
+        data: JSON.stringify({ type: 'WA_EMBEDDED_SIGNUP', event: 'FINISH', data: payload }),
+      }),
+    );
+  });
+}
+
+describe('HubConnectButton — Embedded Signup na própria página', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fbLogin = vi.fn();
+    window.FB = { init: vi.fn(), login: fbLogin };
+    openSpy = vi.fn();
+    window.open = openSpy as unknown as typeof window.open;
+  });
+
+  it('roda o FB.login na página com o config_id do canal e não abre outra aba', async () => {
+    comAppEConfig();
+    await criarInbox();
+
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+    expect(fbLogin.mock.calls[0][1]).toMatchObject({ config_id: 'cfg-456', response_type: 'code' });
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('cai na aba do Hub quando o Hub não devolve app e config do canal', async () => {
+    vi.mocked(evolutionHubService.getConnectInfo).mockResolvedValue({ can_connect: true });
+    await criarInbox();
+
+    await waitFor(() => expect(openSpy).toHaveBeenCalledWith(PUBLIC_LINK, '_blank', 'noopener,noreferrer'));
+    expect(fbLogin).not.toHaveBeenCalled();
+  });
+
+  it('cai na aba do Hub quando o connect_info falha', async () => {
+    vi.mocked(evolutionHubService.getConnectInfo).mockRejectedValue(new Error('502'));
+    await criarInbox();
+
+    await waitFor(() => expect(openSpy).toHaveBeenCalled());
+  });
+
+  it('envia ao Hub os ids da Meta junto do code', async () => {
+    comAppEConfig();
+    vi.mocked(evolutionHubService.connectWhatsapp).mockResolvedValue(undefined);
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    await act(async () => {
+      fbLogin.mock.calls[0][0]({ authResponse: { code: 'code-abc' } });
+    });
+    await concluirNaMeta({ phone_number_id: '111', waba_id: '222', business_id: '333' });
+
+    await waitFor(() =>
+      expect(evolutionHubService.connectWhatsapp).toHaveBeenCalledWith(INBOX_ID, {
+        phone_number_id: '111',
+        waba_id: '222',
+        business_id: '333',
+        auth_code: 'code-abc',
+      }),
+    );
+  });
+
+  it('trata o callback sem authResponse em vez de ficar conectando para sempre', async () => {
+    comAppEConfig();
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    await act(async () => {
+      fbLogin.mock.calls[0][0]({ status: 'unknown' });
+    });
+
+    expect(toastError).toHaveBeenCalled();
+    expect(evolutionHubService.connectWhatsapp).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/inbox/HubConnectButton.embeddedSignup.spec.tsx
+++ b/src/components/inbox/HubConnectButton.embeddedSignup.spec.tsx
@@ -112,6 +112,7 @@ describe('HubConnectButton — Embedded Signup na própria página', () => {
         waba_id: '222',
         business_id: '333',
         auth_code: 'code-abc',
+        connection_mode: 'meta',
       }),
     );
   });
@@ -127,5 +128,67 @@ describe('HubConnectButton — Embedded Signup na própria página', () => {
 
     expect(toastError).toHaveBeenCalled();
     expect(evolutionHubService.connectWhatsapp).not.toHaveBeenCalled();
+    // A tela tem de SAIR do spinner: o toast some e antes sobrava girando.
+    expect(await screen.findByTestId('hub-failed')).toBeTruthy();
+    expect(screen.queryByTestId('hub-waiting')).toBeNull();
+  });
+
+  it('sai do spinner quando a Meta cancela', async () => {
+    comAppEConfig();
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          origin: 'https://www.facebook.com',
+          data: JSON.stringify({ type: 'WA_EMBEDDED_SIGNUP', event: 'CANCEL' }),
+        }),
+      );
+    });
+
+    expect(await screen.findByTestId('hub-failed')).toBeTruthy();
+  });
+
+  it('sai do spinner quando o POST no Hub falha', async () => {
+    comAppEConfig();
+    vi.mocked(evolutionHubService.connectWhatsapp).mockRejectedValue(new Error('boom'));
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    await act(async () => {
+      fbLogin.mock.calls[0][0]({ authResponse: { code: 'code-abc' } });
+    });
+    await concluirNaMeta({ phone_number_id: '111', waba_id: '222', business_id: '333' });
+
+    expect(await screen.findByTestId('hub-failed')).toBeTruthy();
+  });
+
+  it('no caminho em pagina a copy nao fala de aba que abriu', async () => {
+    comAppEConfig();
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Se a aba n.o abriu/i)).toBeNull();
+    expect(screen.getByText(/janela da Meta/i)).toBeTruthy();
+  });
+
+  it('na queda para a aba do Hub a copy antiga continua valendo', async () => {
+    vi.mocked(evolutionHubService.getConnectInfo).mockResolvedValue({ can_connect: true });
+    await criarInbox();
+
+    await waitFor(() => expect(openSpy).toHaveBeenCalled());
+    expect(screen.getByText(/Se a aba n.o abriu/i)).toBeTruthy();
+  });
+
+  it('mostra o erro estruturado do Hub em vez de cair na aba calado', async () => {
+    vi.mocked(evolutionHubService.getConnectInfo).mockRejectedValue({
+      response: { data: { error: 'Plano nao permite app compartilhado', code: 'PLAN_FORBIDS_SHARED' } },
+    });
+    await criarInbox();
+
+    await waitFor(() => expect(openSpy).toHaveBeenCalled());
+    expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/Plano nao permite/i));
   });
 });

--- a/src/components/inbox/HubConnectButton.embeddedSignup.spec.tsx
+++ b/src/components/inbox/HubConnectButton.embeddedSignup.spec.tsx
@@ -133,6 +133,44 @@ describe('HubConnectButton — Embedded Signup na própria página', () => {
     expect(screen.queryByTestId('hub-waiting')).toBeNull();
   });
 
+  it('recusa localmente um FINISH sem waba_id, sem ida ao backend', async () => {
+    comAppEConfig();
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    await act(async () => {
+      fbLogin.mock.calls[0][0]({ authResponse: { code: 'code-abc' } });
+    });
+    await concluirNaMeta({ phone_number_id: '111', business_id: '333' });
+
+    expect(evolutionHubService.connectWhatsapp).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/waba_id/));
+    expect(await screen.findByTestId('hub-failed')).toBeTruthy();
+  });
+
+  // business_id e omitempty no Hub e a Meta nem sempre devolve: exigir aqui
+  // recriaria a recusa indevida que o backend deixou de fazer.
+  it('aceita um FINISH sem business_id e nao manda a chave vazia', async () => {
+    comAppEConfig();
+    vi.mocked(evolutionHubService.connectWhatsapp).mockResolvedValue(undefined);
+    await criarInbox();
+    await waitFor(() => expect(fbLogin).toHaveBeenCalled());
+
+    await act(async () => {
+      fbLogin.mock.calls[0][0]({ authResponse: { code: 'code-abc' } });
+    });
+    await concluirNaMeta({ phone_number_id: '111', waba_id: '222' });
+
+    await waitFor(() =>
+      expect(evolutionHubService.connectWhatsapp).toHaveBeenCalledWith(INBOX_ID, {
+        phone_number_id: '111',
+        waba_id: '222',
+        auth_code: 'code-abc',
+        connection_mode: 'meta',
+      }),
+    );
+  });
+
   it('sai do spinner quando a Meta cancela', async () => {
     comAppEConfig();
     await criarInbox();

--- a/src/components/inbox/HubConnectButton.tsx
+++ b/src/components/inbox/HubConnectButton.tsx
@@ -9,6 +9,7 @@ import {
   evolutionHubService,
   type HubChannel,
 } from '@/services/integrations';
+import { useFacebookSdk } from '@/hooks/useFacebookSdk';
 
 /**
  * Hub-relayed Inbox creation button.
@@ -52,6 +53,14 @@ interface InboxShowResponse {
 
 type Mode = 'new' | 'existing';
 
+interface SignupData {
+  phone_number_id: string;
+  waba_id: string;
+  business_id: string;
+}
+
+const META_ORIGINS = ['https://www.facebook.com', 'https://web.facebook.com'];
+
 const HUB_TYPE_BY_CHANNEL: Record<
   HubConnectButtonProps['channelType'],
   HubChannel['type']
@@ -80,6 +89,10 @@ export default function HubConnectButton({
   const [inboxId, setInboxId] = useState<number | null>(null);
   const [linkedDone, setLinkedDone] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState<'waiting' | 'connected'>('waiting');
+
+  const { loadSdk, initSdk } = useFacebookSdk();
+  const [signupData, setSignupData] = useState<SignupData | null>(null);
+  const [authCode, setAuthCode] = useState<string | null>(null);
 
   const [availableChannels, setAvailableChannels] = useState<HubChannel[]>([]);
   const [loadingChannels, setLoadingChannels] = useState(false);
@@ -187,6 +200,106 @@ export default function HubConnectButton({
     };
   }, [inboxId, connectionStatus, markConnected]);
 
+  // Os ids do canal chegam por postMessage e o code pelo callback do FB.login;
+  // só dá para postar no Hub com os dois.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (!META_ORIGINS.includes(event.origin)) return;
+      try {
+        const data = JSON.parse(event.data);
+        if (data?.type !== 'WA_EMBEDDED_SIGNUP') return;
+
+        if (data.event === 'FINISH' || data.event === 'FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING') {
+          setSignupData({
+            phone_number_id: data.data?.phone_number_id ?? '',
+            waba_id: data.data?.waba_id ?? '',
+            business_id: data.data?.business_id ?? '',
+          });
+        } else if (data.event === 'CANCEL') {
+          toast.error('Conexão cancelada na Meta.');
+          setSubmitting(false);
+        } else if (data.event === 'ERROR') {
+          toast.error(data.data?.error_message || 'A Meta recusou a conexão.');
+          setSubmitting(false);
+        }
+      } catch {
+        // Mensagem da Meta que não é JSON do signup.
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
+
+  useEffect(() => {
+    if (!signupData || !authCode || inboxId === null) return;
+
+    let cancelled = false;
+    evolutionHubService
+      .connectWhatsapp(inboxId, { ...signupData, auth_code: authCode })
+      .then(() => {
+        if (cancelled) return;
+        toast.success('Conexão enviada ao Hub. Aguardando confirmação do canal…');
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        toast.error(apiErrorMessage(error) ?? 'Falha ao concluir a conexão no Hub');
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setSignupData(null);
+        setAuthCode(null);
+        setSubmitting(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [signupData, authCode, inboxId]);
+
+  // Sem app e config do canal (o caso do app compartilhado hoje) devolve false
+  // e o chamador abre a aba do Hub.
+  const startEmbeddedSignup = async (id: number): Promise<boolean> => {
+    let info;
+    try {
+      info = await evolutionHubService.getConnectInfo(id);
+    } catch {
+      return false;
+    }
+
+    if (!info?.meta_app_id || !info?.meta_config_id) return false;
+    if (info.byo_config_missing || info.can_connect === false) return false;
+
+    try {
+      await loadSdk();
+    } catch {
+      return false;
+    }
+    if (!window.FB) return false;
+
+    initSdk({ appId: info.meta_app_id });
+    window.FB.login(
+      (response: unknown) => {
+        const code = (response as { authResponse?: { code?: string } })?.authResponse?.code;
+        if (!code) {
+          // Domínio não liberado, popup fechado ou permissão negada — o SDK não
+          // distingue, e sem tratar a tela ficava "conectando" para sempre.
+          toast.error('A Meta não concluiu a autorização. Use o link para abrir o fluxo em outra aba.');
+          setSubmitting(false);
+          return;
+        }
+        setAuthCode(code);
+      },
+      {
+        config_id: info.meta_config_id,
+        response_type: 'code',
+        override_default_response_type: true,
+        extras: { version: 'v3', featureType: 'whatsapp_business_app_onboarding' },
+      },
+    );
+    return true;
+  };
+
   const handleCreateNew = async () => {
     setSubmitting(true);
     try {
@@ -205,9 +318,16 @@ export default function HubConnectButton({
 
       setInboxId(inbox.id);
       setPublicLink(link);
+      onCreated?.({ inboxId: inbox.id, publicLink: link });
+
+      const inPage = channelType === 'whatsapp_cloud' && (await startEmbeddedSignup(inbox.id));
+      if (inPage) {
+        toast.success('Inbox criada. Conclua a conexão na janela da Meta.');
+        return;
+      }
+
       window.open(link, '_blank', 'noopener,noreferrer');
       toast.success('Inbox criada. Conclua a conexão na aba que foi aberta.');
-      onCreated?.({ inboxId: inbox.id, publicLink: link });
     } catch (error: unknown) {
       // Hub errors arrive structured (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED);
       // reading `data.message` raw dropped the translated text.

--- a/src/components/inbox/HubConnectButton.tsx
+++ b/src/components/inbox/HubConnectButton.tsx
@@ -56,7 +56,8 @@ type Mode = 'new' | 'existing';
 interface SignupData {
   phone_number_id: string;
   waba_id: string;
-  business_id: string;
+  // Optional on the Hub (omitempty) and not always in Meta's FINISH payload.
+  business_id?: string;
 }
 
 const META_ORIGINS = ['https://www.facebook.com', 'https://web.facebook.com'];
@@ -225,10 +226,18 @@ export default function HubConnectButton({
         if (data?.type !== 'WA_EMBEDDED_SIGNUP') return;
 
         if (data.event === 'FINISH' || data.event === 'FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING') {
+          // Defaulting a missing id to '' laundered "Meta sent nothing" into
+          // "Meta sent empty" and only surfaced as a generic 400 from the proxy.
+          const missing = (['phone_number_id', 'waba_id'] as const).filter((key) => !data.data?.[key]);
+          if (missing.length) {
+            failSignup(`A Meta não devolveu ${missing.join(' e ')}. Conclua a conexão pela aba do Hub.`);
+            return;
+          }
+
           setSignupData({
-            phone_number_id: data.data?.phone_number_id ?? '',
-            waba_id: data.data?.waba_id ?? '',
-            business_id: data.data?.business_id ?? '',
+            phone_number_id: data.data.phone_number_id,
+            waba_id: data.data.waba_id,
+            ...(data.data.business_id ? { business_id: data.data.business_id } : {}),
           });
         } else if (data.event === 'CANCEL') {
           failSignup('Conexão cancelada na Meta.');

--- a/src/components/inbox/HubConnectButton.tsx
+++ b/src/components/inbox/HubConnectButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@evoapi/design-system';
 import { toast } from 'sonner';
-import { Loader2, ExternalLink, CheckCircle2, Link2 } from 'lucide-react';
+import { Loader2, ExternalLink, CheckCircle2, Link2, AlertCircle } from 'lucide-react';
 import { api } from '@/services/core';
 import { apiErrorMessage } from '@/utils/apiHelpers';
 import { useGlobalConfig } from '@/contexts/GlobalConfigContext';
@@ -61,6 +61,10 @@ interface SignupData {
 
 const META_ORIGINS = ['https://www.facebook.com', 'https://web.facebook.com'];
 
+// The Hub binds connection_mode as required on MetaConnectRequest, and its own
+// public widget always sends this literal for WhatsApp.
+const HUB_CONNECTION_MODE = 'meta';
+
 const HUB_TYPE_BY_CHANNEL: Record<
   HubConnectButtonProps['channelType'],
   HubChannel['type']
@@ -93,6 +97,10 @@ export default function HubConnectButton({
   const { loadSdk, initSdk } = useFacebookSdk();
   const [signupData, setSignupData] = useState<SignupData | null>(null);
   const [authCode, setAuthCode] = useState<string | null>(null);
+  // Drives the post-creation view. Without it a handled failure only produced a
+  // toast and the screen kept spinning on "waiting" forever.
+  const [signupError, setSignupError] = useState<string | null>(null);
+  const [inPageSignup, setInPageSignup] = useState(false);
 
   const [availableChannels, setAvailableChannels] = useState<HubChannel[]>([]);
   const [loadingChannels, setLoadingChannels] = useState(false);
@@ -200,8 +208,15 @@ export default function HubConnectButton({
     };
   }, [inboxId, connectionStatus, markConnected]);
 
-  // Os ids do canal chegam por postMessage e o code pelo callback do FB.login;
-  // só dá para postar no Hub com os dois.
+  const failSignup = useCallback((message: string) => {
+    toast.error(message);
+    setSignupError(message);
+    setSignupData(null);
+    setAuthCode(null);
+  }, []);
+
+  // The channel ids arrive by postMessage and the code by the FB.login callback;
+  // the Hub can only be called with both.
   useEffect(() => {
     const onMessage = (event: MessageEvent) => {
       if (!META_ORIGINS.includes(event.origin)) return;
@@ -216,54 +231,55 @@ export default function HubConnectButton({
             business_id: data.data?.business_id ?? '',
           });
         } else if (data.event === 'CANCEL') {
-          toast.error('Conexão cancelada na Meta.');
-          setSubmitting(false);
+          failSignup('Conexão cancelada na Meta.');
         } else if (data.event === 'ERROR') {
-          toast.error(data.data?.error_message || 'A Meta recusou a conexão.');
-          setSubmitting(false);
+          failSignup(data.data?.error_message || 'A Meta recusou a conexão.');
         }
       } catch {
-        // Mensagem da Meta que não é JSON do signup.
+        // A Meta message that is not the signup JSON.
       }
     };
 
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, []);
+  }, [failSignup]);
 
   useEffect(() => {
     if (!signupData || !authCode || inboxId === null) return;
 
     let cancelled = false;
     evolutionHubService
-      .connectWhatsapp(inboxId, { ...signupData, auth_code: authCode })
+      .connectWhatsapp(inboxId, { ...signupData, auth_code: authCode, connection_mode: HUB_CONNECTION_MODE })
       .then(() => {
         if (cancelled) return;
         toast.success('Conexão enviada ao Hub. Aguardando confirmação do canal…');
       })
       .catch((error: unknown) => {
         if (cancelled) return;
-        toast.error(apiErrorMessage(error) ?? 'Falha ao concluir a conexão no Hub');
+        failSignup(apiErrorMessage(error) ?? 'Falha ao concluir a conexão no Hub');
       })
       .finally(() => {
         if (cancelled) return;
         setSignupData(null);
         setAuthCode(null);
-        setSubmitting(false);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [signupData, authCode, inboxId]);
+  }, [signupData, authCode, inboxId, failSignup]);
 
-  // Sem app e config do canal (o caso do app compartilhado hoje) devolve false
-  // e o chamador abre a aba do Hub.
+  // Returns false when the Hub sends no app/config for the channel (today's
+  // shared-app case); the caller then opens the Hub tab.
   const startEmbeddedSignup = async (id: number): Promise<boolean> => {
     let info;
     try {
       info = await evolutionHubService.getConnectInfo(id);
-    } catch {
+    } catch (error: unknown) {
+      // The Hub answers structured (PLAN_FORBIDS_SHARED, QUOTA_EXCEEDED). Falling
+      // back to the tab silently would drop the only message the operator gets.
+      const message = apiErrorMessage(error);
+      if (message) toast.error(message);
       return false;
     }
 
@@ -282,10 +298,9 @@ export default function HubConnectButton({
       (response: unknown) => {
         const code = (response as { authResponse?: { code?: string } })?.authResponse?.code;
         if (!code) {
-          // Domínio não liberado, popup fechado ou permissão negada — o SDK não
-          // distingue, e sem tratar a tela ficava "conectando" para sempre.
-          toast.error('A Meta não concluiu a autorização. Use o link para abrir o fluxo em outra aba.');
-          setSubmitting(false);
+          // Domain not allowed, popup closed or permission denied — the SDK does
+          // not tell them apart, and untreated the screen spun on "connecting" forever.
+          failSignup('A Meta não concluiu a autorização. Use o link para abrir o fluxo em outra aba.');
           return;
         }
         setAuthCode(code);
@@ -321,6 +336,7 @@ export default function HubConnectButton({
       onCreated?.({ inboxId: inbox.id, publicLink: link });
 
       const inPage = channelType === 'whatsapp_cloud' && (await startEmbeddedSignup(inbox.id));
+      setInPageSignup(inPage);
       if (inPage) {
         toast.success('Inbox criada. Conclua a conexão na janela da Meta.');
         return;
@@ -396,6 +412,29 @@ export default function HubConnectButton({
       );
     }
 
+    if (signupError) {
+      return (
+        <div className="space-y-3 border rounded-md p-4 bg-muted/30" data-testid="hub-failed">
+          <div className="flex items-center gap-2 text-sm">
+            <AlertCircle className="h-5 w-5 text-destructive" />
+            <span>A conexão não foi concluída.</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{signupError}</p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setSignupError(null);
+              window.open(publicLink, '_blank', 'noopener,noreferrer');
+            }}
+          >
+            <ExternalLink className="h-4 w-4 mr-2" />
+            Tentar pelo Hub em outra aba
+          </Button>
+        </div>
+      );
+    }
+
     return (
       <div className="space-y-3 border rounded-md p-4 bg-muted/30" data-testid="hub-waiting">
         <div className="flex items-center gap-2 text-sm">
@@ -403,7 +442,9 @@ export default function HubConnectButton({
           <span>Inbox criada. Aguardando conexão Meta no Hub…</span>
         </div>
         <p className="text-xs text-muted-foreground">
-          Se a aba não abriu, clique no botão abaixo para reabrir.
+          {inPageSignup
+            ? 'Conclua a autorização na janela da Meta. Se ela não abriu, use o botão abaixo.'
+            : 'Se a aba não abriu, clique no botão abaixo para reabrir.'}
         </p>
         <Button
           type="button"

--- a/src/hooks/useFacebookSdk.spec.ts
+++ b/src/hooks/useFacebookSdk.spec.ts
@@ -1,0 +1,74 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useFacebookSdk } from './useFacebookSdk';
+
+const SDK_SRC = 'https://connect.facebook.net/en_US/sdk.js';
+
+describe('useFacebookSdk', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.head.innerHTML = '';
+    delete (window as { FB?: unknown }).FB;
+    delete (window as { fbAsyncInit?: unknown }).fbAsyncInit;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves as soon as the SDK defines window.FB', async () => {
+    const { result } = renderHook(() => useFacebookSdk());
+    const promise = result.current.loadSdk();
+
+    (window as { FB?: unknown }).FB = { init: vi.fn() };
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  // Three other components inject this same script and overwrite fbAsyncInit
+  // without chaining. Waiting only on that callback deadlocked the caller.
+  it('rejects instead of hanging when a pre-existing script never loads', async () => {
+    const stale = document.createElement('script');
+    stale.id = 'facebook-jssdk';
+    stale.src = SDK_SRC;
+    document.head.appendChild(stale);
+
+    const { result } = renderHook(() => useFacebookSdk());
+    const promise = result.current.loadSdk();
+    const assertion = expect(promise).rejects.toThrow(/failed to load/i);
+
+    await vi.advanceTimersByTimeAsync(11_000);
+    await assertion;
+  });
+
+  it('does not inject a second script when one is already there without an id', async () => {
+    const idless = document.createElement('script');
+    idless.src = SDK_SRC;
+    document.head.appendChild(idless);
+
+    const { result } = renderHook(() => useFacebookSdk());
+    const promise = result.current.loadSdk();
+    const assertion = expect(promise).rejects.toThrow(/failed to load/i);
+
+    expect(document.querySelectorAll(`script[src="${SDK_SRC}"]`)).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(11_000);
+    await assertion;
+  });
+
+  // A failed load used to leave loading.current set, so every later attempt in
+  // the same page got the same dead promise back.
+  it('allows a retry after a failed load', async () => {
+    const { result } = renderHook(() => useFacebookSdk());
+    const first = result.current.loadSdk();
+    const firstAssertion = expect(first).rejects.toThrow(/failed to load/i);
+    await vi.advanceTimersByTimeAsync(11_000);
+    await firstAssertion;
+
+    const second = result.current.loadSdk();
+    (window as { FB?: unknown }).FB = { init: vi.fn() };
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(second).resolves.toBeUndefined();
+  });
+});

--- a/src/hooks/useFacebookSdk.ts
+++ b/src/hooks/useFacebookSdk.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef } from 'react';
+
+const SDK_SRC = 'https://connect.facebook.net/en_US/sdk.js';
+const SDK_SCRIPT_ID = 'facebook-jssdk';
+
+declare global {
+  interface Window {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    FB: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fbAsyncInit?: any;
+  }
+}
+
+export interface FacebookSdkInit {
+  appId: string;
+  version?: string;
+}
+
+/**
+ * Carrega o SDK JS da Meta uma vez por página. O appId só é conhecido em runtime
+ * (vem do Hub, por canal), então o init fica com o consumidor.
+ */
+export function useFacebookSdk() {
+  const loading = useRef<Promise<void> | null>(null);
+
+  const loadSdk = useCallback((): Promise<void> => {
+    if (typeof window === 'undefined') return Promise.reject(new Error('SDK requires a browser'));
+    if (window.FB) return Promise.resolve();
+    if (loading.current) return loading.current;
+
+    loading.current = new Promise<void>((resolve, reject) => {
+      const done = () => resolve();
+      const existing = document.getElementById(SDK_SCRIPT_ID) as HTMLScriptElement | null;
+
+      if (window.FB) {
+        done();
+        return;
+      }
+
+      const previousInit = window.fbAsyncInit;
+      window.fbAsyncInit = () => {
+        previousInit?.();
+        done();
+      };
+
+      if (existing) return;
+
+      const script = document.createElement('script');
+      script.id = SDK_SCRIPT_ID;
+      script.async = true;
+      script.defer = true;
+      script.src = SDK_SRC;
+      script.onerror = () => {
+        loading.current = null;
+        reject(new Error('Facebook SDK failed to load'));
+      };
+      document.head.appendChild(script);
+    });
+
+    return loading.current;
+  }, []);
+
+  const initSdk = useCallback(({ appId, version }: FacebookSdkInit) => {
+    window.FB?.init({
+      appId,
+      version: version || 'v23.0',
+      xfbml: true,
+      autoLogAppEvents: true,
+    });
+  }, []);
+
+  return { loadSdk, initSdk };
+}
+
+export default useFacebookSdk;

--- a/src/hooks/useFacebookSdk.ts
+++ b/src/hooks/useFacebookSdk.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from 'react';
 
 const SDK_SRC = 'https://connect.facebook.net/en_US/sdk.js';
 const SDK_SCRIPT_ID = 'facebook-jssdk';
+const SDK_LOAD_TIMEOUT_MS = 10_000;
 
 declare global {
   interface Window {
@@ -18,8 +19,8 @@ export interface FacebookSdkInit {
 }
 
 /**
- * Carrega o SDK JS da Meta uma vez por página. O appId só é conhecido em runtime
- * (vem do Hub, por canal), então o init fica com o consumidor.
+ * Loads the Meta JS SDK once per page. The appId is only known at runtime
+ * (it comes from the Hub, per channel), so init stays with the consumer.
  */
 export function useFacebookSdk() {
   const loading = useRef<Promise<void> | null>(null);
@@ -30,20 +31,38 @@ export function useFacebookSdk() {
     if (loading.current) return loading.current;
 
     loading.current = new Promise<void>((resolve, reject) => {
-      const done = () => resolve();
-      const existing = document.getElementById(SDK_SCRIPT_ID) as HTMLScriptElement | null;
+      // Three other components load this same script and overwrite fbAsyncInit
+      // without chaining, so our resolve can be dropped. Poll for window.FB and
+      // time out instead of waiting on a callback that may never fire.
+      const started = Date.now();
+      let timer: ReturnType<typeof setInterval> | null = null;
 
-      if (window.FB) {
-        done();
-        return;
-      }
+      const settle = (error?: Error) => {
+        if (timer) clearInterval(timer);
+        timer = null;
+        if (error) {
+          loading.current = null;
+          reject(error);
+        } else {
+          resolve();
+        }
+      };
+
+      timer = setInterval(() => {
+        if (window.FB) return settle();
+        if (Date.now() - started >= SDK_LOAD_TIMEOUT_MS) settle(new Error('Facebook SDK failed to load'));
+      }, 100);
 
       const previousInit = window.fbAsyncInit;
       window.fbAsyncInit = () => {
         previousInit?.();
-        done();
+        settle();
       };
 
+      // CloudWhatsappForm injects the script without an id, so match on src too
+      // or we would append a second copy of the SDK.
+      const existing =
+        document.getElementById(SDK_SCRIPT_ID) ?? document.querySelector(`script[src="${SDK_SRC}"]`);
       if (existing) return;
 
       const script = document.createElement('script');
@@ -51,10 +70,7 @@ export function useFacebookSdk() {
       script.async = true;
       script.defer = true;
       script.src = SDK_SRC;
-      script.onerror = () => {
-        loading.current = null;
-        reject(new Error('Facebook SDK failed to load'));
-      };
+      script.onerror = () => settle(new Error('Facebook SDK failed to load'));
       document.head.appendChild(script);
     });
 

--- a/src/services/integrations/evolutionHubService.ts
+++ b/src/services/integrations/evolutionHubService.ts
@@ -47,7 +47,39 @@ export interface HubChannel {
   created_at?: string;
 }
 
+/** GET /integrations/evolution_hub/connect_info response shape. */
+export interface HubConnectInfo {
+  channel_id?: string;
+  channel_type?: string;
+  status?: string;
+  can_connect?: boolean;
+  connection_url?: string;
+  meta_app_id?: string;
+  meta_config_id?: string;
+  meta_scopes?: string[];
+  byo_config_missing?: boolean;
+}
+
+export interface HubWhatsappSignup {
+  phone_number_id: string;
+  waba_id: string;
+  business_id: string;
+  auth_code: string;
+  connection_mode?: string;
+}
+
 class EvolutionHubService {
+  async getConnectInfo(inboxId: string | number): Promise<HubConnectInfo> {
+    const response = await api.get(
+      `/integrations/evolution_hub/connect_info?inbox_id=${encodeURIComponent(String(inboxId))}`,
+    );
+    return extractData<HubConnectInfo>(response);
+  }
+
+  async connectWhatsapp(inboxId: string | number, signup: HubWhatsappSignup): Promise<void> {
+    await api.post('/integrations/evolution_hub/whatsapp_connect', { inbox_id: inboxId, ...signup });
+  }
+
   async getPlan(): Promise<HubPlan> {
     const response = await api.get('/integrations/evolution_hub/plan');
     return extractData<HubPlan>(response);

--- a/src/services/integrations/evolutionHubService.ts
+++ b/src/services/integrations/evolutionHubService.ts
@@ -63,9 +63,11 @@ export interface HubConnectInfo {
 export interface HubWhatsappSignup {
   phone_number_id: string;
   waba_id: string;
-  business_id: string;
-  auth_code: string;
-  connection_mode?: string;
+  /** Optional on the Hub (omitempty); Meta does not always return them. */
+  business_id?: string;
+  auth_code?: string;
+  /** Required by the Hub's MetaConnectRequest binding. */
+  connection_mode: string;
 }
 
 class EvolutionHubService {


### PR DESCRIPTION
## O que muda

No modo **criar nova conexão** com WhatsApp Cloud via Evo Hub, o `FB.login` passa a rodar na própria página do CRM em vez de mandar o operador para a aba do Hub. O resultado do signup volta ao Hub pelos endpoints que entraram no backend (`evo-ai-crm-community#314`).

Depende daquele PR: sem ele, `getConnectInfo` falha e o componente cai na aba do Hub — o comportamento de hoje.

## A bifurcação, que é o ponto de atenção

O signup em página só acontece quando o `connect_info` devolve `meta_app_id` **e** `meta_config_id`. Testando contra o Hub de produção, um canal no **app compartilhado** não recebe esses campos: o front do próprio Hub tem fallback para o `VITE_META_APP_ID` do build dele (`v = n?.meta_app_id || QM.appId`), env que o CRM não tem.

Então hoje: canal BYO conclui na página; canal shared segue pela aba do Hub. Está registrado no card — as saídas são o Hub passar a mandar os campos no shared, ou o CRM ganhar config própria do app compartilhado.

A aba também segue como degradação quando o SDK não carrega, quando o canal está com `byo_config_missing` e quando `can_connect` vem `false`.

## Callback sem authResponse

Passa a ser erro tratado, com mensagem e volta ao estado anterior. É o caso do domínio não liberado em *Allowed Domains for the JS SDK* (CRM-363), do popup fechado e da permissão negada — o SDK não distingue os três. Hoje nem a página do Hub trata isso: o callback dela só age dentro de `if (authResponse)` e a tela fica "conectando" para sempre.

## Como validar

```
npx vitest run src/components/inbox/
```

10 exemplos. Os 5 novos cobrem: `FB.login` com o `config_id` do canal e sem abrir aba; queda para a aba quando faltam app/config; queda para a aba quando o `connect_info` falha; envio ao Hub dos ids da Meta junto do code; e o callback sem `authResponse`. Os 5 que já existiam continuam verdes.

## Fora deste PR

O `useFacebookSdk` foi criado e é usado pelo caminho novo, mas **não** refatorei `CloudWhatsappForm` e `FacebookChannelForm` para consumi-lo. Os dois são o caminho nativo (Hub desligado), que eu não consigo exercitar neste ambiente — `WP_APP_ID` e `WP_WHATSAPP_CONFIG_ID` estão vazios. Trocar o loader deles às cegas arriscaria o fluxo que hoje funciona; fica como limpeza própria.

## Summary by Sourcery

Conclua conexões Meta do WhatsApp Cloud dentro do CRM, preservando o fluxo pelo Hub como fallback e tratando falhas de forma explícita.

New Features:
- Conclua novas conexões WhatsApp Cloud via Meta Embedded Signup diretamente no CRM quando o Hub fornece a configuração do canal.
- Envie os dados de onboarding da Meta ao Evolution Hub para finalizar a conexão do canal.

Bug Fixes:
- Trate cancelamentos, autorizações sem `authResponse`, payloads incompletos e falhas do Hub sem deixar a interface presa no estado de conexão.
- Permita novas tentativas quando o carregamento do SDK da Meta falhar e evite carregamentos duplicados do script.

Enhancements:
- Mantenha a abertura do fluxo em uma aba do Hub como fallback quando a configuração não estiver disponível, o SDK falhar ou o canal não puder ser conectado.
- Exiba mensagens de erro estruturadas e estados de falha com opção de retomar a conexão pelo Hub.
- Adicione suporte de serviço e tipos para consultar informações de conexão e enviar dados do signup ao Hub.

Tests:
- Adicione testes para o fluxo Embedded Signup, fallbacks para o Hub, tratamento de erros e envio dos dados da Meta.
- Adicione testes para carregamento, timeout, reutilização e retry do SDK do Facebook.