### PR TITLE
feat(pipelines): pending Meta templates stay visible in the stage automation modal

### DIFF
--- a/src/components/pipelines/EditStageModal.tsx
+++ b/src/components/pipelines/EditStageModal.tsx
@@ -137,6 +137,7 @@ export default function EditStageModal({
             id: String(tpl.id),
             name: tpl.name,
             language: tpl.language,
+            status: tpl.status,
           })),
         );
       })

--- a/src/components/pipelines/StageAutomationRules.spec.tsx
+++ b/src/components/pipelines/StageAutomationRules.spec.tsx
@@ -3,10 +3,19 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import StageAutomationRules from './StageAutomationRules';
+import type { MessageTemplateOption } from './StageAutomationRules';
 import type { StageAutomationRule } from '@/types/analytics/pipelines';
 
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+// The pending-templates hint links out to Message Templates; the spec renders
+// without a Router, so useNavigate is stubbed (the rest of the module is real).
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', async importOriginal => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => navigateSpy,
 }));
 
 const inactivityRule = (minutes: number): StageAutomationRule => ({
@@ -117,5 +126,55 @@ describe('StageAutomationRules — inactivity duration (CRM-467)', () => {
         trigger_value: { minutes: 4320, base: 'no_customer_reply' },
       }),
     ]);
+  });
+});
+
+// The owner's annotated spec (2026-08-31): a template PENDING Meta approval must
+// stay visible (disabled, with the approval note) instead of collapsing into
+// "no templates"; all-pending and truly-empty each get an honest hint that links
+// to Message Templates.
+describe('StageAutomationRules — send_template with pending templates', () => {
+  const templateRule = (value: string): StageAutomationRule => ({
+    ...inactivityRule(60),
+    action: 'send_template',
+    action_value: value,
+  });
+  const renderTemplates = (templates: MessageTemplateOption[], value = '') =>
+    render(
+      <StageAutomationRules
+        rules={[templateRule(value)]}
+        onChange={vi.fn()}
+        messageTemplates={templates}
+      />,
+    );
+
+  it('a selected PENDING template renders with the Meta-approval note', () => {
+    renderTemplates(
+      [
+        { id: 'tpl-1', name: 'Boas-vindas', status: 'APPROVED' },
+        { id: 'tpl-2', name: 'Follow-up', status: 'PENDING' },
+      ],
+      'tpl-2',
+    );
+    expect(screen.getByText(/stageAutomation\.templatePending/)).toBeTruthy();
+  });
+
+  it('only pending templates: the hint says they await approval and links out', async () => {
+    renderTemplates([{ id: 'tpl-2', name: 'Follow-up', status: 'PENDING' }]);
+    expect(screen.getByText('stageAutomation.templatesPendingHint')).toBeTruthy();
+    await userEvent.click(screen.getByRole('button', { name: 'stageAutomation.manageTemplates' }));
+    expect(navigateSpy).toHaveBeenCalledWith('/settings/message-templates');
+  });
+
+  it('truly empty: the hint asks to create one, with the same link', () => {
+    renderTemplates([]);
+    expect(screen.getByText('stageAutomation.noTemplatesHint')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'stageAutomation.manageTemplates' })).toBeTruthy();
+  });
+
+  it('approved templates present: no hint below the select', () => {
+    renderTemplates([{ id: 'tpl-1', name: 'Boas-vindas', status: 'APPROVED' }]);
+    expect(screen.queryByText('stageAutomation.templatesPendingHint')).toBeNull();
+    expect(screen.queryByText('stageAutomation.noTemplatesHint')).toBeNull();
   });
 });

--- a/src/components/pipelines/StageAutomationRules.tsx
+++ b/src/components/pipelines/StageAutomationRules.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
 import {
   Button,
@@ -37,6 +38,9 @@ export interface MessageTemplateOption {
   id: string;
   name: string;
   language?: string;
+  /** Provider approval status (WhatsApp Cloud): 'PENDING' renders disabled with a
+   *  "waiting for Meta approval" note instead of vanishing into "no templates". */
+  status?: string;
 }
 
 export interface PipelineWithStages {
@@ -129,6 +133,7 @@ export default function StageAutomationRules({
   messageTemplates = [],
 }: StageAutomationRulesProps) {
   const { t } = useLanguage('pipelines');
+  const navigate = useNavigate();
 
   const [keys, setKeys] = useState<string[]>(() => rules.map(() => generateKey()));
   const prevLengthRef = useRef(rules.length);
@@ -510,30 +515,54 @@ export default function StageAutomationRules({
     }
 
     if (rule.action === 'send_template') {
+      // A PENDING template must stay VISIBLE (disabled, with the approval note):
+      // hiding it read as "no templates" while the account was just waiting on
+      // Meta. The hint below the select routes to Message Templates for both the
+      // all-pending and the truly-empty case.
+      const pendingOnly =
+        messageTemplates.length > 0 && messageTemplates.every(tpl => tpl.status === 'PENDING');
+      const showHint = messageTemplates.length === 0 || pendingOnly;
       return (
-        <Select
-          value={rule.action_value || ''}
-          onValueChange={v => updateRule(index, { action_value: v })}
-          disabled={disabled}
-        >
-          <SelectTrigger className="flex-1">
-            <SelectValue placeholder={t('stageAutomation.selectTemplate')} />
-          </SelectTrigger>
-          <SelectContent>
-            {messageTemplates.length === 0 ? (
-              <SelectItem value={PLACEHOLDER_SENTINEL} disabled>
-                {t('stageAutomation.noTemplates')}
-              </SelectItem>
-            ) : (
-              messageTemplates.map(tpl => (
-                <SelectItem key={tpl.id} value={tpl.id}>
-                  {tpl.name}
-                  {tpl.language ? ` (${tpl.language})` : ''}
+        <div className="flex-1 min-w-0">
+          <Select
+            value={rule.action_value || ''}
+            onValueChange={v => updateRule(index, { action_value: v })}
+            disabled={disabled}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder={t('stageAutomation.selectTemplate')} />
+            </SelectTrigger>
+            <SelectContent>
+              {messageTemplates.length === 0 ? (
+                <SelectItem value={PLACEHOLDER_SENTINEL} disabled>
+                  {t('stageAutomation.noTemplates')}
                 </SelectItem>
-              ))
-            )}
-          </SelectContent>
-        </Select>
+              ) : (
+                messageTemplates.map(tpl => (
+                  <SelectItem key={tpl.id} value={tpl.id} disabled={tpl.status === 'PENDING'}>
+                    {tpl.name}
+                    {tpl.language ? ` (${tpl.language})` : ''}
+                    {tpl.status === 'PENDING' ? ` (${t('stageAutomation.templatePending')})` : ''}
+                  </SelectItem>
+                ))
+              )}
+            </SelectContent>
+          </Select>
+          {showHint && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {pendingOnly
+                ? t('stageAutomation.templatesPendingHint')
+                : t('stageAutomation.noTemplatesHint')}{' '}
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:text-foreground"
+                onClick={() => navigate('/settings/message-templates')}
+              >
+                {t('stageAutomation.manageTemplates')}
+              </button>
+            </p>
+          )}
+        </div>
       );
     }
 

--- a/src/i18n/locales/en/pipelines.json
+++ b/src/i18n/locales/en/pipelines.json
@@ -440,7 +440,11 @@
       "send_direct_message": "Direct message",
       "send_template": "Send template",
       "finalize": "End conversation"
-    }
+    },
+    "templatePending": "Awaiting Meta approval",
+    "templatesPendingHint": "Your templates are still awaiting Meta approval.",
+    "noTemplatesHint": "No templates created yet.",
+    "manageTemplates": "Open Message Templates"
   },
   "editStage": {
     "title": "Edit Stage",

--- a/src/i18n/locales/es/pipelines.json
+++ b/src/i18n/locales/es/pipelines.json
@@ -401,7 +401,11 @@
       "send_direct_message": "Mensaje directo",
       "send_template": "Enviar plantilla",
       "finalize": "Finalizar atención"
-    }
+    },
+    "templatePending": "Esperando la aprobación de Meta",
+    "templatesPendingHint": "Tus plantillas aún esperan la aprobación de Meta.",
+    "noTemplatesHint": "Aún no hay plantillas creadas.",
+    "manageTemplates": "Abrir Plantillas de Mensaje"
   },
   "editStage": {
     "title": "Editar Etapa",

--- a/src/i18n/locales/fr/pipelines.json
+++ b/src/i18n/locales/fr/pipelines.json
@@ -402,7 +402,11 @@
         "no_customer_reply": "Client sans réponse",
         "stage_stagnation": "Bloqué dans l'étape"
       }
-    }
+    },
+    "templatePending": "En attente d'approbation de Meta",
+    "templatesPendingHint": "Vos modèles attendent encore l'approbation de Meta.",
+    "noTemplatesHint": "Aucun modèle créé pour le moment.",
+    "manageTemplates": "Ouvrir les Modèles de Message"
   },
   "editStage": {
     "title": "Modifier l'Étape",

--- a/src/i18n/locales/it/pipelines.json
+++ b/src/i18n/locales/it/pipelines.json
@@ -401,7 +401,11 @@
         "no_customer_reply": "Cliente senza risposta",
         "stage_stagnation": "Fermo nella fase"
       }
-    }
+    },
+    "templatePending": "In attesa di approvazione da Meta",
+    "templatesPendingHint": "I tuoi template sono ancora in attesa di approvazione da Meta.",
+    "noTemplatesHint": "Nessun template creato finora.",
+    "manageTemplates": "Apri Modelli di Messaggio"
   },
   "editStage": {
     "title": "Modifica Fase",

--- a/src/i18n/locales/pt-BR/pipelines.json
+++ b/src/i18n/locales/pt-BR/pipelines.json
@@ -440,7 +440,11 @@
       "send_direct_message": "Mensagem direta",
       "send_template": "Enviar template",
       "finalize": "Finalizar atendimento"
-    }
+    },
+    "templatePending": "Aguardando aprovação da Meta",
+    "templatesPendingHint": "Seus templates ainda aguardam aprovação da Meta.",
+    "noTemplatesHint": "Nenhum template criado ainda.",
+    "manageTemplates": "Abrir Modelos de Mensagem"
   },
   "editStage": {
     "title": "Editar Etapa",

--- a/src/i18n/locales/pt/pipelines.json
+++ b/src/i18n/locales/pt/pipelines.json
@@ -428,7 +428,11 @@
         "no_customer_reply": "Cliente sem responder",
         "stage_stagnation": "Parado na etapa"
       }
-    }
+    },
+    "templatePending": "Aguardando aprovação da Meta",
+    "templatesPendingHint": "Os seus templates ainda aguardam aprovação da Meta.",
+    "noTemplatesHint": "Nenhum template criado ainda.",
+    "manageTemplates": "Abrir Modelos de Mensagem"
   },
   "editStage": {
     "title": "Editar Etapa",


### PR DESCRIPTION
A template still PENDING Meta approval collapsed into 'No templates available' in the send-template action of the stage automation modal.

- PENDING templates render disabled with an 'awaiting Meta approval' note; approved ones stay selectable.
- Honest hint below the select links to Message Templates (all-pending vs truly-empty copy).
- MessageTemplateOption carries the approval status (mapped in EditStageModal).
- i18n in the 6 locales (parity spec green); 4 new spec cases; tsc clean.

Owner-annotated spec of 2026-08-31; pairs with the Darwin copy change in evo-skyway-service ac8aea6.

## Summary by Sourcery

Keep pending Meta templates visible in stage automation while clearly distinguishing approval wait states from an empty template list.

New Features:
- Keep pending Meta templates visible but disabled in the stage automation template selector, with an approval-status note.
- Provide contextual empty-state guidance linking users to Message Templates when templates are unavailable or all are pending.

Bug Fixes:
- Prevent pending templates from being incorrectly presented as though no templates exist.

Enhancements:
- Propagate message-template approval status into stage automation options.
- Add localized messaging across six supported locales for pending and empty template states.

Tests:
- Add coverage for pending-template visibility, all-pending and empty hints, navigation, and approved-template behavior.