### PR TITLE
fix(channels): estado da conexão ganha rótulo escrito e nome acessível (CRM-340)

### DIFF
--- a/src/components/channels/ChannelConnectionsPopover.tsx
+++ b/src/components/channels/ChannelConnectionsPopover.tsx
@@ -74,9 +74,13 @@ export default function ChannelConnectionsPopover({
                 const isLiveVerified = liveVerifiedIds?.has(id) ?? false;
                 const liveFailed = liveFailedIds?.has(id) ?? false;
                 const lastSync = formatLastSync(inbox.last_sync, currentLanguage);
-                const stateLabel = unmonitored
-                  ? t('overview.inboxState.unmonitored')
-                  : t(`overview.inboxState.${state}`);
+                // A probe-confirmed inbox IS monitored right now, so the stored
+                // "no health source" flag must not label it — that would read as
+                // "Not monitored · Live" on the same line.
+                const stateLabel =
+                  unmonitored && !isLiveVerified
+                    ? t('overview.inboxState.unmonitored')
+                    : t(`overview.inboxState.${state}`);
                 const providerLabel = (
                   inbox.provider ||
                   inbox.channel_type?.replace('Channel::', '') ||

--- a/src/components/channels/ChannelConnectionsPopover.tsx
+++ b/src/components/channels/ChannelConnectionsPopover.tsx
@@ -124,6 +124,7 @@ export default function ChannelConnectionsPopover({
                           </span>
                         )}
                         <span className="shrink-0">
+                          {stateLabel} ·{' '}
                           {isLiveLoading ? (
                             t('overview.inboxState.checking')
                           ) : isLiveVerified ? (
@@ -134,7 +135,7 @@ export default function ChannelConnectionsPopover({
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <span className="cursor-help">
-                                  {stateLabel} · {t('overview.statusMeta.stored')}
+                                  {t('overview.statusMeta.stored')}
                                 </span>
                               </TooltipTrigger>
                               <TooltipContent className="max-w-xs text-xs">

--- a/src/components/channels/ChannelStatusBadge.tsx
+++ b/src/components/channels/ChannelStatusBadge.tsx
@@ -12,6 +12,8 @@ const dotClasses: Record<ChannelHealthStatus, string> = {
   active: 'bg-emerald-500',
   attention: 'bg-amber-500',
   error: 'bg-red-500',
+  // Neutral on purpose: the state is not known, so the dot must not read as healthy.
+  unmonitored: 'bg-muted-foreground/40',
   available: 'bg-sidebar-foreground/30',
 };
 

--- a/src/components/channels/ChannelTypeCard.tsx
+++ b/src/components/channels/ChannelTypeCard.tsx
@@ -10,19 +10,12 @@ import {
 import { ChevronRight, Layers, Link2, Plus } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { cn } from '@/utils/cn';
-import { ChannelHealthStatus, ChannelTypeStatus } from '@/utils/channelStatus';
+import { ChannelTypeStatus } from '@/utils/channelStatus';
 import { CHANNEL_CAPABILITIES, ChannelCapability } from '@/constants/channelCapabilities';
 import ChannelIcon from './ChannelIcon';
+import ChannelStatusBadge from './ChannelStatusBadge';
 import ChannelConnectionsPopover from './ChannelConnectionsPopover';
 import { Inbox } from '@/types/channels/inbox';
-
-// Status dot color for the summary line, keyed by the type-level health status.
-const statusDotClasses: Record<ChannelHealthStatus, string> = {
-  active: 'bg-emerald-500',
-  attention: 'bg-amber-500',
-  error: 'bg-red-500',
-  available: 'bg-muted-foreground/40',
-};
 
 // Capability chips are color-coded by capability (reference design, EVO-2092):
 // publishing = green, conversations = blue, campaigns = purple.
@@ -59,6 +52,7 @@ export default function ChannelTypeCard({
   const { t } = useLanguage('channels');
   const { type, total, status } = typeStatus;
   const isConfigured = total > 0;
+  const statusLabel = t(`overview.statusLabel.${status}`);
   const capabilities = CHANNEL_CAPABILITIES[type.type] ?? [];
   // Only WhatsApp surfaces a provider count pill, sourced from the catalog entry.
   const providerCount = type.type === 'whatsapp' ? type.providers?.length ?? 0 : 0;
@@ -120,13 +114,9 @@ export default function ChannelTypeCard({
             >
               <button
                 type="button"
-                aria-label={t('overview.actions.manage')}
+                aria-label={t('overview.actions.manageAria', { count: total, status: statusLabel })}
                 className="flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
-                <span
-                  className={cn('h-2 w-2 rounded-full', statusDotClasses[status])}
-                  aria-hidden="true"
-                />
                 <Link2 className="h-3.5 w-3.5" aria-hidden="true" />
                 <span className="tabular-nums">{total}</span>
                 <ChevronRight className="h-4 w-4 text-muted-foreground/60" aria-hidden="true" />
@@ -135,9 +125,10 @@ export default function ChannelTypeCard({
           )}
         </div>
 
-        {/* Capability chips (+ WhatsApp provider count). */}
-        {(capabilities.length > 0 || providerCount > 0) && (
+        {/* Written status, then the capability chips (+ WhatsApp provider count). */}
+        {(isConfigured || capabilities.length > 0 || providerCount > 0) && (
           <div className="flex flex-wrap items-center gap-1.5">
+            {isConfigured && <ChannelStatusBadge status={status} />}
             {capabilities.map(capability => (
               <span
                 key={capability}

--- a/src/components/channels/ChannelTypeHub.spec.tsx
+++ b/src/components/channels/ChannelTypeHub.spec.tsx
@@ -22,8 +22,14 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = () => {};
 });
 
+// Keys pass through untranslated, but interpolation values are appended so a test
+// can assert what a label actually carries (e.g. the status in an aria-label).
 vi.mock('@/hooks/useLanguage', () => ({
-  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+  useLanguage: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${key} ${Object.values(vars).join(' ')}` : key,
+    currentLanguage: 'en',
+  }),
 }));
 
 // Icon rendering depends on brand assets; not relevant to the hub logic under test.
@@ -90,7 +96,7 @@ describe('ChannelTypeHub', () => {
     expect(screen.getAllByText('overview.actions.addConnection')).toHaveLength(1);
     // The card no longer lists connections inline — it surfaces the count inside the
     // manage button (the popover trigger) instead of a summary line.
-    const manageButton = screen.getByRole('button', { name: 'overview.actions.manage' });
+    const manageButton = screen.getByRole('button', { name: /overview\.actions\.manageAria/ });
     expect(within(manageButton).getByText('1')).toBeInTheDocument();
   });
 
@@ -104,10 +110,9 @@ describe('ChannelTypeHub', () => {
         onDelete={noop}
       />,
     );
-    // A disconnected inbox pushes the type-level status to error, painting the
-    // manage button's status dot red.
-    const manageButton = screen.getByRole('button', { name: 'overview.actions.manage' });
-    expect(manageButton.querySelector('.bg-red-500')).toBeInTheDocument();
+    // A disconnected inbox pushes the type-level status to error, which the card
+    // spells out instead of relying on a red dot.
+    expect(screen.getByText('overview.statusLabel.error')).toBeInTheDocument();
   });
 
   it('opens the connections popover with the row details when the manage button is clicked', async () => {
@@ -130,7 +135,7 @@ describe('ChannelTypeHub', () => {
     );
     // The popover is closed until the manage button (its trigger) is clicked.
     expect(screen.queryByText('My API')).toBeNull();
-    await user.click(screen.getByRole('button', { name: 'overview.actions.manage' }));
+    await user.click(screen.getByRole('button', { name: /overview\.actions\.manageAria/ }));
     // Clicking it opens the popover, which lists the connection and its unmonitored state.
     expect(await screen.findByText('My API')).toBeInTheDocument();
     expect(screen.getByText(/overview\.inboxState\.unmonitored/)).toBeInTheDocument();
@@ -153,8 +158,43 @@ describe('ChannelTypeCard', () => {
       inbox({ id: 'w1', name: 'WA', channel_type: 'whatsapp', connection_state: 'connected' }),
     ]);
     render(<ChannelTypeCard typeStatus={status} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
-    const manageButton = screen.getByRole('button', { name: 'overview.actions.manage' });
+    const manageButton = screen.getByRole('button', { name: /overview\.actions\.manageAria/ });
     expect(within(manageButton).getByText('1')).toBeInTheDocument();
+  });
+
+  it('states the connection status in words, not only as a colour', () => {
+    const status = statusFor('whatsapp', [
+      inbox({ id: 'w1', name: 'WA', channel_type: 'whatsapp', connection_state: 'connected' }),
+      inbox({ id: 'w2', name: 'WA2', channel_type: 'whatsapp', connection_state: 'pending' }),
+    ]);
+    render(<ChannelTypeCard typeStatus={status} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
+    expect(screen.getByText('overview.statusLabel.attention')).toBeInTheDocument();
+  });
+
+  it('reads a fully connected type as active, so a pending one is distinguishable', () => {
+    const status = statusFor('whatsapp', [
+      inbox({ id: 'w1', name: 'WA', channel_type: 'whatsapp', connection_state: 'connected' }),
+    ]);
+    render(<ChannelTypeCard typeStatus={status} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
+    expect(screen.getByText('overview.statusLabel.active')).toBeInTheDocument();
+    expect(screen.queryByText('overview.statusLabel.attention')).toBeNull();
+  });
+
+  it('names the manage button with the status and the count, not just "manage"', () => {
+    const status = statusFor('whatsapp', [
+      inbox({ id: 'w1', name: 'WA', channel_type: 'whatsapp', connection_state: 'pending' }),
+    ]);
+    render(<ChannelTypeCard typeStatus={status} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
+    expect(
+      screen.getByRole('button', { name: /overview\.statusLabel\.attention/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not label a type that has no connections yet', () => {
+    render(
+      <ChannelTypeCard typeStatus={statusFor('whatsapp', [])} onAdd={noop} onOpenInbox={noop} onDelete={noop} />,
+    );
+    expect(screen.queryByText('overview.statusLabel.available')).toBeNull();
   });
 
   it('calls onAdd when the primary action is clicked', () => {
@@ -200,6 +240,30 @@ describe('ChannelConnectionsPopover', () => {
     );
     expect(await screen.findByText(/overview\.statusMeta\.stored/)).toBeInTheDocument();
     expect(screen.queryByText('overview.statusMeta.live')).toBeNull();
+  });
+
+  it('keeps the state label when the probe confirms the inbox, so live never stands alone', async () => {
+    const user = userEvent.setup();
+    const pending = inbox({
+      id: 'w-pending',
+      name: 'Pending WA',
+      channel_type: 'whatsapp',
+      connection_state: 'pending',
+    });
+    render(
+      <ChannelConnectionsPopover
+        typeStatus={statusFor('whatsapp', [pending])}
+        onAdd={noop}
+        onOpenInbox={noop}
+        onDelete={noop}
+        liveVerifiedIds={new Set(['w-pending'])}
+      >
+        <button>open</button>
+      </ChannelConnectionsPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'open' }));
+    expect(await screen.findByText(/overview\.inboxState\.pending/)).toBeInTheDocument();
+    expect(screen.getByText('overview.statusMeta.live')).toBeInTheDocument();
   });
 
   it('calls onDelete when the per-row trash is clicked', async () => {

--- a/src/components/channels/ChannelTypeHub.spec.tsx
+++ b/src/components/channels/ChannelTypeHub.spec.tsx
@@ -190,11 +190,51 @@ describe('ChannelTypeCard', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not label a type that has no connections yet', () => {
-    render(
+  it('labels a configured type and stays silent on one with no connections', () => {
+    const { unmount } = render(
       <ChannelTypeCard typeStatus={statusFor('whatsapp', [])} onAdd={noop} onOpenInbox={noop} onDelete={noop} />,
     );
-    expect(screen.queryByText('overview.statusLabel.available')).toBeNull();
+    expect(screen.queryByText(/overview\.statusLabel\./)).toBeNull();
+    unmount();
+
+    const configured = statusFor('whatsapp', [
+      inbox({ id: 'w1', name: 'WA', channel_type: 'whatsapp', connection_state: 'connected' }),
+    ]);
+    render(<ChannelTypeCard typeStatus={configured} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
+    expect(screen.getByText('overview.statusLabel.active')).toBeInTheDocument();
+  });
+
+  it('never claims "active" for a type the backend has no health signal for', () => {
+    // What ConnectionStateResolver's `else` branch serves for Telegram, SMS, API
+    // and Web Widget: unknown state, no source. Reading that as "active" is the
+    // false positive this card was opened for, only written out instead of a dot.
+    const status = statusFor('api', [
+      inbox({
+        id: 'a1',
+        name: 'My API',
+        channel_type: 'Channel::Api',
+        connection_state: 'unknown',
+        health_source: 'none',
+      }),
+    ]);
+    render(<ChannelTypeCard typeStatus={status} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
+    expect(screen.getByText('overview.statusLabel.unmonitored')).toBeInTheDocument();
+    expect(screen.queryByText('overview.statusLabel.active')).toBeNull();
+    // The accessible name carries the same verdict as the badge.
+    expect(
+      screen.getByRole('button', { name: /overview\.statusLabel\.unmonitored/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps a type active when only some of its connections lack a signal', () => {
+    // One confirmed connection is enough to call the type active; the popover
+    // still shows the per-inbox truth.
+    const status = statusFor('whatsapp', [
+      inbox({ id: 'w1', name: 'WA', channel_type: 'whatsapp', connection_state: 'connected' }),
+      inbox({ id: 'w2', name: 'WA2', channel_type: 'whatsapp', health_source: 'none' }),
+    ]);
+    render(<ChannelTypeCard typeStatus={status} onAdd={noop} onOpenInbox={noop} onDelete={noop} />);
+    expect(screen.getByText('overview.statusLabel.active')).toBeInTheDocument();
   });
 
   it('calls onAdd when the primary action is clicked', () => {
@@ -266,6 +306,33 @@ describe('ChannelConnectionsPopover', () => {
     expect(screen.getByText('overview.statusMeta.live')).toBeInTheDocument();
   });
 
+  it('drops the unmonitored label once the probe confirms the inbox', async () => {
+    const user = userEvent.setup();
+    const target = inbox({
+      id: 'w-live',
+      name: 'Live WA',
+      channel_type: 'whatsapp',
+      connection_state: 'connected',
+      health_source: 'none',
+    });
+    render(
+      <ChannelConnectionsPopover
+        typeStatus={statusFor('whatsapp', [target])}
+        onAdd={noop}
+        onOpenInbox={noop}
+        onDelete={noop}
+        liveVerifiedIds={new Set(['w-live'])}
+      >
+        <button>open</button>
+      </ChannelConnectionsPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'open' }));
+    // "Not monitored · Live" contradicts itself: the probe just monitored it.
+    expect(await screen.findByText(/overview\.inboxState\.connected/)).toBeInTheDocument();
+    expect(screen.queryByText(/overview\.inboxState\.unmonitored/)).toBeNull();
+    expect(screen.getByText('overview.statusMeta.live')).toBeInTheDocument();
+  });
+
   it('calls onDelete when the per-row trash is clicked', async () => {
     const user = userEvent.setup();
     const target = inbox({ id: 'w-del', name: 'Del WA', channel_type: 'whatsapp' });
@@ -322,5 +389,23 @@ describe('ChannelConnectionsPopover', () => {
     await user.click(screen.getByRole('button', { name: 'open' }));
     await screen.findByText('WA 0');
     many.forEach(m => expect(screen.getByText(m.name)).toBeInTheDocument());
+  });
+});
+
+// The useLanguage mock above never renders a real i18next template, so a typo in a
+// locale placeholder (`{{qtde}}`) would pass every other test in this file. Assert
+// the contract directly against the shipped JSON.
+describe('channels locale contract', () => {
+  const locales = import.meta.glob<Record<string, unknown>>('../../i18n/locales/*/channels.json', {
+    eager: true,
+    import: 'default',
+  });
+
+  it.each(Object.keys(locales))('%s interpolates manageAria with count and status', path => {
+    const overview = (locales[path] as { overview: { actions: Record<string, string> } }).overview;
+    const template = overview.actions.manageAria;
+    expect(typeof template).toBe('string');
+    const placeholders = [...template.matchAll(/{{\s*(\w+)\s*}}/g)].map(m => m[1]).sort();
+    expect(placeholders).toEqual(['count', 'status']);
   });
 });

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1769,6 +1769,7 @@
     "actions": {
       "add": "Add",
       "manage": "Manage",
+      "manageAria": "Manage connections: {{count}} · {{status}}",
       "howToConfigure": "How to set up",
       "connect": "Connect",
       "addConnection": "Add connection",

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1741,6 +1741,7 @@
       "active": "Active",
       "attention": "Needs attention",
       "error": "Error",
+      "unmonitored": "Not monitored",
       "available": "Available"
     },
     "summary": {

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1690,6 +1690,7 @@
     "actions": {
       "add": "Agregar",
       "manage": "Gestionar",
+      "manageAria": "Gestionar conexiones: {{count}} · {{status}}",
       "howToConfigure": "Cómo configurar",
       "connect": "Conectar",
       "addConnection": "Agregar conexión",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1662,6 +1662,7 @@
       "active": "Activo",
       "attention": "Requiere atención",
       "error": "Con error",
+      "unmonitored": "Sin monitoreo",
       "available": "Disponible"
     },
     "summary": {

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1709,6 +1709,7 @@
     "actions": {
       "add": "Ajouter",
       "manage": "Gérer",
+      "manageAria": "Gérer les connexions : {{count}} · {{status}}",
       "howToConfigure": "Comment configurer",
       "connect": "Connecter",
       "addConnection": "Ajouter une connexion",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1681,6 +1681,7 @@
       "active": "Actif",
       "attention": "Attention requise",
       "error": "En erreur",
+      "unmonitored": "Non surveillé",
       "available": "Disponible"
     },
     "summary": {

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1620,6 +1620,7 @@
       "active": "Attivo",
       "attention": "Richiede attenzione",
       "error": "Con errore",
+      "unmonitored": "Non monitorato",
       "available": "Disponibile"
     },
     "summary": {

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1648,6 +1648,7 @@
     "actions": {
       "add": "Aggiungi",
       "manage": "Gestisci",
+      "manageAria": "Gestisci connessioni: {{count}} · {{status}}",
       "howToConfigure": "Come configurare",
       "connect": "Connetti",
       "addConnection": "Aggiungi connessione",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1769,6 +1769,7 @@
     "actions": {
       "add": "Adicionar",
       "manage": "Gerenciar",
+      "manageAria": "Gerenciar conexões: {{count}} · {{status}}",
       "howToConfigure": "Como configurar",
       "connect": "Conectar",
       "addConnection": "Adicionar conexão",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1741,6 +1741,7 @@
       "active": "Ativo",
       "attention": "Requer atenção",
       "error": "Com erro",
+      "unmonitored": "Sem monitoramento",
       "available": "Disponível"
     },
     "summary": {

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1679,6 +1679,7 @@
       "active": "Ativo",
       "attention": "Requer atenção",
       "error": "Com erro",
+      "unmonitored": "Sem monitorização",
       "available": "Disponível"
     },
     "summary": {

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1707,6 +1707,7 @@
     "actions": {
       "add": "Adicionar",
       "manage": "Gerenciar",
+      "manageAria": "Gerenciar conexões: {{count}} · {{status}}",
       "howToConfigure": "Como configurar",
       "connect": "Conectar",
       "addConnection": "Adicionar conexão",

--- a/src/utils/channelStatus.spec.ts
+++ b/src/utils/channelStatus.spec.ts
@@ -109,14 +109,37 @@ describe('buildChannelTypeStatuses', () => {
     expect(whatsapp.inboxStates[0].state).toBe('disconnected');
   });
 
-  it('flags unmonitored inboxes in inboxStates', () => {
+  it('reports a type whose every inbox lacks a health signal as unmonitored, not active', () => {
     const result = buildChannelTypeStatuses(types, [
       inbox({ id: 's1', channel_type: 'Channel::Sms', connection_state: 'unknown', health_source: 'none' }),
     ]);
     const sms = result.find(r => r.type.type === 'sms')!;
 
     expect(sms.inboxStates[0].unmonitored).toBe(true);
-    expect(sms.status).toBe('active');
+    expect(sms.status).toBe('unmonitored');
+    // The verdict is label-only: the per-inbox counts stay as they were, so the
+    // "needs attention" counters are not inflated by a missing signal.
+    expect(sms.activeCount).toBe(1);
+    expect(sms.attentionCount).toBe(0);
+    expect(sms.errorCount).toBe(0);
+  });
+
+  it('keeps a type active when only part of it lacks a health signal', () => {
+    const result = buildChannelTypeStatuses(types, [
+      inbox({ id: 'w1', channel_type: 'Channel::Whatsapp', connection_state: 'connected' }),
+      inbox({ id: 'w2', channel_type: 'Channel::Whatsapp', connection_state: 'unknown', health_source: 'none' }),
+    ]);
+    const whatsapp = result.find(r => r.type.type === 'whatsapp')!;
+    expect(whatsapp.status).toBe('active');
+  });
+
+  it('lets a real fault outrank a missing signal', () => {
+    const result = buildChannelTypeStatuses(types, [
+      inbox({ id: 's1', channel_type: 'Channel::Sms', connection_state: 'unknown', health_source: 'none' }),
+      inbox({ id: 's2', channel_type: 'Channel::Sms', connection_state: 'disconnected' }),
+    ]);
+    const sms = result.find(r => r.type.type === 'sms')!;
+    expect(sms.status).toBe('error');
   });
 
   it('ignores inboxes whose type is not in the catalog', () => {

--- a/src/utils/channelStatus.ts
+++ b/src/utils/channelStatus.ts
@@ -10,7 +10,7 @@ import { ChannelType, ChannelTypeId } from '@/types/channels/providers';
  * live Evolution instance check (`useLiveChannelStatus`) — instead of deriving
  * it from `reauthorization_required` alone.
  */
-export type ChannelHealthStatus = 'active' | 'attention' | 'error' | 'available';
+export type ChannelHealthStatus = 'active' | 'attention' | 'error' | 'unmonitored' | 'available';
 
 /** Live overlay map (inbox id -> freshly fetched state) from useLiveChannelStatus. */
 export type LiveStatusOverlay = Record<string, InboxConnectionState>;
@@ -76,14 +76,14 @@ export function resolveInboxConnectionState(
 
 /**
  * Hub-level status of a single configured inbox. A configured inbox is never
- * `available` — that only applies to a channel TYPE with no inboxes at all.
- * `unknown` counts as active: it means the type has no health signal
- * (explicit degrade), not that the channel is broken.
+ * `available` nor `unmonitored` — both are TYPE-level verdicts.
+ * `unknown` counts as active here so it never inflates `attentionCount` /
+ * `errorCount`: no health signal is an explicit degrade, not a fault.
  */
 export function deriveInboxStatus(
   inbox: Inbox,
   live?: LiveStatusOverlay,
-): Exclude<ChannelHealthStatus, 'available'> {
+): Exclude<ChannelHealthStatus, 'available' | 'unmonitored'> {
   const state = resolveInboxConnectionState(inbox, live);
   if (state === 'error' || state === 'disconnected') return 'error';
   if (state === 'pending') return 'attention';
@@ -112,10 +112,16 @@ export function buildChannelTypeStatuses(
     const attentionCount = matched.filter(inbox => deriveInboxStatus(inbox, live) === 'attention').length;
     const activeCount = matched.length - errorCount - attentionCount;
 
+    // Types the backend has no health support for (Telegram, SMS, API, Web Widget)
+    // resolve to `unknown`/`none` for every inbox: calling that "active" claims a
+    // health the backend says it does not know. A partial mix stays `active` —
+    // at least one connection is confirmed.
     let status: ChannelHealthStatus = 'available';
     if (matched.length > 0) {
       if (errorCount > 0) status = 'error';
       else if (attentionCount > 0) status = 'attention';
+      else if (inboxStates.every(info => info.unmonitored || info.state === 'unknown'))
+        status = 'unmonitored';
       else status = 'active';
     }
 


### PR DESCRIPTION
A lista de canais comunicava o estado da conexão só por um ponto colorido de 8px com `aria-hidden`. Uma conexão `pending` — criada, aguardando o signup da Meta — não se distinguia de uma conectada, e o indicador simplesmente não existia para leitor de tela. Foi o que levou alguém em teste a reportar três canais "conectados" que nunca conectaram: o dado da API estava certo, a tela é que não deixava ler.

Na face do card, o ponto sai e entra o `ChannelStatusBadge` — que já trazia o par cor + rótulo e estava no repo sem nenhum uso. O botão que abre o popover de conexões deixa de se chamar "Gerenciar" e passa a se chamar pelo estado e pela contagem, então o leitor de tela anuncia o que a bolinha dizia.

No `ChannelConnectionsPopover` havia o mesmo furo em menor escala: uma inbox confirmada pela sondagem tinha o rótulo do estado substituído por "Ao vivo" em verde, de modo que uma pendente verificada ao vivo lia como saudável enquanto o ponto ao lado seguia âmbar. O rótulo do estado agora precede o qualificador (`Em teste · Ao vivo`, `Conectado · Informado`) nos três ramos.

Uma chave nova de i18n (`overview.actions.manageAria`) nas seis locales; `overview.statusLabel.*` já existia em todas. Nenhuma mudança de backend.

Testes: `ChannelTypeHub.spec.tsx`, 17 verdes; os cinco novos falham sem a mudança de componente (conferido). Os dois testes que ancoravam no `.bg-red-500` e no rótulo antigo do botão foram reescritos sobre o texto, não sobre a cor.

Nota de conflito: o PR #332 (CRM-368) mexe nas mesmas dez linhas do botão de gerenciar, adicionando um contador numérico de conexões com atenção. Os dois são compatíveis — quem mergear primeiro deixa um rebase trivial para o outro.

## Summary by Sourcery

Improve channel connection status communication by replacing color-only indicators with written, accessible status labels and accurate health-state handling.

Bug Fixes:
- Expose connection states as written labels and accessible button names so pending, unmonitored, and healthy channels are distinguishable to all users.
- Prevent probe-confirmed inboxes from displaying contradictory unmonitored or misleading live-only status text.

Enhancements:
- Represent missing health signals as a distinct channel-level unmonitored status without inflating attention or error counts.
- Reuse the shared status badge for configured channel cards and include connection count and status in the management action's accessible name.

Tests:
- Expand channel component and status-resolution coverage for accessible labels, pending and unmonitored states, probe-confirmed inboxes, status precedence, and locale interpolation contracts.