### PR TITLE
fix(permissions): keep status pending until a fetch actually runs (CRM-494)

### DIFF
--- a/src/contexts/PermissionsContext.spec.tsx
+++ b/src/contexts/PermissionsContext.spec.tsx
@@ -19,24 +19,33 @@ vi.mock('./AuthContext', () => ({
   useAuth: () => ({ user: mockUser(), logout: mockLogout }),
 }));
 
+// Mirrors the store: `isLoggedIn` is derived from the current user, so it is
+// false for exactly as long as `useAuth().user` is null. Pinning it to true
+// hid the CRM-494 window, where the provider mounts with neither.
 vi.mock('@/store/authStore', () => ({
-  useAuthStore: { getState: () => ({ isLoggedIn: true }) },
+  useAuthStore: { getState: () => ({ isLoggedIn: Boolean(mockUser()?.id) }) },
 }));
 
 const mockAccountPermissions = vi.fn<[], Promise<string[]>>();
 const mockUserPermissions = vi.fn<[], Promise<string[]>>();
 
+// Deliberately omits `pipelines.read`: a key that is granted but absent from the
+// catalog is denied only while the catalog is loaded, which is how the CRM-494
+// examples below tell a loaded catalog from the null one.
+const resourceActionsPayload = {
+  data: {
+    all_permissions: [
+      { key: 'contacts.read', display_name: 'Contacts - Read' },
+      { key: 'installation_configs.manage', display_name: 'Installation Configs - Manage' },
+    ],
+  },
+};
+
+const mockResourceActions = vi.fn(() => Promise.resolve(resourceActionsPayload));
+
 vi.mock('@/services/permissions', () => ({
   permissionsService: {
-    getResourceActions: () =>
-      Promise.resolve({
-        data: {
-          all_permissions: [
-            { key: 'contacts.read', display_name: 'Contacts - Read' },
-            { key: 'installation_configs.manage', display_name: 'Installation Configs - Manage' },
-          ],
-        },
-      }),
+    getResourceActions: () => mockResourceActions(),
     getUserPermissions: () => mockUserPermissions(),
     getAccountPermissions: () => mockAccountPermissions(),
   },
@@ -241,5 +250,170 @@ describe('PermissionsProvider — the failure panel replaces the tree it wraps (
 
     await waitFor(() => expect(screen.getByTestId('app')).toBeTruthy());
     expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
+  });
+});
+
+// CRM-494. In the embedded shell the provider mounts before the session is
+// restored, and nothing holds the tree back while it is: the reset to `pending`
+// arrived a commit late and the "no user yet" early-returns stamped `loaded` over
+// lists no request had ever asked for. `isReady` then answered true over two empty
+// arrays and `can()` read false for every key — a denial the user could only clear
+// by leaving the screen and coming back.
+describe('PermissionsContext — an unfetched list is never ready (CRM-494)', () => {
+  const renders: { isReady: boolean; account: number; user: number }[] = [];
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  const BootProbe: React.FC = () => {
+    const { isReady, accountPermissions, userPermissions, can } = usePermissions();
+    renders.push({
+      isReady,
+      account: accountPermissions.length,
+      user: userPermissions.length,
+    });
+    return (
+      <>
+        <span data-testid="ready">{String(isReady)}</span>
+        {isReady ? (
+          <>
+            <span data-testid="contacts-read">{String(can('contacts', 'read'))}</span>
+            <span data-testid="pipelines-read">{String(can('pipelines', 'read'))}</span>
+            <span data-testid="installation-manage">
+              {String(can('installation_configs', 'manage'))}
+            </span>
+            <span data-testid="user-contacts-read">
+              {String(can('contacts', 'read', 'user'))}
+            </span>
+          </>
+        ) : null}
+      </>
+    );
+  };
+
+  function tree(blockOnLoadFailure: boolean) {
+    return (
+      <PermissionsProvider blockOnLoadFailure={blockOnLoadFailure}>
+        <BootProbe />
+      </PermissionsProvider>
+    );
+  }
+
+  // Mounts with no user — the state every reload starts from — and only then hands
+  // the session over, the way validityCheck() does a few ticks later.
+  async function bootThenAuthenticate(
+    granted: string[],
+    { blockOnLoadFailure = false, userGranted = ['contacts.read'] } = {},
+  ) {
+    mockUser.mockReturnValue(null);
+    const { rerender } = render(tree(blockOnLoadFailure));
+
+    expect(screen.getByTestId('ready').textContent).toBe('false');
+
+    mockUserPermissions.mockResolvedValue(userGranted);
+    mockAccountPermissions.mockResolvedValue(granted);
+    mockUser.mockReturnValue({ id: 'user-1', name: 'Someone', role: 'agent' });
+    rerender(tree(blockOnLoadFailure));
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('true'));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResourceActions.mockResolvedValue(resourceActionsPayload);
+    renders.length = 0;
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('never reports ready while either permission list is still empty', async () => {
+    await bootThenAuthenticate(['contacts.read']);
+
+    const premature = renders.filter(r => r.isReady && (r.account === 0 || r.user === 0));
+    expect(premature).toEqual([]);
+    // Both lists really did fill, so the filter above had something to reject.
+    expect(renders.at(-1)).toMatchObject({ isReady: true });
+    expect(renders.at(-1)!.account).toBeGreaterThan(0);
+    expect(renders.at(-1)!.user).toBeGreaterThan(0);
+  });
+
+  it('serves the permission once it arrives, instead of a denial', async () => {
+    await bootThenAuthenticate(['contacts.read']);
+
+    expect(screen.getByTestId('contacts-read').textContent).toBe('true');
+    expect(screen.getByTestId('user-contacts-read').textContent).toBe('true');
+  });
+
+  it('still denies a permission the user does not hold', async () => {
+    await bootThenAuthenticate(['contacts.read']);
+
+    // The window closes by waiting for the fetch, not by letting `can()` pass.
+    expect(screen.getByTestId('installation-manage').textContent).toBe('false');
+  });
+
+  it('keeps rendering the children through the window, not the failure panel', async () => {
+    // The shell mounts the provider with the default, so a status stuck at
+    // `pending` would show as a blank tree rather than as the panel.
+    await bootThenAuthenticate(['contacts.read'], { blockOnLoadFailure: true });
+
+    expect(screen.queryByTestId('permissions-load-failure')).toBeNull();
+  });
+
+  it('loads the resource catalog after a reload instead of leaving it null', async () => {
+    await bootThenAuthenticate(['contacts.read', 'pipelines.read']);
+
+    expect(mockResourceActions).toHaveBeenCalledTimes(1);
+    // Granted, but not in the catalog: a null catalog would accept it.
+    expect(screen.getByTestId('pipelines-read').textContent).toBe('false');
+  });
+
+  it('refetches the catalog for the next user instead of reusing the previous one', async () => {
+    await bootThenAuthenticate(['contacts.read']);
+    expect(mockResourceActions).toHaveBeenCalledTimes(1);
+
+    mockAccountPermissions.mockResolvedValue(['installation_configs.manage']);
+    mockUser.mockReturnValue({ id: 'user-2', name: 'Someone Else', role: 'agent' });
+    render(tree(false));
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('installation-manage').at(-1)?.textContent).toBe('true'),
+    );
+    // The second user gets their own catalog, and never sees the first user's grants.
+    expect(mockResourceActions).toHaveBeenCalledTimes(2);
+    expect(screen.getAllByTestId('contacts-read').at(-1)?.textContent).toBe('false');
+    const premature = renders.filter(r => r.isReady && (r.account === 0 || r.user === 0));
+    expect(premature).toEqual([]);
+  });
+
+  it('reports ready with a permissive catalog when the catalog fetch fails', async () => {
+    mockResourceActions.mockRejectedValue(new Error('catalog down'));
+
+    await bootThenAuthenticate(['contacts.read', 'pipelines.read']);
+
+    // A failed catalog must not hold every screen hostage; the grant list still
+    // decides, so an ungranted key stays denied.
+    expect(screen.getByTestId('pipelines-read').textContent).toBe('true');
+    expect(screen.getByTestId('installation-manage').textContent).toBe('false');
+  });
+
+  it('retries the failed catalog on refreshPermissions instead of staying permissive', async () => {
+    mockResourceActions.mockRejectedValueOnce(new Error('catalog down'));
+    mockResourceActions.mockResolvedValue(resourceActionsPayload);
+
+    mockUser.mockReturnValue({ id: 'user-1', name: 'Someone', role: 'agent' });
+    mockUserPermissions.mockResolvedValue([]);
+    mockAccountPermissions.mockResolvedValue(['contacts.read', 'pipelines.read']);
+    render(
+      <PermissionsProvider blockOnLoadFailure={false}>
+        <Probe />
+      </PermissionsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('true'));
+
+    fireEvent.click(screen.getByText('retry'));
+
+    await waitFor(() => expect(mockResourceActions).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/contexts/PermissionsContext.tsx
+++ b/src/contexts/PermissionsContext.tsx
@@ -61,40 +61,66 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
   // Config state
   const [resourceActions, setResourceActions] = useState<ResourceActionsResponse | null>(null);
   const [configLoading, setConfigLoading] = useState(false);
+  const [configStatus, setConfigStatus] = useState<FetchStatus>('pending');
 
-  // Reset on user change so the next user's fetch cycle runs before `isReady`
-  // flips back to true.
-  useEffect(() => {
+  // Reset in render, not in an effect: an effect lands one commit after the render
+  // where the user appears, and `isReady` would answer true in that commit over the
+  // previous cycle's lists (CRM-494).
+  const [permsUserId, setPermsUserId] = useState<string | undefined>(user?.id);
+  if (permsUserId !== user?.id) {
+    setPermsUserId(user?.id);
     setUserPermsStatus('pending');
     setAccountPermsStatus('pending');
-  }, [user?.id]);
+    setConfigStatus('pending');
+    setUserPermissions([]);
+    setAccountPermissions([]);
+    setError(null);
+  }
 
-  // Load permissions config (metadata)
+  // Load permissions config (metadata). Keyed on the user because the provider
+  // mounts before the session is restored on a reload: with empty deps this gave up
+  // there and never retried, leaving `resourceActions` null for the session (CRM-494).
   useEffect(() => {
+    // `pending` is both the first attempt and the retry signal; a settled status
+    // means this user's catalog is already in hand.
+    if (!user?.id || configStatus !== 'pending') {
+      setConfigLoading(false); // a cancelled leg skips its own `finally`
+      return;
+    }
+
+    let cancelled = false;
 
     const loadConfig = async () => {
-      const isAuthenticated = useAuthStore.getState().isLoggedIn;
-      if (!isAuthenticated) return;
-
       try {
         setConfigLoading(true);
         const config = await permissionsService.getResourceActions();
+        if (cancelled) return;
         setResourceActions(config);
+        setConfigStatus('loaded');
       } catch (err) {
+        if (cancelled) return;
         console.error('Error loading permissions config:', err);
+        setConfigStatus('failed');
       } finally {
-        setConfigLoading(false);
+        if (!cancelled) setConfigLoading(false);
       }
     };
 
     loadConfig();
-  }, []);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id, configStatus]);
 
   // Load user permissions
   useEffect(() => {
     if (!user?.id) {
       setUserPermissions([]);
-      setUserPermsStatus('loaded');
+      // `pending`, not `loaded`: no request went out. Stamping `loaded` over the
+      // empty list made `isReady` true in the window before the session arrived,
+      // and `can()` answered false for every key there (CRM-494).
+      setUserPermsStatus('pending');
       setLoading(false); // a cancelled leg no longer clears it in its `finally`
       return;
     }
@@ -109,7 +135,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
         if (!isAuthenticated) {
           if (cancelled) return;
           setUserPermissions([]);
-          setUserPermsStatus('loaded');
+          setUserPermsStatus('pending'); // see the early return above
           return;
         }
 
@@ -143,7 +169,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     const isAuthenticated = useAuthStore.getState().isLoggedIn;
     if (!isAuthenticated || !user) {
       setAccountPermissions([]);
-      setAccountPermsStatus('loaded');
+      setAccountPermsStatus('pending'); // see the user-permissions effect
       setLoading(false); // see the user-permissions effect
       return;
     }
@@ -165,7 +191,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
         if (!isAuthenticated) {
           if (cancelled) return;
           setAccountPermissions([]);
-          setAccountPermsStatus('loaded');
+          setAccountPermsStatus('pending'); // see the user-permissions effect
           return;
         }
 
@@ -276,6 +302,10 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
   const refreshPermissions = useCallback(async () => {
     if (!user?.id) return;
 
+    // A catalog that failed is otherwise never retried, and `isValidPermission`
+    // stays permissive for the rest of the session.
+    if (configStatus === 'failed') setConfigStatus('pending');
+
     setLoading(true);
     setError(null);
 
@@ -308,17 +338,22 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     }
 
     setLoading(false);
-  }, [user?.id]);
+  }, [user?.id, configStatus]);
 
-  // True once user, config and BOTH fetches succeeded. Tracking the outcome
-  // rather than `!loading` keeps consumers from evaluating `can()` against an
-  // empty array — before the fetch effect fires, or after it failed (CRM-164).
+  // True once there is a user, the catalog fetch has settled and BOTH permission
+  // fetches succeeded. Tracking the outcome rather than `!loading` keeps consumers
+  // from evaluating `can()` against an empty array (CRM-164).
+  // `configStatus`, not `configLoading`: a catalog fetch that never started leaves
+  // `configLoading` false, which is the hole the reload window fell through
+  // (CRM-494). A FAILED catalog counts as settled — `isValidPermission` then
+  // accepts any key, but the grant list still decides, and blocking here would
+  // deny every screen on a single catalog blip.
   const isReady = useMemo(() => {
     if (!user) return false;
-    if (configLoading) return false;
+    if (configStatus === 'pending') return false;
     if (loading) return false;
     return userPermsStatus === 'loaded' && accountPermsStatus === 'loaded';
-  }, [configLoading, loading, user, userPermsStatus, accountPermsStatus]);
+  }, [configStatus, loading, user, userPermsStatus, accountPermsStatus]);
 
   // Both must settle first: `loading` is one shared flag that the faster fetch
   // clears, so reporting on the first rejection flashed the panel mid-boot.


### PR DESCRIPTION
## Contexto

CRM-494. No **ecosystem** (shell), dar **F5** numa tela de listagem — `/pipelines` é o caso mais fácil — exibia erro de permissão e a lista não carregava; trocar de item de menu e voltar resolvia. É a metade que o CRM-164 não fechou: aquele resolveu o `failed` (falha de carga servida como negação); este fecha o **`loaded` falso** (a lista que nunca foi buscada também era carimbada como carregada).

Por que só o shell quebra: na SPA standalone o `RouterGuard` segura a árvore até o auth resolver; o shell monta os providers do vendor **sem** o RouterGuard e casa `/pipelines` já no 1º render, então a tela monta dentro da janela em que o usuário ainda é `null`.

## O que muda (`PermissionsContext.tsx`)

- Os quatro early-returns de "ainda não há usuário / não autenticado" mantêm **`pending`** em vez de carimbar `loaded` — nenhum request saiu, então a lista não está carregada.
- O **reset por usuário** sai de um efeito (que chegava um commit atrasado) e vira **derivação no render** (chaveado no `user.id`); limpa também as listas obsoletas e o `error`.
- O efeito de **config (`resource_actions`)** passa a ser chaveado no usuário e dirigido por `configStatus`: antes desistia no mount pré-sessão e, com deps vazias, nunca mais tentava — deixando o catálogo `null` e o `isValidPermission` permissivo pela sessão inteira. O `refreshPermissions` também re-tenta um catálogo que falhou, então o retry do painel de falha o recupera.
- `isReady` passa a gatear em `configStatus` (não `configLoading`): um fetch de config que **nunca começou** também deixa `configLoading` false — era o furo por onde a janela passava.

## Testes

Novos reprodutores montam o provider **sem usuário** e só então entregam a sessão (o caminho do reload), cobrindo: a janela do reload, troca de usuário A→B, catálogo que falha, e o retry do catálogo. O mock do `authStore` passou a derivar `isLoggedIn` do usuário corrente, espelhando a store — sem isso a janela não era exercida. 4 reprodutores falham sem o fix. `tsc` e `eslint` limpos.

## Fora de escopo (CRM-495)

O gate imperativo `can()` nos handlers de clique (ex.: "Novo Contato" em `Contacts.tsx`, sem gate de `permissionsReady`) ainda pode negar um clique feito **dentro** da janela de fetch de permissão logo após o login. Verificado que reproduz **idêntico na develop sem este fix** (não é regressão) — é o endurecimento das 14 telas do card irmão **CRM-495**.

## Summary by Sourcery

Prevent permission checks from treating unfetched data as loaded during authentication, user changes, and catalog failures.

Bug Fixes:
- Keep permission readiness pending until permission fetches actually run and complete, preventing false denials during shell reloads before authentication is restored.
- Retry resource permission catalog loading after session initialization and when a previous catalog fetch failed.
- Reset permission and catalog state immediately when switching users to prevent stale permissions from leaking between sessions.

Enhancements:
- Base readiness on explicit catalog fetch status so an unfetched catalog cannot be treated as loaded while catalog failures remain non-blocking.

Tests:
- Add regression coverage for reload initialization, permission readiness windows, user switching, catalog failures, and catalog retries.