### PR TITLE
fix(chat): reconcile contact.updated against REST before it reaches the store (CRM-447)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,14 @@ jobs:
       #     stays ON TOP of the resource grant per verb, and a CREATE keeps
       #     carrying its scope. Both are gates the server also enforces, so a
       #     revert here only shows up as a 403 in the user's face.
+      #   - contact.updated reconciliation (CRM-447): with PII masking on, the
+      #     account-wide broadcast is masked for every audience while REST
+      #     unmasks per request, so the frame is reconciled against the REST
+      #     contact before it reaches the store. Guards the gates that make that
+      #     affordable — the refetch replaces the frame instead of following it,
+      #     one request per burst, no request for a contact outside the store,
+      #     none at all with the flag off — plus the end-to-end hop from the
+      #     socket handler to the reducer, which no unit spec reaches.
       # The whole list runs in ~35s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -155,7 +163,9 @@ jobs:
             src/services/contacts/contactsService.createContact.spec.ts \
             src/services/contacts/labelsService.spec.ts \
             src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx \
-            src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+            src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx \
+            src/hooks/chat/useContactUpdatedReconciler.spec.tsx \
+            src/contexts/chat/ChatContext.contactUpdated.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,14 +100,14 @@ jobs:
       #     stays ON TOP of the resource grant per verb, and a CREATE keeps
       #     carrying its scope. Both are gates the server also enforces, so a
       #     revert here only shows up as a 403 in the user's face.
-      #   - contact.updated reconciliation (CRM-447): with PII masking on, the
+      #   - contact.updated reconciliation (CRM-447): with masking on, the
       #     account-wide broadcast is masked for every audience while REST
-      #     unmasks per request, so the frame is reconciled against the REST
-      #     contact before it reaches the store. Guards the gates that make that
-      #     affordable — the refetch replaces the frame instead of following it,
-      #     one request per burst, no request for a contact outside the store,
-      #     none at all with the flag off — plus the end-to-end hop from the
-      #     socket handler to the reducer, which no unit spec reaches.
+      #     unmasks per request, so the frame is reconciled against REST before
+      #     it reaches the store. Guards the gates that keep that affordable,
+      #     plus the socket-to-reducer hop no unit spec reaches.
+      #   - ConversationsContext reducer (CRM-445): the contact patch keeps
+      #     reading an empty field as "keep the current value" and keeps matching
+      #     REST-loaded conversations, which carry `contact` and no `meta.sender`.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -165,7 +165,8 @@ jobs:
             src/pages/Customer/Settings/AiCredentials/AiCredentials.spec.tsx \
             src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx \
             src/hooks/chat/useContactUpdatedReconciler.spec.tsx \
-            src/contexts/chat/ChatContext.contactUpdated.spec.tsx
+            src/contexts/chat/ChatContext.contactUpdated.spec.tsx \
+            src/contexts/chat/ConversationsContext.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
       #     one request per burst, no request for a contact outside the store,
       #     none at all with the flag off — plus the end-to-end hop from the
       #     socket handler to the reducer, which no unit spec reaches.
-      # The whole list runs in ~35s and is deterministic.
+      # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
       # forked workers take ~30min on the runner and flake on worker OOM (the

--- a/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
+++ b/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
@@ -14,8 +14,12 @@ vi.mock('@/hooks/chat/useWebSocket', () => ({
   },
 }));
 
+const auth = vi.hoisted(() => ({
+  user: { id: 'user-1', pubsub_token: 'token-1' } as Record<string, unknown>,
+}));
+
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ user: { id: 'user-1', pubsub_token: 'token-1' } }),
+  useAuth: () => auth,
 }));
 
 vi.mock('@/hooks/useLanguage', () => ({
@@ -58,6 +62,7 @@ describe('ChatContext contact.updated end-to-end', () => {
     capturedHandlers = {};
     localStorage.clear();
     getContact.mockReset();
+    auth.user = { id: 'user-1', pubsub_token: 'token-1' };
     useAppDataStore.setState({ account: null });
     vi.useFakeTimers();
   });
@@ -123,6 +128,33 @@ describe('ChatContext contact.updated end-to-end', () => {
 
     expect(getContact).toHaveBeenCalledWith('contact-1', false);
     expect(screen.getByTestId('name').textContent).toBe('João Silva');
+  });
+
+  it('an agent takes the frame without a refetch: REST would mask it the same', async () => {
+    auth.user = { id: 'user-1', pubsub_token: 'token-1', role: { key: 'agent' } };
+    useAppDataStore.setState({
+      account: { settings: { mask_contact_pii: true } },
+    } as unknown as Parameters<typeof useAppDataStore.setState>[0]);
+
+    render(
+      <ChatProvider>
+        <Probe />
+      </ChatProvider>,
+    );
+
+    await act(async () => {
+      capturedHandlers.onContactUpdated?.({
+        id: 'contact-1',
+        name: '55******4020',
+        account_id: 'account-1',
+        custom_attributes: {},
+        additional_attributes: {},
+      });
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(getContact).not.toHaveBeenCalled();
+    expect(screen.getByTestId('name').textContent).toBe('55******4020');
   });
 
   it('with masking off, the frame is applied without a refetch', async () => {

--- a/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
+++ b/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
@@ -22,7 +22,16 @@ vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
 }));
 
+const getContact = vi.fn();
+
+vi.mock('@/services/contacts/contactsService', () => ({
+  contactsService: {
+    getContact: (...args: unknown[]) => getContact(...args),
+  },
+}));
+
 import { ChatProvider, useChatContext } from './ChatContext';
+import { useAppDataStore } from '@/store/appDataStore';
 
 // REST payload shape: `contact` present, no `meta` (ConversationSerializer).
 const restConversation = {
@@ -48,6 +57,8 @@ describe('ChatContext contact.updated end-to-end', () => {
   beforeEach(() => {
     capturedHandlers = {};
     localStorage.clear();
+    getContact.mockReset();
+    useAppDataStore.setState({ account: null });
   });
 
   it('a contact.updated frame renames the contact of a REST-loaded conversation', async () => {
@@ -71,6 +82,66 @@ describe('ChatContext contact.updated end-to-end', () => {
       });
     });
 
+    expect(screen.getByTestId('name').textContent).toBe('João Silva');
+  });
+
+  it('with masking on, the store takes the REST contact and never the masked frame', async () => {
+    // The account flag is what makes the broadcast mask itself for every
+    // audience while REST still unmasks for an admin — the divergence this
+    // reconciliation exists to close.
+    useAppDataStore.setState({
+      account: { settings: { mask_contact_pii: true } },
+    } as unknown as Parameters<typeof useAppDataStore.setState>[0]);
+    getContact.mockResolvedValue({
+      id: 'contact-1',
+      name: 'João Silva',
+      thumbnail: null,
+      custom_attributes: {},
+      additional_attributes: {},
+    });
+
+    render(
+      <ChatProvider>
+        <Probe />
+      </ChatProvider>,
+    );
+
+    expect(screen.getByTestId('name').textContent).toBe('553140204020');
+
+    await act(async () => {
+      capturedHandlers.onContactUpdated?.({
+        id: 'contact-1',
+        name: '55******4020',
+        account_id: 'account-1',
+        custom_attributes: {},
+        additional_attributes: {},
+      });
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+
+    expect(getContact).toHaveBeenCalledWith('contact-1', false);
+    expect(screen.getByTestId('name').textContent).toBe('João Silva');
+  });
+
+  it('with masking off, the frame is applied without a refetch', async () => {
+    render(
+      <ChatProvider>
+        <Probe />
+      </ChatProvider>,
+    );
+
+    await act(async () => {
+      capturedHandlers.onContactUpdated?.({
+        id: 'contact-1',
+        name: 'João Silva',
+        account_id: 'account-1',
+        custom_attributes: {},
+        additional_attributes: {},
+      });
+      await new Promise(resolve => setTimeout(resolve, 300));
+    });
+
+    expect(getContact).not.toHaveBeenCalled();
     expect(screen.getByTestId('name').textContent).toBe('João Silva');
   });
 });

--- a/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
+++ b/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
@@ -86,9 +86,6 @@ describe('ChatContext contact.updated end-to-end', () => {
   });
 
   it('with masking on, the store takes the REST contact and never the masked frame', async () => {
-    // The account flag is what makes the broadcast mask itself for every
-    // audience while REST still unmasks for an admin — the divergence this
-    // reconciliation exists to close.
     useAppDataStore.setState({
       account: { settings: { mask_contact_pii: true } },
     } as unknown as Parameters<typeof useAppDataStore.setState>[0]);

--- a/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
+++ b/src/contexts/chat/ChatContext.contactUpdated.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import React from 'react';
 import type { Conversation } from '@/types/chat/api';
@@ -59,6 +59,11 @@ describe('ChatContext contact.updated end-to-end', () => {
     localStorage.clear();
     getContact.mockReset();
     useAppDataStore.setState({ account: null });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('a contact.updated frame renames the contact of a REST-loaded conversation', async () => {
@@ -113,7 +118,7 @@ describe('ChatContext contact.updated end-to-end', () => {
         custom_attributes: {},
         additional_attributes: {},
       });
-      await new Promise(resolve => setTimeout(resolve, 300));
+      vi.advanceTimersByTime(300);
     });
 
     expect(getContact).toHaveBeenCalledWith('contact-1', false);
@@ -135,7 +140,7 @@ describe('ChatContext contact.updated end-to-end', () => {
         custom_attributes: {},
         additional_attributes: {},
       });
-      await new Promise(resolve => setTimeout(resolve, 300));
+      vi.advanceTimersByTime(300);
     });
 
     expect(getContact).not.toHaveBeenCalled();

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -577,9 +577,6 @@ function useChatIntegration() {
         conversations.updateConversationLastActivity(conversationId, lastActivityAt);
       },
 
-      // Not applied straight to the store: with PII masking on, the broadcast is
-      // masked for everyone while REST unmasks per request, so the frame has to
-      // be reconciled before it lands. See useContactUpdatedReconciler.
       onContactUpdated: reconcileContactUpdated,
     });
   }, [

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -21,6 +21,7 @@ import {
 import { ConversationsContextValue } from '@/types/chat/conversations';
 import { useAppDataStore } from '@/store/appDataStore';
 import { useAuth } from '@/contexts/AuthContext';
+import { isAdminRole } from '@/constants/roles';
 import { playNotificationSound, getAudioSettings } from '@/utils/audioNotificationUtils';
 import { normalizeToUnixSeconds } from '@/utils/time/timeHelpers';
 import { doesConversationMatchFilters } from '@/utils/chat/conversationMatch';
@@ -60,10 +61,14 @@ function useChatIntegration() {
   const activeFiltersRef = useRef<ConversationFilter[]>(filters.state.activeFilters);
   const attachmentReloadTimersRef = useRef<Record<string, number>>({});
   const account = useAppDataStore(state => state.account);
+  // A session the server masks too reads the same values from REST as from the
+  // frame. Unknown role refetches: the cost is a request, the risk is the bug.
+  const roleKey = currentUser?.role?.key;
+  const sessionIsMasked = !!roleKey && !isAdminRole(roleKey);
   const reconcileContactUpdated = useContactUpdatedReconciler({
     conversations: conversations.state.conversations,
     selectedConversationData: conversations.state.selectedConversationData,
-    maskingEnabled: account?.settings?.mask_contact_pii === true,
+    refetchEnabled: account?.settings?.mask_contact_pii === true && !sessionIsMasked,
     apply: conversations.updateContactInConversations,
   });
   useEffect(() => {

--- a/src/contexts/chat/ChatContext.tsx
+++ b/src/contexts/chat/ChatContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useCallback, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 import { usePersistence } from '@/hooks/chat/usePersistence';
+import { useContactUpdatedReconciler } from '@/hooks/chat/useContactUpdatedReconciler';
 import { MessagesProvider, useMessages as useMessagesOriginal } from '@/contexts/chat/MessagesContext';
 import { ConversationsProvider } from '@/contexts/chat/ConversationsContext';
 import { useConversations as useConversationsOriginal } from '@/hooks/chat/useConversations';
@@ -58,6 +59,13 @@ function useChatIntegration() {
   const processedMessageIdsRef = useRef<Set<string>>(new Set());
   const activeFiltersRef = useRef<ConversationFilter[]>(filters.state.activeFilters);
   const attachmentReloadTimersRef = useRef<Record<string, number>>({});
+  const account = useAppDataStore(state => state.account);
+  const reconcileContactUpdated = useContactUpdatedReconciler({
+    conversations: conversations.state.conversations,
+    selectedConversationData: conversations.state.selectedConversationData,
+    maskingEnabled: account?.settings?.mask_contact_pii === true,
+    apply: conversations.updateContactInConversations,
+  });
   useEffect(() => {
     activeFiltersRef.current = filters.state.activeFilters;
   }, [filters.state.activeFilters]);
@@ -569,11 +577,19 @@ function useChatIntegration() {
         conversations.updateConversationLastActivity(conversationId, lastActivityAt);
       },
 
-      onContactUpdated: contact => {
-        conversations.updateContactInConversations(contact);
-      },
+      // Not applied straight to the store: with PII masking on, the broadcast is
+      // masked for everyone while REST unmasks per request, so the frame has to
+      // be reconciled before it lands. See useContactUpdatedReconciler.
+      onContactUpdated: reconcileContactUpdated,
     });
-  }, [websocket, messages, conversations, currentUser, shouldReloadMessageForMissingImageData]);
+  }, [
+    websocket,
+    messages,
+    conversations,
+    currentUser,
+    shouldReloadMessageForMissingImageData,
+    reconcileContactUpdated,
+  ]);
 
   // Integrated actions
   const loadConversationsWithFilters = useCallback(

--- a/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
+++ b/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Contact, Conversation } from '@/types/chat/api';
+
+const getContact = vi.fn();
+
+vi.mock('@/services/contacts/contactsService', () => ({
+  contactsService: {
+    getContact: (...args: unknown[]) => getContact(...args),
+  },
+}));
+
+import { useContactUpdatedReconciler } from './useContactUpdatedReconciler';
+
+// REST shape: `contact`, no `meta` (ConversationSerializer).
+const conversation = {
+  id: 'conv-1',
+  contact: { id: 'contact-1', name: 'João Silva' },
+} as unknown as Conversation;
+
+// What the broadcast carries with the account flag on: masked for every
+// audience, admins included.
+const maskedFrame = {
+  id: 'contact-1',
+  name: '55******4020',
+  email: 'j***@example.com',
+  phone_number: '55******4020',
+} as Contact;
+
+const rawRestContact = {
+  id: 'contact-1',
+  name: '5531984204020',
+  email: 'joao@example.com',
+  phone_number: '5531984204020',
+  thumbnail: 'https://cdn/avatar.png',
+  custom_attributes: {},
+  additional_attributes: {},
+};
+
+function setup(overrides: Partial<Parameters<typeof useContactUpdatedReconciler>[0]> = {}) {
+  const apply = vi.fn();
+  const { result, unmount } = renderHook(() =>
+    useContactUpdatedReconciler({
+      conversations: [conversation],
+      selectedConversationData: null,
+      maskingEnabled: true,
+      apply,
+      ...overrides,
+    }),
+  );
+  return { reconcile: result.current, apply, unmount };
+}
+
+// Lets the debounce fire and the getContact promise settle.
+async function flush() {
+  await act(async () => {
+    vi.advanceTimersByTime(300);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useContactUpdatedReconciler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getContact.mockReset();
+    getContact.mockResolvedValue(rawRestContact);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('applies the REST contact instead of the masked frame', async () => {
+    const { reconcile, apply } = setup();
+
+    act(() => reconcile(maskedFrame));
+    // The masked value must never reach the store, not even for one paint.
+    expect(apply).not.toHaveBeenCalled();
+
+    await flush();
+
+    expect(getContact).toHaveBeenCalledWith('contact-1', false);
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply.mock.calls[0][0]).toMatchObject({
+      id: 'contact-1',
+      name: '5531984204020',
+      email: 'joao@example.com',
+      phone_number: '5531984204020',
+      // `thumbnail` is the key the serializer emits; the store reads avatar_url.
+      avatar_url: 'https://cdn/avatar.png',
+    });
+  });
+
+  it('coalesces a burst on the same contact into a single refetch', async () => {
+    const { reconcile, apply } = setup();
+
+    act(() => {
+      reconcile(maskedFrame);
+      reconcile({ ...maskedFrame, name: '55******4021' });
+      reconcile({ ...maskedFrame, name: '55******4022' });
+    });
+    await flush();
+
+    expect(getContact).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not collapse different contacts into one request', async () => {
+    const other = {
+      id: 'conv-2',
+      contact: { id: 'contact-2', name: 'Maria' },
+    } as unknown as Conversation;
+    const { reconcile } = setup({ conversations: [conversation, other] });
+
+    act(() => {
+      reconcile(maskedFrame);
+      reconcile({ ...maskedFrame, id: 'contact-2' });
+    });
+    await flush();
+
+    expect(getContact).toHaveBeenCalledTimes(2);
+    expect(getContact.mock.calls.map(call => call[0]).sort()).toEqual(['contact-1', 'contact-2']);
+  });
+
+  it('applies the frame without fetching when masking is off', async () => {
+    const { reconcile, apply } = setup({ maskingEnabled: false });
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+
+    expect(getContact).not.toHaveBeenCalled();
+    expect(apply).toHaveBeenCalledWith(maskedFrame);
+  });
+
+  it('applies the frame without fetching for a contact outside the store', async () => {
+    const { reconcile, apply } = setup({ conversations: [] });
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+
+    // No request: contact.updated is an account-wide broadcast, so most frames
+    // are about contacts this client never loaded. The dispatch still goes
+    // through — the reducer ignores what it cannot match, and a store snapshot
+    // one render behind must not swallow a real update.
+    expect(getContact).not.toHaveBeenCalled();
+    expect(apply).toHaveBeenCalledWith(maskedFrame);
+  });
+
+  it('reconciles a contact matched through meta.sender', async () => {
+    const wsBorn = {
+      id: 'conv-ws',
+      meta: { sender: { id: 'contact-1', name: '55******4020' } },
+    } as unknown as Conversation;
+    const { reconcile } = setup({ conversations: [wsBorn] });
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+
+    expect(getContact).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles a contact that only the selected conversation holds', async () => {
+    const { reconcile } = setup({ conversations: [], selectedConversationData: conversation });
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+
+    expect(getContact).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the frame when the refetch fails', async () => {
+    getContact.mockRejectedValue(new Error('network down'));
+    const { reconcile, apply } = setup();
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+
+    expect(apply).toHaveBeenCalledWith(maskedFrame);
+  });
+
+  it('does not touch the store after unmount', async () => {
+    const { reconcile, apply, unmount } = setup();
+
+    act(() => reconcile(maskedFrame));
+    unmount();
+    await flush();
+
+    expect(apply).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
+++ b/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
@@ -12,14 +12,12 @@ vi.mock('@/services/contacts/contactsService', () => ({
 
 import { useContactUpdatedReconciler } from './useContactUpdatedReconciler';
 
-// REST shape: `contact`, no `meta` (ConversationSerializer).
 const conversation = {
   id: 'conv-1',
   contact: { id: 'contact-1', name: 'João Silva' },
 } as unknown as Conversation;
 
-// What the broadcast carries with the account flag on: masked for every
-// audience, admins included.
+// What the broadcast carries with the flag on: masked for every audience.
 const maskedFrame = {
   id: 'contact-1',
   name: '55******4020',
@@ -51,7 +49,6 @@ function setup(overrides: Partial<Parameters<typeof useContactUpdatedReconciler>
   return { reconcile: result.current, apply, unmount };
 }
 
-// Lets the debounce fire and the getContact promise settle.
 async function flush() {
   await act(async () => {
     vi.advanceTimersByTime(300);
@@ -89,7 +86,6 @@ describe('useContactUpdatedReconciler', () => {
       name: '5531984204020',
       email: 'joao@example.com',
       phone_number: '5531984204020',
-      // `thumbnail` is the key the serializer emits; the store reads avatar_url.
       avatar_url: 'https://cdn/avatar.png',
     });
   });
@@ -141,10 +137,6 @@ describe('useContactUpdatedReconciler', () => {
     act(() => reconcile(maskedFrame));
     await flush();
 
-    // No request: contact.updated is an account-wide broadcast, so most frames
-    // are about contacts this client never loaded. The dispatch still goes
-    // through — the reducer ignores what it cannot match, and a store snapshot
-    // one render behind must not swallow a real update.
     expect(getContact).not.toHaveBeenCalled();
     expect(apply).toHaveBeenCalledWith(maskedFrame);
   });
@@ -179,6 +171,32 @@ describe('useContactUpdatedReconciler', () => {
     await flush();
 
     expect(apply).toHaveBeenCalledWith(maskedFrame);
+  });
+
+  it('falls back to the newest frame, not the one the failed request carried', async () => {
+    let rejectFirst: (reason: Error) => void = () => {};
+    getContact
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectFirst = reject; }))
+      .mockResolvedValue(rawRestContact);
+    const { reconcile, apply } = setup();
+
+    act(() => reconcile(maskedFrame));
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(getContact).toHaveBeenCalledTimes(1);
+
+    const newerFrame = { ...maskedFrame, name: '55******9999' } as Contact;
+    act(() => reconcile(newerFrame));
+
+    await act(async () => {
+      rejectFirst(new Error('network down'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apply).toHaveBeenCalledWith(newerFrame);
+    expect(apply).not.toHaveBeenCalledWith(maskedFrame);
   });
 
   it('does not touch the store after unmount', async () => {

--- a/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
+++ b/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
@@ -199,6 +199,64 @@ describe('useContactUpdatedReconciler', () => {
     expect(apply).not.toHaveBeenCalledWith(maskedFrame);
   });
 
+  it('waits out the debounce window before fetching', async () => {
+    const { reconcile } = setup();
+
+    act(() => reconcile(maskedFrame));
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(getContact).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(getContact).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a frame with no contact id', async () => {
+    const { reconcile, apply } = setup();
+
+    act(() => reconcile({ name: 'João Silva' } as Contact));
+    await flush();
+
+    expect(getContact).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('refetches again for a frame that landed while the request was in flight', async () => {
+    let resolveFirst: (value: unknown) => void = () => {};
+    getContact
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirst = resolve; }))
+      .mockResolvedValue(rawRestContact);
+    const { reconcile } = setup();
+
+    act(() => reconcile(maskedFrame));
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(getContact).toHaveBeenCalledTimes(1);
+
+    // Its own timer fires while the request is still open and backs off, so the
+    // second round can only come from the completed request re-arming it.
+    act(() => reconcile({ ...maskedFrame, name: '55******9999' } as Contact));
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(getContact).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst(rawRestContact);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(getContact).toHaveBeenCalledTimes(2);
+  });
+
   it('does not touch the store after unmount', async () => {
     const { reconcile, apply, unmount } = setup();
 

--- a/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
+++ b/src/hooks/chat/useContactUpdatedReconciler.spec.tsx
@@ -41,7 +41,7 @@ function setup(overrides: Partial<Parameters<typeof useContactUpdatedReconciler>
     useContactUpdatedReconciler({
       conversations: [conversation],
       selectedConversationData: null,
-      maskingEnabled: true,
+      refetchEnabled: true,
       apply,
       ...overrides,
     }),
@@ -121,8 +121,8 @@ describe('useContactUpdatedReconciler', () => {
     expect(getContact.mock.calls.map(call => call[0]).sort()).toEqual(['contact-1', 'contact-2']);
   });
 
-  it('applies the frame without fetching when masking is off', async () => {
-    const { reconcile, apply } = setup({ maskingEnabled: false });
+  it('applies the frame without fetching when no refetch is due', async () => {
+    const { reconcile, apply } = setup({ refetchEnabled: false });
 
     act(() => reconcile(maskedFrame));
     await flush();
@@ -212,6 +212,34 @@ describe('useContactUpdatedReconciler', () => {
       vi.advanceTimersByTime(100);
     });
     expect(getContact).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a frame that repeats what the store already reconciled', async () => {
+    const { reconcile, apply } = setup();
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+    expect(getContact).toHaveBeenCalledTimes(1);
+
+    // What an inbound message broadcasts: a last_activity_at bump repeats every
+    // rendered field, and the store already holds the REST answer for them.
+    act(() => reconcile({ ...maskedFrame }));
+    await flush();
+
+    expect(getContact).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches again once a rendered field really moves', async () => {
+    const { reconcile } = setup();
+
+    act(() => reconcile(maskedFrame));
+    await flush();
+
+    act(() => reconcile({ ...maskedFrame, email: 'm***@example.com' } as Contact));
+    await flush();
+
+    expect(getContact).toHaveBeenCalledTimes(2);
   });
 
   it('ignores a frame with no contact id', async () => {

--- a/src/hooks/chat/useContactUpdatedReconciler.ts
+++ b/src/hooks/chat/useContactUpdatedReconciler.ts
@@ -2,25 +2,16 @@ import { useCallback, useEffect, useRef } from 'react';
 import { contactsService } from '@/services/contacts/contactsService';
 import type { Contact, Conversation } from '@/types/chat/api';
 
-// A burst on the same contact (rename + label + block) is three frames; coalesce
-// them into one refetch. Per contact id, never global: two different contacts
-// changing at the same time must not collapse into a single request.
 const RECONCILE_DEBOUNCE_MS = 250;
 
 interface ContactUpdatedReconcilerParams {
   conversations: Conversation[];
   selectedConversationData: Conversation | null;
-  /** `account.settings.mask_contact_pii` — the same flag the server reads. */
+  /** `account.settings.mask_contact_pii`. */
   maskingEnabled: boolean;
   apply: (contact: Contact) => void;
 }
 
-const sameId = (a: string | number | null | undefined, b: string): boolean =>
-  a !== null && a !== undefined && String(a) === b;
-
-// The REST payload keys the chat store reads. `thumbnail` is what the contact
-// serializer emits for the avatar; the websocket mapping already normalises it
-// to `avatar_url`, so do the same here or the avatar disappears on reconcile.
 interface RestContact {
   id?: string;
   name?: string;
@@ -32,12 +23,16 @@ interface RestContact {
   additional_attributes?: unknown;
 }
 
+const sameId = (a: string | number | null | undefined, b: string): boolean =>
+  a !== null && a !== undefined && String(a) === b;
+
 function toStoreContact(id: string, rest: RestContact): Contact {
   return {
     id: String(rest.id ?? id),
     name: rest.name ?? '',
     email: rest.email ?? null,
     phone_number: rest.phone_number ?? null,
+    // The contact serializer emits the avatar as `thumbnail`.
     avatar_url: rest.thumbnail ?? rest.avatar_url ?? null,
     custom_attributes: (rest.custom_attributes ?? {}) as Record<string, unknown>,
     additional_attributes: rest.additional_attributes ?? {},
@@ -45,20 +40,14 @@ function toStoreContact(id: string, rest: RestContact): Contact {
 }
 
 /**
- * Reconciles a `contact.updated` frame against the REST contact before it
- * reaches the chat store.
+ * Turns a `contact.updated` frame into the contact this session is entitled to
+ * see.
  *
- * The broadcast masks PII by the account flag alone — its audience is the whole
- * account token, admins and agents on the same topic — while the REST endpoints
- * mask per request and hand an admin the raw value. Applying the frame directly
- * therefore makes an admin watch the contact mask itself live and come back raw
- * on refresh. Refetching gives each session the version it is entitled to
- * without opening a per-audience broadcast — the path that already cost four
- * rounds of leak regressions and is documented at the top of the server's
- * contact_pii_masker.
- *
- * The refetch replaces the frame instead of following it, so the masked value
- * never reaches the store — patching after would flash it on screen.
+ * The broadcast is masked by the account flag alone, because its audience is
+ * the whole account token; the REST endpoints mask per request and hand an
+ * admin the raw value. Refetching resolves that divergence per session without
+ * a per-audience broadcast. It replaces the frame rather than following it, so
+ * the masked value never reaches the store even for one paint.
  */
 export function useContactUpdatedReconciler({
   conversations,
@@ -76,8 +65,6 @@ export function useContactUpdatedReconciler({
 
   useEffect(() => {
     mountedRef.current = true;
-    // Captured on mount: these containers are never reassigned, so the cleanup
-    // acts on the very objects this render created.
     const timers = timersRef.current;
     const pending = pendingRef.current;
     const inFlight = inFlightRef.current;
@@ -91,10 +78,6 @@ export function useContactUpdatedReconciler({
     };
   }, []);
 
-  // `contact.updated` is broadcast on the account token, so a client receives it
-  // for every contact in the account — including contacts it has never loaded.
-  // Refetching those would be one request per connected client per change, for a
-  // patch the reducer would drop anyway.
   const isInStore = useCallback((contactId: string): boolean => {
     const { conversations: list, selectedConversationData: selected } = paramsRef.current;
     const belongs = (conv: Conversation | null): boolean =>
@@ -119,18 +102,14 @@ export function useContactUpdatedReconciler({
         paramsRef.current.apply(toStoreContact(contactId, rest as unknown as RestContact));
       })
       .catch(err => {
-        // Keeping the realtime update is worth more than the flapping it brings
-        // back: the frame is masked but current, and dropping it would leave the
-        // stale name on screen, which is the bug the realtime wiring exists to
-        // prevent.
         console.error('[contact.updated] Failed to reconcile contact via REST:', err);
         if (!mountedRef.current) return;
-        paramsRef.current.apply(frameContact);
+        // Masked but current beats leaving a stale name on screen. A frame that
+        // landed mid-flight is newer than the one this request carried.
+        paramsRef.current.apply(pendingRef.current[contactId] ?? frameContact);
       })
       .finally(() => {
         inFlightRef.current.delete(contactId);
-        // A frame that landed mid-flight describes a change the response could
-        // not have carried, so it earns its own round.
         if (mountedRef.current && pendingRef.current[contactId]) {
           scheduleRef.current(contactId);
         }
@@ -155,8 +134,6 @@ export function useContactUpdatedReconciler({
     [runRefetch],
   );
 
-  // `runRefetch` re-arms the debounce through this ref to keep the two callbacks
-  // from depending on each other.
   const scheduleRef = useRef(schedule);
   scheduleRef.current = schedule;
 
@@ -168,12 +145,8 @@ export function useContactUpdatedReconciler({
 
       const contactId = String(frameContact.id);
 
-      // With the flag off — the default — frame and REST carry the same values,
-      // so there is nothing to reconcile and no request to spend.
-      //
-      // A contact outside the store is applied straight through rather than
-      // dropped: the reducer already ignores what it cannot match, and a store
-      // snapshot that is one render behind must never swallow a real update.
+      // A contact outside the store is applied rather than dropped: the reducer
+      // ignores what it cannot match, and this snapshot can be one render behind.
       if (!paramsRef.current.maskingEnabled || !isInStore(contactId)) {
         paramsRef.current.apply(frameContact);
         return;

--- a/src/hooks/chat/useContactUpdatedReconciler.ts
+++ b/src/hooks/chat/useContactUpdatedReconciler.ts
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { contactsService } from '@/services/contacts/contactsService';
+import type { Contact, Conversation } from '@/types/chat/api';
+
+// A burst on the same contact (rename + label + block) is three frames; coalesce
+// them into one refetch. Per contact id, never global: two different contacts
+// changing at the same time must not collapse into a single request.
+const RECONCILE_DEBOUNCE_MS = 250;
+
+interface ContactUpdatedReconcilerParams {
+  conversations: Conversation[];
+  selectedConversationData: Conversation | null;
+  /** `account.settings.mask_contact_pii` — the same flag the server reads. */
+  maskingEnabled: boolean;
+  apply: (contact: Contact) => void;
+}
+
+const sameId = (a: string | number | null | undefined, b: string): boolean =>
+  a !== null && a !== undefined && String(a) === b;
+
+// The REST payload keys the chat store reads. `thumbnail` is what the contact
+// serializer emits for the avatar; the websocket mapping already normalises it
+// to `avatar_url`, so do the same here or the avatar disappears on reconcile.
+interface RestContact {
+  id?: string;
+  name?: string;
+  email?: string | null;
+  phone_number?: string | null;
+  thumbnail?: string | null;
+  avatar_url?: string | null;
+  custom_attributes?: Record<string, unknown>;
+  additional_attributes?: unknown;
+}
+
+function toStoreContact(id: string, rest: RestContact): Contact {
+  return {
+    id: String(rest.id ?? id),
+    name: rest.name ?? '',
+    email: rest.email ?? null,
+    phone_number: rest.phone_number ?? null,
+    avatar_url: rest.thumbnail ?? rest.avatar_url ?? null,
+    custom_attributes: (rest.custom_attributes ?? {}) as Record<string, unknown>,
+    additional_attributes: rest.additional_attributes ?? {},
+  } as Contact;
+}
+
+/**
+ * Reconciles a `contact.updated` frame against the REST contact before it
+ * reaches the chat store.
+ *
+ * The broadcast masks PII by the account flag alone — its audience is the whole
+ * account token, admins and agents on the same topic — while the REST endpoints
+ * mask per request and hand an admin the raw value. Applying the frame directly
+ * therefore makes an admin watch the contact mask itself live and come back raw
+ * on refresh. Refetching gives each session the version it is entitled to
+ * without opening a per-audience broadcast — the path that already cost four
+ * rounds of leak regressions and is documented at the top of the server's
+ * contact_pii_masker.
+ *
+ * The refetch replaces the frame instead of following it, so the masked value
+ * never reaches the store — patching after would flash it on screen.
+ */
+export function useContactUpdatedReconciler({
+  conversations,
+  selectedConversationData,
+  maskingEnabled,
+  apply,
+}: ContactUpdatedReconcilerParams): (frameContact: Contact) => void {
+  const paramsRef = useRef({ conversations, selectedConversationData, maskingEnabled, apply });
+  paramsRef.current = { conversations, selectedConversationData, maskingEnabled, apply };
+
+  const timersRef = useRef<Record<string, number>>({});
+  const inFlightRef = useRef<Set<string>>(new Set());
+  const pendingRef = useRef<Record<string, Contact>>({});
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    // Captured on mount: these containers are never reassigned, so the cleanup
+    // acts on the very objects this render created.
+    const timers = timersRef.current;
+    const pending = pendingRef.current;
+    const inFlight = inFlightRef.current;
+
+    return () => {
+      mountedRef.current = false;
+      Object.values(timers).forEach(timerId => window.clearTimeout(timerId));
+      Object.keys(timers).forEach(key => delete timers[key]);
+      Object.keys(pending).forEach(key => delete pending[key]);
+      inFlight.clear();
+    };
+  }, []);
+
+  // `contact.updated` is broadcast on the account token, so a client receives it
+  // for every contact in the account — including contacts it has never loaded.
+  // Refetching those would be one request per connected client per change, for a
+  // patch the reducer would drop anyway.
+  const isInStore = useCallback((contactId: string): boolean => {
+    const { conversations: list, selectedConversationData: selected } = paramsRef.current;
+    const belongs = (conv: Conversation | null): boolean =>
+      !!conv && (sameId(conv.contact?.id, contactId) || sameId(conv.meta?.sender?.id, contactId));
+
+    return list.some(belongs) || belongs(selected);
+  }, []);
+
+  const runRefetch = useCallback((contactId: string) => {
+    const frameContact = pendingRef.current[contactId];
+    if (!frameContact) {
+      return;
+    }
+
+    delete pendingRef.current[contactId];
+    inFlightRef.current.add(contactId);
+
+    contactsService
+      .getContact(contactId, false)
+      .then(rest => {
+        if (!mountedRef.current) return;
+        paramsRef.current.apply(toStoreContact(contactId, rest as unknown as RestContact));
+      })
+      .catch(err => {
+        // Keeping the realtime update is worth more than the flapping it brings
+        // back: the frame is masked but current, and dropping it would leave the
+        // stale name on screen, which is the bug the realtime wiring exists to
+        // prevent.
+        console.error('[contact.updated] Failed to reconcile contact via REST:', err);
+        if (!mountedRef.current) return;
+        paramsRef.current.apply(frameContact);
+      })
+      .finally(() => {
+        inFlightRef.current.delete(contactId);
+        // A frame that landed mid-flight describes a change the response could
+        // not have carried, so it earns its own round.
+        if (mountedRef.current && pendingRef.current[contactId]) {
+          scheduleRef.current(contactId);
+        }
+      });
+  }, []);
+
+  const schedule = useCallback(
+    (contactId: string) => {
+      const existing = timersRef.current[contactId];
+      if (existing) {
+        window.clearTimeout(existing);
+      }
+
+      timersRef.current[contactId] = window.setTimeout(() => {
+        delete timersRef.current[contactId];
+        if (inFlightRef.current.has(contactId)) {
+          return;
+        }
+        runRefetch(contactId);
+      }, RECONCILE_DEBOUNCE_MS);
+    },
+    [runRefetch],
+  );
+
+  // `runRefetch` re-arms the debounce through this ref to keep the two callbacks
+  // from depending on each other.
+  const scheduleRef = useRef(schedule);
+  scheduleRef.current = schedule;
+
+  return useCallback(
+    (frameContact: Contact) => {
+      if (!frameContact?.id) {
+        return;
+      }
+
+      const contactId = String(frameContact.id);
+
+      // With the flag off — the default — frame and REST carry the same values,
+      // so there is nothing to reconcile and no request to spend.
+      //
+      // A contact outside the store is applied straight through rather than
+      // dropped: the reducer already ignores what it cannot match, and a store
+      // snapshot that is one render behind must never swallow a real update.
+      if (!paramsRef.current.maskingEnabled || !isInStore(contactId)) {
+        paramsRef.current.apply(frameContact);
+        return;
+      }
+
+      pendingRef.current[contactId] = frameContact;
+      schedule(contactId);
+    },
+    [isInStore, schedule],
+  );
+}

--- a/src/hooks/chat/useContactUpdatedReconciler.ts
+++ b/src/hooks/chat/useContactUpdatedReconciler.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { contactsService } from '@/services/contacts/contactsService';
+import type { Contact as RestContact } from '@/types/contacts';
 import type { Contact, Conversation } from '@/types/chat/api';
 
 const RECONCILE_DEBOUNCE_MS = 250;
@@ -12,21 +13,15 @@ interface ContactUpdatedReconcilerParams {
   apply: (contact: Contact) => void;
 }
 
-interface RestContact {
-  id?: string;
-  name?: string;
-  email?: string | null;
-  phone_number?: string | null;
-  thumbnail?: string | null;
-  avatar_url?: string | null;
-  custom_attributes?: Record<string, unknown>;
-  additional_attributes?: unknown;
-}
-
 const sameId = (a: string | number | null | undefined, b: string): boolean =>
   a !== null && a !== undefined && String(a) === b;
 
-function toStoreContact(id: string, rest: RestContact): Contact {
+function toStoreContact(id: string, rest: Partial<RestContact> | null | undefined): Contact {
+  if (!rest) {
+    throw new Error(`Empty contact payload for ${id}`);
+  }
+
+
   return {
     id: String(rest.id ?? id),
     name: rest.name ?? '',
@@ -56,7 +51,9 @@ export function useContactUpdatedReconciler({
   apply,
 }: ContactUpdatedReconcilerParams): (frameContact: Contact) => void {
   const paramsRef = useRef({ conversations, selectedConversationData, maskingEnabled, apply });
-  paramsRef.current = { conversations, selectedConversationData, maskingEnabled, apply };
+  useEffect(() => {
+    paramsRef.current = { conversations, selectedConversationData, maskingEnabled, apply };
+  }, [conversations, selectedConversationData, maskingEnabled, apply]);
 
   const timersRef = useRef<Record<string, number>>({});
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -86,6 +83,8 @@ export function useContactUpdatedReconciler({
     return list.some(belongs) || belongs(selected);
   }, []);
 
+  const scheduleRef = useRef<(contactId: string) => void>(() => {});
+
   const runRefetch = useCallback((contactId: string) => {
     const frameContact = pendingRef.current[contactId];
     if (!frameContact) {
@@ -99,7 +98,7 @@ export function useContactUpdatedReconciler({
       .getContact(contactId, false)
       .then(rest => {
         if (!mountedRef.current) return;
-        paramsRef.current.apply(toStoreContact(contactId, rest as unknown as RestContact));
+        paramsRef.current.apply(toStoreContact(contactId, rest));
       })
       .catch(err => {
         console.error('[contact.updated] Failed to reconcile contact via REST:', err);
@@ -134,8 +133,9 @@ export function useContactUpdatedReconciler({
     [runRefetch],
   );
 
-  const scheduleRef = useRef(schedule);
-  scheduleRef.current = schedule;
+  useEffect(() => {
+    scheduleRef.current = schedule;
+  }, [schedule]);
 
   return useCallback(
     (frameContact: Contact) => {

--- a/src/hooks/chat/useContactUpdatedReconciler.ts
+++ b/src/hooks/chat/useContactUpdatedReconciler.ts
@@ -8,8 +8,8 @@ const RECONCILE_DEBOUNCE_MS = 250;
 interface ContactUpdatedReconcilerParams {
   conversations: Conversation[];
   selectedConversationData: Conversation | null;
-  /** `account.settings.mask_contact_pii`. */
-  maskingEnabled: boolean;
+  /** Account masks PII and this session is not one of the masked audiences. */
+  refetchEnabled: boolean;
   apply: (contact: Contact) => void;
 }
 
@@ -21,7 +21,6 @@ function toStoreContact(id: string, rest: Partial<RestContact> | null | undefine
     throw new Error(`Empty contact payload for ${id}`);
   }
 
-
   return {
     id: String(rest.id ?? id),
     name: rest.name ?? '',
@@ -31,39 +30,44 @@ function toStoreContact(id: string, rest: Partial<RestContact> | null | undefine
     avatar_url: rest.thumbnail ?? rest.avatar_url ?? null,
     custom_attributes: (rest.custom_attributes ?? {}) as Record<string, unknown>,
     additional_attributes: rest.additional_attributes ?? {},
-  } as Contact;
+  };
 }
+
+// The fields the reducer patches. Anything else moving on the contact row —
+// `last_activity_at`, bumped by every inbound message — repeats them.
+const renderedSignature = (contact: Contact): string =>
+  [contact.name, contact.email, contact.phone_number, contact.avatar_url]
+    .map(value => value ?? '')
+    .join('\u0000');
 
 /**
  * Turns a `contact.updated` frame into the contact this session is entitled to
- * see.
- *
- * The broadcast is masked by the account flag alone, because its audience is
- * the whole account token; the REST endpoints mask per request and hand an
- * admin the raw value. Refetching resolves that divergence per session without
- * a per-audience broadcast. It replaces the frame rather than following it, so
- * the masked value never reaches the store even for one paint.
+ * see: the broadcast is masked by the account flag alone, REST masks per
+ * request. The refetch replaces the frame rather than following it, so the
+ * masked value never reaches the store even for one paint.
  */
 export function useContactUpdatedReconciler({
   conversations,
   selectedConversationData,
-  maskingEnabled,
+  refetchEnabled,
   apply,
 }: ContactUpdatedReconcilerParams): (frameContact: Contact) => void {
-  const paramsRef = useRef({ conversations, selectedConversationData, maskingEnabled, apply });
+  const paramsRef = useRef({ conversations, selectedConversationData, refetchEnabled, apply });
   useEffect(() => {
-    paramsRef.current = { conversations, selectedConversationData, maskingEnabled, apply };
-  }, [conversations, selectedConversationData, maskingEnabled, apply]);
+    paramsRef.current = { conversations, selectedConversationData, refetchEnabled, apply };
+  }, [conversations, selectedConversationData, refetchEnabled, apply]);
 
   const timersRef = useRef<Record<string, number>>({});
   const inFlightRef = useRef<Set<string>>(new Set());
   const pendingRef = useRef<Record<string, Contact>>({});
+  const signaturesRef = useRef<Record<string, string>>({});
   const mountedRef = useRef(true);
 
   useEffect(() => {
     mountedRef.current = true;
     const timers = timersRef.current;
     const pending = pendingRef.current;
+    const signatures = signaturesRef.current;
     const inFlight = inFlightRef.current;
 
     return () => {
@@ -71,6 +75,7 @@ export function useContactUpdatedReconciler({
       Object.values(timers).forEach(timerId => window.clearTimeout(timerId));
       Object.keys(timers).forEach(key => delete timers[key]);
       Object.keys(pending).forEach(key => delete pending[key]);
+      Object.keys(signatures).forEach(key => delete signatures[key]);
       inFlight.clear();
     };
   }, []);
@@ -145,12 +150,20 @@ export function useContactUpdatedReconciler({
 
       const contactId = String(frameContact.id);
 
-      // A contact outside the store is applied rather than dropped: the reducer
-      // ignores what it cannot match, and this snapshot can be one render behind.
-      if (!paramsRef.current.maskingEnabled || !isInStore(contactId)) {
+      // Applied rather than dropped: the reducer ignores what it cannot match.
+      // The snapshot lags a render, so a contact just added takes this path too.
+      if (!paramsRef.current.refetchEnabled || !isInStore(contactId)) {
         paramsRef.current.apply(frameContact);
         return;
       }
+
+      // Nothing the store renders moved, so it already holds the reconciled
+      // value and the refetch would answer with what is on screen.
+      const signature = renderedSignature(frameContact);
+      if (signature === signaturesRef.current[contactId]) {
+        return;
+      }
+      signaturesRef.current[contactId] = signature;
 
       pendingRef.current[contactId] = frameContact;
       schedule(contactId);


### PR DESCRIPTION
## O problema

Numa conta com `settings.mask_contact_pii` ligado, o admin abre uma conversa e vê o contato cru — nome, e-mail e telefone reais, servidos pelo REST. Basta alguém alterar aquele contato (renomear, etiquetar, bloquear, mexer num atributo) para os três campos mascararem sozinhos na tela, sem ação dele. Um F5 devolve o valor cru. O dado piora ao vivo e melhora no refresh.

Dois predicados no servidor decidem o mascaramento, e ambos estão certos. O broadcast do `contact.updated` sai no token da conta, cuja audiência é admin e agente ao mesmo tempo, então `Contact#push_event_data` mascara pela flag da conta e ignora o usuário corrente. Já os serializers REST mascaram por requisição e entregam o valor cru ao admin. Ligar o frame direto na store, portanto, substitui pelo mascarado exatamente o que a lista REST tinha acabado de escrever cru.

Isso só ganhou superfície agora: enquanto o `contact.updated` era no-op no front, a divergência não aparecia nessa tela.

## A correção

Ao chegar um `contact.updated` com a flag ligada e o contato já presente na store do chat, o cliente refaz o `GET /contacts/:id` e aplica a resposta. Cada sessão passa a receber a versão a que tem direito — admin cru, agente mascarado — sem nenhum broadcast por audiência, que é a direção onde o mascaramento já queimou quatro rodadas de regressão de vazamento no servidor.

A busca substitui o frame em vez de vir depois dele, senão o valor mascarado pisca na tela. Duas comportas seguram o custo: com a flag desligada, que é o default, não há requisição nenhuma; e um contato fora da store é aplicado direto, já que o broadcast é de conta inteira e a maior parte dos frames é sobre contato que este cliente nunca carregou. Rajada no mesmo contato coalesce numa requisição só, por id. Falha na busca cai de volta no frame — mascarado porém atual vale mais que nome velho na tela.

Nenhuma mudança no backend. As quatro superfícies que liam o nome pela store (header, lista, cópia do modal de atribuição e a barra lateral de contato) acertam juntas, porque a correção é no que entra na store.

## Verificação

`tsc -b` limpo, eslint limpo nos arquivos tocados, e a lista opt-in inteira do Vitest verde: 47 arquivos, 589 testes. Os specs que guardam o tempo real do contato seguem passando, que é o que garante que não troquei realtime por refresh.

Cada comporta foi provada por mutação, uma a uma: aplicar o frame direto derruba sete exemplos; buscar a cada frame derruba o caso de rajada; tirar a comporta de relevância derruba o de contato fora da store; tirar a comporta da flag derruba três; tirar o fallback do `catch` derruba o de erro de rede.

Os specs entram na lista opt-in do CI. Vale registrar que os specs do tempo real do contato não estavam nela, então até aqui nada em CI notava uma reversão — e uma reversão é invisível na tela de toda conta que deixa o mascaramento desligado, que é o default.

## Summary by Sourcery

Prevent masked contact.updated broadcasts from overwriting session-appropriate contact data in the chat store.

Bug Fixes:
- Reconcile in-store contact.updated events with the per-request REST contact when PII masking is enabled, preventing masked broadcast data from replacing an administrator’s unmasked contact details.
- Preserve direct event handling for masked sessions, disabled masking, and contacts outside the chat store, with fallback handling when reconciliation requests fail.

Enhancements:
- Add debounced, per-contact reconciliation that coalesces event bursts, avoids redundant fetches, and applies the newest event when requests overlap.
- Integrate reconciliation into chat contact updates so all store-backed contact views receive the appropriate session-specific data.

CI:
- Add the contact reconciliation and chat contact-update test suites to the opt-in CI test list.

Tests:
- Add coverage for REST replacement, event coalescing, store relevance, masking modes, concurrent updates, request failures, debounce behavior, and unmount safety.

## Aceite

1. Flag ligada e contato na store: o frame não chega à store; o que chega é o corpo do `GET /contacts/:id`. Para o admin, nome, e-mail e telefone param de mascarar sozinhos no header, na lista, na cópia do modal de atribuição e na barra lateral, e param de mudar no refresh.
2. Rajada de três eventos do mesmo contato: uma requisição só.
3. Contato ausente da store: nenhuma requisição; o frame é despachado direto, porque o reducer ignora o que não casa e o snapshot lido aqui pode estar um render atrás.
4. Flag desligada, que é o default: nenhuma requisição; o frame é aplicado como antes.
5. Requisição rejeitada: o frame é aplicado e o erro é logado. Se um frame mais novo chegou durante o voo, é ele que vale.
6. Agente com a flag ligada: continua vendo mascarado, agora vindo do REST em vez do frame.
7. Nenhuma mudança no backend.
8. Os specs entram na lista opt-in do CI.

O item 6 não tem teste e não é testável nesta camada: o hook não conhece papel, e a diferença entre admin e agente é toda do `should_mask?` do servidor. O caminho de código é o mesmo do item 1.

Fica registrado um custo aceito: editar um contato pela barra lateral passa a somar uma requisição, porque o `ContactSidebar` já refaz o `getContact` depois de salvar e o `contact.updated` do mesmo salvamento dispara a reconciliação. São call sites com propósitos diferentes — um enriquece a barra lateral com `contact_inboxes`, o outro alimenta a store — e unificá-los pediria um cache compartilhado no serviço, desproporcional para um problema cosmético.