### PR TITLE
fix(ai-agents): remove o eixo perplexity do seletor de modelos (CRM-462)

### DIFF
--- a/src/components/ai_agents/ModelSelector.tsx
+++ b/src/components/ai_agents/ModelSelector.tsx
@@ -22,7 +22,7 @@ const CUSTOM_MODEL_OPTION = '__custom_model__';
 const CUSTOM_OPENAI_PROVIDER = 'custom_openai_compatible';
 
 // Shown before an API key is chosen, and as the fallback when a live listing fails. For
-// the providers with no listing endpoint at all (Vertex, Bedrock, Perplexity) it is the
+// the providers with no listing endpoint at all (Vertex, Bedrock) it is the
 // only source there will ever be. Prefer a rolling alias: it is the only entry here that
 // does not rot on its own.
 export const availableModels = [
@@ -48,12 +48,6 @@ export const availableModels = [
   { value: 'together_ai/deepseek-ai/DeepSeek-V4-Flash-0731', label: 'DeepSeek V4 Flash (Together)', provider: 'together_ai' },
   { value: 'together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo', label: 'Llama 3.3 70B Instruct Turbo', provider: 'together_ai' },
   { value: 'together_ai/Qwen/Qwen3.5-9B', label: 'Qwen 3.5 9B', provider: 'together_ai' },
-  // Sonar Chat Completions is supported only until 2026-09-27; past that these ids need
-  // a new integration, not new values.
-  { value: 'perplexity/sonar-pro', label: 'Sonar Pro', provider: 'perplexity' },
-  { value: 'perplexity/sonar', label: 'Sonar', provider: 'perplexity' },
-  { value: 'perplexity/sonar-reasoning-pro', label: 'Sonar Reasoning Pro', provider: 'perplexity' },
-  { value: 'perplexity/sonar-deep-research', label: 'Sonar Deep Research', provider: 'perplexity' },
   // `global.` where Bedrock offers global routing, `us.` only where it does not, so the
   // picker never pins data residency the deployment did not ask for. Sonnet 4.5 EOL from
   // 2026-09-29.

--- a/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
@@ -4,7 +4,7 @@ import { availableModels } from '@/components/ai_agents/ModelSelector';
 // Shape checks, not freshness. Freshness needs the provider's own answer: the LISTS_LIVE
 // axes get it the moment a key is chosen, and the bedrock axis gets it from the AWS model
 // cards in ModelSelector.bedrockLifecycle.spec.ts. Vertex and Perplexity have neither, so
-// their pins are still only as fresh as the last person who went looking.
+// any pin they carry is only as fresh as the last person who went looking.
 
 const PROVIDER_PREFIX: Record<string, string> = {
   openai: 'openai/',
@@ -72,6 +72,11 @@ describe('availableModels', () => {
   it('claims an exemption only for a provider that is really empty', () => {
     const stale = availableModels.filter(m => PINNED_ON_PURPOSE_EMPTY.includes(m.provider));
     expect(stale).toEqual([]);
+  });
+
+  it('exempts only a provider the picker knows, so a dropped one leaves no dead rule', () => {
+    const unknown = PINNED_ON_PURPOSE_EMPTY.filter(p => !PROVIDER_PREFIX[p]);
+    expect(unknown).toEqual([]);
   });
 
   it('pins at least one entry per provider, so a failed listing is never an empty picker', () => {

--- a/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
@@ -69,6 +69,11 @@ describe('availableModels', () => {
     expect(oversized).toEqual([]);
   });
 
+  it('claims an exemption only for a provider that is really empty', () => {
+    const stale = availableModels.filter(m => PINNED_ON_PURPOSE_EMPTY.includes(m.provider));
+    expect(stale).toEqual([]);
+  });
+
   it('pins at least one entry per provider, so a failed listing is never an empty picker', () => {
     const empty = Object.keys(PROVIDER_PREFIX).filter(
       p => !PINNED_ON_PURPOSE_EMPTY.includes(p) && !availableModels.some(m => m.provider === p),

--- a/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
@@ -20,6 +20,11 @@ const PROVIDER_PREFIX: Record<string, string> = {
 // (pkg/api_key/service/models_fetcher.go); update both together.
 const LISTS_LIVE = ['openai', 'gemini', 'anthropic', 'openrouter', 'deepseek', 'together_ai', 'fireworks_ai'];
 
+// Perplexity is offered as a key type but has no id worth pinning: Sonar Chat
+// Completions rejects any request carrying tools, and its successor speaks the
+// Responses API, which the runtime cannot reach yet.
+const PINNED_ON_PURPOSE_EMPTY = ['perplexity'];
+
 // One current family. The live list wins the moment a key is chosen, so each extra
 // pinned entry is only more surface to rot.
 const MAX_PINNED_WHEN_LISTED_LIVE = 3;
@@ -63,7 +68,7 @@ describe('availableModels', () => {
 
   it('pins at least one entry per provider, so a failed listing is never an empty picker', () => {
     const empty = Object.keys(PROVIDER_PREFIX).filter(
-      p => !availableModels.some(m => m.provider === p),
+      p => !PINNED_ON_PURPOSE_EMPTY.includes(p) && !availableModels.some(m => m.provider === p),
     );
     expect(empty).toEqual([]);
   });

--- a/src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
+++ b/src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
@@ -34,6 +34,18 @@ const openAiKey: ApiKey = {
   updated_at: '2026-01-01T00:00:00Z',
 };
 
+// The other shape of the same row: the provider answers that it does not list at all, so
+// the fallback is the pinned list — which CRM-462 left empty for this axis.
+const UNPINNED = 'perplexity/sonar-pro';
+
+const perplexityKey: ApiKey = {
+  id: 'key-2',
+  name: 'Perplexity',
+  provider: 'perplexity',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
 beforeEach(() => {
   listApiKeyModels.mockReset();
 });
@@ -80,6 +92,24 @@ describe('a value the list no longer offers', () => {
     // assertions below would pass on a picker that never came up.
     expect(await screen.findByText('Custom Model')).toBeInTheDocument();
     expect(screen.getByDisplayValue(RETIRED)).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps it when the provider lists nothing and the pinned list is empty', async () => {
+    const onChange = vi.fn();
+    listApiKeyModels.mockResolvedValue({ provider: 'perplexity', supported: false, models: [] });
+
+    render(
+      <ModelSelector
+        value={UNPINNED}
+        onChange={onChange}
+        apiKeys={[perplexityKey]}
+        apiKeyId={perplexityKey.id}
+      />,
+    );
+
+    await waitFor(() => expect(listApiKeyModels).toHaveBeenCalledWith(perplexityKey.id));
+    await waitFor(() => expect(screen.getByDisplayValue(UNPINNED)).toBeInTheDocument());
     expect(onChange).not.toHaveBeenCalled();
   });
 

--- a/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
@@ -9,7 +9,9 @@ import { availableModels } from '@/components/ai_agents/ModelSelector';
  * watching a date runs on every PR — the network specs are out of CI.
  *
  * Serving an id until its date is the posture, not an oversight: pulling it early costs
- * the user a model that still answers. CRM-462 wrote that down for the perplexity axis.
+ * the user a model that still answers. The exception is an id that already fails before
+ * its date — there is no working model left to cost anyone, and the perplexity axis was
+ * emptied ahead of schedule on exactly that ground.
  */
 
 // End-of-service dates, as the provider published them. A row is added when a pin gains a
@@ -19,12 +21,6 @@ import { availableModels } from '@/components/ai_agents/ModelSelector';
 // an expiry, so it is no deadline to assert. That axis reads the live lifecycle instead,
 // in ModelSelector.bedrockLifecycle.spec.ts.
 const RETIRES_ON: Record<string, string> = {
-  // Perplexity supports Sonar Chat Completions until this date; CRM-462 owns the move to
-  // the Agent API, and this is its "or the axis is emptied" half.
-  'perplexity/sonar': '2026-09-27',
-  'perplexity/sonar-pro': '2026-09-27',
-  'perplexity/sonar-reasoning-pro': '2026-09-27',
-  'perplexity/sonar-deep-research': '2026-09-27',
   // Vertex retires the whole Gemini 2.5 family. Pro has no GA successor to pin yet
   // (3.1 Pro is still Preview), which is exactly why the date needs a guard.
   'vertex_ai/gemini-2.5-pro': '2026-10-16',


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove Perplexity from the model selector’s pinned options while retaining safe handling for existing Perplexity selections.

Bug Fixes:
- Remove Perplexity model entries from the AI model selector because the currently supported integration cannot provide a usable pinned model.

Enhancements:
- Allow Perplexity to remain a supported API-key provider without requiring fallback model pins.
- Preserve existing Perplexity model values when the provider returns no models, preventing configured selections from being cleared.

Tests:
- Add coverage for the intentionally empty Perplexity fallback and preservation of existing unlisted model values.

Chores:
- Remove obsolete Perplexity model retirement tracking.