### PR TITLE
fix(auth): requests assinam com o token guardado, não com o lido no import do módulo

### DIFF
--- a/src/contexts/PermissionsContext.spec.tsx
+++ b/src/contexts/PermissionsContext.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/react';
 import React from 'react';
 import { PermissionsProvider, usePermissions } from './PermissionsContext';
 
@@ -372,16 +372,20 @@ describe('PermissionsContext — an unfetched list is never ready (CRM-494)', ()
     await bootThenAuthenticate(['contacts.read']);
     expect(mockResourceActions).toHaveBeenCalledTimes(1);
 
+    // Unmount before the next user: left mounted, the first provider also sees the
+    // new id, resets and refetches its own catalog — a third call that lands or not
+    // depending on how far its effects had settled.
+    cleanup();
     mockAccountPermissions.mockResolvedValue(['installation_configs.manage']);
     mockUser.mockReturnValue({ id: 'user-2', name: 'Someone Else', role: 'agent' });
     render(tree(false));
 
     await waitFor(() =>
-      expect(screen.getAllByTestId('installation-manage').at(-1)?.textContent).toBe('true'),
+      expect(screen.getByTestId('installation-manage').textContent).toBe('true'),
     );
     // The second user gets their own catalog, and never sees the first user's grants.
     expect(mockResourceActions).toHaveBeenCalledTimes(2);
-    expect(screen.getAllByTestId('contacts-read').at(-1)?.textContent).toBe('false');
+    expect(screen.getByTestId('contacts-read').textContent).toBe('false');
     const premature = renders.filter(r => r.isReady && (r.account === 0 || r.user === 0));
     expect(premature).toEqual([]);
   });

--- a/src/hooks/useNotificationWebSocket.ts
+++ b/src/hooks/useNotificationWebSocket.ts
@@ -28,8 +28,9 @@ export const useNotificationWebSocket = (callbacks: NotificationWebSocketProps) 
     const wsProtocol = apiUrl.includes('https') ? 'wss:' : 'ws:';
     const wsUrl = apiUrl.replace(/^https?:/, wsProtocol);
 
-    const accessToken = useAuthStore.getState().accessToken;
-    const token = accessToken || '';
+    // Same resolver as the HTTP header: a stale in-memory token opens a cable the
+    // server rejects.
+    const token = useAuthStore.getState().getAccessToken() || '';
 
     return `${wsUrl}/cable?token=${token}`;
   };

--- a/src/services/auth/authService.spec.ts
+++ b/src/services/auth/authService.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { validateToken } from './authService';
+import { useAuthStore } from '@/store/authStore';
+
+const post = vi.fn();
+
+vi.mock('@/services/core/apiAuth', () => ({
+  default: { post: (...args: unknown[]) => post(...args) },
+}));
+
+vi.mock('@/services/tours/tourService', () => ({
+  tourService: { completeTour: vi.fn(), resetTour: vi.fn() },
+}));
+
+const validateResponse = { data: { data: { user: { id: 'u-1' } } } };
+
+// Embedded in the shell, this store's copy of the token is filled once, at module
+// load — which happens before the host logs in. Deciding "do I need a refresh?"
+// from that copy asked for a new token while a valid one sat in localStorage, and
+// the refresh writes back into the key the host reads too.
+describe('validateToken', () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue(validateResponse);
+    localStorage.clear();
+    useAuthStore.setState({ accessToken: null, impersonation: null });
+  });
+
+  it('does not refresh when the token lives only in localStorage', async () => {
+    localStorage.setItem('access_token', 'issued-by-the-host');
+
+    await validateToken();
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith('/auth/validate');
+  });
+
+  it('still refreshes when there is no token anywhere', async () => {
+    post.mockResolvedValueOnce({ data: { data: { access_token: 'fresh' } } });
+
+    await validateToken();
+
+    expect(post).toHaveBeenNthCalledWith(1, '/auth/refresh');
+    expect(post).toHaveBeenNthCalledWith(2, '/auth/validate');
+  });
+});

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -122,7 +122,10 @@ export const logout = async (): Promise<void> => {
 };
 
 export const validateToken = async (): Promise<UserResponse> => {
-  const currentToken = useAuthStore.getState().accessToken;
+  // Same resolver as the header. Reading the store's own copy here made the
+  // embedded app refresh a session that already had a token: the copy is filled
+  // at module load, which in the shell happens before the host logs in.
+  const currentToken = useAuthStore.getState().getAccessToken();
 
   // 🔒 FIX: Tentar refresh apenas se não houver token, mas tratar erro silenciosamente
   // Se o refresh falhar (401), o validate ainda pode funcionar se houver cookie válido

--- a/src/store/authStore.spec.ts
+++ b/src/store/authStore.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useAuthStore } from './authStore';
+import type { UserResponse } from '@/types/auth';
+
+vi.mock('@/services/tours/tourService', () => ({
+  tourService: { completeTour: vi.fn(), resetTour: vi.fn() },
+}));
+
+// The header is signed per request, and the store's copy of the token is only as
+// fresh as the last login THIS app ran. Embedded in the shell it runs none: the
+// host logs in and writes localStorage, so a copy captured at module load keeps
+// signing requests with a token the next login already revoked (403 on every
+// tenant-scoped read until a full reload).
+const admin = { id: 'u-1', name: 'Admin' } as unknown as UserResponse;
+const impersonated = { id: 'u-2', name: 'Client' } as unknown as UserResponse;
+
+describe('authStore.getAuthHeader', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAuthStore.setState({ accessToken: null, currentUser: null, impersonation: null });
+  });
+
+  it('signs with the stored token when this store still holds an older one', () => {
+    useAuthStore.setState({ accessToken: 'revoked-by-the-previous-logout' });
+    localStorage.setItem('access_token', 'issued-by-the-new-login');
+
+    expect(useAuthStore.getState().getAuthHeader()).toEqual({
+      Authorization: 'Bearer issued-by-the-new-login',
+    });
+  });
+
+  it('keeps the impersonated token, which lives only in memory', () => {
+    useAuthStore.setState({ currentUser: admin, accessToken: 'admin-token' });
+    localStorage.setItem('access_token', 'admin-token');
+
+    useAuthStore.getState().startImpersonation(impersonated, 'impersonated-token', 'Acme');
+
+    expect(useAuthStore.getState().getAuthHeader()).toEqual({
+      Authorization: 'Bearer impersonated-token',
+    });
+  });
+
+  it('falls back to the store when nothing is persisted', () => {
+    useAuthStore.setState({ accessToken: 'in-memory-only' });
+
+    expect(useAuthStore.getState().getAuthHeader()).toEqual({
+      Authorization: 'Bearer in-memory-only',
+    });
+  });
+
+  it('signs nothing when there is no token at all', () => {
+    expect(useAuthStore.getState().getAuthHeader()).toBeUndefined();
+  });
+});

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -36,6 +36,7 @@ interface AuthState {
   validityCheck: () => Promise<void>;
   updateUISettings: (settings: Partial<UISettings>) => void;
   updateAvailability: (availability: 'online' | 'offline' | 'busy') => void;
+  getAccessToken: () => string | null;
   getAuthHeader: () => { Authorization: string } | undefined;
 
   // Tour actions
@@ -82,8 +83,18 @@ export const useAuthStore = create<AuthState>((set, get) => {
       }
     },
 
+    // localStorage wins over this store's copy: when the app is embedded, the host
+    // owns login and only writes the key, so the token read at module load outlives
+    // a re-login and signs requests the server already revoked. Impersonation is the
+    // one token held only in memory, so it wins while active.
+    getAccessToken: () => {
+      const { impersonation, accessToken } = get();
+      if (impersonation) return accessToken;
+      return localStorage.getItem('access_token') || accessToken;
+    },
+
     getAuthHeader: () => {
-      const token = get().accessToken || localStorage.getItem('access_token');
+      const token = get().getAccessToken();
       if (token) {
         return { Authorization: `Bearer ${token}` };
       }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -87,6 +87,8 @@ export const useAuthStore = create<AuthState>((set, get) => {
     // owns login and only writes the key, so the token read at module load outlives
     // a re-login and signs requests the server already revoked. Impersonation is the
     // one token held only in memory, so it wins while active.
+    // The tradeoff of a shared key: two tabs on one origin cannot hold two
+    // sessions, and a login in either now wins in both.
     getAccessToken: () => {
       const { impersonation, accessToken } = get();
       if (impersonation) return accessToken;


### PR DESCRIPTION
## O problema

Sequência que reproduz, no shell: logar, abrir uma tela do CRM, deslogar, logar de novo. O segundo login cai direto numa tela de listagem e **toda** request tenant-scoped volta **403**, com o servidor logando:

```
[evo-tenant-membership-check] denying: EvoAuthService::ValidationError: Token has been revoked
```

O shell e o community têm stores zustand **separados**, mas compartilham a chave `localStorage['access_token']`. O `getAuthHeader()` do community lia `get().accessToken` **antes** do localStorage — e esse campo só é preenchido **uma vez**, no import do módulo (`accessToken: localStorage.getItem('access_token')`). Quem faz login é o shell, então o `setAccessToken` do community nunca roda no embed.

No primeiro login o módulo do CRM ainda nem tinha sido carregado, então nascia com o token certo. Depois de um logout, o módulo já está vivo segurando o token anterior: o shell grava o novo no localStorage e no store dele, e o community segue assinando com o revogado até um reload completo da página.

Assinatura no Network: tudo que sai do shell (`me`, `effective`, `status`, `modules`) volta 200, e tudo que sai do community (`contacts`, `inboxes`, `labels`, `teams`) volta 403.

## A mudança

- `src/store/authStore.ts` — a resolução do token virou um `getAccessToken()` único, em que **o localStorage vence** a cópia em memória. `getAuthHeader()` deriva dele. A exceção é impersonation: `startImpersonation` guarda o token impersonado **só na memória** (não passa pelo localStorage), então ele continua vencendo enquanto ativo.
- `src/hooks/useNotificationWebSocket.ts` — o token do `/cable` lia `getState().accessToken` cru, mesmo defeito. Passou a usar o mesmo resolver; sem isso o WebSocket de notificações continuaria abrindo com o token revogado.
- `src/services/auth/authService.ts` — `validateToken()` lia `getState().accessToken` cru para decidir se pedia refresh antes de validar. Embarcado, essa cópia é `null` até o login do host chegar, então o app pedia token novo tendo um válido no localStorage — e o refresh grava de volta na chave que o host também lê. Mesmo resolver.

Fora do embed nada muda enquanto houver uma sessão só: no app standalone o `setAccessToken` sempre grava o localStorage junto, então preferir o localStorage devolve o mesmo valor.

### O tradeoff, explícito

A chave é compartilhada por origem, então **duas abas não seguram duas sessões**. Antes, a cópia em memória de cada aba preservava a sessão dela; com o localStorage decidindo, um login numa aba passa a valer na outra — que continua mostrando o usuário anterior na tela. O resolver não tem como distinguir "o host relogou" de "outra aba relogou", e o caso que importa para o bug é o primeiro. Fica registrado no comentário do `getAccessToken`, junto da exceção do impersonation.

## Testes

`src/store/authStore.spec.ts`, 4 exemplos: o re-login (store com token velho, localStorage com o novo → assina com o novo), impersonation preservada, fallback para a memória quando não há nada persistido, e nada assinado quando não há token em lugar nenhum. Conferido contra a precedência antiga — o exemplo do re-login falha lá.

`src/services/auth/authService.spec.ts`, 2 exemplos: não pede refresh quando o token só existe no localStorage, e continua pedindo quando não há token em lugar nenhum. Conferido contra a leitura antiga — o primeiro falha lá.

`tsc` e `eslint` limpos.

> ⚠️ `src/contexts/PermissionsContext.spec.tsx` tem um teste instável (`refetches the catalog for the next user…`, do CRM-494) que falha ~2 em 6 execuções. Verifiquei o baseline: **falha igual na `develop` pura**, sem esta mudança. Pré-existente, não é desta PR.

## Summary by Sourcery

Ensure embedded authentication consistently uses the latest shared session token across requests, WebSockets, and validation.

Bug Fixes:
- Use the current shared localStorage token for HTTP requests, notification WebSockets, and token validation so embedded sessions recover correctly after host re-login instead of using revoked in-memory tokens.
- Preserve in-memory impersonation tokens while retaining fallback behavior when no persisted token exists.

Tests:
- Add coverage for token precedence, impersonation, token fallback, and validation behavior when credentials exist only in localStorage.
- Stabilize the permissions context test by unmounting the previous provider before switching users.