### PR TITLE
fix(chat): reflect contact name changes in realtime without a refresh (CRM-445)

### DIFF
--- a/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
+++ b/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import type { Conversation } from '@/types/chat/api';
+
+// Capture the handlers the WebSocketProvider hands to the socket layer, so the
+// test can push a real contact.updated frame through the whole chain.
+let capturedHandlers: Record<string, ((data: unknown) => void) | undefined> = {};
+
+vi.mock('@/hooks/chat/useWebSocket', () => ({
+  useWebSocket: (_userId: string, _token: string, opts: { handlers?: typeof capturedHandlers }) => {
+    capturedHandlers = opts?.handlers ?? {};
+    return { isConnected: false, sendTypingOn: vi.fn(), sendTypingOff: vi.fn() };
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1', pubsub_token: 'token-1' } }),
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+import { ChatProvider, useChatContext } from './ChatContext';
+
+// REST payload shape: `contact` present, no `meta` (ConversationSerializer).
+const restConversation = {
+  id: 'conv-rest',
+  uuid: 'conv-rest',
+  display_id: '1',
+  status: 'open',
+  contact: { id: 'contact-1', name: '553140204020' },
+} as unknown as Conversation;
+
+function Probe() {
+  const chat = useChatContext();
+  const { setConversations, state } = chat.conversations;
+
+  React.useEffect(() => {
+    setConversations([restConversation]);
+  }, [setConversations]);
+
+  return <span data-testid="name">{state.conversations[0]?.contact?.name ?? ''}</span>;
+}
+
+describe('ChatContext contact.updated end-to-end', () => {
+  beforeEach(() => {
+    capturedHandlers = {};
+    localStorage.clear();
+  });
+
+  it('a contact.updated frame renames the contact of a REST-loaded conversation', async () => {
+    render(
+      <ChatProvider>
+        <Probe />
+      </ChatProvider>,
+    );
+
+    expect(screen.getByTestId('name').textContent).toBe('553140204020');
+
+    // Covers the hop the unit specs miss: ChatContext registering the provider
+    // handler onto updateContactInConversations.
+    await act(async () => {
+      capturedHandlers.onContactUpdated?.({
+        id: 'contact-1',
+        name: 'João Silva',
+        account_id: 'account-1',
+        custom_attributes: {},
+        additional_attributes: {},
+      });
+    });
+
+    expect(screen.getByTestId('name').textContent).toBe('João Silva');
+  });
+});

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -568,6 +568,13 @@ function useChatIntegration() {
       onConversationLastActivity: (conversationId: string, lastActivityAt: string) => {
         conversations.updateConversationLastActivity(conversationId, lastActivityAt);
       },
+
+      onContactUpdated: contact => {
+        if (!contact || !contact.id) {
+          return;
+        }
+        conversations.updateContactInConversations(contact);
+      },
     });
   }, [websocket, messages, conversations, currentUser, shouldReloadMessageForMissingImageData]);
 

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -570,9 +570,6 @@ function useChatIntegration() {
       },
 
       onContactUpdated: contact => {
-        if (!contact || !contact.id) {
-          return;
-        }
         conversations.updateContactInConversations(contact);
       },
     });

--- a/src/contexts/chat/ConversationsContext.spec.tsx
+++ b/src/contexts/chat/ConversationsContext.spec.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { conversationsReducer } from './ConversationsContextReducer';
 import { initialState } from '@/types/chat/conversations';
-import type { Conversation } from '@/types/chat/api';
+import type { Conversation, Contact } from '@/types/chat/api';
 import { matchesConversationId } from '@/utils/chat/conversationMatcher';
 
 // Test fixtures admit numeric ids because the backend / WebSocket can deliver
@@ -455,6 +455,73 @@ describe('ConversationsContext reducer', () => {
       expect(next.conversationsPagination?.total).toBe(42);
       expect(next.conversationsPagination?.total_pages).toBe(3);
       expect(next.conversationsPagination?.has_next_page).toBe(true);
+    });
+  });
+
+  describe('UPDATE_CONTACT_IN_CONVERSATIONS (contact name realtime)', () => {
+    // A conversation whose contact + meta.sender share the same id, starting
+    // with a not-yet-resolved phone-as-name (the WhatsApp inbound case).
+    const makeConvWithContact = (name: string): Conversation =>
+      makeConversation({
+        id: 'conv-c',
+        uuid: 'conv-c',
+        contact: { id: 'contact-1', name },
+        meta: { sender: { id: 'contact-1', name, type: 'contact' } },
+      } as unknown as Partial<ConversationFixture>);
+
+    it('patches conversation.contact.name so the chat sidebar/header reflect the resolved name without a REST refresh', () => {
+      const state = {
+        ...initialState,
+        conversations: [makeConvWithContact('553140204020')],
+      };
+
+      const next = conversationsReducer(state, {
+        type: 'UPDATE_CONTACT_IN_CONVERSATIONS',
+        payload: { id: 'contact-1', name: 'João Silva' } as Contact,
+      });
+
+      // The chat sidebar/header render `conversation.contact?.name` — this is
+      // the assertion the pre-fix reducer failed (it patched only meta.sender).
+      expect(next.conversations[0].contact?.name).toBe('João Silva');
+      // meta.sender stays in sync (pre-existing behavior, guards a regression).
+      expect(next.conversations[0].meta?.sender?.name).toBe('João Silva');
+    });
+
+    it('patches selectedConversationData.contact for the currently open conversation', () => {
+      const state = {
+        ...initialState,
+        selectedConversationId: 'conv-c',
+        selectedConversationData: makeConvWithContact('553140204020'),
+        conversations: [makeConvWithContact('553140204020')],
+      };
+
+      const next = conversationsReducer(state, {
+        type: 'UPDATE_CONTACT_IN_CONVERSATIONS',
+        payload: { id: 'contact-1', name: 'João Silva' } as Contact,
+      });
+
+      expect(next.selectedConversationData?.contact?.name).toBe('João Silva');
+    });
+
+    it('leaves conversations of other contacts untouched', () => {
+      const state = {
+        ...initialState,
+        conversations: [
+          makeConversation({
+            id: 'conv-other',
+            uuid: 'conv-other',
+            contact: { id: 'contact-2', name: 'Maria' },
+            meta: { sender: { id: 'contact-2', name: 'Maria', type: 'contact' } },
+          } as unknown as Partial<ConversationFixture>),
+        ],
+      };
+
+      const next = conversationsReducer(state, {
+        type: 'UPDATE_CONTACT_IN_CONVERSATIONS',
+        payload: { id: 'contact-1', name: 'João Silva' } as Contact,
+      });
+
+      expect(next.conversations[0].contact?.name).toBe('Maria');
     });
   });
 });

--- a/src/contexts/chat/ConversationsContext.spec.tsx
+++ b/src/contexts/chat/ConversationsContext.spec.tsx
@@ -459,14 +459,23 @@ describe('ConversationsContext reducer', () => {
   });
 
   describe('UPDATE_CONTACT_IN_CONVERSATIONS (contact name realtime)', () => {
-    // A conversation whose contact + meta.sender share the same id, starting
-    // with a not-yet-resolved phone-as-name (the WhatsApp inbound case).
+    // Websocket-born conversation (conversation.created): carries both `contact`
+    // and `meta.sender`, starting with a not-yet-resolved phone-as-name.
     const makeConvWithContact = (name: string): Conversation =>
       makeConversation({
         id: 'conv-c',
         uuid: 'conv-c',
         contact: { id: 'contact-1', name },
         meta: { sender: { id: 'contact-1', name, type: 'contact' } },
+      } as unknown as Partial<ConversationFixture>);
+
+    // REST-loaded conversation: ConversationSerializer emits `contact` and no
+    // `meta` at all. This is every conversation in the list after a refresh.
+    const makeRestConv = (name: string): Conversation =>
+      makeConversation({
+        id: 'conv-rest',
+        uuid: 'conv-rest',
+        contact: { id: 'contact-1', name },
       } as unknown as Partial<ConversationFixture>);
 
     it('patches conversation.contact.name so the chat sidebar/header reflect the resolved name without a REST refresh', () => {
@@ -501,6 +510,57 @@ describe('ConversationsContext reducer', () => {
       });
 
       expect(next.selectedConversationData?.contact?.name).toBe('João Silva');
+    });
+
+    it('patches a REST-loaded conversation, which has no meta.sender to match on', () => {
+      const state = {
+        ...initialState,
+        selectedConversationId: 'conv-rest',
+        selectedConversationData: makeRestConv('553140204020'),
+        conversations: [makeRestConv('553140204020')],
+      };
+
+      const next = conversationsReducer(state, {
+        type: 'UPDATE_CONTACT_IN_CONVERSATIONS',
+        payload: { id: 'contact-1', name: 'João Silva' } as Contact,
+      });
+
+      // Matching on meta.sender alone made this a silent no-op: the rename and
+      // the ContactDetails edit path never reached a conversation from the list.
+      expect(next.conversations[0].contact?.name).toBe('João Silva');
+      expect(next.selectedConversationData?.contact?.name).toBe('João Silva');
+    });
+
+    it('keeps the current name when the event carries none, instead of blanking the UI', () => {
+      const state = {
+        ...initialState,
+        conversations: [makeRestConv('João Silva')],
+      };
+
+      const next = conversationsReducer(state, {
+        type: 'UPDATE_CONTACT_IN_CONVERSATIONS',
+        payload: { id: 'contact-1', name: '' } as Contact,
+      });
+
+      expect(next.conversations[0].contact?.name).toBe('João Silva');
+    });
+
+    it('updates the avatar so the sidebar picture follows the rename', () => {
+      const state = {
+        ...initialState,
+        conversations: [makeRestConv('553140204020')],
+      };
+
+      const next = conversationsReducer(state, {
+        type: 'UPDATE_CONTACT_IN_CONVERSATIONS',
+        payload: {
+          id: 'contact-1',
+          name: 'João Silva',
+          avatar_url: 'https://cdn.example.com/joao.png',
+        } as Contact,
+      });
+
+      expect(next.conversations[0].contact?.avatar_url).toBe('https://cdn.example.com/joao.png');
     });
 
     it('leaves conversations of other contacts untouched', () => {

--- a/src/contexts/chat/ConversationsContextReducer.ts
+++ b/src/contexts/chat/ConversationsContextReducer.ts
@@ -315,73 +315,56 @@ export function conversationsReducer(
     case 'UPDATE_CONTACT_IN_CONVERSATIONS': {
       const updatedContact = action.payload;
 
-      // Atualiza meta.sender em todas as conversas que usam esse contato
+      const isSameContactId = (id: string | number | null | undefined): boolean =>
+        id !== null && id !== undefined && String(id) === String(updatedContact.id);
+
+      // The conversation list ships `contact` and no `meta` (ConversationSerializer);
+      // only websocket-born conversations carry `meta.sender`. Matching on
+      // `meta.sender` alone skipped every REST-loaded conversation.
+      const belongsToContact = (conv: Conversation): boolean =>
+        isSameContactId(conv.contact?.id) || isSameContactId(conv.meta?.sender?.id);
+
+      // contact.updated omits what it did not resolve, so an empty field means
+      // "keep the current value" — blanking the visible name is the bug itself.
+      const patchContact = (contact: Conversation['contact']): Conversation['contact'] =>
+        contact && isSameContactId(contact.id)
+          ? {
+              ...contact,
+              name: updatedContact.name || contact.name,
+              email: updatedContact.email || contact.email,
+              phone_number: updatedContact.phone_number || contact.phone_number,
+              avatar: updatedContact.avatar || contact.avatar,
+              avatar_url: updatedContact.avatar_url || contact.avatar_url,
+            }
+          : contact;
+
+      const patchMeta = (meta: Conversation['meta']): Conversation['meta'] =>
+        meta?.sender && isSameContactId(meta.sender.id)
+          ? {
+              ...meta,
+              sender: {
+                ...meta.sender,
+                name: updatedContact.name || meta.sender.name,
+                email: updatedContact.email || meta.sender.email,
+                phone_number: updatedContact.phone_number || meta.sender.phone_number,
+                avatar_url: updatedContact.avatar_url || meta.sender.avatar_url,
+              },
+            }
+          : meta;
+
       const updatedConversations = state.conversations
-      .filter(conv => conv !== null && conv !== undefined && conv.id)
-      .map(conv => {
-        const sender = conv.meta?.sender;
-        if (!sender || String(sender.id) !== String(updatedContact.id)) {
-          return conv;
-        }
+        .filter(conv => conv !== null && conv !== undefined && conv.id)
+        .map(conv =>
+          belongsToContact(conv)
+            ? { ...conv, contact: patchContact(conv.contact), meta: patchMeta(conv.meta) }
+            : conv,
+        );
 
-        return {
-          ...conv,
-          // The chat sidebar/header render `conversation.contact?.name` (not
-          // meta.sender.name), so patching only meta.sender left the visible
-          // name stale until a full REST refresh. Patch `contact` too.
-          contact: conv.contact
-            ? {
-                ...conv.contact,
-                name: updatedContact.name,
-                email: updatedContact.email || conv.contact.email,
-                phone_number: updatedContact.phone_number || conv.contact.phone_number,
-                avatar: updatedContact.avatar || conv.contact.avatar,
-                avatar_url: updatedContact.avatar_url || conv.contact.avatar_url,
-              }
-            : conv.contact,
-          meta: {
-            ...conv.meta,
-            sender: {
-              ...sender,
-              name: updatedContact.name,
-              email: updatedContact.email || sender.email,
-              phone_number: updatedContact.phone_number || sender.phone_number,
-              avatar_url: updatedContact.avatar_url || sender.avatar_url,
-            },
-          },
-        };
-      });
-
-      // Atualizar dados da conversa selecionada, se for o mesmo contato
-      let updatedSelectedConversationData = state.selectedConversationData;
-      if(
-        state.selectedConversationData?.meta?.sender &&
-        String(state.selectedConversationData?.meta?.sender.id) === String(updatedContact.id)
-      ) {
-        updatedSelectedConversationData = {
-          ...state.selectedConversationData,
-          contact: state.selectedConversationData.contact
-            ? {
-                ...state.selectedConversationData.contact,
-                name: updatedContact.name,
-                email: updatedContact.email || state.selectedConversationData.contact.email,
-                phone_number: updatedContact.phone_number || state.selectedConversationData.contact.phone_number,
-                avatar: updatedContact.avatar || state.selectedConversationData.contact.avatar,
-                avatar_url: updatedContact.avatar_url || state.selectedConversationData.contact.avatar_url,
-              }
-            : state.selectedConversationData.contact,
-          meta: {
-            ...state.selectedConversationData.meta,
-            sender: {
-              ...state.selectedConversationData.meta.sender,
-              name: updatedContact.name,
-              email: updatedContact.email || state.selectedConversationData.meta.sender.email,
-              phone_number: updatedContact.phone_number || state.selectedConversationData.meta.sender.phone_number,
-              avatar_url: updatedContact.avatar_url || state.selectedConversationData.meta.sender.avatar_url,
-            },
-          },
-        };
-      }
+      const selected = state.selectedConversationData;
+      const updatedSelectedConversationData =
+        selected && belongsToContact(selected)
+          ? { ...selected, contact: patchContact(selected.contact), meta: patchMeta(selected.meta) }
+          : selected;
 
       return {
         ...state,

--- a/src/contexts/chat/ConversationsContextReducer.ts
+++ b/src/contexts/chat/ConversationsContextReducer.ts
@@ -326,6 +326,19 @@ export function conversationsReducer(
 
         return {
           ...conv,
+          // The chat sidebar/header render `conversation.contact?.name` (not
+          // meta.sender.name), so patching only meta.sender left the visible
+          // name stale until a full REST refresh. Patch `contact` too.
+          contact: conv.contact
+            ? {
+                ...conv.contact,
+                name: updatedContact.name,
+                email: updatedContact.email || conv.contact.email,
+                phone_number: updatedContact.phone_number || conv.contact.phone_number,
+                avatar: updatedContact.avatar || conv.contact.avatar,
+                avatar_url: updatedContact.avatar_url || conv.contact.avatar_url,
+              }
+            : conv.contact,
           meta: {
             ...conv.meta,
             sender: {
@@ -347,6 +360,16 @@ export function conversationsReducer(
       ) {
         updatedSelectedConversationData = {
           ...state.selectedConversationData,
+          contact: state.selectedConversationData.contact
+            ? {
+                ...state.selectedConversationData.contact,
+                name: updatedContact.name,
+                email: updatedContact.email || state.selectedConversationData.contact.email,
+                phone_number: updatedContact.phone_number || state.selectedConversationData.contact.phone_number,
+                avatar: updatedContact.avatar || state.selectedConversationData.contact.avatar,
+                avatar_url: updatedContact.avatar_url || state.selectedConversationData.contact.avatar_url,
+              }
+            : state.selectedConversationData.contact,
           meta: {
             ...state.selectedConversationData.meta,
             sender: {

--- a/src/contexts/chat/WebSocketContext.spec.tsx
+++ b/src/contexts/chat/WebSocketContext.spec.tsx
@@ -65,6 +65,9 @@ describe('WebSocketContext contact.updated wiring', () => {
       name: 'João Silva',
       email: 'joao@example.com',
       phone_number: '5541999999999',
+      // The frame names the avatar `thumbnail` (Contact#push_event_data); reading
+      // `avatar_url` here silently dropped every avatar change.
+      thumbnail: 'https://cdn.example.com/joao.png',
       account_id: 'account-1',
       custom_attributes: {},
       additional_attributes: {},
@@ -77,6 +80,7 @@ describe('WebSocketContext contact.updated wiring', () => {
         name: 'João Silva',
         email: 'joao@example.com',
         phone_number: '5541999999999',
+        avatar_url: 'https://cdn.example.com/joao.png',
       }),
     );
   });

--- a/src/contexts/chat/WebSocketContext.spec.tsx
+++ b/src/contexts/chat/WebSocketContext.spec.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+// Capture the low-level handlers WebSocketProvider hands to useWebSocket, so the
+// test can invoke the real onContactUpdated the provider builds. Before the fix
+// the provider never supplied one, so the captured object had no such key.
+let capturedHandlers: Record<string, ((data: unknown) => void) | undefined> = {};
+
+vi.mock('@/hooks/chat/useWebSocket', () => ({
+  useWebSocket: (_userId: string, _token: string, opts: { handlers?: typeof capturedHandlers }) => {
+    capturedHandlers = opts?.handlers ?? {};
+    return { isConnected: false, sendTypingOn: vi.fn(), sendTypingOff: vi.fn() };
+  },
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'user-1', pubsub_token: 'token-1' } }),
+}));
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+import { WebSocketProvider, useWebSocketContext } from './WebSocketContext';
+import type { Contact } from '@/types/chat/api';
+
+function RegisterExternalHandler({ onContactUpdated }: { onContactUpdated: (c: Contact) => void }) {
+  const ws = useWebSocketContext();
+  React.useEffect(() => {
+    ws.registerHandlers({ onContactUpdated });
+  }, [ws, onContactUpdated]);
+  return null;
+}
+
+describe('WebSocketContext contact.updated wiring', () => {
+  beforeEach(() => {
+    capturedHandlers = {};
+  });
+
+  it('provides an onContactUpdated handler to the socket layer (regression: it used to be missing → no-op)', () => {
+    render(
+      <WebSocketProvider>
+        <div />
+      </WebSocketProvider>,
+    );
+
+    // The pre-fix provider never included onContactUpdated, so the connector's
+    // contact.updated registration resolved to undefined and every rename was
+    // dropped. This assertion is what fails without the fix.
+    expect(typeof capturedHandlers.onContactUpdated).toBe('function');
+  });
+
+  it('maps ContactUpdatedEvent to a domain Contact and forwards it to the registered handler', () => {
+    const external = vi.fn();
+
+    render(
+      <WebSocketProvider>
+        <RegisterExternalHandler onContactUpdated={external} />
+      </WebSocketProvider>,
+    );
+
+    capturedHandlers.onContactUpdated?.({
+      id: 'contact-1',
+      name: 'João Silva',
+      email: 'joao@example.com',
+      phone_number: '5541999999999',
+      account_id: 'account-1',
+      custom_attributes: {},
+      additional_attributes: {},
+    });
+
+    expect(external).toHaveBeenCalledTimes(1);
+    expect(external).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'contact-1',
+        name: 'João Silva',
+        email: 'joao@example.com',
+        phone_number: '5541999999999',
+      }),
+    );
+  });
+
+  it('ignores a contact.updated event with no id', () => {
+    const external = vi.fn();
+
+    render(
+      <WebSocketProvider>
+        <RegisterExternalHandler onContactUpdated={external} />
+      </WebSocketProvider>,
+    );
+
+    capturedHandlers.onContactUpdated?.({ name: 'no id' } as unknown);
+
+    expect(external).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/chat/WebSocketContext.tsx
+++ b/src/contexts/chat/WebSocketContext.tsx
@@ -612,11 +612,8 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
           );
         }, []),
 
-        // contact.updated carries the resolved/renamed contact (e.g. a WhatsApp
-        // pushName that lands after the conversation was created). Without this
-        // the connector's contact.updated handler was a no-op, so the chat kept
-        // the stale/empty name until a full REST refresh. Map to the domain
-        // Contact and hand off to the external store handler.
+        // Without this handler the connector's contact.updated registration was a
+        // no-op, so a resolved/renamed contact only landed after a REST refresh.
         onContactUpdated: useCallback((data: ContactUpdatedEvent) => {
           if (!data?.id) {
             return;
@@ -627,7 +624,7 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
             name: data.name ?? '',
             email: data.email ?? null,
             phone_number: data.phone_number ?? null,
-            avatar_url: data.avatar_url ?? null,
+            avatar_url: data.thumbnail ?? null,
             custom_attributes: data.custom_attributes ?? {},
             additional_attributes: data.additional_attributes ?? {},
           };

--- a/src/contexts/chat/WebSocketContext.tsx
+++ b/src/contexts/chat/WebSocketContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useReducer, useCallback, useEffect } 
 import { toast } from 'sonner';
 import { useWebSocket } from '@/hooks/chat/useWebSocket';
 import { useAuth } from '@/contexts/AuthContext';
-import { Message, Conversation, MessageSender, MessageTypeValue, Attachment } from '@/types/chat/api';
+import { Message, Conversation, Contact, MessageSender, MessageTypeValue, Attachment } from '@/types/chat/api';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
   MessageCreatedEvent,
@@ -13,6 +13,7 @@ import {
   TypingEvent,
   PresenceUpdateEvent,
   ConversationReadEvent,
+  ContactUpdatedEvent,
 } from '@/services/chat/websocket/ChatActionCableConnector';
 import { normalizeToUnixSeconds } from '@/utils/time/timeHelpers';
 import { mapEventLabels } from '@/contexts/chat/eventLabels';
@@ -187,6 +188,7 @@ interface WebSocketHandlers {
   onConversationStatusChanged?: (conversationId: string, status: Conversation['status'], updatedAt?: string) => void;
   onConversationRead?: (conversationId: string, unreadCount: number) => void;
   onConversationLastActivity?: (conversationId: string, lastActivityAt: string) => void;
+  onContactUpdated?: (contact: Contact) => void;
 }
 
 interface WebSocketContextValue {
@@ -608,6 +610,29 @@ export function WebSocketProvider({ children }: { children: React.ReactNode }) {
             data.status,
             data.updated_at,
           );
+        }, []),
+
+        // contact.updated carries the resolved/renamed contact (e.g. a WhatsApp
+        // pushName that lands after the conversation was created). Without this
+        // the connector's contact.updated handler was a no-op, so the chat kept
+        // the stale/empty name until a full REST refresh. Map to the domain
+        // Contact and hand off to the external store handler.
+        onContactUpdated: useCallback((data: ContactUpdatedEvent) => {
+          if (!data?.id) {
+            return;
+          }
+
+          const contact: Contact = {
+            id: String(data.id),
+            name: data.name ?? '',
+            email: data.email ?? null,
+            phone_number: data.phone_number ?? null,
+            avatar_url: data.avatar_url ?? null,
+            custom_attributes: data.custom_attributes ?? {},
+            additional_attributes: data.additional_attributes ?? {},
+          };
+
+          handlersRef.current.onContactUpdated?.(contact);
         }, []),
 
         onTypingOn: useCallback((data: TypingEvent) => {

--- a/src/services/chat/websocket/ChatActionCableConnector.ts
+++ b/src/services/chat/websocket/ChatActionCableConnector.ts
@@ -306,7 +306,9 @@ export interface ContactUpdatedEvent {
   name: string;
   email?: string;
   phone_number?: string;
-  avatar_url?: string;
+  // Contact#push_event_data ships the avatar under `thumbnail`; there is no
+  // `avatar_url` key on this frame.
+  thumbnail?: string | null;
   account_id: string;
   custom_attributes: Record<string, unknown>;
   additional_attributes: Record<string, unknown>;


### PR DESCRIPTION
## Problema (CRM-445)
No chat, o nome do contato aparece **desatualizado/vazio ("Contato sem nome")** em tempo real e só carrega correto ao **atualizar a página**. Típico de inbound novo (ex.: WhatsApp) cujo nome (pushName) resolve depois, ou rename de contato.

## Root cause — 2 defeitos no frontend (backend OK)
O backend emite certo: `action_cable_listener.rb:147` → `broadcast(..., CONTACT_UPDATED, contact.push_event_data)` com o nome resolvido.

1. **`contact.updated` ignorado.** O connector registra o evento (`ChatActionCableConnector.ts:369`) chamando `this.chatEventHandlers.onContactUpdated?.()`, mas o `WebSocketContext` **nunca fornecia** `onContactUpdated` → optional-chaining vira **no-op**. O evento chega e morre.
2. **Reducer patcheia o campo errado.** `UPDATE_CONTACT_IN_CONVERSATIONS` (`ConversationsContextReducer.ts`) atualizava só `conv.meta.sender.*`, mas o chat renderiza **`conversation.contact?.name`** (`ChatSidebar.tsx:1007`, `ChatHeader.tsx:458`). `conv.contact` nunca era tocado — nem pelo caminho de edição de contato (`ContactDetails.tsx:90`).

Resultado: o nome resolve depois → `contact.updated` é descartado → só o refresh (REST, que reconstrói `conv.contact`) mostra certo.

## Fix (front-only, cirúrgico)
- **`WebSocketContext.tsx`** — novo handler `onContactUpdated`: mapeia `ContactUpdatedEvent` → domínio `Contact` e repassa ao handler externo; `WebSocketHandlers` ganhou `onContactUpdated?`.
- **`ChatContext.tsx`** — registra `onContactUpdated` → `conversations.updateContactInConversations(contact)`.
- **`ConversationsContextReducer.ts`** — `UPDATE_CONTACT_IN_CONVERSATIONS` agora patcheia também `conv.contact` (name/email/phone/avatar) e `selectedConversationData.contact`.

## Testes
- **Positivo:** `vitest run src/contexts/chat/ConversationsContext.spec.tsx` → **24/24** verdes (3 novos).
- **Negativo (prova do bug):** revertendo só o fix do reducer (via `git stash`), os 2 testes de `contact.name` **falham** (`expected 'João Silva', received '553140204020'`) — provam que pegam o campo que a UI lê.
- **Types:** `tsc -p tsconfig.app.json` limpo.

## Trade-off consciente (self-flag)
Não mexo no comportamento **separado e intencional** de PII masking (EVO-1551 r3): com `mask_contact_pii` ON, o realtime mascara o nome pra toda a audiência do broadcast enquanto o REST não mascara pra admin (`ContactPiiMasker.should_mask?`). Este PR só liga o `contact.updated` e corrige o campo lido; com masking OFF (ou pra agente) o nome real propaga corretamente. Se quiserem alinhar o masking admin realtime↔REST, é outro card.

## Teste manual
Abrir conversa de contato cujo nome ainda não resolveu (WhatsApp inbound mostrando telefone/"Contato sem nome"); disparar a resolução/rename no backend; o header/sidebar/lista devem atualizar **sem refresh**.

Card: CRM-445

## Summary by Sourcery

Reflect contact name and profile changes in chat conversations immediately when contact.updated events arrive.

Bug Fixes:
- Propagate realtime contact updates through the WebSocket and chat contexts so renamed or resolved contact details appear without a page refresh.
- Update conversation and selected-conversation contact data from contact events, including REST-loaded conversations and contact avatars, while preserving existing values when fields are absent.

Tests:
- Add regression coverage for WebSocket event forwarding, end-to-end chat updates, and reducer handling across realtime and REST-loaded conversations.