### PR TITLE
feat: expose Lock to Single Conversation for Web Widget inboxes

### DIFF
--- a/src/pages/Customer/Channels/ChannelSettings.tsx
+++ b/src/pages/Customer/Channels/ChannelSettings.tsx
@@ -221,7 +221,7 @@ function useInbox(inbox: Inbox | null): InboxHook {
 
     // Can lock to single conversation
     const canLocktoSingleConversation =
-      isASmsInbox || isAWhatsAppChannel || isAFacebookInbox || isAPIInbox;
+      isASmsInbox || isAWhatsAppChannel || isAFacebookInbox || isAPIInbox || isAWebWidgetInbox;
 
     // Templates support - channels that support message templates
     const supportsTemplates =


### PR DESCRIPTION
## Summary
- `canLocktoSingleConversation` in `ChannelSettings.tsx` only included SMS/WhatsApp/Facebook/API inboxes, so the "Lock to Single Conversation" toggle was hidden for Web Widget channels — even though the setting itself (DB column, permitted param, and the `LockToSingleConversationForm` component) already exists and works end-to-end for those other channel types via `ConversationBuilder`.
- Adds `isAWebWidgetInbox` to that condition so the toggle is shown for widget inboxes too.
- Pairs with a companion fix in `evo-ai-crm-community` (PR to follow) that makes the widget's own conversation reuse/reopen logic actually honor this setting, matching `Whatsapp::IncomingMessageBaseService#set_conversation`'s semantics — previously a resolved widget conversation was always silently reused/reopened regardless of the setting, since the widget's controller never consulted `lock_to_single_conversation` at all.

## Testing notes
- Frontend-only change; no behavior change for non-widget inboxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Expose the “Lock to Single Conversation” setting for Web Widget inboxes.