### PR TITLE
fix(channels): canal sem confirmação deixa de aparecer verde no hub (CRM-339)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,8 @@ jobs:
             src/utils/apiHelpers.spec.ts \
             src/hooks/channels/useChannelSubmission.spec.ts \
             src/hooks/channels/useChannelValidation.spec.ts \
+            src/utils/channelStatus.spec.ts \
+            src/components/channels/ChannelTypeHub.spec.tsx \
             src/components/journey/environment-manager/EnvironmentManager.spec.tsx \
             src/components/journey/nodes/actions/add-label/AddLabelNode.spec.tsx \
             src/components/journey/nodes/actions/assign-bot/AssignBotPanel.spec.tsx \

--- a/src/utils/channelStatus.spec.ts
+++ b/src/utils/channelStatus.spec.ts
@@ -66,6 +66,19 @@ describe('deriveInboxStatus', () => {
   it('treats unmonitored (unknown) channels as active — explicit degrade, not broken', () => {
     expect(deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'none' }))).toBe('active');
   });
+
+  it('flags an unknown channel that does have a health source — nothing confirmed the connection', () => {
+    expect(deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'stored_flag' }))).toBe(
+      'attention',
+    );
+    expect(deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'provider_event' }))).toBe(
+      'attention',
+    );
+  });
+
+  it('keeps pre-EVO-1674 payloads, which carry no health source, on active', () => {
+    expect(deriveInboxStatus(inbox({}))).toBe('active');
+  });
 });
 
 describe('buildChannelTypeStatuses', () => {
@@ -117,6 +130,21 @@ describe('buildChannelTypeStatuses', () => {
 
     expect(sms.inboxStates[0].unmonitored).toBe(true);
     expect(sms.status).toBe('active');
+  });
+
+  it('does not badge a token-based channel green while nothing confirms its connection', () => {
+    const result = buildChannelTypeStatuses(types, [
+      inbox({
+        id: 'w1',
+        channel_type: 'Channel::Whatsapp',
+        connection_state: 'unknown',
+        health_source: 'stored_flag',
+      }),
+    ]);
+    const whatsapp = result.find(r => r.type.type === 'whatsapp')!;
+
+    expect(whatsapp).toMatchObject({ total: 1, activeCount: 0, attentionCount: 1, status: 'attention' });
+    expect(whatsapp.inboxStates[0].unmonitored).toBe(false);
   });
 
   it('ignores inboxes whose type is not in the catalog', () => {

--- a/src/utils/channelStatus.ts
+++ b/src/utils/channelStatus.ts
@@ -77,8 +77,12 @@ export function resolveInboxConnectionState(
 /**
  * Hub-level status of a single configured inbox. A configured inbox is never
  * `available` — that only applies to a channel TYPE with no inboxes at all.
- * `unknown` counts as active: it means the type has no health signal
- * (explicit degrade), not that the channel is broken.
+ *
+ * `unknown` splits by `health_source`: with `none` the channel type has no
+ * health signal at all (explicit degrade, still active), but with a real
+ * source it means the backend looked and found nothing confirming the
+ * connection — which must not read as active. A payload without
+ * `health_source` predates EVO-1674 and keeps the old benefit of the doubt.
  */
 export function deriveInboxStatus(
   inbox: Inbox,
@@ -87,6 +91,7 @@ export function deriveInboxStatus(
   const state = resolveInboxConnectionState(inbox, live);
   if (state === 'error' || state === 'disconnected') return 'error';
   if (state === 'pending') return 'attention';
+  if (state === 'unknown' && inbox.health_source && inbox.health_source !== 'none') return 'attention';
   return 'active';
 }
 


### PR DESCRIPTION
## Problema

O backend passou a responder `connection_state: unknown` para canal por token sem evidência de conexão, mas na tela nada mudou: `deriveInboxStatus` jogava todo `unknown` em `active`, então o selo do tipo continuava verde. Só a linha dentro do popover ficava cinza com "Desconhecido". O sintoma que abriu o card — operador vendo canal "conectado" que não entrega — seguia de pé.

`health_source` chegava no payload mas não entrava na conta em lugar nenhum: virava apenas o booleano `unmonitored`.

## Correção

`unknown` agora separa por `health_source`. Com `none`, o tipo de canal não tem sinal de saúde algum e continua `active` — é o degrade explícito que o EVO-1674 desenhou. Com uma fonte real (`stored_flag` ou `provider_event`), o backend olhou e não encontrou nada confirmando a conexão, e isso vai para `attention`. Payload sem `health_source` é anterior ao formato atual e mantém o benefício da dúvida.

Como `buildChannelTypeStatuses` agrega por `deriveInboxStatus`, o selo do card do tipo acompanha sem mudança extra.

## Teste

`src/utils/channelStatus.spec.ts`: 18 verdes. Os 3 exemplos novos cobrem as duas metades do `unknown` e o payload legado, e falham contra a versão anterior do arquivo (2 falhas, 16 passando) — não são vacuamente verdes. `tsc -b` limpo.

Par no backend: evolution-foundation/evo-ai-crm-community#317.

## Summary by Sourcery

Prevent channels lacking confirmed connectivity from appearing healthy in the channel hub while preserving explicit unmonitored and legacy behavior.

Bug Fixes:
- Distinguish unknown channel health states so channels with a real health source but no confirmed connection are shown as requiring attention instead of active.
- Keep legacy payloads without health_source and explicitly unmonitored channels on the existing active fallback.

CI:
- Add channel status utility and channel type hub tests to the test workflow.

Tests:
- Add coverage for health-source-aware status derivation and channel-type attention badges.