### PR TITLE
fix(permissions): F5 negava tudo com a rede toda verde (corrida de hidratacao)

### DIFF
--- a/src/contexts/PermissionsContext.spec.tsx
+++ b/src/contexts/PermissionsContext.spec.tsx
@@ -22,9 +22,14 @@ vi.mock('./AuthContext', () => ({
 // Mirrors the store: `isLoggedIn` is derived from the current user, so it is
 // false for exactly as long as `useAuth().user` is null. Pinning it to true
 // hid the CRM-494 window, where the provider mounts with neither.
-vi.mock('@/store/authStore', () => ({
-  useAuthStore: { getState: () => ({ isLoggedIn: Boolean(mockUser()?.id) }) },
-}));
+// Real zustand store: the provider SUBSCRIBES to isLoggedIn (the F5 race fix),
+// so the mock must be reactive — a plain getState object cannot be called as a
+// hook and could never exercise the hydration flip.
+vi.mock('@/store/authStore', async () => {
+  const { create } = await import('zustand');
+  return { useAuthStore: create(() => ({ isLoggedIn: true })) };
+});
+import { useAuthStore } from '@/store/authStore';
 
 const mockAccountPermissions = vi.fn<[], Promise<string[]>>();
 const mockUserPermissions = vi.fn<[], Promise<string[]>>();
@@ -98,6 +103,7 @@ async function renderWith(role: string, granted: string[]) {
 describe('PermissionsContext — can() stays data-driven (no role short-circuit)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAuthStore.setState({ isLoggedIn: true });
   });
 
   it('denies a permission the user was not granted, even for super_admin', async () => {
@@ -419,5 +425,33 @@ describe('PermissionsContext — an unfetched list is never ready (CRM-494)', ()
     fireEvent.click(screen.getByText('retry'));
 
     await waitFor(() => expect(mockResourceActions).toHaveBeenCalledTimes(2));
+  });
+
+  // F5 inside the embed: the bridge delivers `user` BEFORE the auth store
+  // hydrates isLoggedIn. CRM-494 already keeps the legs at `pending` there;
+  // this pins the OTHER half — the hydration flip must RE-RUN the fetches.
+  // With the old getState() snapshot (invisible to React) this test fails on
+  // the second expectation: ready stays false forever.
+  it('stays pending before hydration, then loads when isLoggedIn flips', async () => {
+    const { act } = await import('@testing-library/react');
+    useAuthStore.setState({ isLoggedIn: false });
+    mockUser.mockReturnValue({ id: 'u1', role: 'agent' });
+    mockUserPermissions.mockResolvedValue(['contacts.read']);
+    mockAccountPermissions.mockResolvedValue(['contacts.read']);
+
+    render(
+      <PermissionsProvider>
+        <Probe />
+      </PermissionsProvider>,
+    );
+
+    expect(screen.getByTestId('ready').textContent).toBe('false');
+
+    await act(async () => {
+      useAuthStore.setState({ isLoggedIn: true });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('true'));
+    expect(screen.getByTestId('contacts-read').textContent).toBe('true');
   });
 });

--- a/src/contexts/PermissionsContext.tsx
+++ b/src/contexts/PermissionsContext.tsx
@@ -45,6 +45,12 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
   blockOnLoadFailure = true,
 }) => {
   const { user } = useAuth();
+  // CRM-494 turned the trusted-empty stamps into `pending`; this closes the
+  // OTHER half of the F5 race: the legs read isLoggedIn through a NON-reactive
+  // useAuthStore.getState() snapshot, so when hydration flipped it nothing
+  // re-ran and the legs stayed `pending` forever. Subscribing makes the flip
+  // re-run the fetch effects.
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
 
   const [userPermissions, setUserPermissions] = useState<string[]>([]);
   const [accountPermissions, setAccountPermissions] = useState<string[]>([]);
@@ -125,20 +131,19 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
       return;
     }
 
+    // Store not hydrated yet (hard refresh inside the embed): unknown, so the
+    // leg stays `pending`; the isLoggedIn dep re-runs this effect on the flip.
+    if (!isLoggedIn) {
+      setUserPermsStatus('pending');
+      return;
+    }
+
     // The fetch can outlive the effect. Without this flag an orphaned rejection
     // would stamp `failed` over a context a newer success already loaded.
     let cancelled = false;
 
     const loadUserPermissions = async () => {
       try {
-        const isAuthenticated = useAuthStore.getState().isLoggedIn;
-        if (!isAuthenticated) {
-          if (cancelled) return;
-          setUserPermissions([]);
-          setUserPermsStatus('pending'); // see the early return above
-          return;
-        }
-
         setLoading(true);
         setError(null);
         const permissions = await permissionsService.getUserPermissions();
@@ -161,16 +166,15 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [user?.id]);
+  }, [user?.id, isLoggedIn]);
 
   // Load account permissions (específicas do account baseadas no AccountUser role)
   useEffect(() => {
-    // Verificar autenticação primeiro - precisa ter user também
-    const isAuthenticated = useAuthStore.getState().isLoggedIn;
-    if (!isAuthenticated || !user) {
+    // Precisa ter user E a store hidratada; ver a perna de user-permissions.
+    if (!isLoggedIn || !user) {
       setAccountPermissions([]);
-      setAccountPermsStatus('pending'); // see the user-permissions effect
-      setLoading(false); // see the user-permissions effect
+      setAccountPermsStatus('pending');
+      setLoading(false);
       return;
     }
 
@@ -186,15 +190,6 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
 
     const loadAccountPermissions = async () => {
       try {
-        const isAuthenticated = useAuthStore.getState().isLoggedIn;
-
-        if (!isAuthenticated) {
-          if (cancelled) return;
-          setAccountPermissions([]);
-          setAccountPermsStatus('pending'); // see the user-permissions effect
-          return;
-        }
-
         setLoading(true);
         setError(null);
         const permissions = await permissionsService.getAccountPermissions();
@@ -218,7 +213,7 @@ export const PermissionsProvider: React.FC<PermissionsProviderProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [user, accountPermissions.length]);
+  }, [user, accountPermissions.length, isLoggedIn]);
 
   const createPermission = useCallback((resource: string, action: string): string => {
     return `${resource}.${action}`;


### PR DESCRIPTION
Reportado em producao: toda atualizacao (F5) na tela de Conversas mostrava o toast "Voce nao tem permissao para visualizar conversas", com zero erros no console e nenhuma request falhando. O usuario era Super Admin com 334 permissoes, `conversations.read` incluida, e o catalogo (`/resource_actions`) tambem a lista. Os dois lados do servidor estavam certos.

## A corrida

No F5 dentro do shell, a bridge entrega o `user` ANTES de a auth store hidratar o `isLoggedIn`. As duas pernas do PermissionsContext liam a store por um snapshot NAO-reativo (`useAuthStore.getState().isLoggedIn`), viam `false` e gravavam **lista vazia com status `loaded`** — o status que o CRM-164 definiu como "confiavel". `isReady` virava true, `can()` negava tudo, e nada re-rodava: `getState()` e invisivel para o React, entao a hidratacao nao dispara efeito nenhum.

No fluxo de login normal o `isLoggedIn` ja era true quando a tela montava, por isso so o F5 quebrava.

## A correcao

O provider agora ASSINA `isLoggedIn`. Usuario presente com store nao hidratada mantem as pernas em `pending` (desconhecido nunca vira negacao confiavel), e o flip re-roda os fetches. A perna do catalogo (`loadConfig`) recebe o mesmo tratamento: com o snapshot ela nunca carregava no F5.

## Prova

O mock do spec vira uma store zustand real (o objeto so-getState antigo nem e chamavel pelo hook novo, e jamais exercitaria a assinatura). O teste novo reproduz a corrida: store nao hidratada -> `isReady` fica false; flip -> carrega e `can()` responde certo.

Falsificado nos dois sentidos: reintroduzindo o snapshot, cai exatamente o teste da corrida (1 failed / 11 passed); restaurando, 12/12. `tsc` limpo.

## Summary by Sourcery

Ensure permission state recovers correctly when authentication hydration completes after the permissions provider mounts.

Bug Fixes:
- Prevent permission checks from being permanently denied after a hard refresh by waiting for auth hydration and rerunning permission loading when authentication state becomes available.

Enhancements:
- Make permission loading reactively track the authentication store so both user and account permission states remain pending while authentication is unknown and become reliable after hydration.

Tests:
- Use a reactive Zustand auth-store mock and add coverage for the pre-hydration pending state followed by successful permission loading.