### PR TITLE
fix(channels): estado desconhecido com sinal do provedor deixa de ser saudável (CRM-368)

### DIFF
--- a/src/utils/channelStatus.spec.ts
+++ b/src/utils/channelStatus.spec.ts
@@ -63,6 +63,12 @@ describe('deriveInboxStatus', () => {
     expect(deriveInboxStatus(inbox({ connection_state: 'error' }))).toBe('error');
   });
 
+  it('flags an unknown state that came WITH a provider signal', () => {
+    expect(
+      deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'provider_event' })),
+    ).toBe('attention');
+  });
+
   it('treats unmonitored (unknown) channels as active — explicit degrade, not broken', () => {
     expect(deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'none' }))).toBe('active');
   });

--- a/src/utils/channelStatus.ts
+++ b/src/utils/channelStatus.ts
@@ -77,8 +77,9 @@ export function resolveInboxConnectionState(
 /**
  * Hub-level status of a single configured inbox. A configured inbox is never
  * `available` — that only applies to a channel TYPE with no inboxes at all.
- * `unknown` counts as active: it means the type has no health signal
- * (explicit degrade), not that the channel is broken.
+ * `unknown` counts as active ONLY when there is no health signal at all
+ * (`health_source: 'none'`) — the explicit degrade. An `unknown` that came WITH a
+ * provider signal is a state we failed to map, not a healthy channel.
  */
 export function deriveInboxStatus(
   inbox: Inbox,
@@ -87,6 +88,7 @@ export function deriveInboxStatus(
   const state = resolveInboxConnectionState(inbox, live);
   if (state === 'error' || state === 'disconnected') return 'error';
   if (state === 'pending') return 'attention';
+  if (state === 'unknown' && inbox.health_source && inbox.health_source !== 'none') return 'attention';
   return 'active';
 }
 


### PR DESCRIPTION
## O que muda

`deriveInboxStatus` para de devolver `active` para um `connection_state: 'unknown'` que veio acompanhado de sinal do provedor.

## Por quê

A função tratava `error`/`disconnected`, tratava `pending`, e devolvia `active` para todo o resto. Para `unknown` com `health_source: 'none'` isso é deliberado e está documentado: o tipo de canal não emite sinal nenhum, e pintar de amarelo seria ruído. Esse caso continua igual, com o teste que já existia fixando.

O que não estava coberto: o `ConnectionStateResolver` também emite `unknown` com `health_source: 'provider_event'` — o ramo `else` dos status do Hub. Aí não é ausência de sinal, é um sinal que não soubemos mapear, e um canal nesse estado aparecia verde.

## Contexto

Saiu de uma sessão avaliando conexões de canal Meta via Evo Hub, onde uma inbox pendente não se distinguia das conectadas. O card CRM-368 registra os outros dois achados da mesma sessão: o canal órfão que sobra no CRM e no Hub quando o operador cancela o signup (consumindo quota do plano), e o estado por canal que o `buildChannelTypeStatuses` calcula em `inboxStates` mas o `ChannelTypeCard` não renderiza — ele mostra só o agregado do tipo.

## Como validar

```
npx vitest run src/utils/channelStatus.spec.ts src/components/channels/ChannelTypeHub.spec.tsx
```

16 + 12 exemplos. O novo cobre `unknown` + `provider_event` → `attention`; o antigo, `unknown` + `none` → `active`.

## Summary by Sourcery

Mark provider-signaled unknown channel states as requiring attention without changing the healthy fallback for channels that emit no health signal.

Bug Fixes:
- Treat unknown connection states accompanied by a provider signal as requiring attention instead of reporting them as active.

Enhancements:
- Preserve active status for unknown channels with no health signal, while documenting the distinction between an unmapped provider state and an intentionally unmonitored channel.

Tests:
- Add coverage for unknown provider-signaled states and retain coverage for unmonitored unknown channels.