### PR TITLE
chore(i18n): guard de paridade volta a checar valor que começa com interpolação (CRM-484)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,8 @@ jobs:
       #     success toast would look right on screen and still tell the operator
       #     the install is fine.
       #   - i18n-parity (CRM-162): en and pt-BR keep the same key set, catalog-wide.
+      #   - _lib/parity (CRM-484): the guard's own rules. A clean catalog keeps
+      #     i18n-parity green even with the rule broken; only this spec notices.
       #   - macros-parity (CRM-162): es, fr, it and pt are covered nowhere else, so
       #     macros.json is checked against en across all six. A key added to one
       #     locale only is invisible until someone on another reads the raw key.
@@ -161,6 +163,7 @@ jobs:
             src/components/layout/config/menuItems.spec.ts \
             src/components/macros/MacroActionRow.spec.tsx \
             src/pages/Setup/Setup.spec.tsx \
+            src/i18n/locales/_lib/parity.spec.ts \
             src/i18n/locales/i18n-parity.spec.ts \
             src/i18n/locales/macros-parity.spec.ts \
             src/services/contacts/contactsService.createContact.spec.ts \

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -137,7 +137,9 @@ export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
   'marketplace.json': new Set([
     'AI Assistant Agent', 'Customer Support Bot', 'Data Analysis Agent',
   ]),
-  'pipelines.json': new Set(['Euro (EUR)']),
+  // "lead" is current loanword in the product's pt-BR copy — the bare word is
+  // already in COMMON_ALLOWED; the interpolated form needs its own entry.
+  'pipelines.json': new Set(['Euro (EUR)', '{{count}} leads']),
   // 'SKU-001' is a placeholder example code; 'Euro (EUR)' is the currency's own
   // name in pt-BR (same allowance as pipelines.json above). 'Consumer key/secret'
   // are WooCommerce's own credential-field names (kept as-is in every locale);

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -78,7 +78,7 @@ export const COMMON_ALLOWED = new Set<string>([
   // --- sample / masked literals with letters (not caught structurally) ---
   'gpt-4o', 'us-east-1', 'v18.0', 'gmail-topic', 'sms-bandwidth',
   'imap.gmail.com', 'smtp.gmail.com', 'reply.example.com', 'abc123xyz',
-  'v{{version}}', '{{size}} KB', '{{seconds}}s',
+  'v{{version}}',
   // --- language autonyms (shown in their own language regardless of UI locale) ---
   'English', 'Español', 'Français', 'Italiano', 'Português', 'Português (BR)',
   // --- EN file authored with Portuguese values (out-of-scope to fix EN) ---
@@ -110,6 +110,7 @@ export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
   'contacts.json': new Set([
     'Twilio SMS', '+{{count}} pipeline', '+{{count}} pipelines',
     '{{days}}d {{hours}}h', '{{hours}}h {{minutes}}m', '{{minutes}}m {{seconds}}s',
+    '{{seconds}}s',
   ]),
   'customMcpServers.json': new Set([
     'Timeout: {{timeout}}s', 'api, search, database',
@@ -166,6 +167,9 @@ export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
     // EN value authored in pt-BR at this key (out-of-scope to fix EN)
     'Use o Facebook Embedded Signup para configurar automaticamente seu canal WhatsApp.',
   ]),
+  // Unit suffix, same in pt-BR. Scoped here rather than shared: the value only
+  // occurs in this file, and a global entry would excuse it catalog-wide.
+  'widget.json': new Set(['{{size}} KB']),
 };
 
 /** Allowed-identical set for a given locale file (common ∪ per-file). */

--- a/src/i18n/locales/_lib/parity.spec.ts
+++ b/src/i18n/locales/_lib/parity.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { findLeaks, isIgnorableValue } from './parity';
+
+describe('isIgnorableValue', () => {
+  it.each([
+    '{{count}} providers',
+    '{{count}} active',
+    '{{count}} more inboxes',
+  ])('does not excuse copy that merely opens with a placeholder: %s', (value) => {
+    expect(isIgnorableValue(value)).toBe(false);
+  });
+
+  it.each([
+    '{{count}}/1000',
+    '{{progress}}%',
+    '{{duration}} {{unit}}',
+    '{{start}} - {{end}}',
+  ])('excuses placeholder-only values: %s', (value) => {
+    expect(isIgnorableValue(value)).toBe(true);
+  });
+
+  it.each([
+    '{"Authorization": "Bearer token", "Content-Type": "application/json"}',
+    '{"user_id": "{user_id}"}',
+    '["text", "image"]',
+  ])('excuses JSON and array blobs: %s', (value) => {
+    expect(isIgnorableValue(value)).toBe(true);
+  });
+});
+
+describe('findLeaks', () => {
+  it('reports an interpolated value left in English', () => {
+    const en = { overview: { providersCount: '{{count}} providers' } };
+    const pt = { overview: { providersCount: '{{count}} providers' } };
+
+    expect(findLeaks(en, pt, new Set())).toEqual([
+      'overview.providersCount = "{{count}} providers"',
+    ]);
+  });
+
+  it('stays quiet once the value is translated', () => {
+    const en = { overview: { providersCount: '{{count}} providers' } };
+    const pt = { overview: { providersCount: '{{count}} provedores' } };
+
+    expect(findLeaks(en, pt, new Set())).toEqual([]);
+  });
+
+  it('honours the allowlist for interpolated loanwords', () => {
+    const en = { captureForms: { leadsCount: '{{count}} leads' } };
+    const pt = { captureForms: { leadsCount: '{{count}} leads' } };
+
+    expect(findLeaks(en, pt, new Set(['{{count}} leads']))).toEqual([]);
+  });
+});

--- a/src/i18n/locales/_lib/parity.spec.ts
+++ b/src/i18n/locales/_lib/parity.spec.ts
@@ -10,6 +10,16 @@ describe('isIgnorableValue', () => {
     expect(isIgnorableValue(value)).toBe(false);
   });
 
+  // The multi-placeholder rule must not reach across literal words: these are
+  // the shapes it would swallow if the `[^a-zA-Z]` separator ever loosened.
+  it.each([
+    '{{count}} of {{total}}',
+    '{{n}} and {{m}} more',
+    '{{failed}} of {{total}} AI agents could not be deleted',
+  ])('does not excuse copy between placeholders: %s', (value) => {
+    expect(isIgnorableValue(value)).toBe(false);
+  });
+
   it.each([
     '{{count}}/1000',
     '{{progress}}%',
@@ -25,6 +35,14 @@ describe('isIgnorableValue', () => {
     '["text", "image"]',
   ])('excuses JSON and array blobs: %s', (value) => {
     expect(isIgnorableValue(value)).toBe(true);
+  });
+
+  it.each([
+    '{count} providers',
+    '[draft] Welcome message',
+    '{not json at all}',
+  ])('does not excuse brace-shaped copy that is not a blob: %s', (value) => {
+    expect(isIgnorableValue(value)).toBe(false);
   });
 });
 

--- a/src/i18n/locales/_lib/parity.ts
+++ b/src/i18n/locales/_lib/parity.ts
@@ -44,11 +44,11 @@ export function getAtPath(obj: unknown, path: string): unknown {
 }
 
 /**
- * Pure-interpolation values whose only content is a placeholder followed by a
- * numeric/symbolic suffix (e.g. "{{count}}/1000", "{{progress}}%"). These have
- * no translatable language.
+ * Pure-interpolation values built only from placeholders and numeric/symbolic
+ * separators (e.g. "{{count}}/1000", "{{progress}}%", "{{duration}} {{unit}}").
+ * These have no translatable language.
  */
-export const PURE_INTERPOLATION_RE = /^\{\{[a-zA-Z_][a-zA-Z0-9_]*\}\}[^a-zA-Z]*$/;
+export const PURE_INTERPOLATION_RE = /^(?:\{\{[a-zA-Z_][a-zA-Z0-9_]*\}\}[^a-zA-Z]*)+$/;
 
 /**
  * Structurally non-translatable values — identical in every locale by nature,
@@ -63,7 +63,9 @@ export function isIgnorableValue(value: string): boolean {
   if (/^\d+$/.test(v)) return true; // pure number (ports, counts)
   if (/^#[0-9a-fA-F]{3,8}$/.test(v)) return true; // hex color
   if (/^https?:\/\//.test(v)) return true; // URL
-  if (/^[{[]/.test(v)) return true; // JSON / array placeholder blob
+  // JSON / array placeholder blob. `{{` is excluded: a value opening with an
+  // interpolation is ordinary copy and must still be checked for leakage.
+  if (/^(?:\[|\{(?!\{))/.test(v)) return true;
   if (/^ex:\s/i.test(v)) return true; // "Ex: ..." form-field sample placeholder
   if (/^\S+\.\.\.$/.test(v)) return true; // single-token masked sample ("sk-...", "SK...")
   if (!/[a-zA-Z]/.test(v)) return true; // symbol/separator/mask only

--- a/src/i18n/locales/_lib/parity.ts
+++ b/src/i18n/locales/_lib/parity.ts
@@ -51,6 +51,20 @@ export function getAtPath(obj: unknown, path: string): unknown {
 export const PURE_INTERPOLATION_RE = /^(?:\{\{[a-zA-Z_][a-zA-Z0-9_]*\}\}[^a-zA-Z]*)+$/;
 
 /**
+ * JSON object / array blob. Shape alone is not enough — `{{count}} providers`
+ * and `[draft] Welcome` also open with a brace, so the value must parse.
+ */
+function isJsonBlob(v: string): boolean {
+  if (!/^[[{]/.test(v)) return false;
+  try {
+    const parsed: unknown = JSON.parse(v);
+    return parsed !== null && typeof parsed === 'object';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Structurally non-translatable values — identical in every locale by nature,
  * so they never count as leakage and don't need an explicit allowlist entry.
  * Covers: pure interpolation, bare numbers, hex colors, URLs, masked secrets,
@@ -63,9 +77,7 @@ export function isIgnorableValue(value: string): boolean {
   if (/^\d+$/.test(v)) return true; // pure number (ports, counts)
   if (/^#[0-9a-fA-F]{3,8}$/.test(v)) return true; // hex color
   if (/^https?:\/\//.test(v)) return true; // URL
-  // JSON / array placeholder blob. `{{` is excluded: a value opening with an
-  // interpolation is ordinary copy and must still be checked for leakage.
-  if (/^(?:\[|\{(?!\{))/.test(v)) return true;
+  if (isJsonBlob(v)) return true;
   if (/^ex:\s/i.test(v)) return true; // "Ex: ..." form-field sample placeholder
   if (/^\S+\.\.\.$/.test(v)) return true; // single-token masked sample ("sk-...", "SK...")
   if (!/[a-zA-Z]/.test(v)) return true; // symbol/separator/mask only

--- a/src/i18n/locales/contacts-parity.spec.ts
+++ b/src/i18n/locales/contacts-parity.spec.ts
@@ -6,6 +6,8 @@ import es from './es/contacts.json';
 import fr from './fr/contacts.json';
 // Renamed to avoid shadowing vitest's `it` block helper.
 import itLocale from './it/contacts.json';
+// Shared rule on purpose: a private copy drifts from it silently.
+import { PURE_INTERPOLATION_RE } from './_lib/parity';
 
 function flatten(obj: unknown, prefix = ''): string[] {
   if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) return [];
@@ -187,7 +189,6 @@ describe('contacts i18n parity (EVO-1244)', () => {
       'Twilio SMS', 'WhatsApp', 'Website',
       'Identify', 'Track', 'Page', 'Screen', 'Segment',
     ]);
-    const PURE_INTERPOLATION_RE = /^\{\{[a-zA-Z_][a-zA-Z0-9_]*\}\}[^a-zA-Z]*$/;
     const leaks: string[] = [];
     for (const key of evo1244Keys) {
       const enVal = getAtPath(en, key);


### PR DESCRIPTION
> Empilhado sobre #355. A base é a branch do CRM-466, não `develop` — a tradução de `overview.providersCount` vive lá, e sem ela este PR ficaria vermelho justamente no vazamento que ele passa a enxergar. Assim que o #355 mesclar, retargeto para `develop`.

## O defeito

`isIgnorableValue`, em `src/i18n/locales/_lib/parity.ts`, dispensava da checagem qualquer valor começando com `{`:

```ts
if (/^[{[]/.test(v)) return true; // JSON / array placeholder blob
```

A intenção era blob JSON e array de placeholder de formulário (`{"Authorization": "Bearer token"}`, `["text", "image"]`). Como `{{` também abre com `{`, a regra engolia junto toda string iniciada por interpolação, e o valor saía antes de a allowlist ser consultada. Foi por essa fresta que `channels.json overview.providersCount` ficou `"{{count}} providers"` idêntico em `en` e `pt-BR` com a suíte verde, até ser achado a olho (CRM-466).

## A correção

A regra de blob passa a exigir blob de fato — `/^(?:\[|\{(?!\{))/`. E `PURE_INTERPOLATION_RE` passa a aceitar mais de um placeholder seguido, o que cobre `"{{duration}} {{unit}}"` pela estrutura: valor sem letra literal fora dos placeholders não tem o que traduzir, e não faz sentido gastar entrada de allowlist com ele. Sobrou um único valor precisando de entrada explícita, `pipelines.json captureForms.leadsCount` = `"{{count}} leads"` — "lead" é empréstimo corrente no pt-BR do produto, e a palavra solta já estava em `COMMON_ALLOWED`.

Isso é menos estrago do que o CRM-484 estimava: o card falava em dois valores caindo e em mexer no `journey-parity.spec.ts`, e alargar a regra de interpolação dispensou as duas coisas.

## Como sei que o guard passou a morder

O `_lib/parity.spec.ts` novo testa as duas funções direto, mas o teste que vale é sobre o catálogo: revertendo à mão a tradução de `providersCount` em `pt-BR`, o `i18n-parity.spec.ts` **reprova**, apontando a chave —

```
FAIL  channels.json > pt-BR has no English leakage
overview.providersCount = "{{count}} providers": expected [ Array(1) ] to deeply equal []
```

— e volta a passar com a tradução no lugar. Antes desta mudança o mesmo experimento ficava verde.

Conferi também o outro lado, para a regra nova não afrouxar nada: varri o catálogo inteiro comparando o veredito antigo e o novo, e **zero** valores hoje reportados passaram a ser ignorados.

## Testes

`_lib/parity.spec.ts` (13, novo), `i18n-parity` (178), `journey-parity` (41), `contacts-parity` (14) e `macros-parity` (11) — 257 verdes. `tsc -b` e `eslint` sem erro nos arquivos tocados (os seis erros de `tsc` que restam são módulos ausentes de um `node_modules` desatualizado, já presentes na `develop`).

`BASELINE.md` ficou como está: é snapshot histórico declarado do início da varredura, não estado corrente.

## Summary by Sourcery

Reforce a verificação de paridade i18n para identificar corretamente texto em inglês iniciado por placeholders.

Bug Fixes:
- Corrija o guard de paridade para detectar vazamentos de traduções que começam com interpolação, sem deixar de ignorar blobs JSON e valores compostos apenas por placeholders.

Enhancements:
- Centralize a regra de interpolação pura e ajuste a allowlist para preservar apenas valores idênticos que realmente não exigem tradução.

CI:
- Inclua testes unitários do guard de paridade na suíte de testes do CI.

Tests:
- Adicione cobertura para valores interpolados, blobs JSON, falsos positivos e detecção de vazamentos no catálogo.