### PR TITLE
fix: capture custom-tool body params as {type, required, description} schema

### DIFF
--- a/src/components/ai_agents/shared/BodyParamsEditor.spec.tsx
+++ b/src/components/ai_agents/shared/BodyParamsEditor.spec.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import BodyParamsEditor from './BodyParamsEditor';
+import { coerceBodyParam, normalizeBodyParams } from './bodyParamSchema';
+
+vi.mock('@/hooks/useLanguage', () => ({
+  useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+describe('coerceBodyParam', () => {
+  it('keeps a valid schema object', () => {
+    expect(
+      coerceBodyParam({ type: 'number', required: false, description: 'age' }),
+    ).toEqual({ type: 'number', required: false, description: 'age' });
+  });
+
+  it('repairs a legacy string into a required string schema', () => {
+    expect(coerceBodyParam('{query}')).toEqual({
+      type: 'string',
+      required: true,
+      description: '',
+    });
+  });
+
+  it('falls back on an unknown type', () => {
+    expect(coerceBodyParam({ type: 'weird' })).toEqual({
+      type: 'string',
+      required: true,
+      description: '',
+    });
+  });
+});
+
+describe('normalizeBodyParams', () => {
+  it('coerces every entry and handles nullish input', () => {
+    expect(normalizeBodyParams(undefined)).toEqual({});
+    expect(
+      normalizeBodyParams({
+        a: '{x}',
+        b: { type: 'boolean', required: false, description: 'flag' },
+      }),
+    ).toEqual({
+      a: { type: 'string', required: true, description: '' },
+      b: { type: 'boolean', required: false, description: 'flag' },
+    });
+  });
+});
+
+describe('BodyParamsEditor', () => {
+  it('serializes a new row to the object schema shape', () => {
+    const onChange = vi.fn();
+    render(
+      <BodyParamsEditor value={{}} onChange={onChange} label="Body" />,
+    );
+    fireEvent.click(screen.getByText('form.fields.bodyParams.addParam'));
+    const nameInput = screen.getByLabelText('Body name');
+    fireEvent.change(nameInput, { target: { value: 'queryText' } });
+
+    const last = onChange.mock.calls.at(-1)![0];
+    expect(last).toEqual({
+      queryText: { type: 'string', required: true, description: '' },
+    });
+  });
+
+  it('reads an existing schema back into rows', () => {
+    render(
+      <BodyParamsEditor
+        value={{
+          queryText: { type: 'string', required: true, description: 'the query' },
+        }}
+        onChange={vi.fn()}
+        label="Body"
+      />,
+    );
+    expect((screen.getByLabelText('Body name') as HTMLInputElement).value).toBe(
+      'queryText',
+    );
+    expect(
+      (screen.getByLabelText('Body description') as HTMLInputElement).value,
+    ).toBe('the query');
+  });
+
+  it('coerces a legacy string value on load', () => {
+    render(
+      <BodyParamsEditor
+        value={{ queryText: '{query}' }}
+        onChange={vi.fn()}
+        label="Body"
+      />,
+    );
+    expect((screen.getByLabelText('Body name') as HTMLInputElement).value).toBe(
+      'queryText',
+    );
+    expect(
+      (screen.getByLabelText('Body description') as HTMLInputElement).value,
+    ).toBe('');
+  });
+});

--- a/src/components/ai_agents/shared/BodyParamsEditor.tsx
+++ b/src/components/ai_agents/shared/BodyParamsEditor.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Button,
+  Checkbox,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@evoapi/design-system';
+import { Plus, X } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
+import type { BodyParamSchema, BodyParamType } from '@/types/ai';
+import { BODY_PARAM_TYPES, coerceBodyParam, normalizeBodyParams } from './bodyParamSchema';
+
+export interface BodyParamsEditorProps {
+  value: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
+  label: string;
+  hint?: string;
+  keyPlaceholder?: string;
+  descriptionPlaceholder?: string;
+  disabled?: boolean;
+  id?: string;
+}
+
+interface Row {
+  id: number;
+  key: string;
+  schema: BodyParamSchema;
+}
+
+let rowCounter = 0;
+const nextRowId = () => ++rowCounter;
+
+const objectToRows = (obj: Record<string, unknown>): Row[] =>
+  Object.entries(obj || {}).map(([key, raw]) => ({
+    id: nextRowId(),
+    key,
+    schema: coerceBodyParam(raw),
+  }));
+
+const rowsToObject = (rows: Row[]): Record<string, BodyParamSchema> => {
+  const out: Record<string, BodyParamSchema> = {};
+  for (const row of rows) {
+    const key = row.key.trim();
+    if (!key) continue;
+    out[key] = row.schema;
+  }
+  return out;
+};
+
+export default function BodyParamsEditor({
+  value,
+  onChange,
+  label,
+  hint,
+  keyPlaceholder,
+  descriptionPlaceholder,
+  disabled = false,
+  id,
+}: BodyParamsEditorProps) {
+  const { t } = useLanguage('customTools');
+  const [rows, setRows] = useState<Row[]>(() => objectToRows(value || {}));
+  const lastEmittedRef = useRef<string>('');
+
+  useEffect(() => {
+    const currentSerialized = JSON.stringify(rowsToObject(rows));
+    const incomingSerialized = JSON.stringify(normalizeBodyParams(value));
+    if (
+      currentSerialized !== incomingSerialized &&
+      incomingSerialized !== lastEmittedRef.current
+    ) {
+      setRows(objectToRows(value || {}));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const emit = (next: Row[]) => {
+    const obj = rowsToObject(next);
+    lastEmittedRef.current = JSON.stringify(obj);
+    onChange(obj);
+  };
+
+  const errors = useMemo(() => {
+    const errs: Record<number, string> = {};
+    const keys = new Map<string, number>();
+    rows.forEach(row => {
+      const trimmed = row.key.trim();
+      if (!trimmed) return;
+      if (keys.has(trimmed)) {
+        errs[row.id] = t('keyValueEditor.errors.duplicateKey');
+      } else {
+        keys.set(trimmed, row.id);
+      }
+    });
+    return errs;
+  }, [rows, t]);
+
+  const updateRow = (rowId: number, patch: Partial<Row>) => {
+    const next = rows.map(r => (r.id === rowId ? { ...r, ...patch } : r));
+    setRows(next);
+    emit(next);
+  };
+
+  const updateSchema = (rowId: number, patch: Partial<BodyParamSchema>) => {
+    const row = rows.find(r => r.id === rowId);
+    if (!row) return;
+    updateRow(rowId, { schema: { ...row.schema, ...patch } });
+  };
+
+  const handleAddRow = () => {
+    const next = [
+      ...rows,
+      {
+        id: nextRowId(),
+        key: '',
+        schema: { type: 'string' as BodyParamType, required: true, description: '' },
+      },
+    ];
+    setRows(next);
+    emit(next);
+  };
+
+  const handleRemoveRow = (rowId: number) => {
+    const next = rows.filter(r => r.id !== rowId);
+    setRows(next);
+    emit(next);
+  };
+
+  return (
+    <div className="space-y-2" data-testid={id ? `${id}-body-editor` : 'body-editor'}>
+      <Label>{label}</Label>
+      {rows.length > 0 && (
+        <div className="space-y-3">
+          {rows.map(row => {
+            const err = errors[row.id];
+            return (
+              <div
+                key={row.id}
+                className="space-y-2 rounded-md border border-input p-3"
+              >
+                <div className="flex gap-2 items-start">
+                  <Input
+                    value={row.key}
+                    onChange={e => updateRow(row.id, { key: e.target.value })}
+                    placeholder={keyPlaceholder || t('keyValueEditor.keyPlaceholder')}
+                    disabled={disabled}
+                    aria-label={`${label} name`}
+                    aria-invalid={!!err}
+                    className={err ? 'border-destructive' : ''}
+                  />
+                  <Select
+                    value={row.schema.type}
+                    onValueChange={v =>
+                      updateSchema(row.id, { type: v as BodyParamType })
+                    }
+                    disabled={disabled}
+                  >
+                    <SelectTrigger
+                      className="w-36"
+                      aria-label={`${label} type`}
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {BODY_PARAM_TYPES.map(type => (
+                        <SelectItem key={type} value={type}>
+                          {t(`form.fields.bodyParams.types.${type}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemoveRow(row.id)}
+                    disabled={disabled}
+                    aria-label={t('keyValueEditor.removeRow')}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                <Input
+                  value={row.schema.description}
+                  onChange={e =>
+                    updateSchema(row.id, { description: e.target.value })
+                  }
+                  placeholder={
+                    descriptionPlaceholder ||
+                    t('form.fields.bodyParams.descriptionPlaceholder')
+                  }
+                  disabled={disabled}
+                  aria-label={`${label} description`}
+                />
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={row.schema.required}
+                    onCheckedChange={checked =>
+                      updateSchema(row.id, { required: checked === true })
+                    }
+                    disabled={disabled}
+                    aria-label={`${label} required`}
+                  />
+                  {t('form.fields.bodyParams.required')}
+                </label>
+                {err && <p className="text-sm text-destructive">{err}</p>}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={handleAddRow}
+        disabled={disabled}
+      >
+        <Plus className="h-4 w-4 mr-1" />
+        {t('form.fields.bodyParams.addParam')}
+      </Button>
+      {hint && <p className="text-sm text-muted-foreground">{hint}</p>}
+    </div>
+  );
+}

--- a/src/components/ai_agents/shared/bodyParamSchema.ts
+++ b/src/components/ai_agents/shared/bodyParamSchema.ts
@@ -1,0 +1,38 @@
+import type { BodyParamSchema, BodyParamType } from '@/types/ai';
+
+export const BODY_PARAM_TYPES: BodyParamType[] = [
+  'string',
+  'number',
+  'boolean',
+  'object',
+  'array',
+];
+
+const isBodyParamType = (v: unknown): v is BodyParamType =>
+  typeof v === 'string' && (BODY_PARAM_TYPES as string[]).includes(v);
+
+/** Coerce a stored body param into the {type, required, description} schema.
+ * Legacy tools saved each param as a plain string (e.g. "{query}"), which the
+ * engine could not read and which crashed tool creation. Loading an old tool
+ * repairs it into the schema shape. */
+export const coerceBodyParam = (raw: unknown): BodyParamSchema => {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    return {
+      type: isBodyParamType(obj.type) ? obj.type : 'string',
+      required: typeof obj.required === 'boolean' ? obj.required : true,
+      description: typeof obj.description === 'string' ? obj.description : '',
+    };
+  }
+  return { type: 'string', required: true, description: '' };
+};
+
+export const normalizeBodyParams = (
+  value: Record<string, unknown> | undefined | null,
+): Record<string, BodyParamSchema> => {
+  const out: Record<string, BodyParamSchema> = {};
+  for (const [key, raw] of Object.entries(value || {})) {
+    out[key] = coerceBodyParam(raw);
+  }
+  return out;
+};

--- a/src/components/ai_agents/shared/index.ts
+++ b/src/components/ai_agents/shared/index.ts
@@ -1,5 +1,8 @@
 export { default as KeyValueEditor } from './KeyValueEditor';
 export type { KeyValueEditorProps } from './KeyValueEditor';
+export { default as BodyParamsEditor } from './BodyParamsEditor';
+export type { BodyParamsEditorProps } from './BodyParamsEditor';
+export { coerceBodyParam, normalizeBodyParams } from './bodyParamSchema';
 export { default as AdvancedJsonCollapse } from './AdvancedJsonCollapse';
 export type { AdvancedJsonCollapseProps } from './AdvancedJsonCollapse';
 export { default as AdvancedJsonEditor } from './AdvancedJsonEditor';

--- a/src/components/customTools/CustomToolForm.spec.tsx
+++ b/src/components/customTools/CustomToolForm.spec.tsx
@@ -85,13 +85,32 @@ describe('CustomToolForm (refactored)', () => {
     const { rerender } = render(
       <CustomToolForm mode="create" onSubmit={() => {}} />,
     );
-    // GET default: 3 key-value editors (headers, query, path)
+    // GET default: 3 key-value editors (headers, query, path), no body editor
     expect(screen.getAllByText('keyValueEditor.addRow').length).toBe(3);
+    expect(screen.queryByText('form.fields.bodyParams.addParam')).toBeNull();
 
     const toolPost: CustomTool = { ...baseTool, method: 'POST' };
     rerender(<CustomToolForm tool={toolPost} mode="edit" onSubmit={() => {}} />);
-    // 4 with body_params
-    expect(screen.getAllByText('keyValueEditor.addRow').length).toBe(4);
+    // Body params now use a dedicated schema editor, not a key-value one
+    expect(screen.getAllByText('keyValueEditor.addRow').length).toBe(3);
+    expect(screen.getByText('form.fields.bodyParams.addParam')).toBeTruthy();
+  });
+
+  it('renders an existing body_params schema in the dedicated editor', () => {
+    const toolWithBody: CustomTool = {
+      ...baseTool,
+      method: 'POST',
+      body_params: {
+        queryText: { type: 'string', required: true, description: 'the query' },
+      },
+    };
+    const { rerender } = render(
+      <CustomToolForm mode="create" onSubmit={() => {}} />,
+    );
+    rerender(<CustomToolForm tool={toolWithBody} mode="edit" onSubmit={() => {}} />);
+    expect(screen.getByTestId('body_params-body-editor')).toBeTruthy();
+    expect(screen.getByDisplayValue('queryText')).toBeTruthy();
+    expect(screen.getByDisplayValue('the query')).toBeTruthy();
   });
 
   it('opens advanced collapse and shows values/error_handling fields when expanded', () => {

--- a/src/components/customTools/CustomToolForm.tsx
+++ b/src/components/customTools/CustomToolForm.tsx
@@ -23,10 +23,12 @@ import {
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import {
   KeyValueEditor,
+  BodyParamsEditor,
   AdvancedJsonCollapse,
   TestRequestButton,
   CredentialRefsEditor,
   mergeRetiredHeaders,
+  normalizeBodyParams,
   splitAuthHeaders,
   useVaultMigrationState,
 } from '@/components/ai_agents/shared';
@@ -112,7 +114,7 @@ export default function CustomToolForm({
         credential_refs: tool.credential_refs || {},
         path_params: (tool.path_params as Record<string, unknown>) || {},
         query_params: (tool.query_params as Record<string, unknown>) || {},
-        body_params: (tool.body_params as Record<string, unknown>) || {},
+        body_params: normalizeBodyParams(tool.body_params as Record<string, unknown>),
         error_handling: (tool.error_handling as Record<string, unknown>) || {},
         values: (tool.values as Record<string, unknown>) || {},
         tags: tool.tags || [],
@@ -453,7 +455,7 @@ export default function CustomToolForm({
           />
 
           {showBodyParams && (
-            <KeyValueEditor
+            <BodyParamsEditor
               id="body_params"
               label={t('form.fields.bodyParams.labelKv')}
               value={formData.body_params}
@@ -461,7 +463,7 @@ export default function CustomToolForm({
               disabled={loading}
               hint={t('form.fields.bodyParams.hint')}
               keyPlaceholder={t('form.fields.bodyParams.keyPlaceholder')}
-              valuePlaceholder={t('form.fields.bodyParams.valuePlaceholder')}
+              descriptionPlaceholder={t('form.fields.bodyParams.descriptionPlaceholder')}
             />
           )}
 

--- a/src/components/customTools/CustomToolWizardModal.spec.tsx
+++ b/src/components/customTools/CustomToolWizardModal.spec.tsx
@@ -76,7 +76,7 @@ describe('CustomToolWizardModal', () => {
       headers: { Authorization: 'Bearer abc' },
       path_params: {},
       query_params: {},
-      body_params: { name: 'value' },
+      body_params: { name: { type: 'string', required: true, description: 'a name' } },
       error_handling: { timeout: 45 },
       values: { __modes_meta__: { input: 'doc image', output: 'json data' } },
       tags: ['api'],
@@ -117,7 +117,11 @@ describe('CustomToolWizardModal', () => {
     // Other fields preserved
     expect(payload.name).toBe('My Existing Tool');
     expect(payload.headers).toEqual({ Authorization: 'Bearer abc' });
-    expect(payload.body_params).toEqual({ name: 'value' });
+    // Body params round-trip as {type, required, description} schema objects,
+    // the shape the tool-execution engine reads (a plain string crashed it).
+    expect(payload.body_params).toEqual({
+      name: { type: 'string', required: true, description: 'a name' },
+    });
   });
 
   it('renders without a Dialog wrapper when embedded=true', () => {
@@ -178,6 +182,36 @@ describe('CustomToolWizardModal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.continue' })); // 5 -> 6
     fireEvent.click(screen.getByRole('button', { name: 'wizard.actions.save' }));
   };
+
+  it('repairs a legacy string body_param into a schema on edit (custom-tool body-params fix)', () => {
+    const legacyTool = {
+      id: 'tool-legacy',
+      name: 'Legacy Tool',
+      description: '',
+      method: 'POST',
+      endpoint: 'https://api.example.com/legacy',
+      headers: {},
+      path_params: {},
+      query_params: {},
+      // The old broken shape: a plain string per body param.
+      body_params: { queryText: '{query}' },
+      error_handling: {},
+      values: {},
+      tags: [],
+      examples: [],
+      input_modes: [],
+      output_modes: [],
+      created_at: '2026-06-24T00:00:00Z',
+      updated_at: '2026-06-24T00:00:00Z',
+    };
+    const onSubmit = vi.fn();
+    render(<CustomToolWizardModal {...makeProps({ tool: legacyTool, onSubmit })} />);
+    walkToFinishAndSave();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].body_params).toEqual({
+      queryText: { type: 'string', required: true, description: '' },
+    });
+  });
 
   it('preserves error_handling extras across an unmodified edit cycle (AC6)', () => {
     const editTool = {

--- a/src/components/customTools/CustomToolWizardModal.tsx
+++ b/src/components/customTools/CustomToolWizardModal.tsx
@@ -4,7 +4,11 @@ import { X, Code2, LayoutList } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
 import { CustomTool, CustomToolFormData } from '@/types/ai';
 import WizardProgress from '@/pages/Customer/Agents/Agent/wizard/WizardProgress';
-import { AdvancedJsonEditor, TestRequestButton } from '@/components/ai_agents/shared';
+import {
+  AdvancedJsonEditor,
+  TestRequestButton,
+  normalizeBodyParams,
+} from '@/components/ai_agents/shared';
 import type { CustomToolTestPayload } from '@/services/agents/customToolsService';
 import {
   Step1_Identity,
@@ -118,7 +122,7 @@ const toolToWizardData = (tool: CustomTool): WizardData => {
     headers: (tool.headers as Record<string, unknown>) || {},
     query_params: (tool.query_params as Record<string, unknown>) || {},
     path_params: (tool.path_params as Record<string, unknown>) || {},
-    body_params: (tool.body_params as Record<string, unknown>) || {},
+    body_params: normalizeBodyParams(tool.body_params as Record<string, unknown>),
     values: cleanValues,
     error_handling: promoted,
     error_handling_extras: extras,

--- a/src/components/customTools/wizard/Step3_Parameters.tsx
+++ b/src/components/customTools/wizard/Step3_Parameters.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@evoapi/design-system';
 import { ArrowRight, ArrowLeft } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
-import { KeyValueEditor } from '@/components/ai_agents/shared';
+import { BodyParamsEditor, KeyValueEditor } from '@/components/ai_agents/shared';
 
 export interface Step3Data {
   method: string;
@@ -48,14 +48,14 @@ export default function Step3_Parameters({ data, onChange, onNext, onBack }: Ste
           />
 
           {showBody && (
-            <KeyValueEditor
+            <BodyParamsEditor
               id="body_params"
               label={t('form.fields.bodyParams.labelKv')}
               value={data.body_params}
               onChange={next => onChange({ ...data, body_params: next })}
               hint={t('form.fields.bodyParams.hint')}
               keyPlaceholder={t('form.fields.bodyParams.keyPlaceholder')}
-              valuePlaceholder={t('form.fields.bodyParams.valuePlaceholder')}
+              descriptionPlaceholder={t('form.fields.bodyParams.descriptionPlaceholder')}
             />
           )}
         </div>

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -91,7 +91,17 @@
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Field name",
         "valuePlaceholder": "Value",
-        "hint": "Body fields sent with POST/PUT/PATCH requests"
+        "hint": "Body fields sent with POST/PUT/PATCH requests",
+        "descriptionPlaceholder": "What this field is for",
+        "required": "Required",
+        "addParam": "Add parameter",
+        "types": {
+          "string": "Text",
+          "number": "Number",
+          "boolean": "Boolean",
+          "object": "Object",
+          "array": "Array"
+        }
       },
       "queryParams": {
         "label": "Query Parameters (JSON)",

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -91,7 +91,17 @@
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nombre del campo",
         "valuePlaceholder": "Valor",
-        "hint": "Campos del cuerpo enviados en solicitudes POST/PUT/PATCH"
+        "hint": "Campos del cuerpo enviados en solicitudes POST/PUT/PATCH",
+        "descriptionPlaceholder": "Para qué sirve este campo",
+        "required": "Obligatorio",
+        "addParam": "Agregar parámetro",
+        "types": {
+          "string": "Texto",
+          "number": "Número",
+          "boolean": "Booleano",
+          "object": "Objeto",
+          "array": "Arreglo"
+        }
       },
       "queryParams": {
         "label": "Parámetros de Query (JSON)",

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -91,7 +91,17 @@
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nom du champ",
         "valuePlaceholder": "Valeur",
-        "hint": "Champs du corps envoyés avec les requêtes POST/PUT/PATCH"
+        "hint": "Champs du corps envoyés avec les requêtes POST/PUT/PATCH",
+        "descriptionPlaceholder": "À quoi sert ce champ",
+        "required": "Obligatoire",
+        "addParam": "Ajouter un paramètre",
+        "types": {
+          "string": "Texte",
+          "number": "Nombre",
+          "boolean": "Booléen",
+          "object": "Objet",
+          "array": "Tableau"
+        }
       },
       "queryParams": {
         "label": "Paramètres de Query (JSON)",

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -91,7 +91,17 @@
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nome campo",
         "valuePlaceholder": "Valore",
-        "hint": "Campi del corpo inviati con richieste POST/PUT/PATCH"
+        "hint": "Campi del corpo inviati con richieste POST/PUT/PATCH",
+        "descriptionPlaceholder": "A cosa serve questo campo",
+        "required": "Obbligatorio",
+        "addParam": "Aggiungi parametro",
+        "types": {
+          "string": "Testo",
+          "number": "Numero",
+          "boolean": "Booleano",
+          "object": "Oggetto",
+          "array": "Array"
+        }
       },
       "queryParams": {
         "label": "Parametri di Query (JSON)",

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -91,7 +91,17 @@
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nome do campo",
         "valuePlaceholder": "Valor",
-        "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH"
+        "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH",
+        "descriptionPlaceholder": "Para que serve este campo",
+        "required": "Obrigatório",
+        "addParam": "Adicionar parâmetro",
+        "types": {
+          "string": "Texto",
+          "number": "Número",
+          "boolean": "Booleano",
+          "object": "Objeto",
+          "array": "Lista"
+        }
       },
       "queryParams": {
         "label": "Parâmetros de Query (JSON)",

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -91,7 +91,17 @@
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nome do campo",
         "valuePlaceholder": "Valor",
-        "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH"
+        "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH",
+        "descriptionPlaceholder": "Para que serve este campo",
+        "required": "Obrigatório",
+        "addParam": "Adicionar parâmetro",
+        "types": {
+          "string": "Texto",
+          "number": "Número",
+          "boolean": "Booleano",
+          "object": "Objeto",
+          "array": "Lista"
+        }
       },
       "queryParams": {
         "label": "Parâmetros de Query (JSON)",

--- a/src/types/ai/customTool.ts
+++ b/src/types/ai/customTool.ts
@@ -1,5 +1,16 @@
 import type { PaginationMeta } from '@/types/core';
 
+export type BodyParamType = 'string' | 'number' | 'boolean' | 'object' | 'array';
+
+/** The schema the AI tool-execution engine expects for each body param. The
+ * wire type stays Record<string, unknown> because legacy tools stored a plain
+ * string per key; the editor normalizes those into this shape on load. */
+export interface BodyParamSchema {
+  type: BodyParamType;
+  required: boolean;
+  description: string;
+}
+
 export interface CustomTool {
   body_params: Record<string, unknown>;
   created_at: string;


### PR DESCRIPTION
## Problem

The custom-tool wizard and edit form saved each body param as a plain string (`{"queryText": "{query}"}`), but the tool-execution engine (processor) expects an object schema `{type, required, description}` per param. Because of the mismatch:

1. The LLM never received the param as a callable argument, so at runtime it sent an empty body and Fastify endpoints (KB, content, ads) rejected the call with `400 body cannot be empty`.
2. Building the tool docstring in the processor crashed with `AttributeError` on the string (fixed in the processor repo PR).

Query params and path params genuinely are key -> value and are left unchanged.

## Fix

- New `BodyParamsEditor` (sibling of `KeyValueEditor`, which is untouched so the Custom MCP consumer is unaffected). Per body param it captures name, type (string/number/boolean/object/array), required, and description, and serializes to:
  ```json
  "body_params": { "queryText": { "type": "string", "required": true, "description": "..." } }
  ```
- Pure helpers (`coerceBodyParam`, `normalizeBodyParams`) live in `bodyParamSchema.ts` so the component file only exports a component (react-refresh rule).
- Wired into both the wizard `Step3_Parameters` and the non-wizard `CustomToolForm` edit path (the edit surface behind `CustomToolModal`).
- Normalize on load in both `toolToWizardData` and the form's effect: a legacy string body param is coerced to `{type: "string", required: true, description: ""}`, so editing an old tool repairs it on save instead of crashing.
- Added the new i18n keys (`descriptionPlaceholder`, `required`, `addParam`, `types.*`) in all six locales (en, es, fr, it, pt, pt-BR).
- Added `BodyParamSchema` type; kept `body_params` on the wire as `Record<string, unknown>` (legacy rows are genuinely unknown).

## Note on the wizard Test button

`getTestPayload()` forwards `body_params` to the core service `runToolTest`, which marshals the map literally as the request body. Before, it sent `{"queryText": "{query}"}`; now it sends the schema object. A reviewer clicking Test against a real endpoint may see a different response than before. This is expected: the schema is the correct persisted shape, and the old string body was never a valid request body anyway (that is the bug). Follow-up (out of scope, core Go service): `runToolTest` should send schema-derived sample values, and `custom_tool.go` should validate the body_params shape server-side.

## Tests

- `BodyParamsEditor.spec.tsx`: coercion, normalize, serialize a new row to the schema, round-trip an existing schema, coerce a legacy string on load.
- `CustomToolWizardModal.spec.tsx`: updated the edit round-trip to assert the schema shape; new test proves a legacy string body param is repaired on edit.
- `CustomToolForm.spec.tsx`: updated the editor-visibility test and added a schema-render assertion.
- 89 tests pass across `customTools` + `ai_agents/shared`; `tsc -b` clean; eslint clean on touched files.

Paired with the processor repo PR that hardens the tool builder against legacy string body params.

https://claude.ai/code/session_018zYu3wd6KQkuG76B9qTXSA