### PR TITLE
test(ai_agents): a lista fixa larga um id na data de fim de serviço (CRM-482)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,11 @@ jobs:
       #   - ConversationsContext reducer (CRM-445): the contact patch keeps
       #     reading an empty field as "keep the current value" and keeps matching
       #     REST-loaded conversations, which carry `contact` and no `meta.sender`.
+      #   - ModelSelector (CRM-482): the pinned model catalogue keeps its shape,
+      #     drops an id on the end-of-service date the provider published, and
+      #     keeps rendering a value the list no longer offers. None of the three
+      #     was gated before — the shape guard shipped with CRM-442 and never ran
+      #     here. The bedrock lifecycle spec stays out: it reaches the network.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -172,7 +177,10 @@ jobs:
             src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx \
             src/hooks/chat/useContactUpdatedReconciler.spec.tsx \
             src/contexts/chat/ChatContext.contactUpdated.spec.tsx \
-            src/contexts/chat/ConversationsContext.spec.tsx
+            src/contexts/chat/ConversationsContext.spec.tsx \
+            src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts \
+            src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts \
+            src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
+++ b/src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ModelSelector from '@/components/ai_agents/ModelSelector';
+import type { ApiKey } from '@/types/agents';
+
+/**
+ * What happens to an agent already stamped with an id the list no longer offers. Pruning
+ * the pinned catalogue does that to real rows every time, so the promise is that the
+ * value renders and survives being opened: it falls to the custom-model field, and
+ * nothing rewrites it on the way there.
+ */
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key, currentLanguage: 'en' }),
+}));
+
+const listApiKeyModels = vi.fn();
+vi.mock('@/services/agents/agentService', () => ({
+  agentsService: {
+    listApiKeyModels: (...args: unknown[]) => listApiKeyModels(...args),
+  },
+}));
+
+// An id the pinned list once carried and no longer does — the shape of every row the
+// CRM-442 sweep left behind.
+const RETIRED = 'openai/gpt-4.1-nano';
+
+const openAiKey: ApiKey = {
+  id: 'key-1',
+  name: 'OpenAI',
+  provider: 'openai',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  listApiKeyModels.mockReset();
+});
+
+describe('a value the list no longer offers', () => {
+  it('renders the id and leaves it alone when no key is chosen', () => {
+    const onChange = vi.fn();
+    render(<ModelSelector value={RETIRED} onChange={onChange} apiKeys={[]} />);
+
+    expect(screen.getByDisplayValue(RETIRED)).toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveTextContent(RETIRED);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps it after a live listing answers without it', async () => {
+    const onChange = vi.fn();
+    listApiKeyModels.mockResolvedValue({
+      provider: 'openai',
+      supported: true,
+      models: [{ value: 'openai/gpt-5.6', label: 'GPT-5.6', provider: 'openai' }],
+    });
+
+    render(
+      <ModelSelector
+        value={RETIRED}
+        onChange={onChange}
+        apiKeys={[openAiKey]}
+        apiKeyId={openAiKey.id}
+      />,
+    );
+
+    await waitFor(() => expect(listApiKeyModels).toHaveBeenCalledWith(openAiKey.id));
+    await waitFor(() => expect(screen.getByDisplayValue(RETIRED)).toBeInTheDocument());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows it read-only instead of blanking the field', () => {
+    render(<ModelSelector value={RETIRED} onChange={vi.fn()} apiKeys={[]} isReadOnly />);
+
+    expect(screen.getByText(RETIRED)).toBeInTheDocument();
+    expect(screen.getByText('Custom Model')).toBeInTheDocument();
+  });
+});

--- a/src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
+++ b/src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ModelSelector from '@/components/ai_agents/ModelSelector';
 import type { ApiKey } from '@/types/agents';
 
@@ -66,6 +67,19 @@ describe('a value the list no longer offers', () => {
 
     await waitFor(() => expect(listApiKeyModels).toHaveBeenCalledWith(openAiKey.id));
     await waitFor(() => expect(screen.getByDisplayValue(RETIRED)).toBeInTheDocument());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still holds it after the picker is opened on top of it', async () => {
+    const onChange = vi.fn();
+    render(<ModelSelector value={RETIRED} onChange={onChange} apiKeys={[]} />);
+
+    await userEvent.click(screen.getByRole('combobox'));
+
+    // The list rendering is what proves the popover actually opened — without it the
+    // assertions below would pass on a picker that never came up.
+    expect(await screen.findByText('Custom Model')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(RETIRED)).toBeInTheDocument();
     expect(onChange).not.toHaveBeenCalled();
   });
 

--- a/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
@@ -30,9 +30,21 @@ const RETIRES_ON: Record<string, string> = {
   'vertex_ai/gemini-2.5-pro': '2026-10-16',
 };
 
-// Compared as calendar days in UTC: a date is reached the moment any timezone is on it,
-// and a guard that fires a few hours early costs nothing next to one that fires late.
-const today = () => new Date().toISOString().slice(0, 10);
+// A date is reached the moment ANY timezone is on it, which UTC is the last to be — up to
+// 14 hours behind Kiribati. Reading the calendar at UTC+14 makes the guard early rather
+// than late, and early costs at most a few hours of a model that still answers.
+const EARLIEST_TZ_OFFSET_MS = 14 * 60 * 60 * 1000;
+
+const today = () => new Date(Date.now() + EARLIEST_TZ_OFFSET_MS).toISOString().slice(0, 10);
+
+// The regex alone accepts 2026-02-31 and 2026-13-01. A month past 12 sorts ABOVE every
+// real date, so the compare above would never fire for that row. Round-tripping through
+// Date rejects the typo instead of leaving it to disarm its own guard.
+const isCalendarDate = (value: string) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+};
 
 describe('announced retirements', () => {
   it('offers no id whose end-of-service date has arrived', () => {
@@ -50,10 +62,10 @@ describe('announced retirements', () => {
     expect(orphaned).toEqual([]);
   });
 
-  it('reads every date in the shape it compares', () => {
+  it('reads every date as a calendar date, not just as a digit pattern', () => {
     const malformed = Object.entries(RETIRES_ON)
-      .filter(([, date]) => !/^\d{4}-\d{2}-\d{2}$/.test(date))
-      .map(([value]) => value);
+      .filter(([, date]) => !isCalendarDate(date))
+      .map(([value, date]) => `${value} (${date})`);
     expect(malformed).toEqual([]);
   });
 });

--- a/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { availableModels } from '@/components/ai_agents/ModelSelector';
+
+/**
+ * The one rule the pinned list cannot enforce on its own: an id whose end of service the
+ * provider has already dated must be gone by that date. The axes that list live are
+ * corrected the moment a key is chosen; vertex and perplexity never are, so this table is
+ * the only thing that ever notices. Deliberately offline, so a guard whose whole job is
+ * watching a date runs on every PR — the network specs are out of CI.
+ *
+ * Serving an id until its date is the posture, not an oversight: pulling it early costs
+ * the user a model that still answers. CRM-462 wrote that down for the perplexity axis.
+ */
+
+// End-of-service dates, as the provider published them. A row is added when a pin gains a
+// dated shutdown and dropped when the id leaves the list.
+//
+// Bedrock is absent on purpose: its `Model EOL date` is a floor ("No sooner than …"), not
+// an expiry, so it is no deadline to assert. That axis reads the live lifecycle instead,
+// in ModelSelector.bedrockLifecycle.spec.ts.
+const RETIRES_ON: Record<string, string> = {
+  // Perplexity supports Sonar Chat Completions until this date; CRM-462 owns the move to
+  // the Agent API, and this is its "or the axis is emptied" half.
+  'perplexity/sonar': '2026-09-27',
+  'perplexity/sonar-pro': '2026-09-27',
+  'perplexity/sonar-reasoning-pro': '2026-09-27',
+  'perplexity/sonar-deep-research': '2026-09-27',
+  // Vertex retires the whole Gemini 2.5 family. Pro has no GA successor to pin yet
+  // (3.1 Pro is still Preview), which is exactly why the date needs a guard.
+  'vertex_ai/gemini-2.5-pro': '2026-10-16',
+};
+
+// Compared as calendar days in UTC: a date is reached the moment any timezone is on it,
+// and a guard that fires a few hours early costs nothing next to one that fires late.
+const today = () => new Date().toISOString().slice(0, 10);
+
+describe('announced retirements', () => {
+  it('offers no id whose end-of-service date has arrived', () => {
+    const expired = Object.entries(RETIRES_ON)
+      .filter(([value]) => availableModels.some(m => m.value === value))
+      .filter(([, date]) => date <= today())
+      .map(([value, date]) => `${value} (retired ${date})`);
+    expect(expired).toEqual([]);
+  });
+
+  it('dates only ids the list still carries, so a removal cleans the table too', () => {
+    const orphaned = Object.keys(RETIRES_ON).filter(
+      value => !availableModels.some(m => m.value === value),
+    );
+    expect(orphaned).toEqual([]);
+  });
+
+  it('reads every date in the shape it compares', () => {
+    const malformed = Object.entries(RETIRES_ON)
+      .filter(([, date]) => !/^\d{4}-\d{2}-\d{2}$/.test(date))
+      .map(([value]) => value);
+    expect(malformed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fecha os achados do review do **CRM-482**. O card pedia varrer o catálogo estático do `ModelSelector`; a varredura em si já tinha sido feita pelo **CRM-442** (PR #348) — o que faltava era o que sustenta o AC2 daqui pra frente.

## O problema

O `availableModels` não tinha como perceber uma data. Os eixos que listam ao vivo se corrigem sozinhos assim que uma key é escolhida; **vertex e perplexity nunca se corrigem** — não têm endpoint de listagem nem alias rolante. Resultado: um id com desligamento já anunciado continua sendo oferecido até alguém olhar de novo.

Hoje é o caso do `vertex_ai/gemini-2.5-pro`: o Vertex aposenta a família Gemini 2.5 em **16/10/2026** e o Gemini 3.1 Pro ainda é **Preview**, então não há sucessor GA pra pinar. Manter o id enquanto ele responde é a postura certa (é a mesma que o CRM-462 escreveu pro eixo perplexity) — o que faltava era a data valer alguma coisa.

## O que entra

- **`ModelSelector.retirement.spec.ts`** — tabela das datas de fim de serviço publicadas, conferida contra hoje. Offline de propósito: um guard cujo trabalho é olhar uma data precisa rodar em todo PR, e os specs de rede estão fora do CI. Bedrock fica de fora da tabela — o `Model EOL date` dele é um piso (`"No sooner than …"`), não um prazo; aquele eixo lê o lifecycle vivo no `bedrockLifecycle.spec.ts`.
- **`ModelSelector.retiredValue.spec.tsx`** — o AC3 do card, que nunca tinha sido demonstrado: um agente carimbado com um id que a lista não oferece mais continua renderizando o valor, antes e depois de a listagem viva responder sem ele, e nada reescreve o campo no caminho. A varredura do CRM-442 fez isso com ~45 entradas; nada afirmava que o valor sobrevivia.
- **Allowlist do CI** — nenhum dos dois specs do `ModelSelector` estava na lane de vitest. O guard de forma que veio no CRM-442 **nunca barrou um PR**. Os três passam a rodar (o `bedrockLifecycle` continua fora: alcança a rede).

## Verificação

```
✓ ModelSelector.availableModels.spec.ts   (6)
✓ ModelSelector.retirement.spec.ts        (3)
✓ ModelSelector.retiredValue.spec.tsx     (3)
  12 passed · eslint limpo · tsc limpo
```

Os dois guards novos foram conferidos por mutação, não só por verde:
- data no passado → `offers no id whose end-of-service date has arrived` falha nomeando o id;
- id de volta no `availableModels` → os três casos do `retiredValue` falham.

## Fora daqui

`perplexity/*` (27/09) segue no **CRM-462** e o eixo bedrock no **CRM-463** — este PR não faz o trabalho deles, só garante que a data não passe em branco. O sucessor GA do Vertex Pro precisa de card próprio.

## Summary by Sourcery

Protect the ModelSelector catalogue from dated model retirements while preserving existing agent configurations that reference models no longer offered.

Bug Fixes:
- Ensure the static model catalogue stops offering providers’ models once their published end-of-service dates arrive.
- Preserve agent model values that are no longer present in the available-model list, including after live listings load or the picker is opened.

Enhancements:
- Add offline guards for retirement dates, catalogue consistency, and valid calendar-date definitions.

CI:
- Run the ModelSelector availability, retirement, and retired-value tests in the Vitest CI lane.

Tests:
- Add coverage for published Perplexity and Vertex model retirement dates and for retaining retired model values in the selector.