### PR TITLE
fix(permissions): telas de listagem carregam quando o veredito de leitura permite (CRM-495)

### DIFF
--- a/src/hooks/rbac/usePermissionGatedLoad.spec.tsx
+++ b/src/hooks/rbac/usePermissionGatedLoad.spec.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { usePermissionGatedLoad } from './usePermissionGatedLoad';
+
+// The regression these examples lock: the screens used to latch the permission
+// decision on the first render where `isReady` was true, so a verdict that was
+// false there — because the grants had not landed yet — told the user he had no
+// permission until he remounted the screen by changing menus. The gate now
+// follows the verdict, and the false-positive denial has to clear itself.
+
+let ready = false;
+let grants: string[] = [];
+
+vi.mock('@/contexts/PermissionsContext', () => ({
+  usePermissions: () => ({
+    can: (resource: string, action: string) => grants.includes(`${resource}.${action}`),
+    isReady: ready,
+  }),
+}));
+
+const load = vi.fn();
+const onDenied = vi.fn();
+
+const Screen = () => {
+  usePermissionGatedLoad({ resource: 'pipelines', load, onDenied });
+  return null;
+};
+
+// Re-renders the SAME component instance: every example below has to hold
+// without the remount that used to be the only way out of a stuck denial.
+const mount = () => {
+  const { rerender } = render(<Screen />);
+  return (nextReady: boolean, nextGrants: string[]) => {
+    ready = nextReady;
+    grants = nextGrants;
+    rerender(<Screen />);
+  };
+};
+
+const setPermissions = (nextReady: boolean, nextGrants: string[]) => {
+  ready = nextReady;
+  grants = nextGrants;
+};
+
+describe('usePermissionGatedLoad', () => {
+  beforeEach(() => {
+    load.mockClear();
+    onDenied.mockClear();
+    setPermissions(false, []);
+  });
+
+  it('loads on its own when the grants land after a denial', () => {
+    setPermissions(true, []);
+    const update = mount();
+
+    expect(load).not.toHaveBeenCalled();
+    expect(onDenied).toHaveBeenCalledTimes(1);
+
+    update(true, ['pipelines.read']);
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a real denial once, and never requests', () => {
+    setPermissions(true, ['contacts.read']);
+    const update = mount();
+
+    update(true, ['contacts.read']);
+    update(true, ['contacts.read']);
+
+    expect(onDenied).toHaveBeenCalledTimes(1);
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('loads once when the permission is granted from the first render', () => {
+    setPermissions(true, ['pipelines.read']);
+    const update = mount();
+
+    update(true, ['pipelines.read']);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(onDenied).not.toHaveBeenCalled();
+  });
+
+  it('stays quiet while the permissions have not settled', () => {
+    const update = mount();
+
+    expect(load).not.toHaveBeenCalled();
+    expect(onDenied).not.toHaveBeenCalled();
+
+    update(true, ['pipelines.read']);
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reload or deny while a refresh dips through not-ready', () => {
+    setPermissions(true, ['pipelines.read']);
+    const update = mount();
+
+    update(false, ['pipelines.read']);
+    update(true, ['pipelines.read']);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(onDenied).not.toHaveBeenCalled();
+  });
+
+  it('calls the loader with no arguments, so it reloads from the top', () => {
+    setPermissions(true, ['pipelines.read']);
+    mount();
+
+    expect(load).toHaveBeenCalledWith();
+  });
+
+  it('stays silent on a denial when the screen passes no onDenied', () => {
+    setPermissions(true, []);
+    const Silent = () => {
+      usePermissionGatedLoad({ resource: 'pipelines', load });
+      return null;
+    };
+
+    expect(() => render(<Silent />)).not.toThrow();
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  it('denies again after a revocation, and reloads when the grant comes back', () => {
+    setPermissions(true, ['pipelines.read']);
+    const update = mount();
+
+    update(true, []);
+    expect(onDenied).toHaveBeenCalledTimes(1);
+
+    update(true, ['pipelines.read']);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/rbac/usePermissionGatedLoad.spec.tsx
+++ b/src/hooks/rbac/usePermissionGatedLoad.spec.tsx
@@ -21,8 +21,8 @@ vi.mock('@/contexts/PermissionsContext', () => ({
 const load = vi.fn();
 const onDenied = vi.fn();
 
-const Screen = () => {
-  usePermissionGatedLoad({ resource: 'pipelines', load, onDenied });
+const Screen = ({ resource = 'pipelines' }: { resource?: string }) => {
+  usePermissionGatedLoad({ resource, load, onDenied });
   return null;
 };
 
@@ -120,6 +120,25 @@ describe('usePermissionGatedLoad', () => {
 
     expect(() => render(<Silent />)).not.toThrow();
     expect(load).not.toHaveBeenCalled();
+  });
+
+  it('re-opens the gate when the resource changes', () => {
+    setPermissions(true, ['pipelines.read']);
+    const { rerender } = render(<Screen />);
+
+    expect(load).toHaveBeenCalledTimes(1);
+
+    // A screen that swapped its resource key would otherwise keep answering with
+    // the previous key's verdict — allowed, and already loaded.
+    rerender(<Screen resource="labels" />);
+
+    expect(onDenied).toHaveBeenCalledTimes(1);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    grants = ['pipelines.read', 'labels.read'];
+    rerender(<Screen resource="labels" />);
+
+    expect(load).toHaveBeenCalledTimes(2);
   });
 
   it('denies again after a revocation, and reloads when the grant comes back', () => {

--- a/src/hooks/rbac/usePermissionGatedLoad.ts
+++ b/src/hooks/rbac/usePermissionGatedLoad.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import { usePermissions } from '@/contexts/PermissionsContext';
+
+interface PermissionGatedLoadArgs {
+  /** Resource key of the read permission. Must stay constant for the component's life. */
+  resource: string;
+  /** The screen's initial load. Fired once per allowed verdict, with no arguments. */
+  load: () => void;
+  /** Reports the denial. Fired once per denied verdict — omit for a silent screen. */
+  onDenied?: () => void;
+}
+
+/**
+ * Runs a list screen's initial load as soon as `can(resource, 'read')` allows it.
+ *
+ * The latch follows the VERDICT, not the first render where permissions were ready:
+ * a false answered before the grants landed used to stick until the screen remounted.
+ */
+export function usePermissionGatedLoad({ resource, load, onDenied }: PermissionGatedLoadArgs): void {
+  const { can, isReady } = usePermissions();
+  const allowed = isReady && can(resource, 'read');
+
+  // Latest-callback refs: callers pass inline closures, which as dependencies
+  // would re-run the gate on every render.
+  const loadRef = useRef(load);
+  const onDeniedRef = useRef(onDenied);
+  useEffect(() => {
+    loadRef.current = load;
+    onDeniedRef.current = onDenied;
+  });
+
+  const loadedRef = useRef(false);
+  const deniedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isReady) return;
+
+    if (allowed) {
+      // A later revocation is a new verdict and gets its own denial.
+      deniedRef.current = false;
+      if (loadedRef.current) return;
+      loadedRef.current = true;
+      loadRef.current();
+      return;
+    }
+
+    // Clearing the load latch is what makes a later grant load instead of staying
+    // empty; a re-grant therefore reloads from the top, as a fresh mount would.
+    loadedRef.current = false;
+    if (deniedRef.current) return;
+    deniedRef.current = true;
+    onDeniedRef.current?.();
+  }, [isReady, allowed]);
+}

--- a/src/hooks/rbac/usePermissionGatedLoad.ts
+++ b/src/hooks/rbac/usePermissionGatedLoad.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { usePermissions } from '@/contexts/PermissionsContext';
 
 interface PermissionGatedLoadArgs {
-  /** Resource key of the read permission. Must stay constant for the component's life. */
+  /** Resource key of the read permission. Changing it re-opens the gate. */
   resource: string;
   /** The screen's initial load. Fired once per allowed verdict, with no arguments. */
   load: () => void;
@@ -31,8 +31,17 @@ export function usePermissionGatedLoad({ resource, load, onDenied }: PermissionG
 
   const loadedRef = useRef(false);
   const deniedRef = useRef(false);
+  const resourceRef = useRef(resource);
 
   useEffect(() => {
+    // Both latches answer for one resource. Keeping them across a change would
+    // carry the old key's verdict onto the new one.
+    if (resourceRef.current !== resource) {
+      resourceRef.current = resource;
+      loadedRef.current = false;
+      deniedRef.current = false;
+    }
+
     if (!isReady) return;
 
     if (allowed) {
@@ -45,10 +54,11 @@ export function usePermissionGatedLoad({ resource, load, onDenied }: PermissionG
     }
 
     // Clearing the load latch is what makes a later grant load instead of staying
-    // empty; a re-grant therefore reloads from the top, as a fresh mount would.
+    // empty. The reload calls `load()` with no arguments, so each screen resumes
+    // from the state it is holding — its current page and filters, not the first.
     loadedRef.current = false;
     if (deniedRef.current) return;
     deniedRef.current = true;
     onDeniedRef.current?.();
-  }, [isReady, allowed]);
+  }, [isReady, allowed, resource]);
 }

--- a/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
+++ b/src/pages/Customer/Agents/CustomMCPServers/CustomMCPServers.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { useLanguage } from '@/hooks/useLanguage';
 import { AgentsCustomMCPsTour } from '@/tours';
 import {
@@ -65,7 +66,7 @@ const INITIAL_STATE: CustomMcpServersState = {
 };
 
 export default function CustomMCPServers() {
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const { t } = useLanguage('customMcpServers');
   const location = useLocation();
   const navigate = useNavigate();
@@ -89,7 +90,6 @@ export default function CustomMCPServers() {
   activeFiltersRef.current = activeFilters;
   const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
   const [testingServer, setTestingServer] = useState<string | null>(null);
-  const hasLoaded = useRef(false);
   // EVO-1953: debounce the server-side search so typing fires one request after
   // it settles, not one per keystroke.
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -156,17 +156,10 @@ export default function CustomMCPServers() {
     [can, t, activeFilters],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadServers();
-    }
-  }, [permissionsReady, loadServers]);
+  usePermissionGatedLoad({
+    resource: 'ai_custom_mcp_servers',
+    load: loadServers,
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
+++ b/src/pages/Customer/Agents/CustomTools/CustomTools.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { useLanguage } from '@/hooks/useLanguage';
 import { AgentsCustomToolsTour } from '@/tours';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, Button } from '@evoapi/design-system';
@@ -36,7 +37,7 @@ import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
 const INITIAL_STATE: CustomToolsState = initialCustomToolsState;
 
 export default function CustomTools() {
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const { t } = useLanguage('customTools');
   const location = useLocation();
   const navigate = useNavigate();
@@ -64,7 +65,6 @@ export default function CustomTools() {
   const [testResultTool, setTestResultTool] = useState<CustomTool | null>(null);
   const [testResultData, setTestResultData] =
     useState<CustomToolTestResponse['test_result'] | null>(null);
-  const hasLoaded = useRef(false);
   // EVO-1953: debounce the server-side search so typing fires one request after
   // it settles, not one per keystroke.
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -134,17 +134,10 @@ export default function CustomTools() {
     [can, t, activeFilters],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadTools();
-    }
-  }, [permissionsReady, loadTools]);
+  usePermissionGatedLoad({
+    resource: 'ai_custom_tools',
+    load: loadTools,
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Agents/MCPServers/MCPServers.tsx
+++ b/src/pages/Customer/Agents/MCPServers/MCPServers.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@evoapi/design-system';
 import { useLanguage } from '@/hooks/useLanguage';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { Grid3X3, List, Server } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 import { MCPServer, MCPServersState, MCPServersListParams } from '@/types/ai';
@@ -38,12 +39,11 @@ const INITIAL_STATE: MCPServersState = {
 
 export default function MCPServers() {
   const { t } = useLanguage('customerMcpServers');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const [state, setState] = useState<MCPServersState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [detailsServer, setDetailsServer] = useState<MCPServer | null>(null);
-  const hasLoaded = useRef(false);
 
   // Load servers
   const loadServers = useCallback(
@@ -85,17 +85,11 @@ export default function MCPServers() {
     [can, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadServers();
-    }
-  }, [permissionsReady, loadServers]);
+  usePermissionGatedLoad({
+    resource: 'ai_mcp_servers',
+    load: loadServers,
+    onDenied: () => toast.error(t('errors.permissionDenied')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Agents/Tools/Tools.tsx
+++ b/src/pages/Customer/Agents/Tools/Tools.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@evoapi/design-system';
 import { useLanguage } from '@/hooks/useLanguage';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { Grid3X3, List, Wrench } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
@@ -41,7 +42,7 @@ const INITIAL_STATE: ToolsState = {
 
 export default function Tools() {
   const { t } = useLanguage('tools');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const [state, setState] = useState<ToolsState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
@@ -49,7 +50,6 @@ export default function Tools() {
   const [filterModalOpen, setFilterModalOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
   const [appliedFilters, setAppliedFilters] = useState<AppliedFilter[]>([]);
-  const hasLoaded = useRef(false);
 
   // Load tools
   const loadTools = useCallback(
@@ -101,17 +101,11 @@ export default function Tools() {
     [can, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadTools();
-    }
-  }, [permissionsReady, loadTools]);
+  usePermissionGatedLoad({
+    resource: 'ai_tools',
+    load: loadTools,
+    onDenied: () => toast.error(t('errors.permissionDenied')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Automation/index.tsx
+++ b/src/pages/Customer/Automation/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
 import { toast } from 'sonner';
@@ -12,6 +12,7 @@ import {
   Button,
 } from '@evoapi/design-system';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { automationService } from '@/services/automation/automationService';
 import type { AutomationRule } from '@/types/automation';
 import { AutomationsHeader, AutomationsTable, AutomationsPagination } from '@/components/automation';
@@ -49,13 +50,12 @@ const INITIAL_STATE: State = {
 export default function AutomationsListPage() {
   const { t } = useLanguage('automation');
   const navigate = useNavigate();
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
 
   const [state, setState] = useState<State>(INITIAL_STATE);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [ruleToDelete, setRuleToDelete] = useState<AutomationRule | null>(null);
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
-  const hasLoaded = useRef(false);
 
   const canRead = can('automation_rules', 'read');
   const canCreate = can('automation_rules', 'create');
@@ -94,13 +94,11 @@ export default function AutomationsListPage() {
     }
   }, [canRead, t]);
 
-  useEffect(() => {
-    if (!permissionsReady) return;
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadAutomations();
-    }
-  }, [permissionsReady, loadAutomations]);
+  usePermissionGatedLoad({
+    resource: 'automation_rules',
+    load: loadAutomations,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   const handleCreate = () => {
     if (!canCreate) {

--- a/src/pages/Customer/Contacts/ScheduledActions.tsx
+++ b/src/pages/Customer/Contacts/ScheduledActions.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
 import { ScheduledActionsTour } from '@/tours';
 import { useLanguage } from '@/hooks/useLanguage';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { scheduledActionsService } from '@/services/scheduledActions/scheduledActionsService';
 import { ScheduledAction } from '@/types/automation';
 import { ScheduleActionModal } from '@/components/scheduledActions/ScheduleActionModal';
@@ -49,12 +50,11 @@ const INITIAL_STATE: ScheduledActionsState = {
 export default function ScheduledActions() {
   const { t } = useLanguage('contacts');
   const navigate = useNavigate();
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const [state, setState] = useState<ScheduledActionsState>(INITIAL_STATE);
   const [modalOpen, setModalOpen] = useState(false);
   const [editingAction, setEditingAction] = useState<ScheduledAction | null>(null);
   const [, setUpdateTrigger] = useState(0); // Force re-render for countdown updates
-  const hasLoaded = useRef(false);
 
   // Load scheduled actions
   const loadActions = useCallback(
@@ -103,19 +103,11 @@ export default function ScheduledActions() {
     [state.meta.current_page, state.meta.per_page, state.statusFilter, state.searchQuery, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) return;
-
-    if (!hasLoaded.current) {
-      if (!can('contacts', 'read')) {
-        toast.error('Você não tem permissão para visualizar ações agendadas');
-        return;
-      }
-      hasLoaded.current = true;
-      loadActions();
-    }
-  }, [permissionsReady, can, loadActions]);
+  usePermissionGatedLoad({
+    resource: 'contacts',
+    load: loadActions,
+    onDenied: () => toast.error('Você não tem permissão para visualizar ações agendadas'),
+  });
 
   // Set up interval to update countdown every second
   useEffect(() => {

--- a/src/pages/Customer/Pipelines/Pipelines.spec.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.spec.tsx
@@ -49,8 +49,12 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// Mutable so the CRM-495 example can flip the verdict between two renders of the
+// same instance, which is the whole point: no remount is allowed to be the fix.
+let canRead = true;
+
 vi.mock('@/contexts/PermissionsContext', () => ({
-  usePermissions: () => ({ can: () => true, isReady: true, loading: false }),
+  usePermissions: () => ({ can: () => canRead, isReady: true, loading: false }),
 }));
 
 vi.mock('@/hooks/useLanguage', () => ({
@@ -81,8 +85,25 @@ async function clickActivate() {
 describe('Pipelines management screen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    canRead = true;
     getPipelines.mockResolvedValue({ data: [inactivePipeline], meta: {} });
     togglePipelineStatus.mockResolvedValue({ ...inactivePipeline, is_active: true });
+  });
+
+  // CRM-495: the screen used to read the permission once, on the first render where
+  // it was ready, and a false answered before the grants landed stuck until remount.
+  it('loads on its own when the read permission lands after the first render (CRM-495)', async () => {
+    canRead = false;
+    const { rerender } = render(<Pipelines />);
+
+    await waitFor(() => expect(error).toHaveBeenCalledWith('messages.noPermissionRead'));
+    expect(getPipelines).not.toHaveBeenCalled();
+
+    canRead = true;
+    rerender(<Pipelines />);
+
+    await waitFor(() => expect(getPipelines).toHaveBeenCalledTimes(1));
+    expect(error).toHaveBeenCalledTimes(1);
   });
 
   it('asks the API for inactive pipelines too (AC2, AC3)', async () => {

--- a/src/pages/Customer/Pipelines/Pipelines.tsx
+++ b/src/pages/Customer/Pipelines/Pipelines.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
 import { useLanguage } from '@/hooks/useLanguage';
@@ -12,6 +12,7 @@ import {
   Button,
 } from '@evoapi/design-system';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { pipelinesService } from '@/services/pipelines';
 import { pipelineDeleteErrorKey } from '@/utils/pipelineDeleteError';
 import {
@@ -74,8 +75,6 @@ export default function Pipelines() {
     failed: boolean;
   } | null>(null);
 
-  const hasLoaded = useRef(false);
-
   // Load pipelines
   const loadPipelines = useCallback(
     async (params?: Partial<PipelinesListParams>) => {
@@ -125,17 +124,11 @@ export default function Pipelines() {
     [state.meta.pagination.page, state.meta.pagination.page_size, can, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadPipelines();
-    }
-  }, [permissionsReady, loadPipelines]);
+  usePermissionGatedLoad({
+    resource: 'pipelines',
+    load: loadPipelines,
+    onDenied: () => toast.error(t('messages.noPermissionRead')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Settings/AccessTokens/AccessTokens.tsx
+++ b/src/pages/Customer/Settings/AccessTokens/AccessTokens.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { SettingsAccessTokensTour } from '@/tours';
 import {
@@ -22,6 +22,7 @@ import {
   regenerateAccessToken,
 } from '@/services/auth/accessTokensService';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import type { AccessToken, AccessTokensState, AccessTokenFormData } from '@/types/auth';
 
 import {
@@ -58,7 +59,7 @@ const INITIAL_STATE: AccessTokensState = {
 };
 
 export default function AccessTokens() {
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const { t } = useTranslation('accessTokens');
   const [state, setState] = useState<AccessTokensState>(INITIAL_STATE);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -68,7 +69,6 @@ export default function AccessTokens() {
   const [editingToken, setEditingToken] = useState<AccessToken | null>(null);
   const [viewTokenModalOpen, setViewTokenModalOpen] = useState(false);
   const [selectedTokenForView, setSelectedTokenForView] = useState<AccessToken | null>(null);
-  const hasLoaded = useRef(false);
 
   // Load tokens
   const loadTokens = useCallback(
@@ -108,18 +108,11 @@ export default function AccessTokens() {
     [can, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadTokens();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permissionsReady]);
+  usePermissionGatedLoad({
+    resource: 'access_tokens',
+    load: loadTokens,
+    onDenied: () => toast.error(t('messages.permissionDenied', { action: 'visualizar' })),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Settings/Integrations/Integrations.tsx
+++ b/src/pages/Customer/Settings/Integrations/Integrations.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { useNavigate } from 'react-router-dom';
 import { SettingsIntegrationsTour } from '@/tours';
@@ -20,6 +20,7 @@ import { Integration, IntegrationCategory } from '@/types/integrations';
 import { IntegrationCard } from '@/components/integrations/base';
 import { toast } from 'sonner';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { useGlobalConfig } from '@/contexts/GlobalConfigContext';
 
 // Integration categories for organization - will be translated
@@ -60,7 +61,7 @@ const INTEGRATION_CATEGORY_MAP: Record<string, string> = {
 
 export default function Integrations() {
   const { t } = useLanguage('integrations');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const { openaiConfigured } = useGlobalConfig();
   const navigate = useNavigate();
   const [integrations, setIntegrations] = useState<Integration[]>([]);
@@ -68,7 +69,6 @@ export default function Integrations() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [processingId, setProcessingId] = useState<string | null>(null);
-  const hasLoaded = useRef(false);
 
   // Load integrations
   const loadIntegrations = useCallback(async () => {
@@ -89,16 +89,11 @@ export default function Integrations() {
     }
   }, [can, t]);
 
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadIntegrations();
-    }
-  }, [permissionsReady, loadIntegrations]);
+  usePermissionGatedLoad({
+    resource: 'integrations',
+    load: loadIntegrations,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   // Handle integration toggle
   const handleToggleIntegration = async (integration: Integration) => {

--- a/src/pages/Customer/Settings/Labels/Labels.tsx
+++ b/src/pages/Customer/Settings/Labels/Labels.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { SettingsLabelsTour } from '@/tours';
 import { toast } from 'sonner';
@@ -16,6 +16,7 @@ import EmptyState from '@/components/base/EmptyState';
 
 import { labelsService } from '@/services/contacts/labelsService';
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { Label, LabelsState, LabelFormData } from '@/types/settings';
 
 import LabelsHeader from '@/components/labels/LabelsHeader';
@@ -49,14 +50,13 @@ const INITIAL_STATE: LabelsState = {
 
 export default function Labels() {
   const { t } = useLanguage('labels');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const [state, setState] = useState<LabelsState>(INITIAL_STATE);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [labelToDelete, setLabelToDelete] = useState<Label | null>(null);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
   const [labelModalOpen, setLabelModalOpen] = useState(false);
   const [editingLabel, setEditingLabel] = useState<Label | null>(null);
-  const hasLoaded = useRef(false);
 
   // Load labels
   const loadLabels = useCallback(async () => {
@@ -87,18 +87,11 @@ export default function Labels() {
     }
   }, [can, t]);
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadLabels();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permissionsReady]);
+  usePermissionGatedLoad({
+    resource: 'labels',
+    load: loadLabels,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Settings/Macros/Macros.tsx
+++ b/src/pages/Customer/Settings/Macros/Macros.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { SettingsMacrosTour } from '@/tours';
 import { toast } from 'sonner';
@@ -15,6 +15,7 @@ import { Settings } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { macrosService } from '@/services/macros';
 import { Macro, MacrosListParams, MacrosState } from '@/types/automation';
 // import { BaseFilter } from '@/types/core';
@@ -58,7 +59,6 @@ export default function Macros() {
   const [, setFilterModalOpen] = useState(false);
   // const [activeFilters, setActiveFilters] = useState<BaseFilter[]>([]);
   const [appliedFilters] = useState<AppliedFilter[]>([]);
-  const hasLoaded = useRef(false);
 
   // Load macros
   const loadMacros = useCallback(
@@ -101,18 +101,11 @@ export default function Macros() {
     [can, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadMacros();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permissionsReady]);
+  usePermissionGatedLoad({
+    resource: 'macros',
+    load: loadMacros,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Settings/Segments/Segments.tsx
+++ b/src/pages/Customer/Settings/Segments/Segments.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '@/hooks/useLanguage';
 import { toast } from 'sonner';
@@ -15,6 +15,7 @@ import { Target } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { segmentsService } from '@/services/segments/segmentsService';
 import { Segment, SegmentsState } from '@/types/analytics';
 
@@ -48,7 +49,7 @@ const INITIAL_STATE: SegmentsState = {
 
 export default function Segments() {
   const { t } = useLanguage('segments');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const navigate = useNavigate();
   const [state, setState] = useState<SegmentsState>(INITIAL_STATE);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -57,7 +58,6 @@ export default function Segments() {
   const [contactIdsDialogOpen, setContactIdsDialogOpen] = useState(false);
   const [selectedSegmentForIds, setSelectedSegmentForIds] = useState<Segment | null>(null);
   const [contactIds, setContactIds] = useState<string[]>([]);
-  const hasLoaded = useRef(false);
 
   // Load segments
   const loadSegments = useCallback(async () => {
@@ -95,18 +95,11 @@ export default function Segments() {
     }
   }, [can, state.meta.pagination.page, state.meta.pagination.page_size, state.searchQuery, t]);
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadSegments();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permissionsReady]);
+  usePermissionGatedLoad({
+    resource: 'segments',
+    load: loadSegments,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Settings/Teams/Teams.tsx
+++ b/src/pages/Customer/Settings/Teams/Teams.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { SettingsTeamsTour } from '@/tours';
 import { toast } from 'sonner';
@@ -8,6 +8,7 @@ import EmptyState from '@/components/base/EmptyState';
 import { useNavigate } from 'react-router-dom';
 
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import TeamsService from '@/services/teams/teamsService';
 import {
   Team,
@@ -53,7 +54,7 @@ const INITIAL_STATE: TeamsState = {
 
 export default function Teams() {
   const { t } = useLanguage('teams');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const navigate = useNavigate();
   const [state, setState] = useState<TeamsState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
@@ -64,7 +65,6 @@ export default function Teams() {
   const [editingTeam, setEditingTeam] = useState<Team | null>(null);
   const [detailsModalOpen, setDetailsModalOpen] = useState(false);
   const [detailsTeam, setDetailsTeam] = useState<Team | null>(null);
-  const hasLoaded = useRef(false);
 
   // Load teams
   const loadTeams = useCallback(
@@ -126,18 +126,11 @@ export default function Teams() {
     [can, t],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadTeams();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permissionsReady]);
+  usePermissionGatedLoad({
+    resource: 'teams',
+    load: loadTeams,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   // Handlers
   const handleSearchChange = (query: string) => {

--- a/src/pages/Customer/Settings/Users/Users.tsx
+++ b/src/pages/Customer/Settings/Users/Users.tsx
@@ -15,6 +15,7 @@ import { Grid3X3, List, Users as UsersIcon } from 'lucide-react';
 import EmptyState from '@/components/base/EmptyState';
 
 import { usePermissions } from '@/contexts/PermissionsContext';
+import { usePermissionGatedLoad } from '@/hooks/rbac/usePermissionGatedLoad';
 import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useAuthStore } from '@/store/authStore';
 import { usersService } from '@/services/users';
@@ -65,7 +66,7 @@ const INITIAL_STATE: UsersState = {
 
 export default function Users() {
   const { t } = useLanguage('users');
-  const { can, isReady: permissionsReady } = usePermissions();
+  const { can } = usePermissions();
   const { currentUser } = useAuthStore();
   const [state, setState] = useState<UsersState>(INITIAL_STATE);
   const [viewMode, setViewMode] = useState<'cards' | 'table'>('cards');
@@ -93,7 +94,6 @@ export default function Users() {
   const [detailsUser, setDetailsUser] = useState<User | null>(null);
   const [roleOptions, setRoleOptions] = useState<{ label: string; value: string }[]>([]);
   const currentUserId = currentUser?.id?.toString() || '';
-  const hasLoaded = useRef(false);
   // EVO-1947: the search term is the one request param every reload has to
   // carry — pagination, per-page and filter-apply all reload the list and none
   // of them know the term. A ref (not state) so those callbacks read the
@@ -179,18 +179,11 @@ export default function Users() {
     [activeFilters, can, t, state.sortBy, state.sortOrder],
   );
 
-  // Initial load
-  useEffect(() => {
-    if (!permissionsReady) {
-      return;
-    }
-
-    if (!hasLoaded.current) {
-      hasLoaded.current = true;
-      loadUsers();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [permissionsReady]);
+  usePermissionGatedLoad({
+    resource: 'users',
+    load: loadUsers,
+    onDenied: () => toast.error(t('messages.permissionDenied.read')),
+  });
 
   // Handlers
   // One request per keystroke used to be free (the server ignored `q`); now it

--- a/src/pages/list-screens-permission-gate.spec.ts
+++ b/src/pages/list-screens-permission-gate.spec.ts
@@ -26,10 +26,18 @@ const GATED_SCREENS = [
   'Customer/Settings/Users/Users.tsx',
 ];
 
-// Matches the readiness flag under both spellings in use: the screens read
-// `isReady` as `permissionsReady`, the shared hook reads it bare.
-const READINESS = /\b(permissionsReady|isReady)\b/;
-const LOAD_ONCE_LATCH = /\b\w*(?:hasLoaded|loaded|hasFetched|fetched)\w*\.current\s*=\s*true/i;
+// The readiness flag under both spellings in use: the screens read `isReady` as
+// `permissionsReady`, the shared hook reads it bare.
+const READINESS = String.raw`(?:permissionsReady|isReady)`;
+
+// The offending SHAPE, not a list of names: an effect gated on readiness whose
+// body latches a boolean ref. Naming the refs instead let `firstRun.current` and
+// friends walk straight past the guard.
+const GATED_EFFECT = new RegExp(
+  String.raw`useEffect\(\s*\(\)\s*=>\s*\{([\s\S]*?)\}\s*,\s*\[([^\]]*)\]\s*\)`,
+  'g',
+);
+const REF_LATCH = /\w+\.current\s*=\s*true/;
 
 const screens = (dir: string): string[] =>
   readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
@@ -50,7 +58,13 @@ describe('list screens gate their initial load through the shared hook', () => {
     const offenders = screens(PAGES)
       .filter(path => {
         const source = readFileSync(path, 'utf8');
-        return READINESS.test(source) && LOAD_ONCE_LATCH.test(source);
+        GATED_EFFECT.lastIndex = 0;
+        for (const [, body, deps] of source.matchAll(GATED_EFFECT)) {
+          if (new RegExp(String.raw`\b${READINESS}\b`).test(deps) && REF_LATCH.test(body)) {
+            return true;
+          }
+        }
+        return false;
       })
       .map(path => relative(PAGES, path));
 

--- a/src/pages/list-screens-permission-gate.spec.ts
+++ b/src/pages/list-screens-permission-gate.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// CRM-495: these screens each owned a copy of the same decision — a load-once ref
+// read on the first render where permissions were ready — so a verdict that was
+// false there stuck until the component remounted. They now share
+// `usePermissionGatedLoad`, and that only stays true while nobody re-inlines it.
+const PAGES = dirname(fileURLToPath(import.meta.url));
+
+const GATED_SCREENS = [
+  'Customer/Agents/CustomMCPServers/CustomMCPServers.tsx',
+  'Customer/Agents/CustomTools/CustomTools.tsx',
+  'Customer/Agents/MCPServers/MCPServers.tsx',
+  'Customer/Agents/Tools/Tools.tsx',
+  'Customer/Automation/index.tsx',
+  'Customer/Contacts/ScheduledActions.tsx',
+  'Customer/Pipelines/Pipelines.tsx',
+  'Customer/Settings/AccessTokens/AccessTokens.tsx',
+  'Customer/Settings/Integrations/Integrations.tsx',
+  'Customer/Settings/Labels/Labels.tsx',
+  'Customer/Settings/Macros/Macros.tsx',
+  'Customer/Settings/Segments/Segments.tsx',
+  'Customer/Settings/Teams/Teams.tsx',
+  'Customer/Settings/Users/Users.tsx',
+];
+
+// Matches the readiness flag under both spellings in use: the screens read
+// `isReady` as `permissionsReady`, the shared hook reads it bare.
+const READINESS = /\b(permissionsReady|isReady)\b/;
+const LOAD_ONCE_LATCH = /\b\w*(?:hasLoaded|loaded|hasFetched|fetched)\w*\.current\s*=\s*true/i;
+
+const screens = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return screens(path);
+    return entry.name.endsWith('.tsx') && !entry.name.endsWith('.spec.tsx') ? [path] : [];
+  });
+
+describe('list screens gate their initial load through the shared hook', () => {
+  it.each(GATED_SCREENS)('%s calls usePermissionGatedLoad', screen => {
+    expect(readFileSync(join(PAGES, screen), 'utf8')).toContain('usePermissionGatedLoad(');
+  });
+
+  // Only the ref-latch shape. The other half of the class — the decision latched
+  // by an effect whose deps are just the readiness flag, with no ref at all — is
+  // still open on ~13 screens and is NOT covered here.
+  it('no screen latches the permission decision in a private ref again', () => {
+    const offenders = screens(PAGES)
+      .filter(path => {
+        const source = readFileSync(path, 'utf8');
+        return READINESS.test(source) && LOAD_ONCE_LATCH.test(source);
+      })
+      .map(path => relative(PAGES, path));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## O problema

14 telas de listagem carregavam a mesma trava copiada: um ref `hasLoaded` dentro de um `useEffect` guardado por `permissionsReady`. Na primeira vez que `permissionsReady` virava true, a tela checava `can(recurso, 'read')` **uma única vez**; se a resposta fosse false — por exemplo porque os grants ainda não tinham chegado — disparava o toast de sem-permissão e nunca mais tentava. Nada re-disparava quando as permissões mudavam depois, nem quando elas simplesmente chegavam.

O sintoma que isso produz é o pior do eixo: dizer ao usuário que ele não tem permissão quando ele tem, e a tela ficar assim até ele desmontar o componente trocando de menu.

## A mudança

Um hook compartilhado, `src/hooks/rbac/usePermissionGatedLoad.ts`, cuja trava segue o **veredito** de `can()` em vez da primeira renderização em que `isReady` ficou true. As 14 telas passaram a chamá-lo; o bloco copiado saiu de todas (−196 / +127 nas telas).

- Falso negativo se destrava sozinho: a tela carrega quando o grant chega, sem remontar.
- Negação real é reportada **uma vez**, sem loop de toast e sem request.
- Permissão concedida desde o primeiro render carrega a lista **uma vez só**, sem request duplicado.
- Limpar a trava de carga na negação é o que faz um re-grant recarregar. A recarga chama `load()` sem argumentos, então cada tela retoma do estado que está segurando — a página e os filtros atuais, não os iniciais.
- As duas travas respondem por UM recurso: trocar o `resource` reabre o portão, em vez de carregar o veredito da chave antiga para a nova.

O `can()` e o rastreio de estado do `PermissionsContext` **não** foram tocados — isso é o CRM-494, já na develop.

## Testes

- `src/hooks/rbac/usePermissionGatedLoad.spec.tsx` — 9 exemplos: os 3 critérios de aceite, o estado ainda não resolvido, um refresh que passa por not-ready sem recarregar nem negar, revogação seguida de re-grant, `load` chamado sem argumentos, a negação silenciosa das telas sem `onDenied`, e a troca de `resource` reabrindo o portão.
- `src/pages/Customer/Pipelines/Pipelines.spec.tsx` — o caso no molde, montando a tela real: nega, não faz request, e ao re-renderizar **a mesma instância** com o grant a lista carrega.
- `src/pages/list-screens-permission-gate.spec.ts` — guard: cada uma das 14 telas chama o hook, e nenhuma tela de `src/pages` volta a travar a decisão num ref privado. O guard casa a **forma** (efeito com a flag de readiness nas deps cujo corpo atribui `true` a um ref), não uma lista de nomes de ref — conferido re-inlinando a trava antiga como `firstRun.current = true`, que a versão por nome deixava passar.

Os três testes de regressão foram conferidos contra a semântica antiga (`deps: [isReady]`) e falham lá — não passam à toa.

`tsc` e `eslint` limpos. 108 testes verdes em 11 arquivos (auth, permissões, RouterGuard, Users, Pipelines).

## Fora de escopo

A mesma classe de bug existe em ~13 outras telas numa forma diferente — sem ref, com a trava sendo o próprio array de deps do efeito (`Settings/CustomAttributes`, `CannedResponses`, `Contacts`, `Journey`, `Campaigns`, `Channels`, `Agents`, `Chat`, `MessageTemplates`, `AccountSettings`, `AiCredentials`, `IntegrationCredentials`, `CrmForms`, `ChatPages`). O card fecha nas 14 nomeadas, então elas ficaram de fora, e o guard **declara em comentário** que não as cobre em vez de fingir cobertura.

## Summary by Sourcery

Make the 14 targeted list screens load according to the latest read-permission verdict instead of caching the first readiness-time decision.

New Features:
- Add a shared permission-gated loading hook for list screens that reacts to the current read-permission verdict.

Bug Fixes:
- Fix list screens that could remain incorrectly denied when permissions arrived or changed after the initial readiness check.
- Prevent duplicate loads for granted permissions and repeated denial notifications for genuinely unauthorized users.

Enhancements:
- Replace duplicated permission-loading logic across 14 list screens with the shared gate, including support for reloads after revocation and re-grant.

Tests:
- Add focused hook tests covering permission resolution, refreshes, denials, resource changes, and re-grants.
- Add a Pipelines regression test proving the same mounted screen loads after its permission changes.
- Add a guard ensuring the 14 targeted screens use the shared hook and do not reintroduce private permission latches.
