### PR TITLE
test(ai_agents): checa o eixo bedrock contra o model card da AWS (CRM-463)

### DIFF
--- a/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { availableModels } from '@/components/ai_agents/ModelSelector';
 
-// Shape checks, not freshness. Freshness needs the provider's own answer, which is
-// why it lives apart: the bedrock axis is checked against the AWS model cards in
-// ModelSelector.bedrockLifecycle.spec.ts, and the axes that list live correct
-// themselves the moment a key is chosen.
+// Shape checks, not freshness. Freshness needs the provider's own answer: the LISTS_LIVE
+// axes get it the moment a key is chosen, and the bedrock axis gets it from the AWS model
+// cards in ModelSelector.bedrockLifecycle.spec.ts. Vertex and Perplexity have neither, so
+// their pins are still only as fresh as the last person who went looking.
 
 const PROVIDER_PREFIX: Record<string, string> = {
   openai: 'openai/',

--- a/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { availableModels } from '@/components/ai_agents/ModelSelector';
 
-// Shape checks, not freshness: nothing local can tell that a provider retired a model.
+// Shape checks, not freshness. Freshness needs the provider's own answer, which is
+// why it lives apart: the bedrock axis is checked against the AWS model cards in
+// ModelSelector.bedrockLifecycle.spec.ts, and the axes that list live correct
+// themselves the moment a key is chosen.
 
 const PROVIDER_PREFIX: Record<string, string> = {
   openai: 'openai/',

--- a/src/components/ai_agents/__tests__/ModelSelector.bedrockLifecycle.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.bedrockLifecycle.spec.ts
@@ -43,6 +43,25 @@ const modelId = (value: string) => value.replace(/^bedrock\//, '');
 const lifecycleOf = (markdown: string) =>
   markdown.match(/\*\*Model lifecycle:\*\*\s*(.+)/)?.[1].trim();
 
+const eolNoticeOf = (markdown: string) =>
+  markdown.match(/\*\*Model EOL date:\*\*\s*(.+)/)?.[1].trim();
+
+// `Model EOL date` is a FLOOR, not an expiry: "No sooner than 3/1/2025" promises the
+// model will not be retired BEFORE that day, and says nothing about after. Four of the
+// pins here sit past their floor and are served normally, so treating the date as an
+// expiry — `new Date(notice) < new Date()` — fails them all while AWS is still serving
+// them. `Model lifecycle` is the field that actually flips, which is why it is the one
+// asserted on.
+//
+// What the notice is good for is catching a change of vocabulary: these three shapes
+// are what the parse above assumes, and a fourth would mean the field started saying
+// something this spec cannot read.
+const EOL_NOTICE_SHAPES = [
+  /^N\/A$/,
+  /^No sooner than \d{1,2}\/\d{1,2}\/\d{4}$/,
+  /^Legacy: \w+ \d{1,2}, \d{4}$/,
+];
+
 const cards = new Map<string, string>();
 let docsReachable = true;
 
@@ -81,7 +100,7 @@ describe('bedrock axis lifecycle', () => {
     expect(missing).toEqual([]);
   });
 
-  it('keeps every pinned id Active — never Legacy, never past EOL', ctx => {
+  it('keeps every pinned id on an Active lifecycle', ctx => {
     if (!docsReachable) return ctx.skip();
 
     // The lifecycle line is the whole point, so a card that stopped carrying one
@@ -90,5 +109,14 @@ describe('bedrock axis lifecycle', () => {
       .map(id => ({ id, lifecycle: lifecycleOf(cards.get(id) ?? '') }))
       .filter(({ lifecycle }) => lifecycle !== 'Active');
     expect(notActive).toEqual([]);
+  });
+
+  it('reads an EOL notice it still knows how to interpret', ctx => {
+    if (!docsReachable) return ctx.skip();
+
+    const unreadable = Object.keys(MODEL_CARD_BY_ID)
+      .map(id => ({ id, notice: eolNoticeOf(cards.get(id) ?? '') }))
+      .filter(({ notice }) => !notice || !EOL_NOTICE_SHAPES.some(shape => shape.test(notice)));
+    expect(unreadable).toEqual([]);
   });
 });

--- a/src/components/ai_agents/__tests__/ModelSelector.bedrockLifecycle.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.bedrockLifecycle.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { availableModels } from '@/components/ai_agents/ModelSelector';
+
+/**
+ * Freshness for the bedrock axis, which the sibling shape spec cannot cover.
+ *
+ * Bedrock has no listing endpoint the product can reach, so the pinned list is
+ * the only source for this axis and nothing corrects it on its own. The AWS docs
+ * do serve each model card as raw markdown — swap `.html` for `.md` — carrying
+ * `Model lifecycle` and `Model EOL date` in plain text, with no credentials. That
+ * is enough to check the pins against the provider instead of against a memory.
+ *
+ * It is what would have caught Llama 3.1 405B, which sat in the picker for weeks
+ * after going Legacy: being listed in the model-card index says nothing about
+ * lifecycle, and the index does not drop a retired model.
+ *
+ * NOT in the CI list on purpose — it reaches the network, so it is neither fast
+ * nor deterministic, the two things that list asks of a spec. Run it by hand when
+ * touching the axis, or on the EOL dates the entries carry.
+ */
+
+const DOCS_BASE = 'https://docs.aws.amazon.com/bedrock/latest/userguide';
+
+// Bedrock ids carry a routing prefix (`global.`, `us.`) that the model card slug
+// does not, and the slug follows the model's marketing name rather than its id —
+// `us.meta.llama3-1-70b-instruct-v1:0` lives in `model-card-meta-llama-3-1-70b-instruct`.
+// No rule derives one from the other, so the pairing is written down. An id with no
+// entry here fails the first example rather than being quietly skipped.
+const MODEL_CARD_BY_ID: Record<string, string> = {
+  'bedrock/global.anthropic.claude-opus-5': 'model-card-anthropic-claude-opus-5',
+  'bedrock/global.anthropic.claude-sonnet-5': 'model-card-anthropic-claude-sonnet-5',
+  'bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0': 'model-card-anthropic-claude-sonnet-4-5',
+  'bedrock/us.meta.llama3-1-70b-instruct-v1:0': 'model-card-meta-llama-3-1-70b-instruct',
+  'bedrock/us.deepseek.r1-v1:0': 'model-card-deepseek-deepseek-r1',
+  'bedrock/mistral.mistral-7b-instruct-v0:2': 'model-card-mistral-ai-mistral-7b-instruct',
+  'bedrock/amazon.nova-micro-v1:0': 'model-card-amazon-nova-micro',
+};
+
+const bedrockEntries = availableModels.filter(m => m.provider === 'bedrock');
+
+const modelId = (value: string) => value.replace(/^bedrock\//, '');
+
+const lifecycleOf = (markdown: string) =>
+  markdown.match(/\*\*Model lifecycle:\*\*\s*(.+)/)?.[1].trim();
+
+const cards = new Map<string, string>();
+let docsReachable = true;
+
+beforeAll(async () => {
+  try {
+    await Promise.all(
+      Object.entries(MODEL_CARD_BY_ID).map(async ([id, slug]) => {
+        const response = await fetch(`${DOCS_BASE}/${slug}.md`);
+        if (!response.ok) {
+          throw new Error(`${slug}.md answered ${response.status}`);
+        }
+        cards.set(id, await response.text());
+      }),
+    );
+  } catch {
+    docsReachable = false;
+  }
+}, 120_000);
+
+describe('bedrock axis lifecycle', () => {
+  it('pairs every pinned bedrock id with a model card to check it against', () => {
+    const unmapped = bedrockEntries.filter(m => !MODEL_CARD_BY_ID[m.value]).map(m => m.value);
+    expect(unmapped).toEqual([]);
+  });
+
+  it('checks a non-empty axis, so a silent list rename never reads as a pass', () => {
+    expect(bedrockEntries.length).toBeGreaterThan(0);
+  });
+
+  it('serves every pinned id from its own model card', ctx => {
+    if (!docsReachable) return ctx.skip();
+
+    const missing = Object.entries(MODEL_CARD_BY_ID)
+      .filter(([id]) => !cards.get(id)?.includes(modelId(id)))
+      .map(([id]) => id);
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps every pinned id Active — never Legacy, never past EOL', ctx => {
+    if (!docsReachable) return ctx.skip();
+
+    // The lifecycle line is the whole point, so a card that stopped carrying one
+    // is reported as such instead of passing on an absent value.
+    const notActive = Object.keys(MODEL_CARD_BY_ID)
+      .map(id => ({ id, lifecycle: lifecycleOf(cards.get(id) ?? '') }))
+      .filter(({ lifecycle }) => lifecycle !== 'Active');
+    expect(notActive).toEqual([]);
+  });
+});

--- a/src/components/ai_agents/__tests__/ModelSelector.bedrockLifecycle.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.bedrockLifecycle.spec.ts
@@ -2,30 +2,17 @@ import { describe, it, expect, beforeAll } from 'vitest';
 import { availableModels } from '@/components/ai_agents/ModelSelector';
 
 /**
- * Freshness for the bedrock axis, which the sibling shape spec cannot cover.
- *
- * Bedrock has no listing endpoint the product can reach, so the pinned list is
- * the only source for this axis and nothing corrects it on its own. The AWS docs
- * do serve each model card as raw markdown — swap `.html` for `.md` — carrying
- * `Model lifecycle` and `Model EOL date` in plain text, with no credentials. That
- * is enough to check the pins against the provider instead of against a memory.
- *
- * It is what would have caught Llama 3.1 405B, which sat in the picker for weeks
- * after going Legacy: being listed in the model-card index says nothing about
- * lifecycle, and the index does not drop a retired model.
- *
- * NOT in the CI list on purpose — it reaches the network, so it is neither fast
- * nor deterministic, the two things that list asks of a spec. Run it by hand when
- * touching the axis, or on the EOL dates the entries carry.
+ * Freshness for the bedrock axis, which the sibling shape spec cannot cover: Bedrock has
+ * no listing endpoint the product can reach, so the pinned list is the only source and
+ * nothing corrects it. The AWS docs serve each model card as raw markdown (`.html` → `.md`),
+ * carrying the id table and `Model lifecycle` in plain text. Reaches the network, so it is
+ * out of the CI list on purpose — run it by hand when touching the axis.
  */
 
 const DOCS_BASE = 'https://docs.aws.amazon.com/bedrock/latest/userguide';
 
-// Bedrock ids carry a routing prefix (`global.`, `us.`) that the model card slug
-// does not, and the slug follows the model's marketing name rather than its id —
-// `us.meta.llama3-1-70b-instruct-v1:0` lives in `model-card-meta-llama-3-1-70b-instruct`.
-// No rule derives one from the other, so the pairing is written down. An id with no
-// entry here fails the first example rather than being quietly skipped.
+// No rule derives the card slug from the id: the id carries a routing prefix (`global.`,
+// `us.`) the slug lacks, and the slug follows the marketing name. Hence the hand pairing.
 const MODEL_CARD_BY_ID: Record<string, string> = {
   'bedrock/global.anthropic.claude-opus-5': 'model-card-anthropic-claude-opus-5',
   'bedrock/global.anthropic.claude-sonnet-5': 'model-card-anthropic-claude-sonnet-5',
@@ -41,21 +28,25 @@ const bedrockEntries = availableModels.filter(m => m.provider === 'bedrock');
 const modelId = (value: string) => value.replace(/^bedrock\//, '');
 
 const lifecycleOf = (markdown: string) =>
-  markdown.match(/\*\*Model lifecycle:\*\*\s*(.+)/)?.[1].trim();
+  markdown.match(/\*\*Model lifecycle:\*\*[ \t]*(.+)/)?.[1].trim();
 
 const eolNoticeOf = (markdown: string) =>
-  markdown.match(/\*\*Model EOL date:\*\*\s*(.+)/)?.[1].trim();
+  markdown.match(/\*\*Model EOL date:\*\*[ \t]*(.+)/)?.[1].trim();
 
-// `Model EOL date` is a FLOOR, not an expiry: "No sooner than 3/1/2025" promises the
-// model will not be retired BEFORE that day, and says nothing about after. Four of the
-// pins here sit past their floor and are served normally, so treating the date as an
-// expiry — `new Date(notice) < new Date()` — fails them all while AWS is still serving
-// them. `Model lifecycle` is the field that actually flips, which is why it is the one
-// asserted on.
-//
-// What the notice is good for is catching a change of vocabulary: these three shapes
-// are what the parse above assumes, and a fourth would mean the field started saying
-// something this spec cannot read.
+const programmaticAccessOf = (markdown: string) =>
+  markdown.split(/^## /m).find(section => section.startsWith('Programmatic Access')) ?? '';
+
+// The id has to be a whole cell of the id table, not a substring of the page: two pins
+// carry no version suffix, so a plain `includes` would read a later `claude-opus-5-1` as
+// still serving the retired `claude-opus-5`, and would also match the code samples.
+const servesId = (markdown: string, id: string) => {
+  const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?<![\\w.:-])${escaped}(?![\\w.:-])`).test(programmaticAccessOf(markdown));
+};
+
+// `Model EOL date` is a floor, not an expiry ("No sooner than 3/1/2025"), so it is no
+// deadline to assert — `Model lifecycle` is the field that flips. What it is good for is
+// noticing a fourth shape, which would mean the field started saying something new.
 const EOL_NOTICE_SHAPES = [
   /^N\/A$/,
   /^No sooner than \d{1,2}\/\d{1,2}\/\d{4}$/,
@@ -63,50 +54,67 @@ const EOL_NOTICE_SHAPES = [
 ];
 
 const cards = new Map<string, string>();
+const cardErrors = new Map<string, string>();
 let docsReachable = true;
 
 beforeAll(async () => {
-  try {
-    await Promise.all(
-      Object.entries(MODEL_CARD_BY_ID).map(async ([id, slug]) => {
-        const response = await fetch(`${DOCS_BASE}/${slug}.md`);
-        if (!response.ok) {
-          throw new Error(`${slug}.md answered ${response.status}`);
-        }
-        cards.set(id, await response.text());
-      }),
-    );
-  } catch {
-    docsReachable = false;
+  const fetches = await Promise.allSettled(
+    Object.entries(MODEL_CARD_BY_ID).map(async ([id, slug]) => ({
+      id,
+      slug,
+      response: await fetch(`${DOCS_BASE}/${slug}.md`),
+    })),
+  );
+
+  // An HTTP status IS an answer, and a card answering 404 is how a retired model leaves
+  // the docs — the very event this spec exists to catch, so it fails below instead of
+  // skipping. Only a request that got no answer at all means the docs are out of reach.
+  docsReachable = fetches.every(f => f.status === 'fulfilled');
+  if (!docsReachable) return;
+
+  for (const settled of fetches) {
+    if (settled.status !== 'fulfilled') continue;
+    const { id, slug, response } = settled.value;
+    if (response.ok) cards.set(id, await response.text());
+    else cardErrors.set(id, `${slug}.md answered ${response.status}`);
   }
 }, 120_000);
 
 describe('bedrock axis lifecycle', () => {
-  it('pairs every pinned bedrock id with a model card to check it against', () => {
-    const unmapped = bedrockEntries.filter(m => !MODEL_CARD_BY_ID[m.value]).map(m => m.value);
-    expect(unmapped).toEqual([]);
+  it('pairs the pinned bedrock ids and the model cards both ways', () => {
+    expect({
+      unmapped: bedrockEntries.filter(m => !MODEL_CARD_BY_ID[m.value]).map(m => m.value),
+      orphaned: Object.keys(MODEL_CARD_BY_ID).filter(
+        id => !bedrockEntries.some(m => m.value === id),
+      ),
+    }).toEqual({ unmapped: [], orphaned: [] });
   });
 
   it('checks a non-empty axis, so a silent list rename never reads as a pass', () => {
     expect(bedrockEntries.length).toBeGreaterThan(0);
   });
 
-  it('serves every pinned id from its own model card', ctx => {
+  it('serves every pinned id from the id table of its own model card', ctx => {
     if (!docsReachable) return ctx.skip();
 
-    const missing = Object.entries(MODEL_CARD_BY_ID)
-      .filter(([id]) => !cards.get(id)?.includes(modelId(id)))
-      .map(([id]) => id);
+    const missing = Object.keys(MODEL_CARD_BY_ID)
+      .map(id => ({
+        id,
+        why:
+          cardErrors.get(id) ??
+          (servesId(cards.get(id) ?? '', modelId(id)) ? '' : 'absent from Programmatic Access'),
+      }))
+      .filter(({ why }) => why);
     expect(missing).toEqual([]);
   });
 
   it('keeps every pinned id on an Active lifecycle', ctx => {
     if (!docsReachable) return ctx.skip();
 
-    // The lifecycle line is the whole point, so a card that stopped carrying one
-    // is reported as such instead of passing on an absent value.
+    // A card that stopped carrying a lifecycle line is reported as such instead of
+    // passing on an absent value.
     const notActive = Object.keys(MODEL_CARD_BY_ID)
-      .map(id => ({ id, lifecycle: lifecycleOf(cards.get(id) ?? '') }))
+      .map(id => ({ id, lifecycle: cardErrors.get(id) ?? lifecycleOf(cards.get(id) ?? '') }))
       .filter(({ lifecycle }) => lifecycle !== 'Active');
     expect(notActive).toEqual([]);
   });
@@ -115,7 +123,7 @@ describe('bedrock axis lifecycle', () => {
     if (!docsReachable) return ctx.skip();
 
     const unreadable = Object.keys(MODEL_CARD_BY_ID)
-      .map(id => ({ id, notice: eolNoticeOf(cards.get(id) ?? '') }))
+      .map(id => ({ id, notice: cardErrors.get(id) ?? eolNoticeOf(cards.get(id) ?? '') }))
       .filter(({ notice }) => !notice || !EOL_NOTICE_SHAPES.some(shape => shape.test(notice)));
     expect(unreadable).toEqual([]);
   });


### PR DESCRIPTION
## Conferência do eixo, e o que ela revelou

Os sete ids do eixo bedrock foram conferidos um a um contra a tabela **Programmatic Access** do model card, com o lifecycle lido junto: **todos Active, nenhum Legacy, nenhum pós-EOL**. As strings também batem com a coluna certa — os três `global.anthropic.*` saem de Global inference ID, `us.meta.llama3-1-70b-instruct-v1:0` e `us.deepseek.r1-v1:0` de Geo inference ID, e `mistral.mistral-7b-instruct-v0:2` e `amazon.nova-micro-v1:0` de Model ID. **Nada a corrigir na lista** — este PR não muda `availableModels`.

O que apareceu na passagem é que a data de 29/09 não é a mais frágil da lista. **Quatro ids já estão com o piso de EOL vencido** — Mistral 7B (01/03/2025), Llama 3.1 70B (23/07/2025), Nova Micro (04/12/2025) e DeepSeek R1 (10/03/2026). Seguem Active, mas o "no sooner than" já passou neles, então podem virar Legacy a qualquer momento sem data futura servindo de aviso. O Sonnet 4.5 é o único com piso à frente, e por isso o único que dá para agendar.

Que é justamente o problema: um AC cumprido à mão vale pelo dia em que foi cumprido.

## O que este PR adiciona

O spec de shape que já existia abria dizendo que nada local sabe se um provider aposentou um modelo. Era verdade quando foi escrito — e é o buraco pelo qual o **Llama 3.1 405B** passou, ficando semanas no seletor depois de virar Legacy.

Deixou de ser verdade para este eixo: **o doc da AWS serve cada model card em markdown bruto**, trocando `.html` por `.md` na URL. Vêm `Model lifecycle` e `Model EOL date` em texto puro, sem credencial. Dá para conferir os pins contra o provider em vez de contra a memória de quem lembrou de olhar.

O guard lê os ids bedrock do próprio `availableModels` — não há segunda lista para divergir — e para cada um verifica que o id aparece no seu model card e que o lifecycle é `Active`.

## Duas decisões que valem explicação

**O mapa id → model card é escrito à mão** porque nenhuma regra deriva um do outro: o id carrega prefixo de roteamento (`global.`, `us.`) que o slug não tem, e o slug segue o nome comercial (`us.meta.llama3-1-70b-instruct-v1:0` mora em `model-card-meta-llama-3-1-70b-instruct`). Um id fixado sem par no mapa **derruba o primeiro exemplo** em vez de ser pulado calado, então pin novo não escapa da conferência.

**Fora da lista do CI de propósito.** Aquela lista pede spec rápido e determinístico, e este alcança a rede. Sem rede ele se pula sozinho e sai 0, no mesmo padrão dos outros guards do ecossistema. Rodar à mão ao mexer no eixo, ou nas datas de EOL que as entradas carregam.

## Verificação

`npx tsc -b` limpo, eslint limpo nos dois arquivos, 10 exemplos verdes entre este spec e o irmão.

Provado por mutação, cada uma exercendo um exemplo diferente:

| mutação | resultado |
|---|---|
| pôr o 405B (Legacy real) no mapa | cai o exemplo de lifecycle |
| tirar um id do mapa | cai o exemplo de pareamento |
| apontar o doc para host inalcançável | os 2 exemplos de rede **pulam**, os 2 locais passam, saída 0 |

A primeira é a que importa: o guard pega exatamente o modelo que passou batido da última vez.

## Nota para quem revisar

Também corrigi o comentário de abertura do spec irmão, que afirmava que nada local pode checar freshness — afirmação que este arquivo passa a contradizer na porta ao lado.

## Summary by Sourcery

Add AWS model-card validation to keep Bedrock model pins aligned with supported, active provider entries.

Enhancements:
- Add a network-backed guard that validates every Bedrock model pin against its AWS model card, including ID pairing, active lifecycle, and recognized EOL metadata.
- Keep Bedrock lifecycle validation separate from the fast CI shape checks while allowing it to skip cleanly when AWS documentation is unreachable.

Tests:
- Add coverage for missing or orphaned Bedrock mappings, non-empty model lists, model-card ID presence, lifecycle status, and EOL notice formats.

Chores:
- Update the neighboring model-list spec comment to document the available freshness checks by provider.

---

## Revisão (commit `e97694c6`)

A tabela de mutação acima descreve o estado do primeiro commit. Depois do commit de review o spec tem **3 exemplos de rede e 2 locais** (5 aqui, **11 verdes** somando o irmão), e a revisão fechou sete achados:

**O que estava furado.** O `beforeAll` tratava `!response.ok` como "docs fora do ar" — um card respondendo 404 pulava os três exemplos de rede e a suite saía verde. Um 404 é exatamente a forma que a aposentadoria toma quando a AWS retira ou renomeia o card, então o guard respondia "passou" no evento que existe para pegar. `Promise.allSettled` agora separa os dois casos: status HTTP é resposta e reprova; só a requisição sem resposta nenhuma pula.

**Presença do id.** Deixou de ser `includes` na página inteira e passou a ser célula da tabela de Programmatic Access, que é o que o AC pede. Os dois pins sem sufixo de versão (`global.anthropic.claude-opus-5`, `...-sonnet-5`) eram o caso vulnerável: um futuro `claude-opus-5-1` no mesmo card cobriria o pin morto.

**Pareamento nos dois sentidos.** Id tirado do eixo e deixado no mapa passava calado.

**Parse.** `\s*` atravessava quebra de linha — com o valor vazio, o capture pegava a linha seguinte. Agora `[ \t]*`.

**Comentário do spec irmão.** A frase deixava de fora `vertex_ai` e `perplexity`, que não estão no `LISTS_LIVE` e não têm listagem nenhuma — o mesmo buraco do 405B, aberto em outro eixo.

Mutação, agora:

| mutação | antes | agora |
|---|---|---|
| card de um modelo responde 404 | **verde** | 3 exemplos caem |
| pin some do card mas segue prefixo de um id vivo | **verde** | cai o de tabela |
| id tirado do eixo e deixado no mapa | **verde** | cai o de pareamento |
| recorte da seção apontado para outra seção | **verde** | cai o de tabela |
| host inexistente / rede bloqueada | pula | pula, exit 0 |
| 405B (Legacy real) fixado no eixo | cai | cai |
| id novo no eixo sem par no mapa | cai | cai |
| uma das formas de EOL notice removida | cai | cai |

⚠️ **O Vitest verde do CI não cobre este spec** — nenhum dos dois `ModelSelector*.spec.ts` está na lista explícita do `test.yml`. Os 11 verdes acima são de execução local.
