### PR TITLE
feat(ai-agents): repõe o eixo perplexity no seletor de modelos (CRM-485)

### DIFF
--- a/src/components/ai_agents/ModelSelector.tsx
+++ b/src/components/ai_agents/ModelSelector.tsx
@@ -22,7 +22,7 @@ const CUSTOM_MODEL_OPTION = '__custom_model__';
 const CUSTOM_OPENAI_PROVIDER = 'custom_openai_compatible';
 
 // Shown before an API key is chosen, and as the fallback when a live listing fails. For
-// the providers with no listing endpoint at all (Vertex, Bedrock) it is the
+// the providers with no listing endpoint at all (Vertex, Bedrock, Perplexity) it is the
 // only source there will ever be. Prefer a rolling alias: it is the only entry here that
 // does not rot on its own.
 export const availableModels = [
@@ -48,6 +48,15 @@ export const availableModels = [
   { value: 'together_ai/deepseek-ai/DeepSeek-V4-Flash-0731', label: 'DeepSeek V4 Flash (Together)', provider: 'together_ai' },
   { value: 'together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo', label: 'Llama 3.3 70B Instruct Turbo', provider: 'together_ai' },
   { value: 'together_ai/Qwen/Qwen3.5-9B', label: 'Qwen 3.5 9B', provider: 'together_ai' },
+  // Reintroduced on the Responses API; the doubled vendor segment is what routes here
+  // instead of the retired Chat Completions ids (see _route_perplexity_through_responses
+  // in the processor's llm_model_routing.py). sonar-reasoning-pro has no successor in
+  // the new catalogue.
+  { value: 'perplexity/perplexity/sonar', label: 'Sonar', provider: 'perplexity' },
+  { value: 'perplexity/preset/pro-search', label: 'Pro Search', provider: 'perplexity' },
+  { value: 'perplexity/preset/deep-research', label: 'Deep Research', provider: 'perplexity' },
+  { value: 'perplexity/preset/advanced-deep-research', label: 'Advanced Deep Research', provider: 'perplexity' },
+  { value: 'perplexity/preset/fast-search', label: 'Fast Search', provider: 'perplexity' },
   // `global.` where Bedrock offers global routing, `us.` only where it does not, so the
   // picker never pins data residency the deployment did not ask for. Sonnet 4.5 EOL from
   // 2026-09-29.

--- a/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts
@@ -23,10 +23,10 @@ const PROVIDER_PREFIX: Record<string, string> = {
 // (pkg/api_key/service/models_fetcher.go); update both together.
 const LISTS_LIVE = ['openai', 'gemini', 'anthropic', 'openrouter', 'deepseek', 'together_ai', 'fireworks_ai'];
 
-// Perplexity is offered as a key type but has no id worth pinning: Sonar Chat
-// Completions rejects any request carrying tools, and its successor speaks the
-// Responses API, which the runtime cannot reach yet.
-const PINNED_ON_PURPOSE_EMPTY = ['perplexity'];
+// No provider is exempt right now: Perplexity's ids came back once the runtime could
+// route to the Responses API. Kept as a named list, not deleted, so the next axis that
+// goes live-only-listing has somewhere to register the same claim.
+const PINNED_ON_PURPOSE_EMPTY: string[] = [];
 
 // One current family. The live list wins the moment a key is chosen, so each extra
 // pinned entry is only more surface to rot.

--- a/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
+++ b/src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts
@@ -11,7 +11,9 @@ import { availableModels } from '@/components/ai_agents/ModelSelector';
  * Serving an id until its date is the posture, not an oversight: pulling it early costs
  * the user a model that still answers. The exception is an id that already fails before
  * its date — there is no working model left to cost anyone, and the perplexity axis was
- * emptied ahead of schedule on exactly that ground.
+ * emptied ahead of schedule on exactly that ground once (its Chat Completions ids). The
+ * axis is pinned again on a different route (Responses API); the same rule applies the
+ * moment any of those ids gets a published end-of-service date.
  */
 
 // End-of-service dates, as the provider published them. A row is added when a pin gains a


### PR DESCRIPTION
## Contexto

Empilhado sobre #366 (CRM-462), que esvaziou o eixo `perplexity` do `ModelSelector` porque a Chat Completions rejeitava `tools`. O processor (evo-ai-processor-community#64) agora fala Responses API para esse eixo, então os ids voltam — em formato novo.

## O que muda

- `ModelSelector.tsx`: 5 ids repostos — `perplexity/perplexity/sonar` (vendor dobrado, é o que roteia para Responses no processor) e 4 presets (`preset/pro-search`, `preset/deep-research`, `preset/advanced-deep-research`, `preset/fast-search`). `sonar-reasoning-pro` não tem sucessor no catálogo novo.
- `ModelSelector.availableModels.spec.ts`: a isenção `PINNED_ON_PURPOSE_EMPTY` sai — o axis deixou de estar vazio de propósito.
- `ModelSelector.retirement.spec.ts`: ajustado o comentário que ficaria enganoso (dava a entender que o eixo segue vazio) — achado na revisão de código.

## Testes

19 testes do `ModelSelector` (`availableModels`, `retirement`, `retiredValue`, `bedrockLifecycle`) verdes + `tsc -b` limpo.

## Depende de

1. **#366 (CRM-462)** — já mergeada; o base desta PR passou a ser a `develop`.
2. **evo-ai-processor-community#64 (CRM-485) — precisa estar em produção ANTES desta.** Os 5 ids só funcionam com o roteamento para a Responses API que aquela PR entrega. Subir o front primeiro coloca no seletor modelos que morrem com `UnsupportedParamsError` no primeiro turno de qualquer agente com ferramenta — exatamente a falha que o card existe para fechar.
