### PR TITLE
feat(pipelines): Webhook de compra no menu do kanban — URL assinada por pipeline (CRM-493)

### DIFF
--- a/src/components/pipelines/PipelinePurchaseWebhookModal.tsx
+++ b/src/components/pipelines/PipelinePurchaseWebhookModal.tsx
@@ -64,11 +64,17 @@ export default function PipelinePurchaseWebhookModal({
     try {
       const data = await purchaseWebhooksService.providers();
       setPayload(data);
-      const firstConfigured = data.providers.find((p) => p.configured);
-      if (firstConfigured) setProvider((current) => current || firstConfigured.provider);
+      // A platform whose credential was removed between two openings must not
+      // stay selected: it would look pickable and mint-ready, and only the
+      // backend's 422 would say otherwise.
+      setProvider((current) => {
+        const stillUsable = data.providers.some((p) => p.provider === current && p.configured);
+        return stillUsable ? current : (data.providers.find((p) => p.configured)?.provider ?? '');
+      });
     } catch {
       toast.error(t('purchaseWebhook.loadError'));
       setPayload({ providers: [], destination_secret_configured: false });
+      setProvider('');
     }
   }, [t]);
 
@@ -83,7 +89,7 @@ export default function PipelinePurchaseWebhookModal({
     !!selected?.requires_destination_secret && payload !== null && !payload.destination_secret_configured;
 
   const generate = async () => {
-    if (!pipeline?.id || !provider) return;
+    if (!pipeline?.id || !selected?.configured) return;
     setGenerating(true);
     setResult(null);
     try {
@@ -200,7 +206,7 @@ export default function PipelinePurchaseWebhookModal({
           <div className="flex justify-end">
             <Button
               onClick={generate}
-              disabled={generating || !provider || !pipeline?.id || destinationMissing}
+              disabled={generating || !selected?.configured || !pipeline?.id || destinationMissing}
               className="gap-1.5"
             >
               {generating ? (

--- a/src/components/pipelines/PipelinePurchaseWebhookModal.tsx
+++ b/src/components/pipelines/PipelinePurchaseWebhookModal.tsx
@@ -1,0 +1,196 @@
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { useLanguage } from '@/hooks/useLanguage';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { Check, Copy, Link2, Loader2 } from 'lucide-react';
+import {
+  purchaseWebhooksService,
+  type PurchaseWebhookProvidersPayload,
+  type PurchaseWebhookUrlPayload,
+} from '@/services/purchaseWebhooks/purchaseWebhooksService';
+import type { Pipeline } from '@/types/analytics';
+
+interface PipelinePurchaseWebhookModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  pipeline: Pipeline | null;
+}
+
+/**
+ * "Webhook de compra" for a single pipeline — opened from the board's ⋮ menu,
+ * next to the capture forms. The operator picks a configured payment platform
+ * (credentials live on the integrations screen), the backend mints the signed
+ * URL bound to THIS pipeline, and the modal hands it over with copy-to-clipboard.
+ */
+export default function PipelinePurchaseWebhookModal({
+  open,
+  onOpenChange,
+  pipeline,
+}: PipelinePurchaseWebhookModalProps) {
+  const { t } = useLanguage('pipelines');
+
+  const [payload, setPayload] = useState<PurchaseWebhookProvidersPayload | null>(null);
+  const [provider, setProvider] = useState('');
+  const [product, setProduct] = useState('');
+  const [result, setResult] = useState<PurchaseWebhookUrlPayload | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const providerLabel = (slug: string) => slug.charAt(0).toUpperCase() + slug.slice(1);
+
+  const loadProviders = useCallback(async () => {
+    try {
+      const data = await purchaseWebhooksService.providers();
+      setPayload(data);
+      const firstConfigured = data.providers.find((p) => p.configured);
+      if (firstConfigured) setProvider((current) => current || firstConfigured.provider);
+    } catch {
+      toast.error(t('purchaseWebhook.loadError'));
+      setPayload({ providers: [], destination_secret_configured: false });
+    }
+  }, [t]);
+
+  useEffect(() => {
+    if (!open) return;
+    setResult(null);
+    setCopied(false);
+    void loadProviders();
+  }, [open, loadProviders]);
+
+  const selected = payload?.providers.find((p) => p.provider === provider);
+  const destinationMissing =
+    !!selected?.requires_destination_secret && payload !== null && !payload.destination_secret_configured;
+
+  const generate = async () => {
+    if (!pipeline?.id || !provider) return;
+    setGenerating(true);
+    setResult(null);
+    try {
+      setResult(
+        await purchaseWebhooksService.mintUrl({
+          provider,
+          pipelineId: pipeline.id,
+          product: product.trim() || undefined,
+        }),
+      );
+    } catch {
+      toast.error(t('purchaseWebhook.mintError'));
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const copyUrl = async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(result.url);
+      setCopied(true);
+      toast.success(t('purchaseWebhook.copied'));
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — the operator copies by hand */
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t('purchaseWebhook.title')}</DialogTitle>
+          <DialogDescription>
+            {t('purchaseWebhook.subtitle', { pipeline: pipeline?.name ?? '' })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label>{t('purchaseWebhook.platform')}</Label>
+            <Select value={provider} onValueChange={setProvider} disabled={payload === null}>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    payload === null
+                      ? t('purchaseWebhook.loadingPlatforms')
+                      : t('purchaseWebhook.platformPlaceholder')
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {(payload?.providers ?? []).map((p) => (
+                  <SelectItem key={p.provider} value={p.provider} disabled={!p.configured}>
+                    {providerLabel(p.provider)}
+                    {!p.configured && ` — ${t('purchaseWebhook.notConfigured')}`}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">{t('purchaseWebhook.credentialsHint')}</p>
+            {destinationMissing && (
+              <p className="text-xs text-destructive">{t('purchaseWebhook.destinationRequired')}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>{t('purchaseWebhook.product')}</Label>
+            <Input
+              value={product}
+              onChange={(e) => setProduct(e.target.value)}
+              placeholder={t('purchaseWebhook.productPlaceholder')}
+            />
+          </div>
+
+          {result && (
+            <div className="space-y-2 rounded-lg border border-border bg-muted/40 p-3">
+              <p className="text-xs font-semibold text-foreground">
+                {result.host_kind === 'whitelabel'
+                  ? t('purchaseWebhook.urlWhitelabel')
+                  : t('purchaseWebhook.urlGlobal')}
+              </p>
+              <div className="flex items-start gap-2 min-w-0">
+                <code className="min-w-0 flex-1 break-all whitespace-pre-wrap rounded-md bg-background border border-border px-2 py-1.5 text-[11px] font-mono leading-5">
+                  {result.url}
+                </code>
+                <Button size="sm" variant="outline" className="gap-1.5 shrink-0" onClick={copyUrl}>
+                  {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  {copied ? t('purchaseWebhook.copiedShort') : t('purchaseWebhook.copy')}
+                </Button>
+              </div>
+              <p className="text-[11px] text-muted-foreground leading-snug">
+                {t('purchaseWebhook.regenerateHint')}
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-end">
+            <Button
+              onClick={generate}
+              disabled={generating || !provider || !pipeline?.id || destinationMissing}
+              className="gap-1.5"
+            >
+              {generating ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Link2 className="h-3.5 w-3.5" />
+              )}
+              {t('purchaseWebhook.generate')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/pipelines/PipelinePurchaseWebhookModal.tsx
+++ b/src/components/pipelines/PipelinePurchaseWebhookModal.tsx
@@ -52,6 +52,14 @@ export default function PipelinePurchaseWebhookModal({
 
   const providerLabel = (slug: string) => slug.charAt(0).toUpperCase() + slug.slice(1);
 
+  // The URL is signed over provider+pipeline+product; the moment any of them
+  // moves, what is on screen belongs to a different destination. Drop it, or
+  // the operator copies a URL the ingress will 401 with no visible reason.
+  const clearResult = () => {
+    setResult(null);
+    setCopied(false);
+  };
+
   const loadProviders = useCallback(async () => {
     try {
       const data = await purchaseWebhooksService.providers();
@@ -66,8 +74,7 @@ export default function PipelinePurchaseWebhookModal({
 
   useEffect(() => {
     if (!open) return;
-    setResult(null);
-    setCopied(false);
+    clearResult();
     void loadProviders();
   }, [open, loadProviders]);
 
@@ -87,8 +94,12 @@ export default function PipelinePurchaseWebhookModal({
           product: product.trim() || undefined,
         }),
       );
-    } catch {
-      toast.error(t('purchaseWebhook.mintError'));
+    } catch (error: unknown) {
+      // Distinct reasons per refusal (no stages, no credential, destination
+      // secret missing) — the generic fallback leaves the operator stuck.
+      const msg = (error as { response?: { data?: { error?: { message?: string } } } })?.response
+        ?.data?.error?.message;
+      toast.error(msg || t('purchaseWebhook.mintError'));
     } finally {
       setGenerating(false);
     }
@@ -102,7 +113,8 @@ export default function PipelinePurchaseWebhookModal({
       toast.success(t('purchaseWebhook.copied'));
       window.setTimeout(() => setCopied(false), 1500);
     } catch {
-      /* clipboard blocked — the operator copies by hand */
+      // Blocked clipboard (non-secure origin) silently did nothing; say so.
+      toast.error(t('purchaseWebhook.copyError'));
     }
   };
 
@@ -119,7 +131,14 @@ export default function PipelinePurchaseWebhookModal({
         <div className="space-y-3">
           <div className="space-y-1.5">
             <Label>{t('purchaseWebhook.platform')}</Label>
-            <Select value={provider} onValueChange={setProvider} disabled={payload === null}>
+            <Select
+              value={provider}
+              onValueChange={(value) => {
+                setProvider(value);
+                clearResult();
+              }}
+              disabled={payload === null}
+            >
               <SelectTrigger>
                 <SelectValue
                   placeholder={
@@ -148,7 +167,10 @@ export default function PipelinePurchaseWebhookModal({
             <Label>{t('purchaseWebhook.product')}</Label>
             <Input
               value={product}
-              onChange={(e) => setProduct(e.target.value)}
+              onChange={(e) => {
+                setProduct(e.target.value);
+                clearResult();
+              }}
               placeholder={t('purchaseWebhook.productPlaceholder')}
             />
           </div>

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -661,7 +661,8 @@
       "deletePipeline": "Delete Pipeline",
       "private": "Private",
       "noDescription": "No description",
-      "captureForms": "Capture Forms"
+      "captureForms": "Capture Forms",
+      "purchaseWebhook": "Purchase webhook"
     },
     "stage": {
       "addStage": "Add Stage",
@@ -876,6 +877,27 @@
       "delete": "Delete Pipeline",
       "deleting": "Deleting..."
     }
+  },
+  "purchaseWebhook": {
+    "title": "Purchase webhook",
+    "subtitle": "An approved purchase on a payment platform becomes a lead in this pipeline: {{pipeline}}",
+    "platform": "Payment platform",
+    "platformPlaceholder": "Pick the platform",
+    "loadingPlatforms": "Loading platforms...",
+    "notConfigured": "no credential saved",
+    "credentialsHint": "Platform credentials live on the CRM Integrations screen.",
+    "destinationRequired": "This platform's credential is public — configure the \"URL destination secret\" on the CRM Integrations screen first.",
+    "product": "Product (optional)",
+    "productPlaceholder": "Only purchases of this product; empty = all",
+    "generate": "Generate URL",
+    "urlWhitelabel": "URL on your brand's domain",
+    "urlGlobal": "Webhook URL",
+    "copy": "Copy",
+    "copiedShort": "Copied",
+    "copied": "URL copied",
+    "regenerateHint": "Paste it in the platform's panel as the approved-purchase webhook destination. If you change the credential or the destination secret, generate and register it again.",
+    "loadError": "Failed to load the platforms",
+    "mintError": "Failed to generate the URL"
   },
   "captureForms": {
     "title": "Capture Forms",

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -895,6 +895,7 @@
     "copy": "Copy",
     "copiedShort": "Copied",
     "copied": "URL copied",
+    "copyError": "Could not copy — copy the URL by hand",
     "regenerateHint": "Paste it in the platform's panel as the approved-purchase webhook destination. If you change the credential or the destination secret, generate and register it again.",
     "loadError": "Failed to load the platforms",
     "mintError": "Failed to generate the URL"

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -888,7 +888,7 @@
     "credentialsHint": "Platform credentials live on the CRM Integrations screen.",
     "destinationRequired": "This platform's credential is public — configure the \"URL destination secret\" on the CRM Integrations screen first.",
     "product": "Product (optional)",
-    "productPlaceholder": "Only purchases of this product; empty = all",
+    "productPlaceholder": "Labels this URL's leads with this product; empty = the platform's own",
     "generate": "Generate URL",
     "urlWhitelabel": "URL on your brand's domain",
     "urlGlobal": "Webhook URL",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -853,6 +853,7 @@
     "copy": "Copiar",
     "copiedShort": "Copiado",
     "copied": "URL copiada",
+    "copyError": "No se pudo copiar — copia la URL manualmente",
     "regenerateHint": "Pégala en el panel de la plataforma como destino del webhook de compra aprobada. Si cambias la credencial o el secreto de destino, genera y registra de nuevo.",
     "loadError": "Error al cargar las plataformas",
     "mintError": "Error al generar la URL"

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -621,7 +621,8 @@
       "deletePipeline": "Eliminar Pipeline",
       "private": "Privado",
       "noDescription": "Sin descripción",
-      "captureForms": "Formularios de Captura"
+      "captureForms": "Formularios de Captura",
+      "purchaseWebhook": "Webhook de compra"
     },
     "stage": {
       "addStage": "Agregar Etapa",
@@ -834,6 +835,27 @@
       "delete": "Eliminar Pipeline",
       "deleting": "Eliminando..."
     }
+  },
+  "purchaseWebhook": {
+    "title": "Webhook de compra",
+    "subtitle": "Una compra aprobada en una plataforma de pago se convierte en lead en este embudo: {{pipeline}}",
+    "platform": "Plataforma de pago",
+    "platformPlaceholder": "Elige la plataforma",
+    "loadingPlatforms": "Cargando plataformas...",
+    "notConfigured": "sin credencial guardada",
+    "credentialsHint": "Las credenciales de las plataformas están en la pantalla de Integraciones del CRM.",
+    "destinationRequired": "La credencial de esta plataforma es pública — configura el \"Secreto de destino de la URL\" en Integraciones del CRM antes de generar.",
+    "product": "Producto (opcional)",
+    "productPlaceholder": "Solo compras de este producto; vacío = todas",
+    "generate": "Generar URL",
+    "urlWhitelabel": "URL en el dominio de tu marca",
+    "urlGlobal": "URL del webhook",
+    "copy": "Copiar",
+    "copiedShort": "Copiado",
+    "copied": "URL copiada",
+    "regenerateHint": "Pégala en el panel de la plataforma como destino del webhook de compra aprobada. Si cambias la credencial o el secreto de destino, genera y registra de nuevo.",
+    "loadError": "Error al cargar las plataformas",
+    "mintError": "Error al generar la URL"
   },
   "captureForms": {
     "title": "Formularios de Captura",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -846,7 +846,7 @@
     "credentialsHint": "Las credenciales de las plataformas están en la pantalla de Integraciones del CRM.",
     "destinationRequired": "La credencial de esta plataforma es pública — configura el \"Secreto de destino de la URL\" en Integraciones del CRM antes de generar.",
     "product": "Producto (opcional)",
-    "productPlaceholder": "Solo compras de este producto; vacío = todas",
+    "productPlaceholder": "Etiqueta los leads de esta URL con este producto; vacío = el de la plataforma",
     "generate": "Generar URL",
     "urlWhitelabel": "URL en el dominio de tu marca",
     "urlGlobal": "URL del webhook",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -854,6 +854,7 @@
     "copy": "Copier",
     "copiedShort": "Copié",
     "copied": "URL copiée",
+    "copyError": "Copie impossible — copiez l'URL à la main",
     "regenerateHint": "Collez-la dans le panneau de la plateforme comme destination du webhook d'achat approuvé. Si vous changez l'identifiant ou le secret de destination, générez et enregistrez à nouveau.",
     "loadError": "Échec du chargement des plateformes",
     "mintError": "Échec de la génération de l'URL"

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -847,7 +847,7 @@
     "credentialsHint": "Les identifiants des plateformes se trouvent dans l'écran Intégrations du CRM.",
     "destinationRequired": "L'identifiant de cette plateforme est public — configurez d'abord le « Secret de destination de l'URL » dans les Intégrations du CRM.",
     "product": "Produit (optionnel)",
-    "productPlaceholder": "Uniquement les achats de ce produit ; vide = tous",
+    "productPlaceholder": "Étiquette les leads de cette URL avec ce produit ; vide = celui de la plateforme",
     "generate": "Générer l'URL",
     "urlWhitelabel": "URL sur le domaine de votre marque",
     "urlGlobal": "URL du webhook",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -622,7 +622,8 @@
       "deletePipeline": "Supprimer le Pipeline",
       "private": "Privé",
       "noDescription": "Sans description",
-      "captureForms": "Formulaires de capture"
+      "captureForms": "Formulaires de capture",
+      "purchaseWebhook": "Webhook d'achat"
     },
     "stage": {
       "addStage": "Ajouter une Étape",
@@ -835,6 +836,27 @@
       "delete": "Supprimer le Pipeline",
       "deleting": "Suppression..."
     }
+  },
+  "purchaseWebhook": {
+    "title": "Webhook d'achat",
+    "subtitle": "Un achat approuvé sur une plateforme de paiement devient un lead dans ce pipeline : {{pipeline}}",
+    "platform": "Plateforme de paiement",
+    "platformPlaceholder": "Choisissez la plateforme",
+    "loadingPlatforms": "Chargement des plateformes...",
+    "notConfigured": "aucun identifiant enregistré",
+    "credentialsHint": "Les identifiants des plateformes se trouvent dans l'écran Intégrations du CRM.",
+    "destinationRequired": "L'identifiant de cette plateforme est public — configurez d'abord le « Secret de destination de l'URL » dans les Intégrations du CRM.",
+    "product": "Produit (optionnel)",
+    "productPlaceholder": "Uniquement les achats de ce produit ; vide = tous",
+    "generate": "Générer l'URL",
+    "urlWhitelabel": "URL sur le domaine de votre marque",
+    "urlGlobal": "URL du webhook",
+    "copy": "Copier",
+    "copiedShort": "Copié",
+    "copied": "URL copiée",
+    "regenerateHint": "Collez-la dans le panneau de la plateforme comme destination du webhook d'achat approuvé. Si vous changez l'identifiant ou le secret de destination, générez et enregistrez à nouveau.",
+    "loadError": "Échec du chargement des plateformes",
+    "mintError": "Échec de la génération de l'URL"
   },
   "captureForms": {
     "title": "Formulaires de capture",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -844,7 +844,7 @@
     "credentialsHint": "Le credenziali delle piattaforme si trovano nella schermata Integrazioni del CRM.",
     "destinationRequired": "La credenziale di questa piattaforma è pubblica — configura prima il \"Segreto di destinazione dell'URL\" nelle Integrazioni del CRM.",
     "product": "Prodotto (opzionale)",
-    "productPlaceholder": "Solo acquisti di questo prodotto; vuoto = tutti",
+    "productPlaceholder": "Etichetta i lead di questo URL con questo prodotto; vuoto = quello della piattaforma",
     "generate": "Genera URL",
     "urlWhitelabel": "URL sul dominio del tuo brand",
     "urlGlobal": "URL del webhook",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -851,6 +851,7 @@
     "copy": "Copia",
     "copiedShort": "Copiato",
     "copied": "URL copiata",
+    "copyError": "Copia non riuscita — copia l'URL a mano",
     "regenerateHint": "Incollala nel pannello della piattaforma come destinazione del webhook di acquisto approvato. Se cambi la credenziale o il segreto di destinazione, genera e registra di nuovo.",
     "loadError": "Errore nel caricamento delle piattaforme",
     "mintError": "Errore nella generazione dell'URL"

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -619,7 +619,8 @@
       "deletePipeline": "Elimina Pipeline",
       "private": "Privato",
       "noDescription": "Nessuna descrizione",
-      "captureForms": "Moduli di acquisizione"
+      "captureForms": "Moduli di acquisizione",
+      "purchaseWebhook": "Webhook di acquisto"
     },
     "stage": {
       "addStage": "Aggiungi Fase",
@@ -832,6 +833,27 @@
       "delete": "Elimina Pipeline",
       "deleting": "Eliminazione..."
     }
+  },
+  "purchaseWebhook": {
+    "title": "Webhook di acquisto",
+    "subtitle": "Un acquisto approvato su una piattaforma di pagamento diventa un lead in questa pipeline: {{pipeline}}",
+    "platform": "Piattaforma di pagamento",
+    "platformPlaceholder": "Scegli la piattaforma",
+    "loadingPlatforms": "Caricamento piattaforme...",
+    "notConfigured": "nessuna credenziale salvata",
+    "credentialsHint": "Le credenziali delle piattaforme si trovano nella schermata Integrazioni del CRM.",
+    "destinationRequired": "La credenziale di questa piattaforma è pubblica — configura prima il \"Segreto di destinazione dell'URL\" nelle Integrazioni del CRM.",
+    "product": "Prodotto (opzionale)",
+    "productPlaceholder": "Solo acquisti di questo prodotto; vuoto = tutti",
+    "generate": "Genera URL",
+    "urlWhitelabel": "URL sul dominio del tuo brand",
+    "urlGlobal": "URL del webhook",
+    "copy": "Copia",
+    "copiedShort": "Copiato",
+    "copied": "URL copiata",
+    "regenerateHint": "Incollala nel pannello della piattaforma come destinazione del webhook di acquisto approvato. Se cambi la credenziale o il segreto di destinazione, genera e registra di nuovo.",
+    "loadError": "Errore nel caricamento delle piattaforme",
+    "mintError": "Errore nella generazione dell'URL"
   },
   "captureForms": {
     "title": "Moduli di acquisizione",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -661,7 +661,8 @@
       "deletePipeline": "Deletar Pipeline",
       "private": "Privado",
       "noDescription": "Sem descrição",
-      "captureForms": "Formulários de Captura"
+      "captureForms": "Formulários de Captura",
+      "purchaseWebhook": "Webhook de compra"
     },
     "stage": {
       "addStage": "Adicionar Etapa",
@@ -877,6 +878,27 @@
       "delete": "Deletar Pipeline",
       "deleting": "Deletando..."
     }
+  },
+  "purchaseWebhook": {
+    "title": "Webhook de compra",
+    "subtitle": "Compra aprovada numa plataforma de pagamento vira lead neste funil: {{pipeline}}",
+    "platform": "Plataforma de pagamento",
+    "platformPlaceholder": "Escolha a plataforma",
+    "loadingPlatforms": "Carregando plataformas...",
+    "notConfigured": "sem credencial salva",
+    "credentialsHint": "As credenciais das plataformas ficam na tela de Integrações do CRM.",
+    "destinationRequired": "A credencial desta plataforma é pública — configure o \"Segredo de destino da URL\" nas Integrações do CRM antes de gerar.",
+    "product": "Produto (opcional)",
+    "productPlaceholder": "Filtra as compras deste produto; vazio = todas",
+    "generate": "Gerar URL",
+    "urlWhitelabel": "URL no domínio da sua marca",
+    "urlGlobal": "URL do webhook",
+    "copy": "Copiar",
+    "copiedShort": "Copiado",
+    "copied": "URL copiada",
+    "regenerateHint": "Cole no painel da plataforma como destino do webhook de compra aprovada. Ao trocar a credencial ou o segredo de destino, gere e registre de novo.",
+    "loadError": "Falha ao carregar as plataformas",
+    "mintError": "Falha ao gerar a URL"
   },
   "captureForms": {
     "title": "Formulários de Captura",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -889,7 +889,7 @@
     "credentialsHint": "As credenciais das plataformas ficam na tela de Integrações do CRM.",
     "destinationRequired": "A credencial desta plataforma é pública — configure o \"Segredo de destino da URL\" nas Integrações do CRM antes de gerar.",
     "product": "Produto (opcional)",
-    "productPlaceholder": "Filtra as compras deste produto; vazio = todas",
+    "productPlaceholder": "Rotula os leads desta URL com este produto; vazio = usa o da plataforma",
     "generate": "Gerar URL",
     "urlWhitelabel": "URL no domínio da sua marca",
     "urlGlobal": "URL do webhook",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -896,6 +896,7 @@
     "copy": "Copiar",
     "copiedShort": "Copiado",
     "copied": "URL copiada",
+    "copyError": "Falha ao copiar — copie a URL manualmente",
     "regenerateHint": "Cole no painel da plataforma como destino do webhook de compra aprovada. Ao trocar a credencial ou o segredo de destino, gere e registre de novo.",
     "loadError": "Falha ao carregar as plataformas",
     "mintError": "Falha ao gerar a URL"

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -874,7 +874,7 @@
     "credentialsHint": "As credenciais das plataformas ficam na tela de Integrações do CRM.",
     "destinationRequired": "A credencial desta plataforma é pública — configure o \"Segredo de destino da URL\" nas Integrações do CRM antes de gerar.",
     "product": "Produto (opcional)",
-    "productPlaceholder": "Filtra as compras deste produto; vazio = todas",
+    "productPlaceholder": "Rotula os leads desta URL com este produto; vazio = usa o da plataforma",
     "generate": "Gerar URL",
     "urlWhitelabel": "URL no domínio da sua marca",
     "urlGlobal": "URL do webhook",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -649,7 +649,8 @@
       "deletePipeline": "Deletar Pipeline",
       "private": "Privado",
       "noDescription": "Sem descrição",
-      "captureForms": "Formulários de Captura"
+      "captureForms": "Formulários de Captura",
+      "purchaseWebhook": "Webhook de compra"
     },
     "stage": {
       "addStage": "Adicionar Etapa",
@@ -862,6 +863,27 @@
       "delete": "Deletar Pipeline",
       "deleting": "Deletando..."
     }
+  },
+  "purchaseWebhook": {
+    "title": "Webhook de compra",
+    "subtitle": "Compra aprovada numa plataforma de pagamento vira lead neste funil: {{pipeline}}",
+    "platform": "Plataforma de pagamento",
+    "platformPlaceholder": "Escolha a plataforma",
+    "loadingPlatforms": "Carregando plataformas...",
+    "notConfigured": "sem credencial salva",
+    "credentialsHint": "As credenciais das plataformas ficam na tela de Integrações do CRM.",
+    "destinationRequired": "A credencial desta plataforma é pública — configure o \"Segredo de destino da URL\" nas Integrações do CRM antes de gerar.",
+    "product": "Produto (opcional)",
+    "productPlaceholder": "Filtra as compras deste produto; vazio = todas",
+    "generate": "Gerar URL",
+    "urlWhitelabel": "URL no domínio da sua marca",
+    "urlGlobal": "URL do webhook",
+    "copy": "Copiar",
+    "copiedShort": "Copiado",
+    "copied": "URL copiada",
+    "regenerateHint": "Cole no painel da plataforma como destino do webhook de compra aprovada. Ao trocar a credencial ou o segredo de destino, gere e registre de novo.",
+    "loadError": "Falha ao carregar as plataformas",
+    "mintError": "Falha ao gerar a URL"
   },
   "captureForms": {
     "title": "Formulários de Captura",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -881,6 +881,7 @@
     "copy": "Copiar",
     "copiedShort": "Copiado",
     "copied": "URL copiada",
+    "copyError": "Falha ao copiar — copie a URL manualmente",
     "regenerateHint": "Cole no painel da plataforma como destino do webhook de compra aprovada. Ao trocar a credencial ou o segredo de destino, gere e registre de novo.",
     "loadError": "Falha ao carregar as plataformas",
     "mintError": "Falha ao gerar a URL"

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -40,6 +40,7 @@ import {
   GitBranch,
   MessageSquare,
   FileText,
+  Link2,
 } from 'lucide-react';
 
 import { pipelinesService } from '@/services/pipelines';
@@ -62,6 +63,7 @@ import DeleteStageModal from '@/components/pipelines/DeleteStageModal';
 import DeletePipelineModal from '@/components/pipelines/DeletePipelineModal';
 import ReorderStagesModal from '@/components/pipelines/ReorderStagesModal';
 import PipelineCaptureFormsModal from '@/components/pipelines/PipelineCaptureFormsModal';
+import PipelinePurchaseWebhookModal from '@/components/pipelines/PipelinePurchaseWebhookModal';
 import { ScheduleActionModal } from '@/components/scheduledActions';
 
 // Status/priority badge styles use the design system's semantic Tailwind classes
@@ -178,6 +180,7 @@ export default function PipelineKanban() {
   const [showDeletePipelineModal, setShowDeletePipelineModal] = useState(false);
   const [showReorderStagesModal, setShowReorderStagesModal] = useState(false);
   const [showCaptureFormsModal, setShowCaptureFormsModal] = useState(false);
+  const [showPurchaseWebhookModal, setShowPurchaseWebhookModal] = useState(false);
   const [isDeletingPipeline, setIsDeletingPipeline] = useState(false);
   const [isReorderingStages, setIsReorderingStages] = useState(false);
   const [scheduleActionOpen, setScheduleActionOpen] = useState(false);
@@ -904,6 +907,10 @@ export default function PipelineKanban() {
                       <FileText className="h-4 w-4 mr-2" />
                       {t('kanban.header.captureForms')}
                     </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => setShowPurchaseWebhookModal(true)}>
+                      <Link2 className="h-4 w-4 mr-2" />
+                      {t('kanban.header.purchaseWebhook')}
+                    </DropdownMenuItem>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem className="text-destructive" onClick={handleDeletePipeline}>
                       <Trash2 className="h-4 w-4 mr-2" />
@@ -1629,6 +1636,14 @@ export default function PipelineKanban() {
         pipeline={pipeline}
         stages={stages}
         allPipelines={allPipelines}
+      />
+
+      {/* Purchase webhook URL (CRM-493): a compra aprovada numa plataforma de
+          pagamento vira lead NESTE pipeline — a URL assinada nasce aqui. */}
+      <PipelinePurchaseWebhookModal
+        open={showPurchaseWebhookModal}
+        onOpenChange={setShowPurchaseWebhookModal}
+        pipeline={pipeline}
       />
     </div>
   );

--- a/src/pages/Customer/Pipelines/PipelineKanban.tsx
+++ b/src/pages/Customer/Pipelines/PipelineKanban.tsx
@@ -1638,8 +1638,8 @@ export default function PipelineKanban() {
         allPipelines={allPipelines}
       />
 
-      {/* Purchase webhook URL (CRM-493): a compra aprovada numa plataforma de
-          pagamento vira lead NESTE pipeline — a URL assinada nasce aqui. */}
+      {/* An approved purchase on a payment platform becomes a lead in THIS
+          pipeline — the signed URL for it is minted here. */}
       <PipelinePurchaseWebhookModal
         open={showPurchaseWebhookModal}
         onOpenChange={setShowPurchaseWebhookModal}

--- a/src/services/purchaseWebhooks/purchaseWebhooksService.ts
+++ b/src/services/purchaseWebhooks/purchaseWebhooksService.ts
@@ -1,0 +1,50 @@
+import api from '@/services/core/api';
+import { extractData } from '@/utils/apiHelpers';
+
+/**
+ * Superfície de config do webhook de compra (CRM-493): quais plataformas de
+ * pagamento estão registradas/configuradas e a URL assinada que o operador
+ * registra numa delas. Consome /api/v1/purchase_webhooks (o ingress de entrega
+ * em si é outro caminho, não-autenticado).
+ */
+export interface PurchaseWebhookProvider {
+  provider: string;
+  configured: boolean;
+  requires_destination_secret: boolean;
+}
+
+export interface PurchaseWebhookProvidersPayload {
+  providers: PurchaseWebhookProvider[];
+  destination_secret_configured: boolean;
+}
+
+export interface PurchaseWebhookUrlPayload {
+  url: string;
+  host_kind: 'whitelabel' | 'global';
+}
+
+class PurchaseWebhooksService {
+  private readonly baseUrl = '/purchase_webhooks';
+
+  async providers(): Promise<PurchaseWebhookProvidersPayload> {
+    const res = await api.get(`${this.baseUrl}/providers`);
+    return extractData<PurchaseWebhookProvidersPayload>(res);
+  }
+
+  async mintUrl(params: {
+    provider: string;
+    pipelineId: string;
+    product?: string;
+  }): Promise<PurchaseWebhookUrlPayload> {
+    const res = await api.get(`${this.baseUrl}/url`, {
+      params: {
+        provider: params.provider,
+        pipeline_id: params.pipelineId,
+        ...(params.product ? { product: params.product } : {}),
+      },
+    });
+    return extractData<PurchaseWebhookUrlPayload>(res);
+  }
+}
+
+export const purchaseWebhooksService = new PurchaseWebhooksService();

--- a/src/services/purchaseWebhooks/purchaseWebhooksService.ts
+++ b/src/services/purchaseWebhooks/purchaseWebhooksService.ts
@@ -2,10 +2,10 @@ import api from '@/services/core/api';
 import { extractData } from '@/utils/apiHelpers';
 
 /**
- * Superfície de config do webhook de compra (CRM-493): quais plataformas de
- * pagamento estão registradas/configuradas e a URL assinada que o operador
- * registra numa delas. Consome /api/v1/purchase_webhooks (o ingress de entrega
- * em si é outro caminho, não-autenticado).
+ * Config surface of the purchase webhook: which payment platforms are
+ * registered/configured, and the signed URL the operator registers at one.
+ * Hits /api/v1/purchase_webhooks — the delivery ingress is a separate,
+ * unauthenticated path.
  */
 export interface PurchaseWebhookProvider {
   provider: string;


### PR DESCRIPTION
## Summary
- O ⋮ do funil ganha **"Webhook de compra"**, ao lado dos Formulários de Captura: o operador escolhe a plataforma de pagamento (só as com credencial; plataforma de chave pública exige o segredo de destino antes) e um produto opcional, e o backend minta a URL assinada **já amarrada a este pipeline** — copy-to-clipboard e instrução de registrar no painel da plataforma.
- Antes a URL só nascia via console, e escolher o pipeline fora de contexto convidava ao erro; aqui o funil é o da tela.
- Consome `GET /api/v1/purchase_webhooks/{providers,url}` (PR irmã no backend community).

## Security
- Sem segredo no cliente: o modal só vê flags de configuração; a URL é o artefato público por definição. RBAC no backend (`pipelines.update`).

## Test plan
- `npx vitest run src/i18n/locales/i18n-parity.spec.ts` — 178/178 (chaves novas nos 6 idiomas).
- `npx tsc --noEmit` ✅
- Manual: plataforma sem credencial desabilitada; com credencial gera e copia; host global e whitelabel refletidos no rótulo; redelivery/URL adulterada validados contra o ingress.

## Changed Files
- `src/components/pipelines/PipelinePurchaseWebhookModal.tsx` (novo)
- `src/services/purchaseWebhooks/purchaseWebhooksService.ts` (novo)
- `src/pages/Customer/Pipelines/PipelineKanban.tsx`
- `src/i18n/locales/{pt,pt-BR,en,es,fr,it}/pipelines.json`

## Related PRs
- backend community: endpoints `purchase_webhooks` (providers + url)

## Linked Issue
- CRM-493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gLJMk7XnBVDmcypsR6VUg

## Summary by Sourcery

Enable operators to generate and copy signed purchase webhook URLs directly from the relevant pipeline.

New Features:
- Add a pipeline-specific purchase webhook flow to the Kanban menu, allowing operators to select a configured payment platform and optional product, generate a signed URL, and copy it for registration.

Enhancements:
- Expose payment platform configuration status and global or whitelabel webhook destination details in the generation dialog.
- Support localized purchase webhook labels and guidance across all six supported languages.