### PR TITLE
feat(frontend): evento Compra aprovada no manifesto de eventos (CRM-316)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,9 @@ jobs:
       #     keeps rendering a value the list no longer offers. None of the three
       #     was gated before — the shape guard shipped with CRM-442 and never ran
       #     here. The bedrock lifecycle spec stays out: it reaches the network.
+      #   - events manifest catalog (CRM-316): the mirror of the evo-flow event
+      #     catalog the journey trigger and segment editor read. A drift (name,
+      #     category, field type) only shows as an event the UI cannot pick.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -180,7 +183,8 @@ jobs:
             src/contexts/chat/ConversationsContext.spec.tsx \
             src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts \
             src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts \
-            src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx
+            src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx \
+            src/lib/events-manifest/catalog.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,8 @@ jobs:
       #     keeps rendering a value the list no longer offers. None of the three
       #     was gated before — the shape guard shipped with CRM-442 and never ran
       #     here. The bedrock lifecycle spec stays out: it reaches the network.
-      #   - events manifest catalog (CRM-316): the mirror of the evo-flow event
-      #     catalog the journey trigger and segment editor read. A drift (name,
-      #     category, field type) only shows as an event the UI cannot pick.
+      #   - events manifest catalog (CRM-316): mirror of the evo-flow catalog the
+      #     journey trigger and segment editor read; a drift only shows in the UI.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in

--- a/src/components/journey/shared/EventSelector/EventSelector.tsx
+++ b/src/components/journey/shared/EventSelector/EventSelector.tsx
@@ -6,6 +6,7 @@ import {
   MessageCircle,
   MessageSquare,
   Megaphone,
+  ShoppingCart,
   Sparkles,
   type LucideIcon,
 } from 'lucide-react';
@@ -62,6 +63,7 @@ const CATEGORY_ICON: Record<EventCategory, LucideIcon> = {
   conversation: MessageCircle,
   message: MessageSquare,
   campaign: Megaphone,
+  purchase: ShoppingCart,
   custom: Sparkles,
 };
 

--- a/src/components/segments/SegmentConditionEditor.tsx
+++ b/src/components/segments/SegmentConditionEditor.tsx
@@ -56,6 +56,7 @@ const SEGMENT_EVENT_CATEGORY_LABELS: Record<EventCategory, string> = {
   conversation: 'Eventos de Conversa',
   message: 'Eventos de Mensagem',
   campaign: 'Eventos de Campanha',
+  purchase: 'Eventos de Compra',
   custom: 'Personalizado',
 };
 

--- a/src/i18n/locales/en/events.json
+++ b/src/i18n/locales/en/events.json
@@ -11,6 +11,7 @@
     "conversation": "Conversation events",
     "message": "Message events",
     "campaign": "Campaign events",
+    "purchase": "Purchase events",
     "custom": "Custom"
   },
   "propertiesForm": {

--- a/src/i18n/locales/es/events.json
+++ b/src/i18n/locales/es/events.json
@@ -11,6 +11,7 @@
     "conversation": "Eventos de Conversación",
     "message": "Eventos de Mensaje",
     "campaign": "Eventos de Campaña",
+    "purchase": "Eventos de compra",
     "custom": "Personalizado"
   },
   "propertiesForm": {

--- a/src/i18n/locales/fr/events.json
+++ b/src/i18n/locales/fr/events.json
@@ -11,6 +11,7 @@
     "conversation": "Événements de conversation",
     "message": "Événements de message",
     "campaign": "Événements de campagne",
+    "purchase": "Événements d'achat",
     "custom": "Personnalisé"
   },
   "propertiesForm": {

--- a/src/i18n/locales/it/events.json
+++ b/src/i18n/locales/it/events.json
@@ -11,6 +11,7 @@
     "conversation": "Eventi di conversazione",
     "message": "Eventi di messaggio",
     "campaign": "Eventi di campagna",
+    "purchase": "Eventi di acquisto",
     "custom": "Personalizzato"
   },
   "propertiesForm": {

--- a/src/i18n/locales/pt-BR/events.json
+++ b/src/i18n/locales/pt-BR/events.json
@@ -11,6 +11,7 @@
     "conversation": "Eventos de Conversa",
     "message": "Eventos de Mensagem",
     "campaign": "Eventos de Campanha",
+    "purchase": "Eventos de Compra",
     "custom": "Personalizado"
   },
   "propertiesForm": {

--- a/src/i18n/locales/pt/events.json
+++ b/src/i18n/locales/pt/events.json
@@ -11,6 +11,7 @@
     "conversation": "Eventos de Conversa",
     "message": "Eventos de Mensagem",
     "campaign": "Eventos de Campanha",
+    "purchase": "Eventos de Compra",
     "custom": "Personalizado"
   },
   "propertiesForm": {

--- a/src/lib/events-manifest/catalog.spec.ts
+++ b/src/lib/events-manifest/catalog.spec.ts
@@ -38,7 +38,7 @@ describe('frontend events manifest mirror', () => {
     );
   });
 
-  it('groups events by category covering all 5 categories', () => {
+  it('groups events by category covering all 6 categories', () => {
     const grouped = Object.fromEntries(EVENT_CATEGORIES.map((c) => [c, getEventsByCategory(c)]));
     expect(grouped.contact.length).toBeGreaterThanOrEqual(6);
     // EVO-1263: 2 original (created/resolved) + 5 added (activity, first_reply,
@@ -46,6 +46,8 @@ describe('frontend events manifest mirror', () => {
     expect(grouped.conversation).toHaveLength(7);
     expect(grouped.message.length).toBeGreaterThanOrEqual(4);
     expect(grouped.campaign.length).toBeGreaterThanOrEqual(4);
+    // CRM-316: the purchase captured by the CRM webhook, in its own group.
+    expect(grouped.purchase.map((e) => e.eventName)).toEqual(['purchase.approved']);
     expect(grouped.custom).toHaveLength(1);
   });
 
@@ -53,9 +55,12 @@ describe('frontend events manifest mirror', () => {
   // EvoFlow::EVENT_NAMES (lib/events/evo_flow_event_names.rb), which has 22
   // canonical names including `custom`. This count is the single guard keeping
   // the frontend manifest faithful to the backend enum — keep it strict.
-  it('mirrors the backend EvoFlow::EVENT_NAMES count exactly (22)', () => {
-    expect(EVENT_NAMES).toHaveLength(22);
-    expect(getEventCatalog()).toHaveLength(22);
+  // 22 + purchase.approved (CRM-316). pipeline.stage_changed exists on the
+  // backend but is deliberately absent here: the journey builder exposes it
+  // as its own trigger type, not as a pickable event.
+  it('mirrors the backend EvoFlow::EVENT_NAMES count exactly (23)', () => {
+    expect(EVENT_NAMES).toHaveLength(23);
+    expect(getEventCatalog()).toHaveLength(23);
   });
 
   // EVO-1263 (AC1): the 5 conversation events that previously existed only in

--- a/src/lib/events-manifest/catalog.spec.ts
+++ b/src/lib/events-manifest/catalog.spec.ts
@@ -51,16 +51,18 @@ describe('frontend events manifest mirror', () => {
     expect(grouped.custom).toHaveLength(1);
   });
 
-  // EVO-1263 (AC1): the manifest is a strict replica of the backend SSOT
-  // EvoFlow::EVENT_NAMES (lib/events/evo_flow_event_names.rb), which has 22
-  // canonical names including `custom`. This count is the single guard keeping
-  // the frontend manifest faithful to the backend enum — keep it strict.
-  // 22 + purchase.approved (CRM-316). pipeline.stage_changed exists on the
-  // backend but is deliberately absent here: the journey builder exposes it
-  // as its own trigger type, not as a pickable event.
-  it('mirrors the backend EvoFlow::EVENT_NAMES count exactly (23)', () => {
-    expect(EVENT_NAMES).toHaveLength(23);
-    expect(getEventCatalog()).toHaveLength(23);
+  // EVO-1263 (AC1): this count is the single guard keeping the manifest faithful
+  // to the backend SSOT EvoFlow::EVENT_NAMES (lib/events/evo_flow_event_names.rb)
+  // — keep it strict, and bump BACKEND_COUNT with the backend, not with this file.
+  const BACKEND_COUNT = 24;
+  // Exposed by the journey builder as its own trigger type, never picked as an event.
+  const NOT_MIRRORED = ['pipeline.stage_changed'];
+
+  it('mirrors the backend EvoFlow::EVENT_NAMES, minus what is deliberately absent', () => {
+    const expected = BACKEND_COUNT - NOT_MIRRORED.length;
+    expect(EVENT_NAMES).toHaveLength(expected);
+    expect(getEventCatalog()).toHaveLength(expected);
+    NOT_MIRRORED.forEach((name) => expect(EVENT_NAMES).not.toContain(name));
   });
 
   // EVO-1263 (AC1): the 5 conversation events that previously existed only in

--- a/src/lib/events-manifest/catalog.ts
+++ b/src/lib/events-manifest/catalog.ts
@@ -328,7 +328,7 @@ const ENTRIES: EventCatalogEntry[] = [
       },
       optional: {
         product: f('string'),
-        amount: f('number'),
+        amount: f('number', 'Currency major unit (e.g. 197.5 reais), never cents'),
         currency: f('string'),
         platform_event: f('string', 'Event name as the platform sent it'),
         outcome: f('string', 'created | already_in_pipeline'),

--- a/src/lib/events-manifest/catalog.ts
+++ b/src/lib/events-manifest/catalog.ts
@@ -308,6 +308,38 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'User-defined event with free-form key/value properties.',
     schema: { required: {}, optional: {} },
   },
+  // CRM-316: an approved purchase captured by the purchase webhook, emitted by
+  // the CRM with the contact resolved. First-class so a journey trigger can
+  // filter on product/amount and a segment can ask "bought X" / "spent > Y".
+  {
+    eventName: 'purchase.approved',
+    category: 'purchase',
+    dtoType: 'track',
+    labelPt: 'Compra aprovada',
+    labelEn: 'Purchase approved',
+    description: 'A purchase was approved on a payment platform and captured as a lead in the CRM.',
+    schema: {
+      required: {
+        provider: f('string', 'Payment platform key (virtu, hotmart, kiwify, cakto)'),
+        purchase_id: f('string', 'Purchase/order id on the platform'),
+        pipeline_id: f('uuid'),
+        pipeline_item_id: f('uuid', 'Card that holds the purchase'),
+        source: f('string'),
+      },
+      optional: {
+        product: f('string'),
+        amount: f('number'),
+        currency: f('string'),
+        platform_event: f('string', 'Event name as the platform sent it'),
+        outcome: f('string', 'created | already_in_pipeline'),
+        new_contact: f('boolean', 'Whether the purchase created the contact'),
+        contact_id: f('uuid'),
+        pipeline_name: f('string'),
+        pipeline_stage_id: f('uuid'),
+        pipeline_stage_name: f('string'),
+      },
+    },
+  },
 ];
 
 export const EVENT_CATEGORIES: readonly EventCategory[] = [
@@ -315,6 +347,7 @@ export const EVENT_CATEGORIES: readonly EventCategory[] = [
   'conversation',
   'message',
   'campaign',
+  'purchase',
   'custom',
 ] as const;
 

--- a/src/lib/events-manifest/catalog.ts
+++ b/src/lib/events-manifest/catalog.ts
@@ -308,9 +308,8 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'User-defined event with free-form key/value properties.',
     schema: { required: {}, optional: {} },
   },
-  // CRM-316: an approved purchase captured by the purchase webhook, emitted by
-  // the CRM with the contact resolved. First-class so a journey trigger can
-  // filter on product/amount and a segment can ask "bought X" / "spent > Y".
+  // CRM-316: purchase webhook capture, with the contact the CRM resolved — a
+  // journey trigger filters on product/amount, a segment asks "spent > Y".
   {
     eventName: 'purchase.approved',
     category: 'purchase',

--- a/src/lib/events-manifest/event-names.ts
+++ b/src/lib/events-manifest/event-names.ts
@@ -20,6 +20,7 @@ export const EVENT_NAMES = [
   'campaign.message.sent',
   'campaign.message.opened',
   'campaign.message.clicked',
+  'purchase.approved',
   'custom',
 ] as const;
 

--- a/src/lib/events-manifest/types.ts
+++ b/src/lib/events-manifest/types.ts
@@ -10,7 +10,7 @@ export interface EventSchema {
   optional: Record<string, FieldSpec>;
 }
 
-export type EventCategory = 'contact' | 'conversation' | 'message' | 'campaign' | 'custom';
+export type EventCategory = 'contact' | 'conversation' | 'message' | 'campaign' | 'purchase' | 'custom';
 
 export type EventDtoType = 'track' | 'identify';
 


### PR DESCRIPTION
## Summary
- Espelho do catálogo de eventos do evo-flow ganha `purchase.approved` na categoria nova `purchase` ("Compra aprovada" / "Purchase approved"), com o mesmo schema do backend.
- Categoria aparece no seletor de evento do gatilho de jornada (ícone de carrinho) e no editor de condição de segmento ("Eventos de Compra"), com a chave `categories.purchase` nos 6 locales.
- `catalog.spec.ts` entra na lane Vitest (lista fechada).

## Security
- Só manifesto, rótulos e i18n. Sem chamada nova, sem dado sensível.

## Test plan
- `npx vitest run src/lib/events-manifest/catalog.spec.ts src/i18n/locales/i18n-parity.spec.ts`
- `npx tsc --noEmit`
- Camada conta: Jornadas → nova jornada → gatilho por evento mostra "Eventos de Compra → Compra aprovada"; Segmentos → condição por evento idem.

## Nota
- O manifesto do front já não trazia `pipeline.stage_changed` (23 eventos contra 24 do backend). Drift pré-existente, fora do escopo.
- A tela do gatilho por evento hoje pede os campos `required` do catálogo como inputs obrigatórios (ids de compra/card). Defeito anterior a esta PR, tratado em card próprio.

## Changed Files
- `src/lib/events-manifest/event-names.ts`
- `src/lib/events-manifest/types.ts`
- `src/lib/events-manifest/catalog.ts`
- `src/lib/events-manifest/catalog.spec.ts`
- `src/components/journey/shared/EventSelector/EventSelector.tsx`
- `src/components/segments/SegmentConditionEditor.tsx`
- `src/i18n/locales/{pt,pt-BR,en,es,fr,it}/events.json`
- `.github/workflows/test.yml`

## Related PRs
- evo-flow (deploy primeiro): https://github.com/evolution-foundation/evo-flow-community/pull/124
- CRM: https://github.com/evolution-foundation/evo-ai-crm-community/pull/345
- frontend (vendor/crm): https://github.com/evolution-foundation/evo-ai-frontend-community/pull/369

## Linked Issue
- CRM-316

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxYjUwr2vV69kYddiXJHRo

## Summary by Sourcery

Add support for approved purchase events across the frontend event manifest, journey triggers, and segment conditions.

New Features:
- Add the `purchase.approved` event to the frontend event manifest under a new Purchase category, including its localized labels and schema.
- Expose Purchase events in journey event triggers and segment event conditions with localized category labels.

Enhancements:
- Update manifest validation to account for the expanded backend event set while explicitly excluding the pre-existing pipeline stage event from the frontend mirror.

CI:
- Include the event manifest catalog test in the Vitest CI lane.

Tests:
- Extend catalog coverage to validate the new Purchase category and `purchase.approved` event.