### PR TITLE
fix(credentials): exige create no botão da instalação e cobre o scope no CREATE (CRM-413)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,11 @@ jobs:
       #   - contactsService.createContact / labelsService (CRM-321, CRM-381): the
       #     writes keep resolving to the unwrapped payload; re-declaring the envelope
       #     makes the caller unwrap twice and blank the page.
-      # The whole list runs in ~30s and is deterministic.
+      #   - AiCredentials / IntegrationCredentials (CRM-413): the scope privilege
+      #     stays ON TOP of the resource grant per verb, and a CREATE keeps
+      #     carrying its scope. Both are gates the server also enforces, so a
+      #     revert here only shows up as a 403 in the user's face.
+      # The whole list runs in ~35s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
       # forked workers take ~30min on the runner and flake on worker OOM (the
@@ -149,7 +153,9 @@ jobs:
             src/i18n/locales/i18n-parity.spec.ts \
             src/i18n/locales/macros-parity.spec.ts \
             src/services/contacts/contactsService.createContact.spec.ts \
-            src/services/contacts/labelsService.spec.ts
+            src/services/contacts/labelsService.spec.ts \
+            src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx \
+            src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/hooks/useCredentialScopePermissions.ts
+++ b/src/hooks/useCredentialScopePermissions.ts
@@ -1,0 +1,42 @@
+import { usePermissions } from '@/contexts/PermissionsContext';
+import type { ApiKeyScope } from '@/types/agents';
+
+/**
+ * The permission gate shared by the two credential screens (AI keys and
+ * integration credentials). They ask the same questions of two different
+ * resources, and when they each answered them on their own the two drifted:
+ * the same defect had to be fixed twice.
+ *
+ * The rule it encodes: the scope privilege sits ON TOP of the resource grant,
+ * never instead of it. The server checks BOTH — the verb on the route, and
+ * installation_configs.manage inside the handler when the scope is
+ * `installation` — so a control gated on only one of them is a dead end that
+ * ends in a 403. Per verb, because delete does not travel through update.
+ */
+export function useCredentialScopePermissions(resource: string) {
+  const { can, isReady: permissionsReady } = usePermissions();
+
+  const canRead = can(resource, 'read');
+  const canCreate = can(resource, 'create');
+  const canUpdate = can(resource, 'update');
+  const canDelete = can(resource, 'delete');
+  // Writing at the installation level is a separate privilege: an account admin
+  // sees the inherited default but cannot change it.
+  const canManageInstallation = can('installation_configs', 'manage');
+
+  const inScope = (granted: boolean, scope: ApiKeyScope) =>
+    granted && (scope === 'installation' ? canManageInstallation : true);
+
+  return {
+    can,
+    permissionsReady,
+    canRead,
+    canCreate,
+    canUpdate,
+    canDelete,
+    canManageInstallation,
+    canCreateInScope: (scope: ApiKeyScope) => inScope(canCreate, scope),
+    canUpdateInScope: (scope: ApiKeyScope) => inScope(canUpdate, scope),
+    canDeleteInScope: (scope: ApiKeyScope) => inScope(canDelete, scope),
+  };
+}

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { toast } from 'sonner';
 import AiCredentials from './AiCredentials';
@@ -401,6 +401,14 @@ describe('AiCredentials — deactivate keeps the row and can be undone (CRM-174)
 describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
   const findInstallationRow = () => screen.findByRole('cell', { name: 'Chave da casa' });
 
+  // Scoped to the section instead of indexed into getAllByText: the account's
+  // add button lives in the page header, so an index follows any layout change
+  // to the wrong button.
+  const installationSection = () => screen.getByLabelText('sections.installation');
+  const addInstallationButton = () => within(installationSection()).getByText('actions.add');
+  const addAccountButton = () =>
+    screen.getAllByText('actions.add').find(button => !installationSection().contains(button))!;
+
   beforeEach(() => {
     mockRegistry([OPENAI_KEY, INSTALLATION_KEY]);
   });
@@ -422,9 +430,7 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
     render(<AiCredentials />);
 
     await findInstallationRow();
-    // The section header carries its own add button.
-    const addButtons = screen.getAllByText('actions.add');
-    await user.click(addButtons[addButtons.length - 1]);
+    await user.click(addInstallationButton());
 
     await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da casa');
     await user.click(screen.getByLabelText('form.labels.provider'));
@@ -450,8 +456,7 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
     render(<AiCredentials />);
 
     await findInstallationRow();
-    // The page header's button is the account one, and it comes first.
-    await user.click(screen.getAllByText('actions.add')[0]);
+    await user.click(addAccountButton());
 
     await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da conta');
     await user.click(screen.getByLabelText('form.labels.provider'));
@@ -473,7 +478,35 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
     render(<AiCredentials />);
 
     await findInstallationRow();
-    expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
+    expect(within(installationSection()).queryByText('actions.add')).not.toBeInTheDocument();
+  });
+
+  // The same rule on the update axis: the PUT route demands ai_api_keys.update
+  // whatever the scope, so installation_configs.manage alone must not light up
+  // the edit controls.
+  it('keeps the installation row read-only without ai_api_keys.update', async () => {
+    granted = [
+      ...ALL_PERMISSIONS.filter(permission => permission !== 'ai_api_keys.update'),
+      'installation_configs.manage',
+    ];
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    expect(screen.queryAllByLabelText('actions.edit')).toHaveLength(0);
+    expect(screen.getByText('inheritedReadOnly')).toBeInTheDocument();
+  });
+
+  // Delete does not travel through update: dropping the update grant must not
+  // take the trash icon with it, on either row.
+  it('keeps the delete control without ai_api_keys.update', async () => {
+    granted = [
+      ...ALL_PERMISSIONS.filter(permission => permission !== 'ai_api_keys.update'),
+      'installation_configs.manage',
+    ];
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    expect(screen.getAllByLabelText('actions.delete')).toHaveLength(2);
   });
 
   it('renders installation credentials read-only without installation_configs.manage (AC2)', async () => {
@@ -616,6 +649,27 @@ describe('AiCredentials — creating (AC2)', () => {
     await user.click(screen.getByText('actions.save'));
 
     await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+  });
+
+  // handleSave used to run every save through the update gate, so a create-only
+  // grant was refused a credential the server would have accepted.
+  it('creates at account scope without ai_api_keys.update', async () => {
+    const user = userEvent.setup();
+    granted = ['ai_api_keys.read', 'ai_api_keys.create'];
+    createApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.add'));
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova');
+    await user.click(screen.getByLabelText('form.labels.provider'));
+    await user.click(await screen.findByRole('option', { name: 'OpenAI' }));
+    await user.type(screen.getByLabelText('form.labels.key'), 'sk-create-only');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createApiKey).toHaveBeenCalled());
+    expect(createApiKey.mock.calls[0][0]).toMatchObject({ scope: 'account' });
   });
 
   it('sends name, provider and key to the registry once the form is complete', async () => {

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx
@@ -427,12 +427,53 @@ describe('AiCredentials — installation scope (1.2 AC1, AC2)', () => {
     await user.click(addButtons[addButtons.length - 1]);
 
     await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da casa');
+    await user.click(screen.getByLabelText('form.labels.provider'));
+    await user.click(await screen.findByRole('option', { name: 'OpenAI' }));
     await user.type(screen.getByLabelText('form.labels.key'), 'sk-house-0002');
     await user.click(screen.getByText('actions.save'));
 
-    // Provider is still required, so nothing is sent — the scope plumbing is
-    // asserted by the payload test below.
-    await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+    // The whole point of the section: the CREATE carries scope 'installation',
+    // or the row lands on the account and the Evo default stays empty.
+    await waitFor(() => expect(createApiKey).toHaveBeenCalled());
+    expect(createApiKey.mock.calls[0][0]).toMatchObject({
+      name: 'Nova da casa',
+      provider: 'openai',
+      key_value: 'sk-house-0002',
+      scope: 'installation',
+    });
+  });
+
+  it('sends scope account when the add button of the account section is used', async () => {
+    const user = userEvent.setup();
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    createApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    // The page header's button is the account one, and it comes first.
+    await user.click(screen.getAllByText('actions.add')[0]);
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da conta');
+    await user.click(screen.getByLabelText('form.labels.provider'));
+    await user.click(await screen.findByRole('option', { name: 'OpenAI' }));
+    await user.type(screen.getByLabelText('form.labels.key'), 'sk-acct-0003');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createApiKey).toHaveBeenCalled());
+    expect(createApiKey.mock.calls[0][0]).toMatchObject({ scope: 'account' });
+  });
+
+  // The scope privilege is ON TOP of ai_api_keys.create, not instead of it:
+  // offering the button to someone the server will refuse is a dead end.
+  it('hides the installation add button without ai_api_keys.create', async () => {
+    granted = [
+      ...ALL_PERMISSIONS.filter(permission => permission !== 'ai_api_keys.create'),
+      'installation_configs.manage',
+    ];
+    render(<AiCredentials />);
+
+    await findInstallationRow();
+    expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
   });
 
   it('renders installation credentials read-only without installation_configs.manage (AC2)', async () => {
@@ -562,7 +603,7 @@ describe('AiCredentials — in-use panel (1.2 AC9)', () => {
 });
 
 describe('AiCredentials — creating (AC2)', () => {
-  it('sends name, provider and key to the registry', async () => {
+  it('blocks the save when the provider was never picked', async () => {
     const user = userEvent.setup();
     createApiKey.mockResolvedValue(OPENAI_KEY);
     render(<AiCredentials />);
@@ -574,8 +615,30 @@ describe('AiCredentials — creating (AC2)', () => {
     await user.type(screen.getByLabelText('form.labels.key'), 'sk-nova-0001');
     await user.click(screen.getByText('actions.save'));
 
-    // Provider is required, so an untouched select must block the save.
     await waitFor(() => expect(createApiKey).not.toHaveBeenCalled());
+  });
+
+  it('sends name, provider and key to the registry once the form is complete', async () => {
+    const user = userEvent.setup();
+    createApiKey.mockResolvedValue(OPENAI_KEY);
+    render(<AiCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.add'));
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova');
+    await user.click(screen.getByLabelText('form.labels.provider'));
+    await user.click(await screen.findByRole('option', { name: 'Anthropic' }));
+    await user.type(screen.getByLabelText('form.labels.key'), 'sk-nova-0001');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createApiKey).toHaveBeenCalled());
+    expect(createApiKey.mock.calls[0][0]).toMatchObject({
+      name: 'Nova',
+      provider: 'anthropic',
+      key_value: 'sk-nova-0001',
+      scope: 'account',
+    });
   });
 });
 

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { usePermissions } from '@/contexts/PermissionsContext';
+import { useCredentialScopePermissions } from '@/hooks/useCredentialScopePermissions';
 import { toast } from 'sonner';
 import {
   Badge,
@@ -58,7 +58,6 @@ const EMPTY_DRAFT: CredentialDraft = {
 
 export default function AiCredentials() {
   const { t } = useLanguage('aiCredentials');
-  const { can, isReady: permissionsReady } = usePermissions();
 
   const [credentials, setCredentials] = useState<ApiKey[]>([]);
   // The server's word on the legacy fallback: 'pending' while a request is in
@@ -75,13 +74,13 @@ export default function AiCredentials() {
   const [credentialToDelete, setCredentialToDelete] = useState<ApiKey | null>(null);
   const [agentsUsingCredential, setAgentsUsingCredential] = useState<string[]>([]);
 
-  const canRead = can('ai_api_keys', 'read');
-  const canCreate = can('ai_api_keys', 'create');
-  const canUpdate = can('ai_api_keys', 'update');
-  const canDelete = can('ai_api_keys', 'delete');
-  // Writing at the installation level is a separate privilege: an account admin
-  // sees the inherited default but cannot change it.
-  const canManageInstallation = can('installation_configs', 'manage');
+  const {
+    permissionsReady,
+    canRead,
+    canCreateInScope,
+    canUpdateInScope,
+    canDeleteInScope,
+  } = useCredentialScopePermissions('ai_api_keys');
 
   const isEditing = Boolean(draft.id);
 
@@ -242,16 +241,6 @@ export default function AiCredentials() {
     setFormOpen(true);
   };
 
-  // The scope privilege sits ON TOP of the ai_api_keys.* grant, never instead
-  // of it: the server checks BOTH (the route verb and, for the installation
-  // scope, installation_configs.manage), so a control gated on only one is a
-  // dead end. Per verb, because delete does not imply update.
-  const canInScope = (granted: boolean, scope: ApiKeyScope) =>
-    granted && (scope === 'installation' ? canManageInstallation : true);
-
-  const canCreateInScope = (scope: ApiKeyScope) => canInScope(canCreate, scope);
-  const canUpdateInScope = (scope: ApiKeyScope) => canInScope(canUpdate, scope);
-  const canDeleteInScope = (scope: ApiKeyScope) => canInScope(canDelete, scope);
 
   const handleSave = async () => {
     const needsKey = !isEditing;

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -242,16 +242,16 @@ export default function AiCredentials() {
     setFormOpen(true);
   };
 
-  // Editing an installation credential needs the installation privilege;
-  // account credentials only need ai_api_keys.update.
-  const canWriteScope = (scope: ApiKeyScope) =>
-    scope === 'installation' ? canManageInstallation : canUpdate;
+  // The scope privilege sits ON TOP of the ai_api_keys.* grant, never instead
+  // of it: the server checks BOTH (the route verb and, for the installation
+  // scope, installation_configs.manage), so a control gated on only one is a
+  // dead end. Per verb, because delete does not imply update.
+  const canInScope = (granted: boolean, scope: ApiKeyScope) =>
+    granted && (scope === 'installation' ? canManageInstallation : true);
 
-  // The scope privilege sits ON TOP of ai_api_keys.create, not instead of it:
-  // an installation admin without create would otherwise get a button the
-  // server rejects.
-  const canCreateInScope = (scope: ApiKeyScope) =>
-    canCreate && (scope === 'installation' ? canManageInstallation : true);
+  const canCreateInScope = (scope: ApiKeyScope) => canInScope(canCreate, scope);
+  const canUpdateInScope = (scope: ApiKeyScope) => canInScope(canUpdate, scope);
+  const canDeleteInScope = (scope: ApiKeyScope) => canInScope(canDelete, scope);
 
   const handleSave = async () => {
     const needsKey = !isEditing;
@@ -260,7 +260,7 @@ export default function AiCredentials() {
       return;
     }
 
-    const allowed = isEditing ? canWriteScope(draft.scope) : canCreateInScope(draft.scope);
+    const allowed = isEditing ? canUpdateInScope(draft.scope) : canCreateInScope(draft.scope);
     if (!allowed) {
       toast.error(t('messages.permissionDenied.installation'));
       return;
@@ -399,7 +399,7 @@ export default function AiCredentials() {
   }
 
   const renderCredentialsTable = (rows: ApiKey[], scope: ApiKeyScope) => {
-    const writable = canWriteScope(scope);
+    const writable = canUpdateInScope(scope);
 
     return (
       <div className="overflow-x-auto border rounded-lg">
@@ -458,7 +458,7 @@ export default function AiCredentials() {
                         </span>
                       )
                     )}
-                    {canDelete && writable && (
+                    {canDeleteInScope(scope) && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -485,7 +485,7 @@ export default function AiCredentials() {
           <h1 className="text-2xl font-semibold">{t('title')}</h1>
           <p className="text-muted-foreground">{t('description')}</p>
         </div>
-        {canCreate && (
+        {canCreateInScope('account') && (
           <Button onClick={() => openCreateForm('account')}>
             <Plus className="mr-2 h-4 w-4" />
             {t('actions.add')}
@@ -544,7 +544,7 @@ export default function AiCredentials() {
             title={t('empty.title')}
             description={t('empty.description')}
             action={
-              canCreate
+              canCreateInScope('account')
                 ? { label: t('actions.addFirst'), onClick: () => openCreateForm('account') }
                 : undefined
             }

--- a/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
+++ b/src/pages/Customer/Settings/AiCredentials/AiCredentials.tsx
@@ -247,6 +247,12 @@ export default function AiCredentials() {
   const canWriteScope = (scope: ApiKeyScope) =>
     scope === 'installation' ? canManageInstallation : canUpdate;
 
+  // The scope privilege sits ON TOP of ai_api_keys.create, not instead of it:
+  // an installation admin without create would otherwise get a button the
+  // server rejects.
+  const canCreateInScope = (scope: ApiKeyScope) =>
+    canCreate && (scope === 'installation' ? canManageInstallation : true);
+
   const handleSave = async () => {
     const needsKey = !isEditing;
     if (!draft.name.trim() || !draft.provider || (needsKey && !draft.key_value.trim())) {
@@ -254,7 +260,8 @@ export default function AiCredentials() {
       return;
     }
 
-    if (!canWriteScope(draft.scope)) {
+    const allowed = isEditing ? canWriteScope(draft.scope) : canCreateInScope(draft.scope);
+    if (!allowed) {
       toast.error(t('messages.permissionDenied.installation'));
       return;
     }
@@ -552,7 +559,7 @@ export default function AiCredentials() {
           <h2 className="text-sm font-medium uppercase text-muted-foreground">
             {t('sections.installation')}
           </h2>
-          {canManageInstallation && (
+          {canCreateInScope('installation') && (
             <Button variant="outline" size="sm" onClick={() => openCreateForm('installation')}>
               <Plus className="mr-2 h-4 w-4" />
               {t('actions.add')}

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -232,6 +232,26 @@ describe('IntegrationCredentials — creating only static (AC2, AC4)', () => {
     expect(payload.scope).toBe('account');
   });
 
+  // handleSave used to run every save through the update gate, so a create-only
+  // grant was refused a credential the server would have accepted.
+  it('creates at account scope without ai_integration_credentials.update', async () => {
+    const user = userEvent.setup();
+    granted = ['ai_integration_credentials.read', 'ai_integration_credentials.create'];
+    createIntegrationCredential.mockResolvedValue(DIFY_CREDENTIAL);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getByText('actions.add'));
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova');
+    await user.type(screen.getByLabelText('form.labels.provider'), 'dify');
+    await user.type(screen.getByLabelText('form.labels.value'), 'create-only-0001');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createIntegrationCredential).toHaveBeenCalled());
+    expect(createIntegrationCredential.mock.calls[0][0]).toMatchObject({ scope: 'account' });
+  });
+
   it('blocks the save when name, provider or value is missing', async () => {
     const user = userEvent.setup();
     render(<IntegrationCredentials />);
@@ -367,11 +387,17 @@ describe('IntegrationCredentials — OAuth connections section (2.5 AC1, AC2, AC
 });
 
 // EVO-2250 story 2.2: the installation link of the chain. Writing at that
-// level is gated on installation_configs.manage, NOT on the update grant of
-// the resource — the negative proofs below fail if the component ever swaps
-// canManageInstallation for canUpdate.
+// level needs installation_configs.manage ON TOP of the resource grant for the
+// verb in play — never one instead of the other. The negative proofs below fail
+// if the component ever swaps one for the other, in either direction.
 describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
   const findInstallationRow = () => screen.findByRole('cell', { name: 'n8n da casa' });
+
+  // Scoped to the section instead of indexed into getAllByText: the account's
+  // add button lives in the page header, so an index follows any layout change
+  // to the wrong button.
+  const installationSection = () => screen.getByLabelText('sections.installation');
+  const addInstallationButton = () => within(installationSection()).getByText('actions.add');
 
   beforeEach(() => {
     listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, INSTALLATION_CREDENTIAL]);
@@ -437,9 +463,7 @@ describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
     render(<IntegrationCredentials />);
 
     await findInstallationRow();
-    // The section header's add button is the second one on the page.
-    const addButtons = screen.getAllByText('actions.add');
-    await user.click(addButtons[addButtons.length - 1]);
+    await user.click(addInstallationButton());
 
     await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da casa');
     await user.type(screen.getByLabelText('form.labels.provider'), 'n8n');
@@ -451,6 +475,7 @@ describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
       name: 'Nova da casa',
       provider: 'n8n',
       value: 'house-secret-0002',
+      kind: 'static',
       scope: 'installation',
     });
   });
@@ -468,7 +493,39 @@ describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
     render(<IntegrationCredentials />);
 
     await findInstallationRow();
-    expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
+    expect(within(installationSection()).queryByText('actions.add')).not.toBeInTheDocument();
+  });
+
+  // The same rule on the update axis: the PUT route demands
+  // ai_integration_credentials.update whatever the scope, so
+  // installation_configs.manage alone must not light up the edit controls.
+  it('keeps the installation row read-only without ai_integration_credentials.update', async () => {
+    granted = [
+      ...ALL_PERMISSIONS.filter(
+        permission => permission !== 'ai_integration_credentials.update',
+      ),
+      'installation_configs.manage',
+    ];
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    expect(screen.queryAllByLabelText('actions.edit')).toHaveLength(0);
+    expect(screen.getByText('inheritedReadOnly')).toBeInTheDocument();
+  });
+
+  // Delete does not travel through update: dropping the update grant must not
+  // take the trash icon with it, on either row.
+  it('keeps the delete control without ai_integration_credentials.update', async () => {
+    granted = [
+      ...ALL_PERMISSIONS.filter(
+        permission => permission !== 'ai_integration_credentials.update',
+      ),
+      'installation_configs.manage',
+    ];
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    expect(screen.getAllByLabelText('actions.delete')).toHaveLength(2);
   });
 
   it('shows the empty hint when the installation has nothing', async () => {

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -227,6 +227,9 @@ describe('IntegrationCredentials — creating only static (AC2, AC4)', () => {
     const [payload] = createIntegrationCredential.mock.calls[0];
     expect(payload.kind).toBe('static');
     expect(payload.value).toBe('app-secret-0001');
+    // The page-level button is the account one: without this the row could
+    // silently land at another scope.
+    expect(payload.scope).toBe('account');
   });
 
   it('blocks the save when name, provider or value is missing', async () => {
@@ -422,6 +425,50 @@ describe('IntegrationCredentials — installation scope (2.2 AC8)', () => {
     const [id, payload] = updateIntegrationCredential.mock.calls[0];
     expect(id).toBe('cred-installation');
     expect(payload.scope).toBe('installation');
+  });
+
+  // The whole point of the section: the CREATE carries scope 'installation',
+  // or the row lands on the account and the Evo default stays empty. Updating
+  // an existing row cannot prove this — it inherits the scope it already had.
+  it('lets an installation admin CREATE at that level, carrying the scope', async () => {
+    const user = userEvent.setup();
+    granted = [...ALL_PERMISSIONS, 'installation_configs.manage'];
+    createIntegrationCredential.mockResolvedValue(INSTALLATION_CREDENTIAL);
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    // The section header's add button is the second one on the page.
+    const addButtons = screen.getAllByText('actions.add');
+    await user.click(addButtons[addButtons.length - 1]);
+
+    await user.type(await screen.findByLabelText('form.labels.name'), 'Nova da casa');
+    await user.type(screen.getByLabelText('form.labels.provider'), 'n8n');
+    await user.type(screen.getByLabelText('form.labels.value'), 'house-secret-0002');
+    await user.click(screen.getByText('actions.save'));
+
+    await waitFor(() => expect(createIntegrationCredential).toHaveBeenCalled());
+    expect(createIntegrationCredential.mock.calls[0][0]).toMatchObject({
+      name: 'Nova da casa',
+      provider: 'n8n',
+      value: 'house-secret-0002',
+      scope: 'installation',
+    });
+  });
+
+  // The scope privilege is ON TOP of ai_integration_credentials.create, not
+  // instead of it: offering the button to someone the server will refuse is a
+  // dead end.
+  it('hides the installation add button without ai_integration_credentials.create', async () => {
+    granted = [
+      ...ALL_PERMISSIONS.filter(
+        permission => permission !== 'ai_integration_credentials.create',
+      ),
+      'installation_configs.manage',
+    ];
+    render(<IntegrationCredentials />);
+
+    await findInstallationRow();
+    expect(screen.queryByText('actions.add')).not.toBeInTheDocument();
   });
 
   it('shows the empty hint when the installation has nothing', async () => {

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -228,16 +228,16 @@ export default function IntegrationCredentials() {
     setFormOpen(true);
   };
 
-  // Editing an installation credential needs the installation privilege;
-  // account credentials only need ai_integration_credentials.update.
-  const canWriteScope = (scope: ApiKeyScope) =>
-    scope === 'installation' ? canManageInstallation : canUpdate;
+  // The scope privilege sits ON TOP of the ai_integration_credentials.* grant, never instead
+  // of it: the server checks BOTH (the route verb and, for the installation
+  // scope, installation_configs.manage), so a control gated on only one is a
+  // dead end. Per verb, because delete does not imply update.
+  const canInScope = (granted: boolean, scope: ApiKeyScope) =>
+    granted && (scope === 'installation' ? canManageInstallation : true);
 
-  // The scope privilege sits ON TOP of ai_integration_credentials.create, not
-  // instead of it: an installation admin without create would otherwise get a
-  // button the server rejects.
-  const canCreateInScope = (scope: ApiKeyScope) =>
-    canCreate && (scope === 'installation' ? canManageInstallation : true);
+  const canCreateInScope = (scope: ApiKeyScope) => canInScope(canCreate, scope);
+  const canUpdateInScope = (scope: ApiKeyScope) => canInScope(canUpdate, scope);
+  const canDeleteInScope = (scope: ApiKeyScope) => canInScope(canDelete, scope);
 
   const openEditForm = (credential: IntegrationCredential) => {
     setDraft({
@@ -257,7 +257,7 @@ export default function IntegrationCredentials() {
       return;
     }
 
-    const allowed = isEditing ? canWriteScope(draft.scope) : canCreateInScope(draft.scope);
+    const allowed = isEditing ? canUpdateInScope(draft.scope) : canCreateInScope(draft.scope);
     if (!allowed) {
       toast.error(t('messages.permissionDenied.installation'));
       return;
@@ -380,7 +380,7 @@ export default function IntegrationCredentials() {
   }
 
   const renderCredentialsTable = (rows: IntegrationCredential[], scope: ApiKeyScope) => {
-    const writable = canWriteScope(scope);
+    const writable = canUpdateInScope(scope);
 
     return (
       <div className="overflow-x-auto border rounded-lg">
@@ -437,7 +437,7 @@ export default function IntegrationCredentials() {
                         </span>
                       )
                     )}
-                    {canDelete && writable && (
+                    {canDeleteInScope(scope) && (
                       <Button
                         variant="ghost"
                         size="sm"
@@ -464,7 +464,7 @@ export default function IntegrationCredentials() {
           <h1 className="text-2xl font-semibold">{t('title')}</h1>
           <p className="text-muted-foreground">{t('description')}</p>
         </div>
-        {canCreate && (
+        {canCreateInScope('account') && (
           <Button onClick={() => openCreateForm('account')}>
             <Plus className="mr-2 h-4 w-4" />
             {t('actions.add')}
@@ -511,7 +511,7 @@ export default function IntegrationCredentials() {
             title={t('empty.title')}
             description={t('empty.description')}
             action={
-              canCreate
+              canCreateInScope('account')
                 ? { label: t('actions.addFirst'), onClick: () => openCreateForm('account') }
                 : undefined
             }

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -233,6 +233,12 @@ export default function IntegrationCredentials() {
   const canWriteScope = (scope: ApiKeyScope) =>
     scope === 'installation' ? canManageInstallation : canUpdate;
 
+  // The scope privilege sits ON TOP of ai_integration_credentials.create, not
+  // instead of it: an installation admin without create would otherwise get a
+  // button the server rejects.
+  const canCreateInScope = (scope: ApiKeyScope) =>
+    canCreate && (scope === 'installation' ? canManageInstallation : true);
+
   const openEditForm = (credential: IntegrationCredential) => {
     setDraft({
       id: credential.id,
@@ -251,7 +257,8 @@ export default function IntegrationCredentials() {
       return;
     }
 
-    if (!canWriteScope(draft.scope)) {
+    const allowed = isEditing ? canWriteScope(draft.scope) : canCreateInScope(draft.scope);
+    if (!allowed) {
       toast.error(t('messages.permissionDenied.installation'));
       return;
     }
@@ -519,7 +526,7 @@ export default function IntegrationCredentials() {
           <h2 className="text-sm font-medium uppercase text-muted-foreground">
             {t('sections.installation')}
           </h2>
-          {canManageInstallation && (
+          {canCreateInScope('installation') && (
             <Button variant="outline" size="sm" onClick={() => openCreateForm('installation')}>
               <Plus className="mr-2 h-4 w-4" />
               {t('actions.add')}

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { usePermissions } from '@/contexts/PermissionsContext';
+import { useCredentialScopePermissions } from '@/hooks/useCredentialScopePermissions';
 import { toast } from 'sonner';
 import {
   Badge,
@@ -77,7 +77,6 @@ interface ConsumerInUse {
 
 export default function IntegrationCredentials() {
   const { t } = useLanguage('integrationCredentials');
-  const { can, isReady: permissionsReady } = usePermissions();
 
   const [credentials, setCredentials] = useState<IntegrationCredential[]>([]);
   const [loading, setLoading] = useState(false);
@@ -89,14 +88,14 @@ export default function IntegrationCredentials() {
     useState<IntegrationCredential | null>(null);
   const [consumersInUse, setConsumersInUse] = useState<ConsumerInUse[]>([]);
 
-  const canRead = can('ai_integration_credentials', 'read');
-  const canCreate = can('ai_integration_credentials', 'create');
-  const canUpdate = can('ai_integration_credentials', 'update');
-  const canDelete = can('ai_integration_credentials', 'delete');
-  // Writing at the installation level is a separate privilege: an account admin
-  // sees the inherited default but cannot change it (story 2.2, same rule as
-  // the AI credentials screen).
-  const canManageInstallation = can('installation_configs', 'manage');
+  const {
+    can,
+    permissionsReady,
+    canRead,
+    canCreateInScope,
+    canUpdateInScope,
+    canDeleteInScope,
+  } = useCredentialScopePermissions('ai_integration_credentials');
   // Disconnecting delegates to the agent-integration flow, which the backend
   // gates on ai_agents.update — the vault grants play no part here.
   const canDisconnect = can('ai_agents', 'update');
@@ -228,16 +227,6 @@ export default function IntegrationCredentials() {
     setFormOpen(true);
   };
 
-  // The scope privilege sits ON TOP of the ai_integration_credentials.* grant, never instead
-  // of it: the server checks BOTH (the route verb and, for the installation
-  // scope, installation_configs.manage), so a control gated on only one is a
-  // dead end. Per verb, because delete does not imply update.
-  const canInScope = (granted: boolean, scope: ApiKeyScope) =>
-    granted && (scope === 'installation' ? canManageInstallation : true);
-
-  const canCreateInScope = (scope: ApiKeyScope) => canInScope(canCreate, scope);
-  const canUpdateInScope = (scope: ApiKeyScope) => canInScope(canUpdate, scope);
-  const canDeleteInScope = (scope: ApiKeyScope) => canInScope(canDelete, scope);
 
   const openEditForm = (credential: IntegrationCredential) => {
     setDraft({


### PR DESCRIPTION
## O que muda

Dois achados da revisão do CRM-413, nas duas telas de credenciais.

### 1. O botão da seção installation não exigia `create`

O botão "adicionar" da seção installation era gated só por `installation_configs.manage`, enquanto o da conta exige `create`. Quem tinha a permissão de instalação e **não** tinha `ai_api_keys.create` (ou `ai_integration_credentials.create`) ganhava um botão que o servidor recusa.

O privilégio de escopo vem **por cima** do create, não no lugar dele. `canCreateInScope` passa a exigir os dois, e o `handleSave` recheca o create no ramo de criação em vez de só o de update.

### 2. Nenhum teste assertava `scope` num payload de CREATE

Os dois testes chamados `sends the scope` eram **update** — que não prova nada aqui, porque um update herda o escopo que a linha já tinha.

E o teste chamado `lets an installation admin add a credential at that level` afirmava `expect(createApiKey).not.toHaveBeenCalled()`: o formulário nunca preenchia o provider obrigatório, então nada era criado. O comentário dentro dele remetia a "the payload test below", que também era um update.

Ou seja: o caminho que a seção installation existe para exercitar — criar uma credencial **com `scope: 'installation'`** — não tinha cobertura nenhuma nas duas telas.

Os testes agora completam o formulário (inclusive operando o Select de provider, que os polyfills de `src/test/setup.ts` já suportavam) e afirmam o payload, nos dois escopos e nas duas telas, mais o gate do item 1. O que era misnomer foi renomeado para o que de fato verifica.

## Testes

**86 testes nas duas telas, todos passando** (eram 81).

⚠️ A suíte completa do repo tem **49 falhas em 10 arquivos** (`ChatSidebar`, `ContactAvatar`, `tokens.contrast`, `Sidebar`, `MainLayout`, `MessageList`, `opusRecorder`, `NewChannel`, `Chat`, `lastSavedMark`). **Elas são pré-existentes, não desta PR** — rodei os mesmos 10 arquivos no commit base `85eff52` e o resultado é idêntico, 49 falhas e 40 passando. Nenhum deles toca as telas de credenciais. Vale um card à parte.

## Contexto

Faz parte do CRM-413. O grosso do card (a camada da agência no fallback BYO) está em evolution-foundation/evo-enterprise-licensing-ruby#116; a tela, em evolution-foundation/evolution-ecosystem-frontend#110. Esta PR é independente das duas — pode entrar em qualquer ordem.

### 3. O CREATE no escopo conta exigia `update` (corrigido junto, faltava dizer)

`handleSave` rodava **todo** save pelo `canWriteScope`, que no escopo conta é
`canUpdate`. Ou seja: quem tinha `create` e não tinha `update` levava
"permissão negada" numa criação que o servidor teria aceitado (a rota do POST
pede só o create). O `canCreateInScope` no ramo de criação conserta isso — e
agora tem teste (`creates at account scope without ai_*.update`).

### 4. O gate de escopo por verbo, e as telas no CI

Segunda leva, dos achados da revisão desta própria PR:

- O privilégio de escopo estava por cima do create mas continuava **no lugar
  do update**: `installation_configs.manage` sozinho acendia Editar e
  Ativar/Desativar na linha da installation, e o PUT recusa sem
  `ai_api_keys.update`. `canWriteScope` virou `canInScope(grant, scope)` com um
  helper por verbo — o que também separa o **delete** do update (o ícone de
  lixeira dependia dos dois; o DELETE nunca pediu update).
- **Nenhum dos dois specs estava na lista opt-in do `test.yml`**, então o check
  verde desta PR não rodava um único dos testes que ela adiciona. Entraram na
  lista: 5,1s somados, 100% mockados — os três critérios que o próprio workflow
  define.
- Seleção de botão por índice no DOM trocada por `within(seção)`; a asserção do
  gate passa a olhar só a seção que o nome do teste promete; `kind: 'static'`
  afirmado também no CREATE da installation.

**92 testes nas duas telas** (eram 86; eram 81 antes da PR).

## Summary by Sourcery

Align credential screen authorization with server-side verb and scope requirements, and cover the corrected behavior with focused tests.

Bug Fixes:
- Ensure credential creation, editing, and deletion controls require the appropriate resource permission together with installation-scope privileges.
- Allow account-scope credential creation with only the create permission and include the selected scope in create requests.

Enhancements:
- Share credential scope permission logic between AI and integration credential screens with verb-specific checks.

CI:
- Add both credential screen test suites to the CI opt-in test workflow.

Tests:
- Expand coverage for account and installation credential creation payloads and scope-based permission gates.
