### PR TITLE
fix(channels): rótulo de estado pendente descreve espera de confirmação (CRM-465)

### DIFF
--- a/src/components/channels/ChannelConnectionsPopover.tsx
+++ b/src/components/channels/ChannelConnectionsPopover.tsx
@@ -119,15 +119,14 @@ export default function ChannelConnectionsPopover({
                       <div className="truncate text-sm font-medium text-foreground">
                         {inbox.name}
                       </div>
-                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                        <Link2 className="h-3 w-3 shrink-0" aria-hidden="true" />
-                        {providerLabel && <span className="truncate">{providerLabel}</span>}
-                        {providerLabel && (
-                          <span className="shrink-0" aria-hidden="true">
-                            ·
-                          </span>
-                        )}
-                        <span className="shrink-0">
+                      <div className="flex items-start gap-1 text-xs text-muted-foreground">
+                        <Link2 className="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+                        {/* One wrapping text flow, not three flex items. This column is
+                            ~190px wide, and in most locales the state label alone is wider
+                            than that — as three items the label could not shrink and ran
+                            under the row's action buttons, taking the provider name with it. */}
+                        <span className="min-w-0 break-words">
+                          {providerLabel && `${providerLabel} · `}
                           {stateLabel} ·{' '}
                           {isLiveLoading ? (
                             t('overview.inboxState.checking')

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1749,7 +1749,7 @@
     "inboxState": {
       "connected": "Connected",
       "disconnected": "Disconnected",
-      "pending": "Testing",
+      "pending": "Awaiting confirmation",
       "error": "Error",
       "unknown": "Unknown",
       "unmonitored": "Not monitored",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1670,7 +1670,7 @@
     "inboxState": {
       "connected": "Conectado",
       "disconnected": "Desconectado",
-      "pending": "En prueba",
+      "pending": "Esperando confirmación",
       "error": "Error",
       "unknown": "Desconocido",
       "unmonitored": "Sin monitoreo",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1689,7 +1689,7 @@
     "inboxState": {
       "connected": "Connecté",
       "disconnected": "Déconnecté",
-      "pending": "En test",
+      "pending": "En attente de confirmation",
       "error": "Erreur",
       "unknown": "Inconnu",
       "unmonitored": "Non surveillé",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1628,7 +1628,7 @@
     "inboxState": {
       "connected": "Connesso",
       "disconnected": "Disconnesso",
-      "pending": "In prova",
+      "pending": "In attesa di conferma",
       "error": "Errore",
       "unknown": "Sconosciuto",
       "unmonitored": "Non monitorato",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1749,7 +1749,7 @@
     "inboxState": {
       "connected": "Conectado",
       "disconnected": "Desconectado",
-      "pending": "Em teste",
+      "pending": "Aguardando confirmação",
       "error": "Erro",
       "unknown": "Desconhecido",
       "unmonitored": "Sem monitoramento",

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1687,7 +1687,7 @@
     "inboxState": {
       "connected": "Conectado",
       "disconnected": "Desconectado",
-      "pending": "Em teste",
+      "pending": "A aguardar confirmação",
       "error": "Erro",
       "unknown": "Desconhecido",
       "unmonitored": "Sem monitorização",


### PR DESCRIPTION
As seis locales traduziam `overview.inboxState.pending` como "Em teste" / "Testing" / "En prueba" / "En test" / "In prova". O estado não é teste nenhum: é canal esperando uma confirmação chegar. Enquanto o rótulo ficava atrás de um ponto colorido a palavra quase não aparecia; agora que o estado é lido em texto na linha da conexão, ela toma a tela.

O `pending` tem **quatro** produtores no `Channels::ConnectionStateResolver`, não só o signup da Meta:

- `connection_state_resolver.rb:68` — hub do WhatsApp aguardando o signup concluir (um `if hub_status == 'pending'` inline; não existe um `HUB_STATUS_MAP` no repo, como esta descrição afirmava antes);
- `connection_state_resolver.rb:84` — `sendgrid_state`, com `webhook_registration_status` pendente;
- `CONNECTION_MAP['connecting']` (`:26`) — sessão QR estabelecendo;
- `connection_state_resolver.rb:96` — `hub_state` de FacebookPage e Instagram, que a versão anterior desta descrição não listava.

Por isso o termo escolhido é o genérico de espera por confirmação, e não algo específico de Meta ou de signup — ele cobre os quatro.

Cada locale usa o vocabulário que o próprio arquivo já tem para o pendente de aprovação de template: "Awaiting confirmation", "Esperando confirmación", "En attente de confirmation", "In attesa di conferma", "A aguardar confirmação" (pt-PT, casando com "A aguardar aprovação") e "Aguardando confirmação" (pt-BR). Consumidor único: `ChannelConnectionsPopover.tsx`.

## Segundo commit — a linha da conexão comporta o rótulo

Os rótulos novos não cabiam na linha: a coluna de texto do popover tem 190px e o span do estado, que era `shrink-0`, pede 196px em en, 226px em pt-BR e 234px em fr. Como só o nome do provedor tinha `truncate`, ele era o único a ceder — sumia inteiro e o estado ainda passava por baixo dos botões de gerenciar e excluir, cortado na borda do popover em es, fr, it e pt-BR. Estouro medido no Chromium com as classes resolvidas: **+33px en, +47 pt, +57 es, +63 pt-BR, +66 it, +71 fr**.

O estouro não nasceu aqui — `unmonitored` já vazava em it (+36px) e pt (+19px) desde que o rótulo escrito entrou no popover (CRM-340). O que mudou é que passou a vazar nos seis locales, inclusive en, e no estado que esta PR existe para tornar legível.

Os três flex items (provedor / separador / estado) viram um fluxo de texto só, que quebra linha quando precisa. Linha curta (`zapi · Connected · Live`) continua numa linha só e com a mesma altura; só as longas passam a ocupar duas.

## Verificação

Os seis JSON continuam válidos, sem chave duplicada. `eslint` e `tsc -b` limpos. Com a develop atual mergeada (inclui a CRM-484, que reescreveu `_lib/parity.ts` depois do check anterior desta PR), passam `i18n-parity`, `macros-parity`, `_lib/parity`, `contacts-parity`, `channelStatus` e `ChannelTypeHub` — **272 exemplos, 0 falhas**.
