### PR TITLE
chore(i18n): remove chaves órfãs do hub de canais e traduz a contagem de provedores (CRM-466)

### DIFF
--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1734,7 +1734,6 @@
   },
   "overview": {
     "noIntegrationConfigured": "No integration configured",
-    "tabLabel": "Overview",
     "title": "Channel overview",
     "subtitle": "See every channel type, its status, and how to set it up.",
     "statusLabel": {
@@ -1743,14 +1742,6 @@
       "error": "Error",
       "unmonitored": "Not monitored",
       "available": "Available"
-    },
-    "summary": {
-      "active": "{{count}} active",
-      "attention": "{{count}} need attention",
-      "error": "{{count}} with errors",
-      "notConfigured": "Not configured",
-      "connected": "{{count}} connected",
-      "total": "{{count}} connections"
     },
     "drawer": {
       "title": "Connections"
@@ -1767,17 +1758,14 @@
     "needsAttention_one": "{{count}} connection needing attention",
     "needsAttention_other": "{{count}} connections needing attention",
     "liveCheckFailed": "Live check failed — showing the last known state",
-    "moreInboxes": "+{{count}} more inboxes",
     "providersCount": "{{count}} providers",
     "actions": {
       "add": "Add",
       "manage": "Manage",
       "manageAria": "Manage connections: {{count}} · {{status}}",
-      "howToConfigure": "How to set up",
       "connect": "Connect",
       "addConnection": "Add connection",
-      "deleteConnection": "Delete connection",
-      "viewAds": "View ads"
+      "deleteConnection": "Delete connection"
     },
     "capabilities": {
       "publishing": "Publishing",
@@ -1789,16 +1777,6 @@
       "stored": "Reported",
       "storedTooltip": "State reported by the configuration, not verified live",
       "lastSync": "Synced {{time}}"
-    },
-    "help": {
-      "website": "Embed a live-chat widget on your website so visitors can talk to your team in real time.",
-      "whatsapp": "Connect WhatsApp through a provider (WhatsApp Cloud, Evolution, Twilio and others) to send and receive messages.",
-      "telegram": "Connect a Telegram bot using its token to receive and reply to messages from Telegram users.",
-      "instagram": "Link your Instagram professional account to handle direct messages from the inbox.",
-      "facebook": "Link a Facebook page to manage Messenger conversations from the inbox.",
-      "sms": "Send and receive SMS through a provider such as Twilio or Bandwidth.",
-      "email": "Connect a mailbox (Gmail or Outlook) to turn emails into conversations.",
-      "api": "Use the channel API to integrate any custom or in-house system."
     }
   }
 }

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1760,7 +1760,6 @@
     "liveCheckFailed": "Live check failed — showing the last known state",
     "providersCount": "{{count}} providers",
     "actions": {
-      "add": "Add",
       "manage": "Manage",
       "manageAria": "Manage connections: {{count}} · {{status}}",
       "connect": "Connect",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1655,7 +1655,6 @@
   },
   "overview": {
     "noIntegrationConfigured": "Ninguna integración configurada",
-    "tabLabel": "Resumen",
     "title": "Resumen de canales",
     "subtitle": "Mira todos los tipos de canal, su estado y cómo configurarlos.",
     "statusLabel": {
@@ -1664,14 +1663,6 @@
       "error": "Con error",
       "unmonitored": "Sin monitoreo",
       "available": "Disponible"
-    },
-    "summary": {
-      "active": "{{count}} activo(s)",
-      "attention": "{{count}} con atención",
-      "error": "{{count}} con error",
-      "notConfigured": "No configurado",
-      "connected": "{{count}} conectada(s)",
-      "total": "{{count}} conexiones"
     },
     "drawer": {
       "title": "Conexiones"
@@ -1688,17 +1679,14 @@
     "needsAttention_one": "{{count}} conexión que necesita atención",
     "needsAttention_other": "{{count}} conexiones que necesitan atención",
     "liveCheckFailed": "La verificación en vivo falló — mostrando el último estado conocido",
-    "moreInboxes": "+{{count}} bandejas más",
     "providersCount": "{{count}} proveedores",
     "actions": {
       "add": "Agregar",
       "manage": "Gestionar",
       "manageAria": "Gestionar conexiones: {{count}} · {{status}}",
-      "howToConfigure": "Cómo configurar",
       "connect": "Conectar",
       "addConnection": "Agregar conexión",
-      "deleteConnection": "Eliminar conexión",
-      "viewAds": "Ver anuncios"
+      "deleteConnection": "Eliminar conexión"
     },
     "capabilities": {
       "publishing": "Publicación",
@@ -1710,16 +1698,6 @@
       "stored": "Informado",
       "storedTooltip": "Estado informado por la configuración, no verificado en vivo",
       "lastSync": "Sincronizado {{time}}"
-    },
-    "help": {
-      "website": "Inserta un widget de chat en vivo en tu sitio web para hablar con los visitantes en tiempo real.",
-      "whatsapp": "Conecta WhatsApp mediante un proveedor (WhatsApp Cloud, Evolution, Twilio y otros) para enviar y recibir mensajes.",
-      "telegram": "Conecta un bot de Telegram con su token para recibir y responder mensajes.",
-      "instagram": "Vincula tu cuenta profesional de Instagram para gestionar mensajes directos desde la bandeja.",
-      "facebook": "Vincula una página de Facebook para gestionar conversaciones de Messenger desde la bandeja.",
-      "sms": "Envía y recibe SMS mediante un proveedor como Twilio o Bandwidth.",
-      "email": "Conecta un buzón (Gmail u Outlook) para convertir correos en conversaciones.",
-      "api": "Usa la API de canales para integrar cualquier sistema propio o personalizado."
     }
   }
 }

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1681,7 +1681,6 @@
     "liveCheckFailed": "La verificación en vivo falló — mostrando el último estado conocido",
     "providersCount": "{{count}} proveedores",
     "actions": {
-      "add": "Agregar",
       "manage": "Gestionar",
       "manageAria": "Gestionar conexiones: {{count}} · {{status}}",
       "connect": "Conectar",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1674,7 +1674,6 @@
   },
   "overview": {
     "noIntegrationConfigured": "Aucune intégration configurée",
-    "tabLabel": "Aperçu",
     "title": "Aperçu des canaux",
     "subtitle": "Consultez tous les types de canaux, leur statut et comment les configurer.",
     "statusLabel": {
@@ -1683,14 +1682,6 @@
       "error": "En erreur",
       "unmonitored": "Non surveillé",
       "available": "Disponible"
-    },
-    "summary": {
-      "active": "{{count}} actif(s)",
-      "attention": "{{count}} à vérifier",
-      "error": "{{count}} en erreur",
-      "notConfigured": "Non configuré",
-      "connected": "{{count}} connectée(s)",
-      "total": "{{count}} connexions"
     },
     "drawer": {
       "title": "Connexions"
@@ -1707,17 +1698,14 @@
     "needsAttention_one": "{{count}} connexion nécessitant une attention",
     "needsAttention_other": "{{count}} connexions nécessitant une attention",
     "liveCheckFailed": "La vérification en direct a échoué — affichage du dernier état connu",
-    "moreInboxes": "+{{count}} autres boîtes de réception",
     "providersCount": "{{count}} fournisseurs",
     "actions": {
       "add": "Ajouter",
       "manage": "Gérer",
       "manageAria": "Gérer les connexions : {{count}} · {{status}}",
-      "howToConfigure": "Comment configurer",
       "connect": "Connecter",
       "addConnection": "Ajouter une connexion",
-      "deleteConnection": "Supprimer la connexion",
-      "viewAds": "Voir les annonces"
+      "deleteConnection": "Supprimer la connexion"
     },
     "capabilities": {
       "publishing": "Publication",
@@ -1729,16 +1717,6 @@
       "stored": "Déclaré",
       "storedTooltip": "État déclaré par la configuration, non vérifié en direct",
       "lastSync": "Synchronisé {{time}}"
-    },
-    "help": {
-      "website": "Intégrez un widget de chat en direct sur votre site pour échanger avec les visiteurs en temps réel.",
-      "whatsapp": "Connectez WhatsApp via un fournisseur (WhatsApp Cloud, Evolution, Twilio, etc.) pour envoyer et recevoir des messages.",
-      "telegram": "Connectez un bot Telegram à l'aide de son token pour recevoir et répondre aux messages.",
-      "instagram": "Reliez votre compte professionnel Instagram pour gérer les messages directs depuis la boîte de réception.",
-      "facebook": "Reliez une page Facebook pour gérer les conversations Messenger depuis la boîte de réception.",
-      "sms": "Envoyez et recevez des SMS via un fournisseur comme Twilio ou Bandwidth.",
-      "email": "Connectez une boîte mail (Gmail ou Outlook) pour transformer les e-mails en conversations.",
-      "api": "Utilisez l'API de canaux pour intégrer n'importe quel système personnalisé."
     }
   }
 }

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1700,7 +1700,6 @@
     "liveCheckFailed": "La vérification en direct a échoué — affichage du dernier état connu",
     "providersCount": "{{count}} fournisseurs",
     "actions": {
-      "add": "Ajouter",
       "manage": "Gérer",
       "manageAria": "Gérer les connexions : {{count}} · {{status}}",
       "connect": "Connecter",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1639,7 +1639,6 @@
     "liveCheckFailed": "La verifica in tempo reale non è riuscita — viene mostrato l'ultimo stato noto",
     "providersCount": "{{count}} provider",
     "actions": {
-      "add": "Aggiungi",
       "manage": "Gestisci",
       "manageAria": "Gestisci connessioni: {{count}} · {{status}}",
       "connect": "Connetti",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1613,7 +1613,6 @@
   },
   "overview": {
     "noIntegrationConfigured": "Nessuna integrazione configurata",
-    "tabLabel": "Panoramica",
     "title": "Panoramica dei canali",
     "subtitle": "Vedi tutti i tipi di canale, il loro stato e come configurarli.",
     "statusLabel": {
@@ -1622,14 +1621,6 @@
       "error": "Con errore",
       "unmonitored": "Non monitorato",
       "available": "Disponibile"
-    },
-    "summary": {
-      "active": "{{count}} attivo/i",
-      "attention": "{{count}} da verificare",
-      "error": "{{count}} con errore",
-      "notConfigured": "Non configurato",
-      "connected": "{{count}} connessa/e",
-      "total": "{{count}} connessioni"
     },
     "drawer": {
       "title": "Connessioni"
@@ -1646,17 +1637,14 @@
     "needsAttention_one": "{{count}} connessione che richiede attenzione",
     "needsAttention_other": "{{count}} connessioni che richiedono attenzione",
     "liveCheckFailed": "La verifica in tempo reale non è riuscita — viene mostrato l'ultimo stato noto",
-    "moreInboxes": "+{{count}} altre caselle",
     "providersCount": "{{count}} provider",
     "actions": {
       "add": "Aggiungi",
       "manage": "Gestisci",
       "manageAria": "Gestisci connessioni: {{count}} · {{status}}",
-      "howToConfigure": "Come configurare",
       "connect": "Connetti",
       "addConnection": "Aggiungi connessione",
-      "deleteConnection": "Elimina connessione",
-      "viewAds": "Vedi annunci"
+      "deleteConnection": "Elimina connessione"
     },
     "capabilities": {
       "publishing": "Pubblicazione",
@@ -1668,16 +1656,6 @@
       "stored": "Dichiarato",
       "storedTooltip": "Stato dichiarato dalla configurazione, non verificato in diretta",
       "lastSync": "Sincronizzato {{time}}"
-    },
-    "help": {
-      "website": "Incorpora un widget di chat dal vivo sul tuo sito per parlare con i visitatori in tempo reale.",
-      "whatsapp": "Collega WhatsApp tramite un provider (WhatsApp Cloud, Evolution, Twilio e altri) per inviare e ricevere messaggi.",
-      "telegram": "Collega un bot Telegram usando il suo token per ricevere e rispondere ai messaggi.",
-      "instagram": "Collega il tuo account professionale Instagram per gestire i messaggi diretti dalla casella.",
-      "facebook": "Collega una pagina Facebook per gestire le conversazioni di Messenger dalla casella.",
-      "sms": "Invia e ricevi SMS tramite un provider come Twilio o Bandwidth.",
-      "email": "Collega una casella email (Gmail o Outlook) per trasformare le email in conversazioni.",
-      "api": "Usa l'API dei canali per integrare qualsiasi sistema personalizzato."
     }
   }
 }

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1760,7 +1760,6 @@
     "liveCheckFailed": "A verificação ao vivo falhou — exibindo o último estado conhecido",
     "providersCount": "{{count}} provedores",
     "actions": {
-      "add": "Adicionar",
       "manage": "Gerenciar",
       "manageAria": "Gerenciar conexões: {{count}} · {{status}}",
       "connect": "Conectar",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1734,7 +1734,6 @@
   },
   "overview": {
     "noIntegrationConfigured": "Nenhuma integração configurada",
-    "tabLabel": "Visão geral",
     "title": "Visão geral dos canais",
     "subtitle": "Veja todos os tipos de canal, o status de cada um e como configurar.",
     "statusLabel": {
@@ -1743,14 +1742,6 @@
       "error": "Com erro",
       "unmonitored": "Sem monitoramento",
       "available": "Disponível"
-    },
-    "summary": {
-      "active": "{{count}} ativo(s)",
-      "attention": "{{count}} com atenção",
-      "error": "{{count}} com erro",
-      "notConfigured": "Não configurado",
-      "connected": "{{count}} conectada(s)",
-      "total": "{{count}} conexões"
     },
     "drawer": {
       "title": "Conexões"
@@ -1767,17 +1758,14 @@
     "needsAttention_one": "{{count}} conexão precisando de atenção",
     "needsAttention_other": "{{count}} conexões precisando de atenção",
     "liveCheckFailed": "A verificação ao vivo falhou — exibindo o último estado conhecido",
-    "moreInboxes": "+{{count}} outras caixas de entrada",
-    "providersCount": "{{count}} providers",
+    "providersCount": "{{count}} provedores",
     "actions": {
       "add": "Adicionar",
       "manage": "Gerenciar",
       "manageAria": "Gerenciar conexões: {{count}} · {{status}}",
-      "howToConfigure": "Como configurar",
       "connect": "Conectar",
       "addConnection": "Adicionar conexão",
-      "deleteConnection": "Excluir conexão",
-      "viewAds": "Ver anúncios"
+      "deleteConnection": "Excluir conexão"
     },
     "capabilities": {
       "publishing": "Publicação",
@@ -1789,16 +1777,6 @@
       "stored": "Informado",
       "storedTooltip": "Estado informado pela configuração, não verificado ao vivo",
       "lastSync": "Sincronizado {{time}}"
-    },
-    "help": {
-      "website": "Incorpore um widget de chat ao vivo no seu site para conversar com visitantes em tempo real.",
-      "whatsapp": "Conecte o WhatsApp por um provedor (WhatsApp Cloud, Evolution, Twilio e outros) para enviar e receber mensagens.",
-      "telegram": "Conecte um bot do Telegram usando o token para receber e responder mensagens.",
-      "instagram": "Vincule sua conta profissional do Instagram para tratar mensagens diretas pela caixa de entrada.",
-      "facebook": "Vincule uma página do Facebook para gerenciar conversas do Messenger pela caixa de entrada.",
-      "sms": "Envie e receba SMS por um provedor como Twilio ou Bandwidth.",
-      "email": "Conecte uma caixa de e-mail (Gmail ou Outlook) para transformar e-mails em conversas.",
-      "api": "Use a API de canais para integrar qualquer sistema próprio ou personalizado."
     }
   }
 }

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1672,7 +1672,6 @@
   },
   "overview": {
     "noIntegrationConfigured": "Nenhuma integração configurada",
-    "tabLabel": "Visão geral",
     "title": "Visão geral dos canais",
     "subtitle": "Veja todos os tipos de canal, o status de cada um e como configurar.",
     "statusLabel": {
@@ -1681,14 +1680,6 @@
       "error": "Com erro",
       "unmonitored": "Sem monitorização",
       "available": "Disponível"
-    },
-    "summary": {
-      "active": "{{count}} ativo(s)",
-      "attention": "{{count}} com atenção",
-      "error": "{{count}} com erro",
-      "notConfigured": "Não configurado",
-      "connected": "{{count}} conectada(s)",
-      "total": "{{count}} conexões"
     },
     "drawer": {
       "title": "Conexões"
@@ -1705,17 +1696,14 @@
     "needsAttention_one": "{{count}} ligação a precisar de atenção",
     "needsAttention_other": "{{count}} ligações a precisar de atenção",
     "liveCheckFailed": "A verificação ao vivo falhou — a mostrar o último estado conhecido",
-    "moreInboxes": "+{{count}} outras caixas de entrada",
-    "providersCount": "{{count}} providers",
+    "providersCount": "{{count}} provedores",
     "actions": {
       "add": "Adicionar",
       "manage": "Gerenciar",
       "manageAria": "Gerenciar conexões: {{count}} · {{status}}",
-      "howToConfigure": "Como configurar",
       "connect": "Conectar",
       "addConnection": "Adicionar conexão",
-      "deleteConnection": "Excluir conexão",
-      "viewAds": "Ver anúncios"
+      "deleteConnection": "Excluir conexão"
     },
     "capabilities": {
       "publishing": "Publicação",
@@ -1727,16 +1715,6 @@
       "stored": "Informado",
       "storedTooltip": "Estado informado pela configuração, não verificado ao vivo",
       "lastSync": "Sincronizado {{time}}"
-    },
-    "help": {
-      "website": "Incorpore um widget de chat ao vivo no seu site para conversar com visitantes em tempo real.",
-      "whatsapp": "Conecte o WhatsApp por um provedor (WhatsApp Cloud, Evolution, Twilio e outros) para enviar e receber mensagens.",
-      "telegram": "Conecte um bot do Telegram usando o token para receber e responder mensagens.",
-      "instagram": "Vincule sua conta profissional do Instagram para tratar mensagens diretas pela caixa de entrada.",
-      "facebook": "Vincule uma página do Facebook para gerenciar conversas do Messenger pela caixa de entrada.",
-      "sms": "Envie e receba SMS por um provedor como Twilio ou Bandwidth.",
-      "email": "Conecte uma caixa de e-mail (Gmail ou Outlook) para transformar e-mails em conversas.",
-      "api": "Use a API de canais para integrar qualquer sistema próprio ou personalizado."
     }
   }
 }

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1698,7 +1698,6 @@
     "liveCheckFailed": "A verificação ao vivo falhou — a mostrar o último estado conhecido",
     "providersCount": "{{count}} provedores",
     "actions": {
-      "add": "Adicionar",
       "manage": "Gerenciar",
       "manageAria": "Gerenciar conexões: {{count}} · {{status}}",
       "connect": "Conectar",


### PR DESCRIPTION
## O que muda

Duas limpezas no bloco `overview` do `channels.json`, nas seis locales (`en`, `pt`, `pt-BR`, `es`, `fr`, `it`). Nenhuma muda comportamento.

**Tradução.** `overview.providersCount` estava em inglês em `pt` e `pt-BR` (`"{{count}} providers"`) — agora `"{{count}} provedores"`, alinhado com `es`/`fr` e com o "provedor" que o próprio arquivo já usa. A pílula aparece no card do WhatsApp, único tipo do catálogo com contagem de provedores.

**Chaves sem consumidor.** Removidas 18 folhas que ninguém lê: `overview.tabLabel`, `overview.summary` (6), `overview.moreInboxes`, `overview.actions.howToConfigure`, `overview.actions.viewAds` e `overview.help` (8). São resto do hub anterior ao redesign de `11f2da2`, carregadas nas seis locales desde então. `howToConfigure` e `viewAds` não constavam do card — apareceram na varredura e têm a mesma prova das demais.

## Como confirmei que não há consumidor

Varri as 48 folhas de `overview` contra `src/**/*.{ts,tsx}` por chave literal e por chave montada em template (`overview.<pai>.${...}`), fora de `locales/`. As que sobram — `statusLabel.*`, `inboxState.*`, `capabilities.*`, `statusMeta.*`, `actions.*` restantes, `needsAttention_one/_other`, `drawer.title`, `liveCheckFailed`, `noIntegrationConfigured`, `title`, `subtitle`, `providersCount` — todas têm call site. Também conferi que nenhuma branch remota usa as removidas.

## Testes

`i18n-parity.spec.ts` (178) e `ChannelTypeHub.spec.tsx` (30) verdes. `tsc -b` sem erro novo (os seis que restam são módulos ausentes de um `node_modules` desatualizado, presentes já na `develop` e sem relação com JSON de locale). As seis locales seguem com o mesmo conjunto de chaves em `overview`, e nenhum arquivo ganhou ou perdeu newline final.

## Observação — vira CRM-484

O `i18n-parity.spec.ts` passava com `providersCount` idêntico entre `en` e `pt-BR` porque `isIgnorableValue` (`_lib/parity.ts`) trata como blob JSON qualquer valor que **comece** com `{` — regra escrita para placeholder de formulário (`{"Authorization": ...}`, `["text", "image"]`), que acaba engolindo toda string iniciada por `{{interpolação}}` antes de a allowlist ser consultada. Sete valores do catálogo caem nessa fresta hoje; cinco já estão em allowlist e passariam por mérito próprio, e só o `providersCount` era vazamento real. Este PR resolve o caso concreto, não a regra — que ficou em CRM-484.

## Summary by Sourcery

Clean up channel overview translations by removing orphaned keys and localizing provider counts in Portuguese.

Bug Fixes:
- Translate the Portuguese provider-count label in the channels overview locales.

Enhancements:
- Remove unused overview translation keys from all supported channel locales while preserving parity across locale files.

Tests:
- Verify locale key parity and channel hub behavior after the translation cleanup.