### PR TITLE
fix(widget): render interactive CSAT survey instead of plain text

### DIFF
--- a/src/components/widget/CSATInput.tsx
+++ b/src/components/widget/CSATInput.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { useLanguage } from '@/hooks/useLanguage';
+import { widgetService } from '@/services/widget/widgetService';
+
+const RATINGS = [
+  { value: 1, emoji: '😞' },
+  { value: 2, emoji: '😑' },
+  { value: 3, emoji: '😐' },
+  { value: 4, emoji: '😀' },
+  { value: 5, emoji: '😍' },
+];
+
+interface CSATInputProps {
+  messageId: string | number;
+  displayType?: 'emoji' | 'star';
+  alreadySubmittedRating?: number;
+}
+
+export const CSATInput = ({
+  messageId,
+  displayType = 'emoji',
+  alreadySubmittedRating,
+}: CSATInputProps) => {
+  const { t } = useLanguage('widget');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [submittedRating, setSubmittedRating] = useState<number | null>(alreadySubmittedRating ?? null);
+
+  const handleSubmit = async (rating: number) => {
+    setError('');
+    setIsSubmitting(true);
+
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const token = params.get('website_token') || '';
+      if (!token) {
+        setError(t('csat.error'));
+        return;
+      }
+
+      await widgetService.updateMessageSubmittedValues(token, messageId, {
+        csat_survey_response: { rating },
+      });
+      setSubmittedRating(rating);
+    } catch {
+      setError(t('csat.error'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (submittedRating) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-green-50 border border-green-200 text-green-700 text-sm">
+        <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+        <span>{t('csat.success')}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      <div className="flex justify-center gap-2">
+        {RATINGS.map(({ value, emoji }) => (
+          <button
+            key={value}
+            type="button"
+            disabled={isSubmitting}
+            onClick={() => handleSubmit(value)}
+            aria-label={t(`csat.ratings.${value}`)}
+            className="flex items-center justify-center w-9 h-9 rounded-full border border-slate-200 text-lg transition-transform hover:scale-110 disabled:opacity-50"
+          >
+            {displayType === 'star' ? '⭐'.repeat(value) : emoji}
+          </button>
+        ))}
+      </div>
+      {error && <p className="mt-1 text-xs text-red-500 text-center">{error}</p>}
+    </div>
+  );
+};

--- a/src/components/widget/MessageList.tsx
+++ b/src/components/widget/MessageList.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/shared/attachments';
 import { ReplyToMessage } from './ReplyToMessage';
 import { EmailCollectInput } from './EmailCollectInput';
+import { CSATInput } from './CSATInput';
+import type { CSATSurveyResponse } from '@/types/core/survey';
 import { openAttachmentInNewTab } from '@/components/chat/messages/utils/openAttachmentInNewTab';
 
 export interface MessageItem {
@@ -55,6 +57,7 @@ export interface MessageItem {
         quoted?: string;
       };
     };
+    display_type?: 'emoji' | 'star';
   };
 }
 
@@ -179,10 +182,35 @@ const MessageList: React.FC<MessageListProps> = ({
       {items.map(m => {
         const hasAvatar = !!(m.avatarUrl || inboundAvatarUrl);
         const isEmailCollect = m.contentType === 'input_email';
+        const isCsat = m.contentType === 'input_csat';
+        const csatSubmittedRating = (m.submittedValues as { csat_survey_response?: CSATSurveyResponse })
+          ?.csat_survey_response?.rating;
         const isSelect =
           m.contentType === 'input_select' && Array.isArray(m.items) && m.items.length > 0;
         const selectDisabled = isSelect && !!m.submittedValues;
         const selectText = isSelect ? stripSelectFromText(m.text, m.items || []) : m.text;
+
+        // Render CSAT survey as a special interactive message
+        if (isCsat) {
+          return (
+            <div key={m.id} className="mb-2 flex justify-center animate-fadeIn">
+              <div className="max-w-[90%] w-full mx-auto">
+                <div className="text-[13px] leading-tight rounded-[10px] shadow-sm bg-white border border-slate-200 px-3 py-3">
+                  {m.text && (
+                    <div className="whitespace-pre-wrap break-words text-slate-700 mb-2 text-center">
+                      {m.text}
+                    </div>
+                  )}
+                  <CSATInput
+                    messageId={m.originalId || m.id}
+                    displayType={m.contentAttributes?.display_type}
+                    alreadySubmittedRating={csatSubmittedRating}
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        }
 
         // Render email collect input as a special interactive message
         if (isEmailCollect) {

--- a/src/i18n/locales/en/widget.json
+++ b/src/i18n/locales/en/widget.json
@@ -130,6 +130,17 @@
     "success": "Email saved successfully!",
     "error": "Error saving email. Please try again."
   },
+  "csat": {
+    "success": "Thanks for your feedback!",
+    "error": "Error submitting your rating. Please try again.",
+    "ratings": {
+      "1": "Poor",
+      "2": "Fair",
+      "3": "Average",
+      "4": "Good",
+      "5": "Excellent"
+    }
+  },
   "preChatForm": {
     "message": "Message",
     "messagePlaceholder": "Type your message here...",

--- a/src/i18n/locales/es/widget.json
+++ b/src/i18n/locales/es/widget.json
@@ -130,6 +130,17 @@
     "success": "Email guardado con éxito!",
     "error": "Error al guardar email. Intente nuevamente."
   },
+  "csat": {
+    "success": "¡Gracias por su feedback!",
+    "error": "Error al enviar su evaluación. Intente nuevamente.",
+    "ratings": {
+      "1": "Malo",
+      "2": "Regular",
+      "3": "Promedio",
+      "4": "Bueno",
+      "5": "Excelente"
+    }
+  },
   "preChatForm": {
     "message": "Mensaje",
     "messagePlaceholder": "Escriba su mensaje aquí...",

--- a/src/i18n/locales/fr/widget.json
+++ b/src/i18n/locales/fr/widget.json
@@ -130,6 +130,17 @@
     "success": "Email enregistré avec succès !",
     "error": "Erreur lors de l'enregistrement. Veuillez réessayer."
   },
+  "csat": {
+    "success": "Merci pour votre retour !",
+    "error": "Erreur lors de l'envoi de votre évaluation. Veuillez réessayer.",
+    "ratings": {
+      "1": "Mauvais",
+      "2": "Passable",
+      "3": "Moyen",
+      "4": "Bon",
+      "5": "Excellent"
+    }
+  },
   "preChatForm": {
     "message": "Message",
     "messagePlaceholder": "Écrivez votre message ici...",

--- a/src/i18n/locales/it/widget.json
+++ b/src/i18n/locales/it/widget.json
@@ -130,6 +130,17 @@
     "success": "Email salvata con successo!",
     "error": "Errore nel salvataggio dell'email. Riprova."
   },
+  "csat": {
+    "success": "Grazie per il tuo feedback!",
+    "error": "Errore nell'invio della valutazione. Riprova.",
+    "ratings": {
+      "1": "Scarso",
+      "2": "Sufficiente",
+      "3": "Nella media",
+      "4": "Buono",
+      "5": "Eccellente"
+    }
+  },
   "preChatForm": {
     "message": "Messaggio",
     "messagePlaceholder": "Scrivi il tuo messaggio qui...",

--- a/src/i18n/locales/pt-BR/widget.json
+++ b/src/i18n/locales/pt-BR/widget.json
@@ -130,6 +130,17 @@
     "success": "Email salvo com sucesso!",
     "error": "Erro ao salvar email. Tente novamente."
   },
+  "csat": {
+    "success": "Obrigado pelo seu feedback!",
+    "error": "Erro ao enviar sua avaliação. Tente novamente.",
+    "ratings": {
+      "1": "Ruim",
+      "2": "Razoável",
+      "3": "Médio",
+      "4": "Bom",
+      "5": "Excelente"
+    }
+  },
   "preChatForm": {
     "message": "Mensagem",
     "messagePlaceholder": "Digite sua mensagem aqui...",

--- a/src/i18n/locales/pt/widget.json
+++ b/src/i18n/locales/pt/widget.json
@@ -130,6 +130,17 @@
     "success": "Email guardado com sucesso!",
     "error": "Erro ao guardar email. Tente novamente."
   },
+  "csat": {
+    "success": "Obrigado pelo seu feedback!",
+    "error": "Erro ao enviar a sua avaliação. Tente novamente.",
+    "ratings": {
+      "1": "Mau",
+      "2": "Razoável",
+      "3": "Médio",
+      "4": "Bom",
+      "5": "Excelente"
+    }
+  },
   "preChatForm": {
     "message": "Mensagem",
     "messagePlaceholder": "Escreva a sua mensagem aqui...",

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -147,14 +147,17 @@ export default function Widget() {
       submittedEmail: m.submitted_email || undefined,
       items: Array.isArray(m.content_attributes?.items) ? m.content_attributes.items : undefined,
       submittedValues: m.content_attributes?.submitted_values || undefined,
-      contentAttributes: m.content_attributes?.email
-        ? {
-            email: {
-              html_content: m.content_attributes.email.html_content,
-              text_content: m.content_attributes.email.text_content,
-            },
-          }
-        : undefined,
+      contentAttributes: (() => {
+        const email = m.content_attributes?.email;
+        const displayType = m.content_attributes?.display_type;
+        if (!email && !displayType) return undefined;
+        return {
+          email: email
+            ? { html_content: email.html_content, text_content: email.text_content }
+            : undefined,
+          display_type: displayType,
+        };
+      })(),
     };
   };
 

--- a/src/services/widget/widgetService.ts
+++ b/src/services/widget/widgetService.ts
@@ -3,6 +3,7 @@ import axios, { AxiosError, AxiosInstance } from 'axios';
 import { extractData } from '@/utils/apiHelpers';
 import { wdebug } from '@/utils/widget/debug';
 import type { WidgetConfig, PreChatSubmissionData, WidgetMessage } from '@/types/settings';
+import type { CSATSurveyResponse } from '@/types/core/survey';
 import i18n from '@/i18n/config';
 
 // Use shared API client (baseURL = VITE_API_URL/api/v1 -> Evolution CRM)
@@ -598,7 +599,9 @@ class WidgetService {
   async updateMessageSubmittedValues(
     websiteToken: string,
     messageId: string | number,
-    submittedValues: { name: string; title: string; value: string },
+    submittedValues:
+      | { name: string; title: string; value: string }
+      | { csat_survey_response: CSATSurveyResponse },
   ) {
     const response = await this.requestWithBaseFallback((client) =>
       client.patch(


### PR DESCRIPTION
## Summary
- The widget's `MessageList` had no rendering branch for `content_type: "input_csat"` — unlike `input_email`/`input_select`, CSAT survey messages fell through to the generic bubble and displayed as plain italic text with no rating buttons.
- Adds a `CSATInput` component (emoji/star rating, 1-5) rendered for `input_csat` messages, wired to the existing `PATCH /widget/messages/:id` `submitted_values.csat_survey_response` flow (already fully supported server-side — no backend changes needed).
- Passes `content_attributes.display_type` (`emoji`/`star`) through to the widget so the correct rating style renders.
- Adds `csat.*` i18n strings to all 6 widget locales (en/es/fr/it/pt/pt-BR).

## Test plan
- [ ] Trigger a CSAT survey message in a conversation and confirm the widget renders interactive rating buttons instead of plain text
- [ ] Submit a rating and confirm a `CsatSurveyResponse` is created and the widget shows a success state
- [ ] Verify both `display_type: emoji` and `display_type: star` inbox configs render correctly

## Summary by Sourcery

Render CSAT survey messages as interactive rating controls in the widget and support submitting responses.

New Features:
- Render interactive 1–5 CSAT rating controls in the widget with emoji or star display styles.
- Persist submitted CSAT ratings and show a confirmation state after submission.

Bug Fixes:
- Fix CSAT survey messages falling back to plain text instead of displaying usable rating controls.

Chores:
- Add localized CSAT labels, rating descriptions, success, and error messages across all supported widget locales.