### PR TITLE
fix(api): strip Content-Type for FormData uploads so the browser sets the multipart boundary

### DIFF
--- a/src/services/core/api.ts
+++ b/src/services/core/api.ts
@@ -69,7 +69,11 @@ api.interceptors.request.use(config => {
     config.headers.Authorization = authHeader.Authorization;
   }
 
-  if (config.data instanceof FormData && config.headers['Content-Type'] === undefined) {
+  if (config.data instanceof FormData) {
+    // The instance default sets Content-Type: application/json, which axios
+    // merges into config.headers before this interceptor runs — so it's
+    // never actually `undefined` here. Strip it unconditionally so the
+    // browser can set the correct multipart/form-data boundary itself.
     delete config.headers['Content-Type'];
     delete config.headers['content-type'];
   }

--- a/src/services/core/apiPublic.ts
+++ b/src/services/core/apiPublic.ts
@@ -19,9 +19,13 @@ apiPublic.interceptors.request.use((config) => {
     config.headers.Authorization = authHeader.Authorization;
   }
 
-  // Don't override Content-Type for FormData requests
-  if (config.data instanceof FormData && config.headers['Content-Type'] === undefined) {
+  // Don't override Content-Type for FormData requests. The instance default
+  // sets application/json, which axios merges into config.headers before
+  // this interceptor runs, so it's never actually `undefined` here — strip
+  // it unconditionally so the browser can set the multipart boundary itself.
+  if (config.data instanceof FormData) {
     delete config.headers['Content-Type'];
+    delete config.headers['content-type'];
   }
 
   return config;


### PR DESCRIPTION
## Summary
- Both `api.ts` and `apiPublic.ts` create their axios instance with a default header `Content-Type: application/json`. Axios merges instance defaults into `config.headers` **before** request interceptors run, so the existing guard `config.headers['Content-Type'] === undefined` for FormData bodies was never true — it was dead code.
- Practical effect: any `FormData` upload through these clients (e.g. the inbox avatar upload) went out with `Content-Type: application/json` and no multipart boundary, so the backend couldn't parse the file. The upload appeared to succeed in the UI (optimistic state) but the file was never actually persisted.
- Fix: strip `Content-Type` unconditionally whenever `config.data instanceof FormData`, so the browser can set the correct `multipart/form-data; boundary=...` header itself.

## Testing notes
- Reproduced against a live inbox avatar upload: before the fix, the PATCH request carried `Content-Type: application/json` with a payload far too small to contain the image; after the fix, the browser sets the multipart header and the avatar persists.
- No behavior change for JSON requests (the instance default still applies as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure FormData uploads are sent with browser-generated multipart headers so uploaded files are parsed and persisted correctly.

Bug Fixes:
- Fix FormData uploads in authenticated and public API clients by removing the default JSON Content-Type so browsers generate valid multipart boundaries.
- Preserve the existing JSON request Content-Type behavior for non-FormData requests.