### PR TITLE
fix(journey): gatilho por evento sem ids obrigatórios e filtros usáveis (CRM-519)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,8 +127,11 @@ jobs:
       #     fails on any new one, with no baseline.
       #   - trigger filter contract (CRM-519): every key the event trigger offers
       #     as a filter has a label and help in all locales, a select for ids and
-      #     closed sets, and no timestamp/object. A new catalog key that misses
-      #     one of these only shows up as a raw key in the user's face.
+      #     closed sets, and no timestamp/object, and every lookup asks for a full
+      #     page instead of the endpoint default. A new catalog key that misses one
+      #     of these only shows up as a raw key in the user's face. journey-parity
+      #     is the ONLY guard for the six-locale event-switch keys (i18n-parity
+      #     skips journey.json), and EventBasicConfig owns the switch notice/Undo.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -203,7 +206,9 @@ jobs:
             src/components/customTools/CustomToolWizardModal.spec.tsx \
             src/components/journey/theme-tokens.spec.ts \
             src/components/journey/shared/EventPropertiesForm/filterFields.spec.ts \
-            src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
+            src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx \
+            src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx \
+            src/i18n/locales/journey-parity.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,10 @@ jobs:
       #   - theme tokens on journey/segment screens (CRM-520): a fixed
       #     gray/white/black class only looks right in one theme; the guard
       #     fails on any new one, with no baseline.
+      #   - trigger filter contract (CRM-519): every key the event trigger offers
+      #     as a filter has a label and help in all locales, a select for ids and
+      #     closed sets, and no timestamp/object. A new catalog key that misses
+      #     one of these only shows up as a raw key in the user's face.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -197,7 +201,9 @@ jobs:
             src/components/ai_agents/shared/BodyParamsEditor.spec.tsx \
             src/components/customTools/CustomToolForm.spec.tsx \
             src/components/customTools/CustomToolWizardModal.spec.tsx \
-            src/components/journey/theme-tokens.spec.ts
+            src/components/journey/theme-tokens.spec.ts \
+            src/components/journey/shared/EventPropertiesForm/filterFields.spec.ts \
+            src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.spec.tsx
@@ -143,40 +143,58 @@ describe('JourneyTriggerPanel — event trigger tabs (EVO-1276)', () => {
     const user = userEvent.setup();
     const { onUpdate, onClose } = renderPanel();
 
-    await selectEvent(user, /contact created|contato criado/i);
-    await user.type(screen.getByLabelText(/^id\s*\*?$/i), 'id-1');
-    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
+    await selectEvent(user, /message created|mensagem criada/i);
+    // CRM-519: filters are optional and live behind the "+ Add filter" picker
+    // (third combobox: trigger type, event selector, picker).
+    await user.click(screen.getAllByRole('combobox')[2]);
+    await user.click(within(await screen.findByRole('listbox')).getByText('content'));
+    await user.type(screen.getByRole('textbox', { name: /content/i }), 'oi');
 
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(onUpdate).toHaveBeenCalledTimes(1);
     const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
-    expect(saved.eventProperties).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ path: 'id' }),
-        expect.objectContaining({ path: 'source' }),
-      ]),
-    );
+    expect(saved.eventProperties).toEqual([
+      { path: 'content', operator: { type: 'Equals', value: 'oi' } },
+    ]);
     expect(saved.variableMappings ?? []).toHaveLength(0);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('AC5: clicking Save with a required property empty while on Avançado snaps back to Básico without saving', async () => {
+  it('AC5 (CRM-519): Save from Avançado with an event chosen and no filters persists and closes', async () => {
     const user = userEvent.setup();
     const { onUpdate, onClose } = renderPanel();
 
-    // Select an event with required fields but leave them empty → invalid.
     await selectEvent(user, /contact created|contato criado/i);
-
-    // Move to Avançado, then attempt to save.
     await user.click(screen.getByRole('tab', { name: /Advanced|Avançado|Avanzado|Avanzato|Avancé/ }));
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
-    // Bounced back to Básico; nothing persisted/closed.
-    const basicTab = screen.getByRole('tab', { name: /Basic|Básico|Base|Basique/ });
-    expect(basicTab.getAttribute('aria-selected')).toBe('true');
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    const saved = onUpdate.mock.calls[0][1] as JourneyTriggerNodeData;
+    expect(saved.eventName).toBe('contact.created');
+    expect(saved.eventProperties ?? []).toHaveLength(0);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('AC5b (CRM-519): Save stays disabled with no event chosen or a custom event without a name, with the reason under the field', async () => {
+    const user = userEvent.setup();
+    const { onUpdate } = renderPanel();
+
+    const save = () => screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+    expect(save().disabled).toBe(true);
+    expect(screen.getByText(/choose an event|escolha um evento/i)).toBeTruthy();
+
+    await selectEvent(user, /custom event|evento personalizado/i);
+    expect(save().disabled).toBe(true);
+    expect(screen.getByText(/type the custom event name to save|digite o nome do evento personalizado para salvar/i)).toBeTruthy();
+    await user.click(save());
     expect(onUpdate).not.toHaveBeenCalled();
-    expect(onClose).not.toHaveBeenCalled();
+
+    await user.type(screen.getByPlaceholderText(/custom event name|nome do evento custom/i), 'button_clicked');
+    expect(save().disabled).toBe(false);
+    await user.click(save());
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect((onUpdate.mock.calls[0][1] as JourneyTriggerNodeData).eventName).toBe('button_clicked');
   });
 
   it('AC6: selecting "Custom event" in Básico reveals the free-text custom-name input', async () => {

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -80,9 +80,9 @@ export function JourneyTriggerPanel({
   }, [data]);
 
   const handleSave = () => {
-    // Event-tabs path uses an enabled Save + this guard (instead of saveDisabled)
-    // so an invalid save snaps the user back to Básico where the inline
-    // required-field error lives, rather than silently doing nothing. See EVO-1276.
+    // Save is disabled while the event config is invalid (CRM-519, same
+    // dirty && isValid pattern as the action panels); this guard only keeps a
+    // programmatic call from persisting a half-configured trigger.
     if (showEventConfig && !eventPropsValid) {
       setActiveTab('basico');
       return;
@@ -215,16 +215,16 @@ export function JourneyTriggerPanel({
     icon: <Play className="w-5 h-5 text-green-500" />,
     onCancel: onClose,
     onSave: handleSave,
-    dirty,
+    // Event trigger: no event chosen (or custom without a name) keeps Save off;
+    // the inline message under the field says what is missing (CRM-519).
+    dirty: showEventConfig ? dirty && eventPropsValid : dirty,
     saveLabel: t('panels.actions.save'),
     cancelLabel: t('panels.actions.cancel'),
     savingAriaLabel: t('modal.actions.saving'),
     contentClassName: 'max-w-[800px]',
   };
 
-  // Event trigger type: Básico/Avançado tabs (EVO-1276). Save is enabled and the
-  // empty-required-field case is handled by handleSave's guard, so the user is
-  // bounced to Básico where the inline error is visible.
+  // Event trigger type: Básico/Avançado tabs (EVO-1276).
   if (showEventConfig) {
     const advancedBadge =
       variableMappingsCount > 0 ? (

--- a/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
+++ b/src/components/journey/nodes/trigger/JourneyTriggerPanel.tsx
@@ -58,8 +58,9 @@ export function JourneyTriggerPanel({
   const [showPipelineStageChangedConfig, setShowPipelineStageChangedConfig] = useState(
     data.triggerType === 'pipelineStageChanged',
   );
-  // Required-field validity reported by EventBasicConfig. True (non-blocking)
-  // whenever the event config isn't shown, so other trigger types can always Save.
+  // Event-config validity reported by EventBasicConfig: an event is chosen, and
+  // a custom one has its name. True (non-blocking) whenever the event config
+  // isn't shown, so other trigger types can always Save.
   const [eventPropsValid, setEventPropsValid] = useState(true);
   // Active tab for the event trigger's Básico/Avançado layout (EVO-1276).
   const [activeTab, setActiveTab] = useState<'basico' | 'avancado'>('basico');
@@ -215,9 +216,10 @@ export function JourneyTriggerPanel({
     icon: <Play className="w-5 h-5 text-green-500" />,
     onCancel: onClose,
     onSave: handleSave,
+    dirty,
     // Event trigger: no event chosen (or custom without a name) keeps Save off;
     // the inline message under the field says what is missing (CRM-519).
-    dirty: showEventConfig ? dirty && eventPropsValid : dirty,
+    saveDisabled: showEventConfig && !eventPropsValid,
     saveLabel: t('panels.actions.save'),
     cancelLabel: t('panels.actions.cancel'),
     savingAriaLabel: t('modal.actions.saving'),

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx
@@ -9,7 +9,7 @@ import '@/i18n/config';
 // Focused coverage for the extracted Básico half (EVO-1276). The broader event
 // flow is already locked in by EventConfiguration.spec.tsx (which now drives this
 // component through composition); these tests assert the pieces this subcomponent
-// directly owns: validity reporting, the required-field marker, and the
+// directly owns: validity reporting, the optional-filter picker, and the
 // preserve/clear switch dialog.
 
 interface HarnessProps {
@@ -49,44 +49,95 @@ async function selectEvent(user: ReturnType<typeof userEvent.setup>, label: RegE
 }
 
 describe('EventBasicConfig (EVO-1276)', () => {
-  it('reports validity = false with no event selected and flips to true once required fields are filled', async () => {
+  it('reports validity = false with no event selected and true as soon as one is chosen', async () => {
     const onValidityChange = vi.fn();
     const user = userEvent.setup();
     render(<Harness onValidityChange={onValidityChange} />);
 
     expect(onValidityChange).toHaveBeenLastCalledWith(false);
 
+    // CRM-519: properties are optional filters, never required inputs.
     await selectEvent(user, /contact created|contato criado/i);
-    expect(onValidityChange).toHaveBeenLastCalledWith(false); // id + source still empty
-
-    await user.type(screen.getByLabelText(/^id\s*\*?$/i), 'id-1');
-    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
     expect(onValidityChange).toHaveBeenLastCalledWith(true);
   });
 
-  it('renders required schema fields with a "*" marker', async () => {
+  it('offers schema keys as filters without a required marker or the event ids', async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await selectEvent(user, /message delivered|mensagem entregue/i);
 
-    const label = screen.getByText('message_id');
-    expect(within(label).getByText('*')).toBeTruthy();
+    expect(screen.queryByText('*')).toBeNull();
+    expect(screen.queryByText('message_id')).toBeNull();
+    expect(screen.getAllByRole('combobox').length).toBeGreaterThan(1); // "+ Add filter" picker
   });
 
-  it('prompts preserve/clear when switching events with existing values', async () => {
+  it('keeps compatible filters on an event switch, reports the dropped ones and undoes on request', async () => {
+    const onEventPropertiesChange = vi.fn();
     const user = userEvent.setup();
     render(
       <Harness
         initialEventName="message.delivered"
         initialEventProperties={[
           { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+          { path: 'channel_type', operator: { type: 'Equals', value: 'wa' } },
         ]}
+        onEventPropertiesChange={onEventPropertiesChange}
       />,
     );
 
     await selectEvent(user, /conversation created|conversa criada/i);
-    expect(
-      await screen.findByText(/preserve compatible values|preservar valores compatíveis/i),
-    ).toBeTruthy();
+
+    // No dialog: channel_type (same key + type) stays, message_id is dropped and reported.
+    expect(onEventPropertiesChange).toHaveBeenLastCalledWith([
+      { path: 'channel_type', operator: { type: 'Equals', value: 'wa' } },
+    ]);
+    const notice = screen.getByRole('status');
+    expect(notice.textContent).toMatch(/1 filtro removido|1 filter removed/i);
+
+    await user.click(within(notice).getByRole('button', { name: /desfazer|undo/i }));
+    expect(onEventPropertiesChange).toHaveBeenLastCalledWith([
+      { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+      { path: 'channel_type', operator: { type: 'Equals', value: 'wa' } },
+    ]);
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.getByRole('textbox', { name: /message_id/ })).toHaveProperty('value', 'm-1');
+  });
+
+  it('drops the Undo offer once the user edits a filter after the switch', async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="message.delivered"
+        initialEventProperties={[
+          { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+          { path: 'content', operator: { type: 'Equals', value: 'oi' } },
+        ]}
+      />,
+    );
+
+    // conversation.activity keeps `content` and drops `message_id`.
+    await selectEvent(user, /conversation activity|atividade na conversa/i);
+    expect(screen.getByRole('status')).toBeTruthy();
+
+    await user.type(screen.getByRole('textbox', { name: /content/ }), '!');
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('custom mode is only valid once a name is typed, and says so under the field', async () => {
+    const onValidityChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness onValidityChange={onValidityChange} />);
+
+    // No event yet: the message sits under the selector.
+    expect(screen.getByText(/choose an event|escolha um evento/i)).toBeTruthy();
+
+    await selectEvent(user, /custom event|evento personalizado/i);
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    expect(screen.queryByText(/choose an event|escolha um evento/i)).toBeNull();
+    expect(screen.getByText(/type the custom event name to save|digite o nome do evento personalizado para salvar/i)).toBeTruthy();
+
+    await user.type(screen.getByPlaceholderText(/custom event name|nome do evento custom/i), 'button_clicked');
+    expect(onValidityChange).toHaveBeenLastCalledWith(true);
+    expect(screen.queryByText(/type the custom event name to save|digite o nome do evento personalizado para salvar/i)).toBeNull();
   });
 });

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx
@@ -10,7 +10,7 @@ import '@/i18n/config';
 // flow is already locked in by EventConfiguration.spec.tsx (which now drives this
 // component through composition); these tests assert the pieces this subcomponent
 // directly owns: validity reporting, the optional-filter picker, and the
-// preserve/clear switch dialog.
+// event-switch notice with Undo.
 
 interface HarnessProps {
   initialEventName?: string;

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
@@ -1,15 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  Button,
-  Label,
-  Separator,
-} from '@evoapi/design-system';
+import { Button, Label } from '@evoapi/design-system';
 import { VariableInput } from '@/components/journey/environment-manager';
 import { EventSelector } from '@/components/journey/shared/EventSelector';
 import { EventPropertiesForm } from '@/components/journey/shared/EventPropertiesForm';
@@ -18,7 +8,6 @@ import {
   resolveLegacyEventName,
   propertiesToRecord,
   recordToProperties,
-  validateEventProperties,
   preserveCompatibleValues,
   type EventProperty,
 } from '@/lib/events-manifest';
@@ -30,8 +19,8 @@ export interface EventBasicConfigProps {
   onEventNameChange: (name: string) => void;
   onEventPropertiesChange: (properties: EventProperty[]) => void;
   // Optional: only the Flow Builder (JourneyTriggerPanel) gates Save on this.
-  // Campaigns/Wait omit it and rely on the inline required-field indicators
-  // <EventPropertiesForm> renders. See EVO-1275.
+  // A config is savable as soon as an event is chosen — filters are optional
+  // (CRM-519). See EVO-1275.
   onValidityChange?: (valid: boolean) => void;
   // Optional: in contexts without a journey (e.g. trigger-type Campaigns) it is
   // omitted, so useJourneyVariables skips the fetch and the autocomplete degrades
@@ -54,7 +43,8 @@ export function EventBasicConfig({
   onValidityChange,
   journeyId,
 }: EventBasicConfigProps) {
-  const { t } = useLanguage('journey');
+  const { t, currentLanguage } = useLanguage('journey');
+  const { t: tEvents } = useLanguage('events');
 
   // selectorValue tracks which dropdown entry is rendered as selected
   // (canonical event name OR the literal 'custom' placeholder); customName
@@ -91,33 +81,55 @@ export function EventBasicConfig({
   // derive the flat Record the form consumes WITHOUT mutating the source.
   const record = useMemo(() => propertiesToRecord(eventProperties), [eventProperties]);
 
+  // Localized in events.json (`events.<name with _>.description`); the catalog
+  // description is English-only and never shown outside the en locale.
   const canonicalDescription =
-    !isCustomMode && selectorValue ? getEvent(selectorValue)?.description : undefined;
+    !isCustomMode && selectorValue && getEvent(selectorValue)
+      ? tEvents(`events.${selectorValue.replace(/\./g, '_')}.description`, { defaultValue: '' })
+      : undefined;
 
   // Emit validity to opted-in consumers, but only when it actually flips so we
   // don't churn the parent's state on every keystroke.
   const lastValidityRef = useRef<boolean | null>(null);
   useEffect(() => {
-    // An event trigger with no event chosen yet is not a savable config — treat
-    // the empty selection as invalid (formEventName === selectorValue, which is
-    // '' until something is picked; 'custom' once Custom is selected).
-    const valid =
-      formEventName === '' ? false : validateEventProperties(formEventName, record).valid;
+    // A config is savable once an event is chosen — properties are optional
+    // filters, not required inputs (CRM-519). Custom mode needs the typed
+    // name: 'custom' alone is a placeholder, not an event.
+    const valid = isCustomMode ? customName.trim() !== '' : selectorValue !== '';
     if (lastValidityRef.current !== valid) {
       lastValidityRef.current = valid;
       onValidityChange?.(valid);
     }
-  }, [formEventName, record, onValidityChange]);
+  }, [isCustomMode, customName, selectorValue, onValidityChange]);
 
-  // Pending event switch awaiting the user's preserve/clear decision.
-  const [pendingSwitch, setPendingSwitch] = useState<{ from: string; to: string } | null>(null);
+  // CRM-519: switching events keeps the filters the new event also has (same
+  // key and type) and drops the rest, no dialog. A dropped filter is reported
+  // inline with Undo, which restores the previous event and its filters.
+  const [dropped, setDropped] = useState<{
+    count: number;
+    toEventName: string;
+    prevEventName: string;
+    prevSelectorValue: string;
+    prevCustomName: string;
+    prevProperties: EventProperty[];
+  } | null>(null);
+
+  const eventLabel = (name: string) => {
+    const entry = getEvent(name);
+    if (!entry) return name;
+    return currentLanguage.toLowerCase().startsWith('pt') ? entry.labelPt : entry.labelEn;
+  };
 
   const handleSelectorChange = ({ eventName: picked, isCustom }: { eventName: string; isCustom: boolean }) => {
     const prevFormEvent = formEventName;
     const nextFormEvent = isCustom ? 'custom' : picked;
+    const snapshot = {
+      prevEventName: eventName,
+      prevSelectorValue: selectorValue,
+      prevCustomName: customName,
+      prevProperties: eventProperties,
+    };
 
-    // The event NAME (and selector) updates immediately so the schema reflects
-    // the new event; the properties decision is deferred to the confirm dialog.
     if (isCustom) {
       setSelectorValue('custom');
       lastPushedRef.current = customName;
@@ -129,11 +141,25 @@ export function EventBasicConfig({
       onEventNameChange(picked);
     }
 
-    const identityChanged = prevFormEvent !== nextFormEvent;
-    const hasValues = Object.keys(record).length > 0;
-    if (identityChanged && hasValues) {
-      setPendingSwitch({ from: prevFormEvent, to: nextFormEvent });
-    }
+    setDropped(null);
+    if (prevFormEvent === nextFormEvent || Object.keys(record).length === 0) return;
+
+    const kept = preserveCompatibleValues(record, prevFormEvent, nextFormEvent);
+    const droppedCount = Object.keys(record).length - Object.keys(kept).length;
+    if (droppedCount === 0) return;
+
+    onEventPropertiesChange(recordToProperties(kept, eventProperties));
+    setDropped({ count: droppedCount, toEventName: nextFormEvent, ...snapshot });
+  };
+
+  const handleUndoSwitch = () => {
+    if (!dropped) return;
+    setSelectorValue(dropped.prevSelectorValue);
+    setCustomName(dropped.prevCustomName);
+    lastPushedRef.current = dropped.prevEventName;
+    onEventNameChange(dropped.prevEventName);
+    onEventPropertiesChange(dropped.prevProperties);
+    setDropped(null);
   };
 
   const handleCustomNameChange = (next: string) => {
@@ -143,25 +169,13 @@ export function EventBasicConfig({
   };
 
   const handlePropertiesRecordChange = (next: Record<string, unknown>) => {
+    // A manual edit supersedes the switch: Undo would clobber it otherwise.
+    setDropped(null);
     onEventPropertiesChange(recordToProperties(next, eventProperties));
-  };
-
-  const handlePreserveValues = () => {
-    if (pendingSwitch) {
-      const kept = preserveCompatibleValues(record, pendingSwitch.from, pendingSwitch.to);
-      onEventPropertiesChange(recordToProperties(kept, eventProperties));
-    }
-    setPendingSwitch(null);
-  };
-
-  const handleClearValues = () => {
-    onEventPropertiesChange([]);
-    setPendingSwitch(null);
   };
 
   return (
     <>
-      <Separator />
       <div className="space-y-4">
         <Label className="text-sidebar-foreground font-medium">
           {t('triggerComponents.event.configuration')}
@@ -178,13 +192,16 @@ export function EventBasicConfig({
             onChange={handleSelectorChange}
             className="bg-sidebar border-sidebar-border text-sidebar-foreground"
           />
+          {selectorValue === '' && (
+            <p className="text-xs text-destructive">{t('triggerComponents.event.selectEventRequired')}</p>
+          )}
           {canonicalDescription && (
             <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
           )}
           {isCustomMode && (
             <div className="space-y-2 pt-1">
               <Label htmlFor="custom-event-name" className="text-sm font-medium">
-                {t('triggerComponents.event.eventName')}
+                {t('triggerComponents.event.customEventNameLabel')}
               </Label>
               <VariableInput
                 id="custom-event-name"
@@ -194,6 +211,11 @@ export function EventBasicConfig({
                 className="bg-sidebar border-sidebar-border text-sidebar-foreground"
                 journeyId={journeyId}
               />
+              {customName.trim() === '' && (
+                <p className="text-xs text-destructive">
+                  {t('triggerComponents.event.customEventNameRequired')}
+                </p>
+              )}
               <p className="text-xs text-amber-700 dark:text-amber-300">
                 {t('triggerComponents.event.customEventWarning')}
               </p>
@@ -203,13 +225,35 @@ export function EventBasicConfig({
 
         {/* Propriedades do evento */}
         <div className="space-y-3">
-          <Label
-            id="event-trigger-properties-label"
-            className="text-sidebar-foreground font-medium text-sm"
+          {/* The custom editor carries its own title; one heading is enough. */}
+          {!isCustomMode && (
+            <Label
+              id="event-trigger-properties-label"
+              className="text-sidebar-foreground font-medium text-sm"
+            >
+              {t('triggerComponents.event.eventProperties')}
+            </Label>
+          )}
+          {dropped && (
+            <div
+              role="status"
+              className="flex items-center justify-between gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-foreground"
+            >
+              <span>
+                {t('triggerComponents.event.eventSwitch.dropped', {
+                  count: dropped.count,
+                  event: eventLabel(dropped.toEventName),
+                })}
+              </span>
+              <Button type="button" variant="ghost" size="sm" className="h-7" onClick={handleUndoSwitch}>
+                {t('triggerComponents.event.eventSwitch.undo')}
+              </Button>
+            </div>
+          )}
+          <div
+            role={isCustomMode ? undefined : 'group'}
+            aria-labelledby={isCustomMode ? undefined : 'event-trigger-properties-label'}
           >
-            {t('triggerComponents.event.eventProperties')}
-          </Label>
-          <div role="group" aria-labelledby="event-trigger-properties-label">
             <EventPropertiesForm
               eventName={formEventName}
               value={record}
@@ -219,34 +263,6 @@ export function EventBasicConfig({
         </div>
       </div>
 
-      {/* Preserve-compatible-values confirm on event switch */}
-      <AlertDialog
-        open={pendingSwitch !== null}
-        onOpenChange={open => {
-          // Dismissing (Esc) without an explicit choice would otherwise strand
-          // the newly-selected event with the previous event's values (incl.
-          // keys absent from the new schema). Default a dismiss to the safe
-          // Clear. Explicit Preserve/Clear close via state, not onOpenChange.
-          if (!open) handleClearValues();
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t('triggerComponents.event.eventSwitch.title')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {t('triggerComponents.event.eventSwitch.body')}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <Button variant="outline" onClick={handleClearValues}>
-              {t('triggerComponents.event.eventSwitch.clear')}
-            </Button>
-            <Button onClick={handlePreserveValues}>
-              {t('triggerComponents.event.eventSwitch.preserve')}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 }

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
@@ -30,8 +30,9 @@ export interface EventBasicConfigProps {
 
 /**
  * Básico half of the event trigger config (EVO-1276): the event selector, the
- * custom-event free-text input, the schema-driven <EventPropertiesForm>, the
- * preserve/clear switch dialog, and required-field validity reporting. Extracted
+ * custom-event free-text input, the schema-driven <EventPropertiesForm> (optional
+ * filters), the event-switch notice with Undo, and validity reporting (an event
+ * chosen; custom needs its name). Extracted
  * verbatim from EventConfiguration so it can be consumed directly by the Básico
  * tab without duplicating the stateful selector across tab subtrees.
  */
@@ -175,94 +176,91 @@ export function EventBasicConfig({
   };
 
   return (
-    <>
-      <div className="space-y-4">
-        <Label className="text-sidebar-foreground font-medium">
-          {t('triggerComponents.event.configuration')}
+    <div className="space-y-4">
+      <Label className="text-sidebar-foreground font-medium">
+        {t('triggerComponents.event.configuration')}
+      </Label>
+
+      {/* Nome do evento */}
+      <div className="space-y-2">
+        <Label htmlFor="event-trigger-name" className="text-sm font-medium">
+          {t('triggerComponents.event.eventName')}
         </Label>
-
-        {/* Nome do evento */}
-        <div className="space-y-2">
-          <Label htmlFor="event-trigger-name" className="text-sm font-medium">
-            {t('triggerComponents.event.eventName')}
-          </Label>
-          <EventSelector
-            id="event-trigger-name"
-            value={selectorValue || undefined}
-            onChange={handleSelectorChange}
-            className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-          />
-          {selectorValue === '' && (
-            <p className="text-xs text-destructive">{t('triggerComponents.event.selectEventRequired')}</p>
-          )}
-          {canonicalDescription && (
-            <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
-          )}
-          {isCustomMode && (
-            <div className="space-y-2 pt-1">
-              <Label htmlFor="custom-event-name" className="text-sm font-medium">
-                {t('triggerComponents.event.customEventNameLabel')}
-              </Label>
-              <VariableInput
-                id="custom-event-name"
-                value={customName}
-                onChange={e => handleCustomNameChange(e.target.value)}
-                placeholder={t('triggerComponents.event.customEventNamePlaceholder')}
-                className="bg-sidebar border-sidebar-border text-sidebar-foreground"
-                journeyId={journeyId}
-              />
-              {customName.trim() === '' && (
-                <p className="text-xs text-destructive">
-                  {t('triggerComponents.event.customEventNameRequired')}
-                </p>
-              )}
-              <p className="text-xs text-amber-700 dark:text-amber-300">
-                {t('triggerComponents.event.customEventWarning')}
-              </p>
-            </div>
-          )}
-        </div>
-
-        {/* Propriedades do evento */}
-        <div className="space-y-3">
-          {/* The custom editor carries its own title; one heading is enough. */}
-          {!isCustomMode && (
-            <Label
-              id="event-trigger-properties-label"
-              className="text-sidebar-foreground font-medium text-sm"
-            >
-              {t('triggerComponents.event.eventProperties')}
+        <EventSelector
+          id="event-trigger-name"
+          value={selectorValue || undefined}
+          onChange={handleSelectorChange}
+          className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+        />
+        {selectorValue === '' && (
+          <p className="text-xs text-destructive">{t('triggerComponents.event.selectEventRequired')}</p>
+        )}
+        {canonicalDescription && (
+          <p className="text-xs text-muted-foreground">{canonicalDescription}</p>
+        )}
+        {isCustomMode && (
+          <div className="space-y-2 pt-1">
+            <Label htmlFor="custom-event-name" className="text-sm font-medium">
+              {t('triggerComponents.event.customEventNameLabel')}
             </Label>
-          )}
-          {dropped && (
-            <div
-              role="status"
-              className="flex items-center justify-between gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-foreground"
-            >
-              <span>
-                {t('triggerComponents.event.eventSwitch.dropped', {
-                  count: dropped.count,
-                  event: eventLabel(dropped.toEventName),
-                })}
-              </span>
-              <Button type="button" variant="ghost" size="sm" className="h-7" onClick={handleUndoSwitch}>
-                {t('triggerComponents.event.eventSwitch.undo')}
-              </Button>
-            </div>
-          )}
-          <div
-            role={isCustomMode ? undefined : 'group'}
-            aria-labelledby={isCustomMode ? undefined : 'event-trigger-properties-label'}
-          >
-            <EventPropertiesForm
-              eventName={formEventName}
-              value={record}
-              onChange={handlePropertiesRecordChange}
+            <VariableInput
+              id="custom-event-name"
+              value={customName}
+              onChange={e => handleCustomNameChange(e.target.value)}
+              placeholder={t('triggerComponents.event.customEventNamePlaceholder')}
+              className="bg-sidebar border-sidebar-border text-sidebar-foreground"
+              journeyId={journeyId}
             />
+            {customName.trim() === '' && (
+              <p className="text-xs text-destructive">
+                {t('triggerComponents.event.customEventNameRequired')}
+              </p>
+            )}
+            <p className="text-xs text-amber-700 dark:text-amber-300">
+              {t('triggerComponents.event.customEventWarning')}
+            </p>
           </div>
-        </div>
+        )}
       </div>
 
-    </>
+      {/* Propriedades do evento */}
+      <div className="space-y-3">
+        {/* The custom editor carries its own title; one heading is enough. */}
+        {!isCustomMode && (
+          <Label
+            id="event-trigger-properties-label"
+            className="text-sidebar-foreground font-medium text-sm"
+          >
+            {t('triggerComponents.event.eventProperties')}
+          </Label>
+        )}
+        {dropped && (
+          <div
+            role="status"
+            className="flex items-center justify-between gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-foreground"
+          >
+            <span>
+              {t('triggerComponents.event.eventSwitch.dropped', {
+                count: dropped.count,
+                event: eventLabel(dropped.toEventName),
+              })}
+            </span>
+            <Button type="button" variant="ghost" size="sm" className="h-7" onClick={handleUndoSwitch}>
+              {t('triggerComponents.event.eventSwitch.undo')}
+            </Button>
+          </div>
+        )}
+        <div
+          role={isCustomMode ? undefined : 'group'}
+          aria-labelledby={isCustomMode ? undefined : 'event-trigger-properties-label'}
+        >
+          <EventPropertiesForm
+            eventName={formEventName}
+            value={record}
+            onChange={handlePropertiesRecordChange}
+          />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventBasicConfig.tsx
@@ -29,12 +29,11 @@ export interface EventBasicConfigProps {
 }
 
 /**
- * Básico half of the event trigger config (EVO-1276): the event selector, the
- * custom-event free-text input, the schema-driven <EventPropertiesForm> (optional
- * filters), the event-switch notice with Undo, and validity reporting (an event
- * chosen; custom needs its name). Extracted
- * verbatim from EventConfiguration so it can be consumed directly by the Básico
- * tab without duplicating the stateful selector across tab subtrees.
+ * Básico half of the event trigger config (EVO-1276): event selector, custom-event
+ * input, the <EventPropertiesForm> filters, the event-switch notice with Undo, and
+ * validity reporting (an event chosen; custom needs its name). Lives apart from
+ * EventConfiguration so the Básico tab can mount it without the stateful selector
+ * being duplicated across tab subtrees.
  */
 export function EventBasicConfig({
   eventName,

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.both-contexts.spec.tsx
@@ -92,6 +92,18 @@ async function selectContactCreated(user: ReturnType<typeof userEvent.setup>) {
   await user.click(within(listbox).getByText(/contact created|contato criado/i));
 }
 
+async function selectConversationCreated(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('combobox'));
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(/conversation created|conversa criada/i));
+}
+
+async function selectMessageCreated(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('combobox'));
+  const listbox = await screen.findByRole('listbox');
+  await user.click(within(listbox).getByText(/message created|mensagem criada/i));
+}
+
 async function selectCustomEvent(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('combobox'));
   const listbox = await screen.findByRole('listbox');
@@ -112,9 +124,11 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
       const user = userEvent.setup();
       // EventSelector (EVO-1271 / 10.6) — the combobox is the primary entry point.
       expect(screen.getByRole('combobox')).toBeTruthy();
-      // After picking a canonical event, the schema-driven form renders its fields.
-      await selectContactCreated(user);
-      expect(screen.getByLabelText(/source/i)).toBeTruthy();
+      // After picking a canonical event, the schema-driven form offers its
+      // keys as optional filters behind the picker (CRM-519).
+      await selectConversationCreated(user);
+      expect(screen.getByText(/add filter|adicionar filtro/i)).toBeTruthy();
+      expect(screen.queryByText('*')).toBeNull();
     },
   );
 
@@ -137,12 +151,14 @@ describe('EventConfiguration — shared across Flow Builder + Campaign contexts'
       const { onEventPropertiesChange } = renderInContext(context);
       const user = userEvent.setup();
 
-      await selectContactCreated(user);
-      await user.type(screen.getByLabelText(/source/i), 'crm');
+      await selectMessageCreated(user);
+      await user.click(screen.getAllByRole('combobox')[1]);
+      await user.click(within(await screen.findByRole('listbox')).getByText('content'));
+      await user.type(screen.getByRole('textbox', { name: /content/i }), 'oi');
 
       // Option A: the persisted shape stays the {path, operator} array.
       const last = onEventPropertiesChange.mock.calls.at(-1)?.[0];
-      expect(last).toEqual([{ path: 'source', operator: { type: 'Equals', value: 'crm' } }]);
+      expect(last).toEqual([{ path: 'content', operator: { type: 'Equals', value: 'oi' } }]);
     },
   );
 

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.spec.tsx
@@ -73,7 +73,7 @@ describe('EventConfiguration — event name UI', () => {
     expect(onEventNameChange).toHaveBeenCalledWith('contact.created');
     // Description from the manifest entry appears under the selector.
     expect(
-      await screen.findByText(/a new contact was created/i),
+      await screen.findByText(/a new contact was created|um contato novo foi criado/i),
     ).toBeTruthy();
   });
 
@@ -116,7 +116,7 @@ describe('EventConfiguration — event name UI', () => {
     ).toBeNull();
     // The canonical description is surfaced.
     expect(
-      screen.getByText(/a new contact was created/i),
+      screen.getByText(/a new contact was created|um contato novo foi criado/i),
     ).toBeTruthy();
   });
 
@@ -139,7 +139,7 @@ describe('EventConfiguration — event name UI', () => {
       screen.queryByPlaceholderText(/custom event name|nome do evento custom/i),
     ).not.toBeNull();
     // The canonical description must NOT be rendered (we're still in custom mode).
-    expect(screen.queryByText(/a new contact was created/i)).toBeNull();
+    expect(screen.queryByText(/a new contact was created|um contato novo foi criado/i)).toBeNull();
     // And the warning is still visible.
     expect(
       screen.getByText(/custom events have no schema validation|não têm validação de schema/i),
@@ -148,16 +148,14 @@ describe('EventConfiguration — event name UI', () => {
 });
 
 describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)', () => {
-  it('AC1: renders required schema fields with a "*" marker under the Required section', async () => {
+  it('AC1 (CRM-519): renders the filters section with no required marker and no event ids', async () => {
     const user = userEvent.setup();
     render(<Harness />);
     await selectEvent(user, /message delivered|mensagem entregue/i);
 
-    expect(screen.getByText(/required fields|campos obrigatórios/i)).toBeTruthy();
-    // message.delivered requires message_id; the schema field renders with a "*".
-    const label = screen.getByText('message_id');
-    expect(label).toBeTruthy();
-    expect(within(label).getByText('*')).toBeTruthy();
+    expect(screen.getByText(/filters \(optional\)|filtros \(opcionais\)/i)).toBeTruthy();
+    expect(screen.queryByText('*')).toBeNull();
+    expect(screen.queryByText('message_id')).toBeNull();
   });
 
   it('AC3: the optional-field autocomplete lists schema optionals and adds a field on select', async () => {
@@ -169,7 +167,7 @@ describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)'
     const comboboxes = screen.getAllByRole('combobox');
     expect(comboboxes.length).toBeGreaterThan(1);
     await user.click(comboboxes[1]);
-    const option = await screen.findByRole('option', { name: 'status' });
+    const option = within(await screen.findByRole('listbox')).getByText('status');
     expect(option).toBeTruthy();
     await user.click(option);
 
@@ -185,20 +183,24 @@ describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)'
 
     expect(screen.getByText(/custom properties|propriedades personalizadas|propiedades personalizadas|propriétés personnalisées|proprietà personalizzate/i)).toBeTruthy();
     expect(screen.getAllByPlaceholderText(/key|chave|clave|clé|key/i).length).toBeGreaterThan(0);
-    // Custom mode is never schema-blocked.
+    // Custom mode needs a typed name before it is savable (CRM-519).
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    await user.type(screen.getByPlaceholderText(/custom event name|nome do evento custom/i), 'button_clicked');
     expect(onValidityChange).toHaveBeenLastCalledWith(true);
   });
 
-  it('AC6: filling a required field persists an Equals filter-condition array', async () => {
+  it('AC6: filling a filter persists an Equals filter-condition array', async () => {
     const onEventPropertiesChange = vi.fn();
     const user = userEvent.setup();
     render(<Harness onEventPropertiesChange={onEventPropertiesChange} />);
-    await selectEvent(user, /contact created|contato criado/i);
+    await selectEvent(user, /message created|mensagem criada/i);
 
-    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
+    await user.click(screen.getAllByRole('combobox')[1]);
+    await user.click(within(await screen.findByRole('listbox')).getByText('content'));
+    await user.type(screen.getByRole('textbox', { name: /content/i }), 'oi');
 
     const last = onEventPropertiesChange.mock.calls.at(-1)?.[0];
-    expect(last).toEqual([{ path: 'source', operator: { type: 'Equals', value: 'crm' } }]);
+    expect(last).toEqual([{ path: 'content', operator: { type: 'Equals', value: 'oi' } }]);
   });
 
   it('AC7: editing a legacy non-Equals field collapses it to Equals while untouched rows keep their operator', async () => {
@@ -227,22 +229,17 @@ describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)'
     expect(channelType?.operator.value).toBe('wa');
   });
 
-  it('AC2 (validity): reports invalid while a required field is empty and valid once filled', async () => {
+  it('AC2 (validity, CRM-519): reports valid as soon as an event is chosen — filters are optional', async () => {
     const onValidityChange = vi.fn();
     const user = userEvent.setup();
     render(<Harness onValidityChange={onValidityChange} />);
-    await selectEvent(user, /contact created|contato criado/i);
-
-    // contact.created requires id + source; both empty → invalid.
     expect(onValidityChange).toHaveBeenLastCalledWith(false);
 
-    await user.type(screen.getByLabelText(/^id\s*\*?$/i), 'id-1');
-    await user.type(screen.getByLabelText(/^source\s*\*?$/i), 'crm');
-
+    await selectEvent(user, /contact created|contato criado/i);
     expect(onValidityChange).toHaveBeenLastCalledWith(true);
   });
 
-  it('AC4: switching canonical events prompts preserve/clear; Preserve keeps compatible values and drops the rest', async () => {
+  it('AC4 (CRM-519): switching events keeps compatible filters, drops the rest and says so', async () => {
     const onEventPropertiesChange = vi.fn();
     const user = userEvent.setup();
     render(
@@ -260,22 +257,37 @@ describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)'
 
     await selectEvent(user, /conversation created|conversa criada/i);
 
-    // Confirm dialog appears.
-    expect(
-      await screen.findByText(/preserve compatible values|preservar valores compatíveis/i),
-    ).toBeTruthy();
-
-    await user.click(screen.getByRole('button', { name: /preserve compatible|preservar compatíveis/i }));
-
     const last = onEventPropertiesChange.mock.calls.at(-1)?.[0] as EventProperty[];
     const keys = last.map(p => p.path).sort();
     // conversation.created shares conversation_id (uuid), source (string), channel_type (string);
-    // message_id is absent from its schema → dropped.
+    // message_id is absent from its schema → dropped, and the notice says so.
     expect(keys).toEqual(['channel_type', 'conversation_id', 'source']);
-    expect(keys).not.toContain('message_id');
+    expect(screen.getByRole('status').textContent).toMatch(/1 filtro removido|1 filter removed/i);
+    expect(screen.queryByText(/preserve compatible values|preservar valores compatíveis/i)).toBeNull();
   });
 
-  it('AC4: choosing Clear on an event switch resets properties to an empty array', async () => {
+  it('AC4 (CRM-519): no notice when every filter also exists on the new event', async () => {
+    const onEventPropertiesChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        initialEventName="conversation.created"
+        initialEventProperties={[
+          { path: 'inbox_id', operator: { type: 'Equals', value: 'i-1' } },
+        ]}
+        onEventPropertiesChange={onEventPropertiesChange}
+      />,
+    );
+
+    await selectEvent(user, /conversation resolved|conversa resolvida/i);
+
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(onEventPropertiesChange).not.toHaveBeenCalled();
+    expect(screen.getByText('inbox_id')).toBeTruthy();
+  });
+
+  it('M1 (CRM-519): Undo restores the previous event and its filters', async () => {
+    const onEventNameChange = vi.fn();
     const onEventPropertiesChange = vi.fn();
     const user = userEvent.setup();
     render(
@@ -284,38 +296,21 @@ describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)'
         initialEventProperties={[
           { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
         ]}
+        onEventNameChange={onEventNameChange}
         onEventPropertiesChange={onEventPropertiesChange}
       />,
     );
 
     await selectEvent(user, /conversation created|conversa criada/i);
-    await user.click(screen.getByRole('button', { name: /clear all|limpar tudo/i }));
-
     expect(onEventPropertiesChange).toHaveBeenLastCalledWith([]);
-  });
 
-  it('M1: dismissing the event-switch dialog (Esc) defaults to Clear, never stranding old values', async () => {
-    const onEventPropertiesChange = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <Harness
-        initialEventName="message.delivered"
-        initialEventProperties={[
-          { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
-        ]}
-        onEventPropertiesChange={onEventPropertiesChange}
-      />,
-    );
+    await user.click(within(screen.getByRole('status')).getByRole('button', { name: /desfazer|undo/i }));
 
-    await selectEvent(user, /conversation created|conversa criada/i);
-    expect(
-      await screen.findByText(/preserve compatible values|preservar valores compatíveis/i),
-    ).toBeTruthy();
-
-    await user.keyboard('{Escape}');
-
-    // Dismiss must not leave message.delivered's values under conversation.created.
-    expect(onEventPropertiesChange).toHaveBeenLastCalledWith([]);
+    expect(onEventNameChange).toHaveBeenLastCalledWith('message.delivered');
+    expect(onEventPropertiesChange).toHaveBeenLastCalledWith([
+      { path: 'message_id', operator: { type: 'Equals', value: 'm-1' } },
+    ]);
+    expect(screen.queryByRole('status')).toBeNull();
   });
 
   it('M2: an optional field that already holds a value is shown on open (not hidden behind the picker)', () => {
@@ -342,8 +337,11 @@ describe('EventConfiguration — schema-driven Event Properties form (EVO-1275)'
     // No event chosen yet → invalid (Save must not be enabled by an empty config).
     expect(onValidityChange).toHaveBeenLastCalledWith(false);
 
-    // Custom event has no required fields → valid once selected.
+    // A canonical event is valid as soon as it is chosen (CRM-519); custom
+    // still waits for its name.
     await selectEvent(user, /custom event|evento personalizado/i);
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    await user.type(screen.getByPlaceholderText(/custom event name|nome do evento custom/i), 'x');
     expect(onValidityChange).toHaveBeenLastCalledWith(true);
   });
 });

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -9,8 +9,8 @@ interface EventConfigurationProps {
   onEventNameChange: (name: string) => void;
   onEventPropertiesChange: (properties: EventProperty[]) => void;
   // Optional: only the Flow Builder (JourneyTriggerPanel) gates Save on this.
-  // Campaigns/Wait omit it and rely on the inline required-field indicators
-  // <EventPropertiesForm> renders. See EVO-1275.
+  // A config is savable as soon as an event is chosen — filters are optional
+  // (CRM-519). See EVO-1275.
   onValidityChange?: (valid: boolean) => void;
   variableMappings?: DataMapping[];
   onVariableMappingsChange?: (mappings: DataMapping[]) => void;

--- a/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/EventConfiguration.tsx
@@ -25,10 +25,7 @@ interface EventConfigurationProps {
  * halves into one stacked block. The Flow Builder's tabbed layout (EVO-1276)
  * consumes <EventBasicConfig> / <EventAdvancedConfig> directly per tab; the
  * Campaigns/Wait (section="all") contexts keep using THIS composed component, so
- * its public signature and visible layout are preserved. (One source-order nuance:
- * the event-switch <AlertDialog> now lives inside EventBasicConfig, so it sits
- * before the Avançado block in the tree — but it is portal-rendered and inert
- * when closed, so the rendered output is unchanged.) The Avançado half renders
+ * its public signature and visible layout are preserved. The Avançado half renders
  * only when `onVariableMappingsChange` is provided.
  */
 export function EventConfiguration({

--- a/src/components/journey/nodes/trigger/components/TriggerDescription.tsx
+++ b/src/components/journey/nodes/trigger/components/TriggerDescription.tsx
@@ -32,8 +32,6 @@ export function TriggerDescription({ triggerType }: TriggerDescriptionProps) {
   };
 
   return (
-    <div className="p-4 rounded-lg bg-sidebar-accent/20 border border-sidebar-border/50">
-      <p className="text-sm text-sidebar-foreground/70">{getDescription()}</p>
-    </div>
+    <p className="text-sm text-sidebar-foreground/70">{getDescription()}</p>
   );
 }

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
@@ -1,9 +1,44 @@
 import { useState } from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EventPropertiesForm, type EventPropertiesValue } from './EventPropertiesForm';
 import i18n from '@/i18n/config';
+
+vi.mock('@/services/pipelines/pipelinesService', () => ({
+  pipelinesService: { getPipelines: vi.fn(), getPipelineStages: vi.fn() },
+}));
+vi.mock('@/services/channels/inboxesService', () => ({
+  default: { list: vi.fn() },
+}));
+vi.mock('@/services/contacts/labelsService', () => ({
+  labelsService: { getLabels: vi.fn() },
+}));
+vi.mock('@/services/users/usersService', () => ({
+  default: { getUsers: vi.fn() },
+}));
+vi.mock('@/services/campaigns/campaignsService', () => ({
+  campaignsService: { getCampaigns: vi.fn() },
+}));
+vi.mock('@/services/messageTemplates/globalMessageTemplatesService', () => ({
+  default: { getTemplates: vi.fn() },
+}));
+
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import InboxesService from '@/services/channels/inboxesService';
+
+const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
+const mockGetStages = pipelinesService.getPipelineStages as unknown as ReturnType<typeof vi.fn>;
+const mockListInboxes = InboxesService.list as unknown as ReturnType<typeof vi.fn>;
+
+const INBOXES = {
+  data: [
+    { id: 'i1', name: 'WhatsApp Vendas', channel_type: 'Channel::Whatsapp' },
+    { id: 'i2', name: 'Insta Suporte', channel_type: 'Channel::Instagram' },
+  ],
+};
+
+const e = (key: string) => i18n.t(`events:${key}`);
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -20,6 +55,16 @@ function Harness({ eventName, initial = {} }: { eventName: string; initial?: Eve
   );
 }
 
+function persisted(): Record<string, unknown> {
+  return JSON.parse(screen.getByTestId('value').textContent ?? '{}');
+}
+
+async function openPicker(user: ReturnType<typeof userEvent.setup>) {
+  // A combobox takes no name from content: locate the picker by its label text.
+  await user.click(screen.getByText(e('propertiesForm.addFieldLabel')));
+  return screen.findByRole('listbox');
+}
+
 describe('EventPropertiesForm', () => {
   it('returns null for an unknown event name', () => {
     const { container } = render(
@@ -28,52 +73,193 @@ describe('EventPropertiesForm', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  // AC5: message.delivered shows message_id + channel_type + conversation_id + source as required
-  it('renders required fields for message.delivered (AC5)', () => {
-    render(<Harness eventName="message.delivered" />);
-    // Each required field renders as a label with the field name and a "*" suffix.
-    expect(screen.getByText('message_id')).toBeTruthy();
-    expect(screen.getByText('channel_type')).toBeTruthy();
-    expect(screen.getByText('conversation_id')).toBeTruthy();
-    expect(screen.getByText('source')).toBeTruthy();
-  });
-
-  it('exposes optional fields behind a single picker (collapsed by default)', () => {
-    render(<Harness eventName="message.delivered" />);
-    // Optional field names should NOT be rendered yet; they should be inside the picker (combobox role).
-    expect(screen.queryByText('previous_status')).toBeNull();
-    expect(screen.queryByText('external_error')).toBeNull();
-  });
-
-  it('reveals an optional field on selection from the picker', async () => {
+  // CRM-519: a catalog "required" key is what the producer always sends, not
+  // what the user must type. Nothing is required; ids of the event itself are
+  // not even offered.
+  it('offers schema keys as optional filters and never asks for the event ids', async () => {
     const user = userEvent.setup();
-    render(<Harness eventName="message.delivered" />);
+    render(<Harness eventName="campaign.triggered" />);
 
-    // The picker is a Select with the i18n "Add field" placeholder.
-    const picker = screen.getByRole('combobox');
-    await user.click(picker);
-    const listbox = await screen.findByRole('listbox');
-    await user.click(within(listbox).getByText('previous_status'));
+    expect(screen.queryByText('*')).toBeNull();
+    expect(screen.queryByText('pipeline_item_id')).toBeNull();
+    expect(screen.queryByText('contact_id')).toBeNull();
+    expect(screen.getByText(e('propertiesForm.filtersHint'))).toBeTruthy();
 
-    expect(screen.getByText('previous_status')).toBeTruthy();
+    const listbox = await openPicker(user);
+    for (const key of ['pipeline_id', 'pipeline_stage_id', 'is_lead', 'assigned_by_id']) {
+      expect(within(listbox).getByText(key)).toBeTruthy();
+    }
+    // Identity of the event itself, producer bookkeeping, raw dumps and the
+    // display names that duplicate an id with a select are not filters.
+    for (const key of [
+      'pipeline_item_id',
+      'contact_id',
+      'conversation_id',
+      'source',
+      'custom_fields',
+      'pipeline_name',
+      'pipeline_stage_name',
+    ]) {
+      expect(within(listbox).queryByText(key)).toBeNull();
+    }
   });
 
-  it('writes the user input into value via onChange', async () => {
+  it('hides conversation_id and message_id for conversation and message events', async () => {
     const user = userEvent.setup();
-    render(<Harness eventName="message.delivered" />);
+    render(<Harness eventName="conversation.created" />);
+    expect(screen.queryByText('conversation_id')).toBeNull();
 
-    const input = screen.getByLabelText(/^message_id/);
-    await user.type(input, 'msg-uuid-1');
-
-    const persisted = JSON.parse(screen.getByTestId('value').textContent ?? '{}');
-    expect(persisted.message_id).toBe('msg-uuid-1');
+    const listbox = await openPicker(user);
+    expect(within(listbox).getByText('inbox_id')).toBeTruthy();
+    expect(within(listbox).queryByText('conversation_id')).toBeNull();
   });
 
-  it('flags required-missing visually when a required field is empty', () => {
-    render(<Harness eventName="message.delivered" />);
-    // All required fields start empty in the harness -> warnings render.
-    const warnings = screen.getAllByText(/Required field|Campo obrigatório/i);
-    expect(warnings.length).toBeGreaterThanOrEqual(4);
+  it('shows the human label with the raw key and a help line for a translated field', async () => {
+    const user = userEvent.setup();
+    render(<Harness eventName="conversation.created" />);
+
+    const listbox = await openPicker(user);
+    expect(within(listbox).getByText(e('fields.inbox_id.label'))).toBeTruthy();
+    await user.click(within(listbox).getByText('inbox_id'));
+
+    expect(screen.getByText(e('fields.inbox_id.label'))).toBeTruthy();
+    expect(screen.getByText('inbox_id')).toBeTruthy();
+    expect(screen.getByText(e('fields.inbox_id.help'))).toBeTruthy();
+  });
+
+  it('adds a filter from the picker, writes the typed value and removes it again', async () => {
+    const user = userEvent.setup();
+    render(<Harness eventName="message.created" />);
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('content'));
+    await user.type(screen.getByRole('textbox', { name: /content/ }), 'oi');
+    expect(persisted().content).toBe('oi');
+
+    await user.click(
+      screen.getByRole('button', { name: `${e('propertiesForm.removeFilterAriaLabel')} content` }),
+    );
+    expect(persisted()).toEqual({});
+    expect(screen.queryByText('content')).toBeNull();
+  });
+
+  it('renders a closed-set key as a select with translated option labels', async () => {
+    const user = userEvent.setup();
+    render(<Harness eventName="message.created" />);
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('message_type'));
+
+    await user.click(screen.getByTestId('enum-message_type'));
+    const options = await screen.findByRole('listbox');
+    expect(within(options).getByText(e('fields.message_type.options.incoming'))).toBeTruthy();
+    await user.click(within(options).getByText(e('fields.message_type.options.outgoing')));
+    expect(persisted().message_type).toBe('outgoing');
+  });
+
+  it('hides timestamps and objects from the contact events and labels the contact fields', async () => {
+    const user = userEvent.setup();
+    render(<Harness eventName="contact.created" />);
+
+    const listbox = await openPicker(user);
+    for (const key of ['created_at', 'updated_at', 'customAttributes', 'additionalAttributes', 'id']) {
+      expect(within(listbox).queryByText(key)).toBeNull();
+    }
+    expect(within(listbox).getByText(e('fields.email.label'))).toBeTruthy();
+    expect(within(listbox).getByText(e('fields.phone_number.label'))).toBeTruthy();
+  });
+
+  it('renders pipeline_id as a select fed by the pipelines list', async () => {
+    mockGetPipelines.mockResolvedValueOnce({ data: [{ id: 'p1', name: 'Vendas' }, { id: 'p2', name: 'Suporte' }] });
+    const user = userEvent.setup();
+    render(<Harness eventName="campaign.triggered" />);
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('pipeline_id'));
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+
+    await user.click(screen.getByTestId('lookup-pipeline'));
+    const options = await screen.findByRole('listbox');
+    await user.click(within(options).getByText('Vendas'));
+    expect(persisted().pipeline_id).toBe('p1');
+  });
+
+  it('keeps the stage select disabled until a pipeline filter is chosen, then loads its stages', async () => {
+    mockGetPipelines.mockResolvedValue({ data: [{ id: 'p1', name: 'Vendas' }] });
+    mockGetStages.mockResolvedValue({ data: [{ id: 's1', name: 'Novo' }] });
+    const user = userEvent.setup();
+    render(<Harness eventName="campaign.triggered" initial={{ pipeline_stage_id: '' }} />);
+
+    // No pipeline yet: the stage select says so and is disabled.
+    const stage = screen.getByTestId('lookup-pipeline_stage');
+    expect(stage).toHaveProperty('disabled', true);
+    expect(within(stage).getByText(e('propertiesForm.lookupNeedsPipeline'))).toBeTruthy();
+    expect(mockGetStages).not.toHaveBeenCalled();
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('pipeline_id'));
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalled());
+    await user.click(screen.getByTestId('lookup-pipeline'));
+    await user.click(within(await screen.findByRole('listbox')).getByText('Vendas'));
+
+    await waitFor(() => expect(mockGetStages).toHaveBeenCalledWith('p1'));
+    await waitFor(() => expect(screen.getByTestId('lookup-pipeline_stage')).toHaveProperty('disabled', false));
+  });
+
+  // CRM-519 item 10: an inbox and its channel type are one filter, not two.
+  describe('inbox_id × channel_type', () => {
+    it('narrows the channel list to the chosen channel type', async () => {
+      mockListInboxes.mockResolvedValue(INBOXES);
+      const user = userEvent.setup();
+      render(<Harness eventName="conversation.created" initial={{ channel_type: 'Channel::Instagram' }} />);
+
+      const listbox = await openPicker(user);
+      await user.click(within(listbox).getByText('inbox_id'));
+      await waitFor(() => expect(mockListInboxes).toHaveBeenCalled());
+
+      await user.click(screen.getByTestId('lookup-inbox'));
+      const options = await screen.findByRole('listbox');
+      expect(within(options).getByText('Insta Suporte')).toBeTruthy();
+      expect(within(options).queryByText('WhatsApp Vendas')).toBeNull();
+    });
+
+    it('stops offering channel_type once an inbox is chosen', async () => {
+      mockListInboxes.mockResolvedValue(INBOXES);
+      const user = userEvent.setup();
+      // conversation.resolved still has other keys to offer, so the picker renders.
+      render(<Harness eventName="conversation.resolved" initial={{ inbox_id: 'i1' }} />);
+
+      const listbox = await openPicker(user);
+      expect(within(listbox).getByText('resolved_by_type')).toBeTruthy();
+      expect(within(listbox).queryByText('channel_type')).toBeNull();
+    });
+
+    it('flags a legacy pair that contradicts itself and keeps the remove button', async () => {
+      mockListInboxes.mockResolvedValue(INBOXES);
+      render(
+        <Harness
+          eventName="conversation.created"
+          initial={{ inbox_id: 'i1', channel_type: 'Channel::Instagram' }}
+        />,
+      );
+
+      const alert = await screen.findByRole('alert');
+      expect(alert.textContent).toContain(e('fields.channel_type.options.Channel__Whatsapp'));
+      expect(
+        screen.getByRole('button', { name: `${e('propertiesForm.removeFilterAriaLabel')} channel_type` }),
+      ).toBeTruthy();
+    });
+  });
+
+  it('still shows a persisted legacy id filter so it can be removed', async () => {
+    const user = userEvent.setup();
+    render(<Harness eventName="message.delivered" initial={{ message_id: 'm-1' }} />);
+
+    expect(screen.getByLabelText(/^message_id$/)).toHaveProperty('value', 'm-1');
+    await user.click(
+      screen.getByRole('button', { name: `${e('propertiesForm.removeFilterAriaLabel')} message_id` }),
+    );
+    expect(persisted()).toEqual({});
   });
 
   // AC4: custom event -> free key/value editor
@@ -90,8 +276,7 @@ describe('EventPropertiesForm', () => {
     await user.type(screen.getByPlaceholderText(/^key|^chave/i), 'env');
     await user.type(screen.getByPlaceholderText(/^value|^valor/i), 'staging');
 
-    const persisted = JSON.parse(screen.getByTestId('value').textContent ?? '{}');
-    expect(persisted.env).toBe('staging');
+    expect(persisted().env).toBe('staging');
   });
 
   it('seeds the custom editor with existing value entries', () => {
@@ -101,9 +286,9 @@ describe('EventPropertiesForm', () => {
     expect(keys[1]).toHaveProperty('value', 'user_id');
   });
 
-  // F1: switching eventName drops revealed optional fields that don't exist in
-  // the new schema, so SchemaField never receives spec=undefined.
-  it('does not crash when eventName switches away from a schema with revealed optionals', async () => {
+  // F1: switching eventName drops revealed filters that don't exist in the
+  // new schema, so FilterRow never receives spec=undefined.
+  it('does not crash when eventName switches away from a schema with revealed filters', async () => {
     const user = userEvent.setup();
     function Switcher() {
       const [eventName, setEventName] = useState('message.delivered');
@@ -117,34 +302,25 @@ describe('EventPropertiesForm', () => {
     }
     render(<Switcher />);
 
-    // Reveal an optional field on message.delivered
-    const picker = screen.getByRole('combobox');
-    await user.click(picker);
-    const listbox = await screen.findByRole('listbox');
+    const listbox = await openPicker(user);
     await user.click(within(listbox).getByText('previous_status'));
     expect(screen.getByText('previous_status')).toBeTruthy();
 
-    // Switch eventName; previous_status is not in contact.created's schema —
-    // must NOT throw and must NOT render previous_status anymore.
     await user.click(screen.getByText('switch'));
     expect(screen.queryByText('previous_status')).toBeNull();
-    // contact.created shows its own required fields
-    expect(screen.getByText('id')).toBeTruthy();
+    expect(screen.getByText(e('propertiesForm.addFieldLabel'))).toBeTruthy();
   });
 });
 
 describe('EventPropertiesForm — section labels name a group (CRM-141)', () => {
-  const e = (key: string) => i18n.t(`events:${key}`);
-
-  it('names the schema-driven sections as groups', () => {
+  it('names the filters section as a group', async () => {
+    const user = userEvent.setup();
     render(<Harness eventName="message.delivered" />);
 
-    const required = screen.getByRole('group', { name: e('propertiesForm.requiredSectionLabel') });
-    expect(within(required).getByText('message_id')).toBeTruthy();
-
-    expect(
-      screen.getByRole('group', { name: e('propertiesForm.optionalSectionLabel') }),
-    ).toBeTruthy();
+    const group = screen.getByRole('group', { name: e('propertiesForm.optionalSectionLabel') });
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('previous_status'));
+    expect(within(group).getByText('previous_status')).toBeTruthy();
   });
 
   it('names the custom key/value editor as a group and keeps its id per instance', () => {
@@ -157,9 +333,7 @@ describe('EventPropertiesForm — section labels name a group (CRM-141)', () => 
 
     const groups = screen.getAllByRole('group', { name: e('propertiesForm.customSectionLabel') });
     expect(groups).toHaveLength(2);
-    // Two editors on screen must not share the label id, or the second group
-    // would borrow the first one's name.
-    const [first, second] = groups.map(g => g.getAttribute('aria-labelledby'));
-    expect(first).not.toBe(second);
+    const ids = groups.map((g) => g.getAttribute('aria-labelledby'));
+    expect(ids[0]).not.toBe(ids[1]);
   });
 });

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
@@ -251,6 +251,51 @@ describe('EventPropertiesForm', () => {
     });
   });
 
+  // The event the card names as blocked: purchase.approved (CRM-316).
+  describe('purchase.approved', () => {
+    it('offers the purchase fields as filters and hides the ids of the purchase and the card', async () => {
+      const user = userEvent.setup();
+      render(<Harness eventName="purchase.approved" />);
+
+      expect(screen.queryByText('*')).toBeNull();
+      const listbox = await openPicker(user);
+      for (const key of ['provider', 'product', 'amount', 'currency', 'outcome', 'new_contact', 'pipeline_id']) {
+        expect(within(listbox).getByText(key)).toBeTruthy();
+      }
+      for (const key of ['purchase_id', 'pipeline_item_id', 'contact_id', 'source']) {
+        expect(within(listbox).queryByText(key)).toBeNull();
+      }
+    });
+
+    it('keeps product as free text (the platform string, not a CRM product) and amount numeric', async () => {
+      const user = userEvent.setup();
+      render(<Harness eventName="purchase.approved" />);
+
+      let listbox = await openPicker(user);
+      await user.click(within(listbox).getByText('product'));
+      await user.type(screen.getByRole('textbox', { name: /product/ }), 'Curso X');
+      expect(persisted().product).toBe('Curso X');
+
+      listbox = await openPicker(user);
+      await user.click(within(listbox).getByText('amount'));
+      await user.type(screen.getByRole('spinbutton', { name: /amount/ }), '197.5');
+      expect(persisted().amount).toBe(197.5);
+    });
+
+    it('renders outcome as a select with the two CRM outcomes', async () => {
+      const user = userEvent.setup();
+      render(<Harness eventName="purchase.approved" />);
+
+      const listbox = await openPicker(user);
+      await user.click(within(listbox).getByText('outcome'));
+      await user.click(screen.getByTestId('enum-outcome'));
+      const options = await screen.findByRole('listbox');
+      expect(within(options).getByText(e('fields.outcome.options.created'))).toBeTruthy();
+      await user.click(within(options).getByText(e('fields.outcome.options.already_in_pipeline')));
+      expect(persisted().outcome).toBe('already_in_pipeline');
+    });
+  });
+
   it('still shows a persisted legacy id filter so it can be removed', async () => {
     const user = userEvent.setup();
     render(<Harness eventName="message.delivered" initial={{ message_id: 'm-1' }} />);

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
@@ -26,10 +26,15 @@ vi.mock('@/services/messageTemplates/globalMessageTemplatesService', () => ({
 
 import { pipelinesService } from '@/services/pipelines/pipelinesService';
 import InboxesService from '@/services/channels/inboxesService';
+import { labelsService } from '@/services/contacts/labelsService';
+import UsersService from '@/services/users/usersService';
+import { campaignsService } from '@/services/campaigns/campaignsService';
+import GlobalMessageTemplateService from '@/services/messageTemplates/globalMessageTemplatesService';
 
-const mockGetPipelines = pipelinesService.getPipelines as unknown as ReturnType<typeof vi.fn>;
-const mockGetStages = pipelinesService.getPipelineStages as unknown as ReturnType<typeof vi.fn>;
-const mockListInboxes = InboxesService.list as unknown as ReturnType<typeof vi.fn>;
+const asMock = (fn: unknown) => fn as unknown as ReturnType<typeof vi.fn>;
+const mockGetPipelines = asMock(pipelinesService.getPipelines);
+const mockGetStages = asMock(pipelinesService.getPipelineStages);
+const mockListInboxes = asMock(InboxesService.list);
 
 const INBOXES = {
   data: [
@@ -380,5 +385,49 @@ describe('EventPropertiesForm — section labels name a group (CRM-141)', () => 
     expect(groups).toHaveLength(2);
     const ids = groups.map((g) => g.getAttribute('aria-labelledby'));
     expect(ids[0]).not.toBe(ids[1]);
+  });
+});
+
+// CRM-519 review: a lookup that asks for the default page silently drops every
+// record past it (20 in the CRM, 25 in evo-flow) — the dropdown looks complete
+// and is not. Pin the page size each lookup sends.
+describe('EventPropertiesForm — lookup page sizes', () => {
+  const cases: Array<[string, string, () => ReturnType<typeof vi.fn>, unknown]> = [
+    ['conversation.created', 'inbox_id', () => asMock(InboxesService.list), { per_page: 200 }],
+    ['contact.label.added', 'labelId', () => asMock(labelsService.getLabels), { per_page: 200 }],
+    // The auth service caps page_size at MAX_PAGE_SIZE = 100.
+    ['campaign.triggered', 'assigned_by_id', () => asMock(UsersService.getUsers), { per_page: 100 }],
+    // evo-flow's CampaignQueryDto rejects anything over 100.
+    ['campaign.message.sent', 'campaign_id', () => asMock(campaignsService.getCampaigns), { per_page: 100 }],
+    // message_templates has an explicit unpaginated branch for -1.
+    [
+      'campaign.message.sent',
+      'template_id',
+      () => asMock(GlobalMessageTemplateService.getTemplates),
+      { per_page: -1 },
+    ],
+  ];
+
+  it.each(cases)('%s → %s asks for a full page', async (eventName, key, getMock, expected) => {
+    const mock = getMock();
+    mock.mockResolvedValue({ data: [] });
+    const user = userEvent.setup();
+    render(<Harness eventName={eventName} />);
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText(key));
+
+    await waitFor(() => expect(mock).toHaveBeenCalledWith(expected));
+  });
+
+  it('asks the pipeline endpoints for nothing — they do not paginate', async () => {
+    mockGetPipelines.mockResolvedValue({ data: [] });
+    const user = userEvent.setup();
+    render(<Harness eventName="purchase.approved" />);
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('pipeline_id'));
+
+    await waitFor(() => expect(mockGetPipelines).toHaveBeenCalledWith());
   });
 });

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.stories.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof EventPropertiesForm> = {
     docs: {
       description: {
         component:
-          'Schema-aware form for canonical event payloads. Renders required fields by spec.type, hides optional behind a picker, and switches to a free key/value editor when `eventName=custom`. Foundation for the EVO-1275 (10.7) Event Properties refactor.',
+          'Schema-aware form for canonical event payloads. Every schema key is an optional filter behind a picker (ids of the event itself are not offered), rendered by spec.type — CRM record ids as selects —, and switches to a free key/value editor when `eventName=custom`. Foundation for the EVO-1275 (10.7) Event Properties refactor.',
       },
     },
   },

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -1,5 +1,5 @@
 import { useId, useMemo, useState, useEffect } from 'react';
-import { Plus, X, AlertTriangle, ChevronsUpDown } from 'lucide-react';
+import { Plus, X, ChevronsUpDown } from 'lucide-react';
 import {
   Button,
   Checkbox,
@@ -14,10 +14,29 @@ import {
   Popover,
   PopoverContent,
   PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from '@evoapi/design-system';
 import { cn } from '@/lib/utils';
 import { getEvent, isCustomEvent, type FieldSpec } from '@/lib/events-manifest';
 import { useLanguage } from '@/hooks/useLanguage';
+import { pipelinesService } from '@/services/pipelines/pipelinesService';
+import InboxesService from '@/services/channels/inboxesService';
+import { labelsService } from '@/services/contacts/labelsService';
+import UsersService from '@/services/users/usersService';
+import { campaignsService } from '@/services/campaigns/campaignsService';
+import GlobalMessageTemplateService from '@/services/messageTemplates/globalMessageTemplatesService';
+import {
+  LOOKUP_FIELDS,
+  PAIRED_TYPE_FIELDS,
+  filterableFields,
+  optionLabelKey,
+  schemaFields,
+  type LookupKind,
+} from './filterFields';
 
 export type EventPropertiesValue = Record<string, unknown>;
 
@@ -38,6 +57,12 @@ export function EventPropertiesForm({
 }: EventPropertiesFormProps) {
   const { t } = useLanguage('events');
   const entry = getEvent(eventName);
+  // Per-field copy lives in events.json `fields.<key>`; a key without a
+  // translation falls back to the raw name (and the catalog description).
+  const fieldLabel = (field: string) => t(`fields.${field}.label`, { defaultValue: field });
+  // No English fallback to the catalog description: a missing help line is a
+  // gap the filterFields contract spec reports, not something to paper over.
+  const fieldHelp = (field: string) => t(`fields.${field}.help`, { defaultValue: '' });
   const isCustom = isCustomEvent(eventName);
 
   if (!entry) {
@@ -57,70 +82,99 @@ export function EventPropertiesForm({
   }
 
   return (
-    <SchemaDrivenFields
-      requiredFields={entry.schema.required}
-      optionalFields={entry.schema.optional}
+    <FilterFields
+      allFields={schemaFields(entry)}
+      offeredFields={filterableFields(entry)}
       value={value}
       onChange={onChange}
       disabled={disabled}
       className={className}
       t={t}
+      fieldLabel={fieldLabel}
+      fieldHelp={fieldHelp}
     />
   );
 }
 
-function SchemaDrivenFields({
-  requiredFields,
-  optionalFields,
+// CRM-519: every schema key is an optional equality filter — there is no
+// "required" section. `offeredFields` is what the picker lists; `allFields`
+// also covers identity keys so a persisted legacy row still renders (and can
+// be removed) even though it is no longer offered.
+function FilterFields({
+  allFields,
+  offeredFields,
   value,
   onChange,
   disabled,
   className,
   t,
+  fieldLabel,
+  fieldHelp,
 }: {
-  requiredFields: Record<string, FieldSpec>;
-  optionalFields: Record<string, FieldSpec>;
+  allFields: Record<string, FieldSpec>;
+  offeredFields: Record<string, FieldSpec>;
   value: EventPropertiesValue;
   onChange: (next: EventPropertiesValue) => void;
   disabled?: boolean;
   className?: string;
-  t: (key: string) => string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  fieldLabel: (field: string) => string;
+  fieldHelp: (field: string) => string;
 }) {
-  // EVO-1275: seed from any optional fields that already carry a value, so a
+  // EVO-1275: seed from any field that already carries a value, so a
   // reopened node (or values preserved across an event switch) renders them
-  // instead of hiding persisted data behind the "+ Add field" picker.
-  const [shownOptional, setShownOptional] = useState<string[]>(
-    () => Object.keys(value).filter((field) => field in optionalFields),
+  // instead of hiding persisted data behind the "+ Add filter" picker.
+  const [shown, setShown] = useState<string[]>(() =>
+    Object.keys(value).filter((field) => field in allFields),
   );
 
-  // F1 fix: when eventName changes upstream, optionalFields changes synchronously
-  // but shownOptional state lingers. Compute the filtered set at render time
-  // so a stale entry never reaches SchemaField as spec=undefined. The useEffect
-  // below prunes the stored state on next tick for tidiness.
-  const visibleOptional = useMemo(
-    () => shownOptional.filter((field) => field in optionalFields),
-    [shownOptional, optionalFields],
+  // F1 fix: when eventName changes upstream, allFields changes synchronously
+  // but `shown` lingers. Filter at render time so a stale entry never reaches
+  // FilterRow with spec=undefined; the effect below prunes the state.
+  const visible = useMemo(
+    () => shown.filter((field) => field in allFields),
+    [shown, allFields],
   );
 
-  // Prune entries that no longer belong to the current schema AND surface any
-  // optional field that has a value (e.g. preserved across an event switch).
-  // Returns the previous array unchanged when nothing differs, so a fresh
-  // `value` object reference with identical content can't cause a render loop.
   useEffect(() => {
-    setShownOptional((prev) => {
-      const pruned = prev.filter((field) => field in optionalFields);
+    setShown((prev) => {
+      const pruned = prev.filter((field) => field in allFields);
       const withValues = Object.keys(value).filter(
-        (field) => field in optionalFields && !pruned.includes(field),
+        (field) => field in allFields && !pruned.includes(field),
       );
       if (withValues.length === 0 && pruned.length === prev.length) return prev;
       return [...pruned, ...withValues];
     });
-  }, [optionalFields, value]);
+  }, [allFields, value]);
 
-  const optionalKeysAvailable = useMemo(
-    () => Object.keys(optionalFields).filter((k) => !visibleOptional.includes(k)),
-    [optionalFields, visibleOptional],
+  const impliedTypeFields = useMemo(
+    () =>
+      Object.entries(PAIRED_TYPE_FIELDS)
+        .filter(([idField]) => value[idField] !== undefined && value[idField] !== '')
+        .map(([, typeField]) => typeField),
+    [value],
   );
+
+  const available = useMemo(
+    () =>
+      Object.keys(offeredFields).filter(
+        (k) => !visible.includes(k) && !impliedTypeFields.includes(k),
+      ),
+    [offeredFields, visible, impliedTypeFields],
+  );
+
+  // Types of the loaded lookup options (inbox id -> channel type), so a type
+  // filter that contradicts the chosen id can be flagged.
+  const [optionTypes, setOptionTypes] = useState<Record<string, string>>({});
+  const conflictFor = (field: string): string | undefined => {
+    const idField = Object.entries(PAIRED_TYPE_FIELDS).find(([, typeField]) => typeField === field)?.[0];
+    if (!idField) return undefined;
+    const id = value[idField];
+    const own = value[field];
+    if (typeof id !== 'string' || !id || typeof own !== 'string' || !own) return undefined;
+    const actual = optionTypes[id];
+    return actual && actual !== own ? actual : undefined;
+  };
 
   const handleFieldChange = (field: string, raw: unknown) => {
     const next = { ...value };
@@ -132,114 +186,319 @@ function SchemaDrivenFields({
     onChange(next);
   };
 
-  const handleAddOptional = (field: string) => {
-    setShownOptional((prev) => [...prev, field]);
+  const handleRemove = (field: string) => {
+    setShown((prev) => prev.filter((f) => f !== field));
+    if (field in value) {
+      const next = { ...value };
+      delete next[field];
+      onChange(next);
+    }
   };
 
-  return (
-    <div className={cn('space-y-4', className)}>
-      {Object.keys(requiredFields).length > 0 && (
-        <FieldSection title={t('propertiesForm.requiredSectionLabel')}>
-          {Object.entries(requiredFields).map(([field, spec]) => (
-            <SchemaField
-              key={field}
-              field={field}
-              spec={spec}
-              required
-              value={value[field]}
-              onChange={(raw) => handleFieldChange(field, raw)}
-              disabled={disabled}
-              t={t}
-            />
-          ))}
-        </FieldSection>
-      )}
-
-      {(visibleOptional.length > 0 || optionalKeysAvailable.length > 0) && (
-        <FieldSection title={t('propertiesForm.optionalSectionLabel')}>
-          {visibleOptional.map((field) => (
-            <SchemaField
-              key={field}
-              field={field}
-              spec={optionalFields[field]}
-              required={false}
-              value={value[field]}
-              onChange={(raw) => handleFieldChange(field, raw)}
-              disabled={disabled}
-              t={t}
-            />
-          ))}
-
-          {optionalKeysAvailable.length > 0 && (
-            <OptionalFieldPicker
-              fields={optionalKeysAvailable}
-              onAdd={handleAddOptional}
-              disabled={disabled}
-              label={t('propertiesForm.addFieldLabel')}
-              searchPlaceholder={t('propertiesForm.addFieldSearchPlaceholder')}
-              noResultsLabel={t('propertiesForm.noResultsLabel')}
-            />
-          )}
-        </FieldSection>
-      )}
-    </div>
-  );
-}
-
-function FieldSection({ title, children }: { title: string; children: React.ReactNode }) {
   const labelId = useId();
+
   return (
-    <div className="space-y-3">
+    <div className={cn('space-y-3', className)}>
       <Label id={labelId} className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
-        {title}
+        {t('propertiesForm.optionalSectionLabel')}
       </Label>
+      <p className="text-xs text-muted-foreground">{t('propertiesForm.filtersHint')}</p>
       <div className="space-y-2" role="group" aria-labelledby={labelId}>
-        {children}
+        {visible.map((field) => (
+          <FilterRow
+            key={field}
+            field={field}
+            spec={allFields[field]}
+            value={value[field]}
+            pipelineId={typeof value.pipeline_id === 'string' ? value.pipeline_id : undefined}
+            filterType={
+              PAIRED_TYPE_FIELDS[field] && typeof value[PAIRED_TYPE_FIELDS[field]] === 'string'
+                ? (value[PAIRED_TYPE_FIELDS[field]] as string)
+                : undefined
+            }
+            conflictType={conflictFor(field)}
+            onOptionsLoaded={(loaded) =>
+              setOptionTypes((prev) => {
+                const next = { ...prev };
+                for (const o of loaded) if (o.type) next[o.id] = o.type;
+                return next;
+              })
+            }
+            onChange={(raw) => handleFieldChange(field, raw)}
+            onRemove={() => handleRemove(field)}
+            disabled={disabled}
+            t={t}
+            label={fieldLabel(field)}
+            help={fieldHelp(field)}
+          />
+        ))}
+
+        {available.length > 0 && (
+          <FilterPicker
+            fields={available}
+            fieldLabel={fieldLabel}
+            onAdd={(field) => setShown((prev) => [...prev, field])}
+            disabled={disabled}
+            label={t('propertiesForm.addFieldLabel')}
+            searchPlaceholder={t('propertiesForm.addFieldSearchPlaceholder')}
+            noResultsLabel={t('propertiesForm.noResultsLabel')}
+          />
+        )}
       </div>
     </div>
   );
 }
 
-function SchemaField({
+function FilterRow({
   field,
   spec,
-  required,
+  value,
+  pipelineId,
+  filterType,
+  conflictType,
+  onOptionsLoaded,
+  onChange,
+  onRemove,
+  disabled,
+  t,
+  label,
+  help,
+}: {
+  field: string;
+  spec: FieldSpec;
+  value: unknown;
+  pipelineId?: string;
+  filterType?: string;
+  conflictType?: string;
+  onOptionsLoaded?: (options: LookupOption[]) => void;
+  onChange: (raw: unknown) => void;
+  onRemove: () => void;
+  disabled?: boolean;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+  label: string;
+  help: string;
+}) {
+  const id = useId();
+  const lookup = LOOKUP_FIELDS[field];
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-2">
+        <Label htmlFor={id} className="text-sm">
+          {label}
+          {label !== field && (
+            <span className="ml-1.5 font-mono text-xs font-normal text-muted-foreground">{field}</span>
+          )}
+        </Label>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label={`${t('propertiesForm.removeFilterAriaLabel')} ${field}`}
+        >
+          <X className="h-3.5 w-3.5" aria-hidden="true" />
+        </Button>
+      </div>
+      {lookup ? (
+        <LookupSelect
+          id={id}
+          kind={lookup}
+          value={typeof value === 'string' ? value : ''}
+          pipelineId={pipelineId}
+          filterType={filterType}
+          onOptionsLoaded={onOptionsLoaded}
+          onChange={onChange}
+          disabled={disabled}
+          t={t}
+        />
+      ) : spec.options ? (
+        <EnumSelect
+          id={id}
+          field={field}
+          options={spec.options}
+          value={typeof value === 'string' ? value : ''}
+          onChange={onChange}
+          disabled={disabled}
+          t={t}
+        />
+      ) : (
+        <FieldInput id={id} spec={spec} value={value} onChange={onChange} disabled={disabled} />
+      )}
+      {help && <p className="text-xs text-muted-foreground">{help}</p>}
+      {conflictType && (
+        <p role="alert" className="text-xs text-destructive">
+          {t('propertiesForm.pairConflict', {
+            actual: t(optionLabelKey(field, conflictType), { defaultValue: conflictType }),
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface LookupOption {
+  id: string;
+  name: string;
+  type?: string;
+}
+
+async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<LookupOption[]> {
+  switch (kind) {
+    case 'pipeline': {
+      const response = await pipelinesService.getPipelines();
+      return (response?.data || []).map((p) => ({ id: String(p.id), name: p.name }));
+    }
+    case 'pipeline_stage': {
+      if (!pipelineId) return [];
+      const response = await pipelinesService.getPipelineStages(pipelineId);
+      return (response?.data || []).map((s) => ({ id: String(s.id), name: s.name }));
+    }
+    case 'inbox': {
+      const response = await InboxesService.list();
+      return (response?.data || []).map((i) => ({ id: String(i.id), name: i.name, type: i.channel_type }));
+    }
+    case 'label': {
+      const response = await labelsService.getLabels();
+      return (response?.data || []).map((l) => ({ id: String(l.id), name: l.title }));
+    }
+    case 'agent': {
+      const response = await UsersService.getUsers();
+      return (response?.data || []).map((u) => ({ id: String(u.id), name: u.name }));
+    }
+    case 'campaign': {
+      const response = await campaignsService.getCampaigns();
+      return (response?.data || []).map((c) => ({ id: String(c.id), name: c.title || c.name }));
+    }
+    case 'template': {
+      const response = await GlobalMessageTemplateService.getTemplates();
+      return (response?.data || []).map((m) => ({ id: String(m.id), name: m.name }));
+    }
+  }
+}
+
+// The stage list depends on the pipeline filter in the same form: without a
+// pipeline the select stays disabled and says so, instead of listing every
+// stage of every pipeline.
+function LookupSelect({
+  id,
+  kind,
+  value,
+  pipelineId,
+  filterType,
+  onOptionsLoaded,
+  onChange,
+  disabled,
+  t,
+}: {
+  id: string;
+  kind: LookupKind;
+  value: string;
+  pipelineId?: string;
+  filterType?: string;
+  onOptionsLoaded?: (options: LookupOption[]) => void;
+  onChange: (raw: unknown) => void;
+  disabled?: boolean;
+  t: (key: string) => string;
+}) {
+  const [options, setOptions] = useState<LookupOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const needsPipeline = kind === 'pipeline_stage' && !pipelineId;
+
+  useEffect(() => {
+    if (needsPipeline) {
+      setOptions([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setFailed(false);
+    loadLookup(kind, pipelineId)
+      .then((list) => {
+        if (cancelled) return;
+        setOptions(list);
+        onOptionsLoaded?.(list);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onOptionsLoaded is a stable lifter
+  }, [kind, pipelineId, needsPipeline]);
+
+  const shown = filterType ? options.filter((o) => !o.type || o.type === filterType) : options;
+
+  const placeholder = needsPipeline
+    ? t('propertiesForm.lookupNeedsPipeline')
+    : loading
+      ? t('propertiesForm.lookupLoading')
+      : failed
+        ? t('propertiesForm.lookupError')
+        : t('propertiesForm.lookupPlaceholder');
+
+  return (
+    <div className="space-y-1">
+      <Select
+        value={value}
+        onValueChange={(next) => onChange(next)}
+        disabled={disabled || needsPipeline || loading || failed}
+      >
+        <SelectTrigger id={id} className="w-full" data-testid={`lookup-${kind}`}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent onWheel={(e) => e.stopPropagation()}>
+          {shown.map((option) => (
+            <SelectItem key={option.id} value={option.id}>
+              {option.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {!loading && !failed && !needsPipeline && shown.length === 0 && (
+        <p className="text-xs text-muted-foreground">{t('propertiesForm.lookupEmpty')}</p>
+      )}
+    </div>
+  );
+}
+
+function EnumSelect({
+  id,
+  field,
+  options,
   value,
   onChange,
   disabled,
   t,
 }: {
+  id: string;
   field: string;
-  spec: FieldSpec;
-  required: boolean;
-  value: unknown;
+  options: readonly string[];
+  value: string;
   onChange: (raw: unknown) => void;
   disabled?: boolean;
-  t: (key: string) => string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
-  const id = useId();
-  const missing = required && (value === undefined || value === '' || value === null);
-
   return (
-    <div className="space-y-1">
-      <Label htmlFor={id} className="text-sm">
-        {field}
-        {required && <span className="ml-0.5 text-destructive">*</span>}
-      </Label>
-      <FieldInput
-        id={id}
-        spec={spec}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-      />
-      {spec.description && (
-        <p className="text-xs text-muted-foreground">{spec.description}</p>
-      )}
-      {missing && (
-        <p className="text-xs text-destructive">{t('propertiesForm.requiredFieldMissing')}</p>
-      )}
-    </div>
+    <Select value={value} onValueChange={(next) => onChange(next)} disabled={disabled}>
+      <SelectTrigger id={id} className="w-full" data-testid={`enum-${field}`}>
+        <SelectValue placeholder={t('propertiesForm.lookupPlaceholder')} />
+      </SelectTrigger>
+      <SelectContent onWheel={(e) => e.stopPropagation()}>
+        {options.map((option) => (
+          <SelectItem key={option} value={option}>
+            {t(optionLabelKey(field, option), { defaultValue: option })}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 
@@ -309,11 +568,11 @@ function dateInputValue(raw: unknown): string {
   return d.toISOString().slice(0, 16);
 }
 
-// Per card: "Campos opcionais como 'Add field' expandível com autocomplete
-// da lista" — searchable typeahead picker built on cmdk Command, mirroring
-// the EventSelector pattern.
-function OptionalFieldPicker({
+// Searchable typeahead picker built on cmdk Command, mirroring the
+// EventSelector pattern.
+function FilterPicker({
   fields,
+  fieldLabel,
   onAdd,
   disabled,
   label,
@@ -321,6 +580,7 @@ function OptionalFieldPicker({
   noResultsLabel,
 }: {
   fields: string[];
+  fieldLabel: (field: string) => string;
   onAdd: (field: string) => void;
   disabled?: boolean;
   label: string;
@@ -328,8 +588,10 @@ function OptionalFieldPicker({
   noResultsLabel: string;
 }) {
   const [open, setOpen] = useState(false);
+  // `modal`: inside the node Dialog the wheel dies on the dialog's scroll lock
+  // otherwise (Radix Popover-in-Dialog).
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <Button
           type="button"
@@ -355,13 +617,16 @@ function OptionalFieldPicker({
               {fields.map((field) => (
                 <CommandItem
                   key={field}
-                  value={field}
+                  value={`${field} ${fieldLabel(field)}`}
                   onSelect={() => {
                     onAdd(field);
                     setOpen(false);
                   }}
                 >
-                  {field}
+                  <span>{fieldLabel(field)}</span>
+                  {fieldLabel(field) !== field && (
+                    <span className="ml-auto pl-3 font-mono text-xs text-muted-foreground">{field}</span>
+                  )}
                 </CommandItem>
               ))}
             </CommandGroup>
@@ -436,10 +701,6 @@ function CustomKeyValueEditor({
 
   return (
     <div className={cn('space-y-3', className)}>
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
-        <span>{t('propertiesForm.customWarning')}</span>
-      </div>
       <Label
         id={labelId}
         className="text-sm font-medium uppercase tracking-wide text-muted-foreground"

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -58,7 +58,7 @@ export function EventPropertiesForm({
   const { t } = useLanguage('events');
   const entry = getEvent(eventName);
   // Per-field copy lives in events.json `fields.<key>`; a key without a
-  // translation falls back to the raw name (and the catalog description).
+  // translation shows its raw name.
   const fieldLabel = (field: string) => t(`fields.${field}.label`, { defaultValue: field });
   // No English fallback to the catalog description: a missing help line is a
   // gap the filterFields contract spec reports, not something to paper over.
@@ -345,6 +345,9 @@ interface LookupOption {
   type?: string;
 }
 
+// The list endpoints page at 20 by default; ask for the same page sizes the
+// contact/chat filters use so an account with dozens of labels or agents
+// still sees all of them (pipelines and stages do not paginate).
 async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<LookupOption[]> {
   switch (kind) {
     case 'pipeline': {
@@ -357,15 +360,15 @@ async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<Lookup
       return (response?.data || []).map((s) => ({ id: String(s.id), name: s.name }));
     }
     case 'inbox': {
-      const response = await InboxesService.list();
+      const response = await InboxesService.list({ per_page: 200 });
       return (response?.data || []).map((i) => ({ id: String(i.id), name: i.name, type: i.channel_type }));
     }
     case 'label': {
-      const response = await labelsService.getLabels();
+      const response = await labelsService.getLabels({ per_page: 200 });
       return (response?.data || []).map((l) => ({ id: String(l.id), name: l.title }));
     }
     case 'agent': {
-      const response = await UsersService.getUsers();
+      const response = await UsersService.getUsers({ per_page: 100 });
       return (response?.data || []).map((u) => ({ id: String(u.id), name: u.name }));
     }
     case 'campaign': {
@@ -373,7 +376,7 @@ async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<Lookup
       return (response?.data || []).map((c) => ({ id: String(c.id), name: c.title || c.name }));
     }
     case 'template': {
-      const response = await GlobalMessageTemplateService.getTemplates();
+      const response = await GlobalMessageTemplateService.getTemplates({ per_page: -1 });
       return (response?.data || []).map((m) => ({ id: String(m.id), name: m.name }));
     }
   }
@@ -431,7 +434,7 @@ function LookupSelect({
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- onOptionsLoaded is a stable lifter
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- onOptionsLoaded is an inline arrow; depending on it would refetch on every parent render
   }, [kind, pipelineId, needsPipeline]);
 
   const shown = filterType ? options.filter((o) => !o.type || o.type === filterType) : options;

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -345,9 +345,9 @@ interface LookupOption {
   type?: string;
 }
 
-// The list endpoints page at 20 by default; ask for the same page sizes the
-// contact/chat filters use so an account with dozens of labels or agents
-// still sees all of them (pipelines and stages do not paginate).
+// Every paged list endpoint gets an explicit page size, or the default (20 in
+// the CRM, 25 in evo-flow) truncates the dropdown in silence. Agents cap at
+// the auth service's MAX_PAGE_SIZE of 100; pipelines and stages do not paginate.
 async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<LookupOption[]> {
   switch (kind) {
     case 'pipeline': {
@@ -372,7 +372,7 @@ async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<Lookup
       return (response?.data || []).map((u) => ({ id: String(u.id), name: u.name }));
     }
     case 'campaign': {
-      const response = await campaignsService.getCampaigns();
+      const response = await campaignsService.getCampaigns({ per_page: 100 });
       return (response?.data || []).map((c) => ({ id: String(c.id), name: c.title || c.name }));
     }
     case 'template': {

--- a/src/components/journey/shared/EventPropertiesForm/filterFields.spec.ts
+++ b/src/components/journey/shared/EventPropertiesForm/filterFields.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { getEvent } from '@/lib/events-manifest';
+import { EVENT_NAMES } from '@/lib/events-manifest/event-names';
+import en from '@/i18n/locales/en/events.json';
+import ptBR from '@/i18n/locales/pt-BR/events.json';
+import pt from '@/i18n/locales/pt/events.json';
+import es from '@/i18n/locales/es/events.json';
+import fr from '@/i18n/locales/fr/events.json';
+import itLocale from '@/i18n/locales/it/events.json';
+import { LOOKUP_FIELDS, filterableFields } from './filterFields';
+
+// CRM-519 regression guard: every key the trigger form OFFERS as a filter must
+// be usable by a person — a human label in every locale, a select when the
+// value is a CRM id or a closed set, never a raw timestamp/object. A new
+// catalog key that misses one of these fails here, not in the user's face.
+const LOCALES: Record<string, Record<string, unknown>> = { en, 'pt-BR': ptBR, pt, es, fr, it: itLocale };
+
+type FieldsBlock = Record<string, { label?: string; help?: string; options?: Record<string, string> }>;
+
+function fieldsOf(locale: Record<string, unknown>): FieldsBlock {
+  return (locale.fields ?? {}) as FieldsBlock;
+}
+
+const offered = EVENT_NAMES.map((name) => getEvent(name))
+  .filter((entry): entry is NonNullable<typeof entry> => !!entry && entry.eventName !== 'custom')
+  .flatMap((entry) => Object.entries(filterableFields(entry)).map(([key, spec]) => ({ key, spec, event: entry.eventName })));
+
+const offeredKeys = [...new Set(offered.map((o) => o.key))].sort();
+
+describe('trigger filter contract (CRM-519)', () => {
+  it('offers at least one filter somewhere', () => {
+    expect(offeredKeys.length).toBeGreaterThan(0);
+  });
+
+  it.each(Object.keys(LOCALES))('%s has a non-empty label for every offered key', (name) => {
+    const fields = fieldsOf(LOCALES[name]);
+    const missing = offeredKeys.filter((key) => !fields[key]?.label?.trim());
+    expect(missing).toEqual([]);
+  });
+
+  it.each(Object.keys(LOCALES))('%s has a help line for every offered key', (name) => {
+    const fields = fieldsOf(LOCALES[name]);
+    const missing = offeredKeys.filter((key) => !fields[key]?.help?.trim());
+    expect(missing).toEqual([]);
+  });
+
+  it.each(Object.keys(LOCALES))('%s describes every catalog event', (name) => {
+    const events = (LOCALES[name].events ?? {}) as Record<string, { description?: string }>;
+    const missing = EVENT_NAMES.filter((n) => !events[n.replace(/\./g, '_')]?.description?.trim());
+    expect(missing).toEqual([]);
+  });
+
+  it('never offers a date or object key (equality on those never matches)', () => {
+    const bad = offered.filter((o) => o.spec.type === 'date' || o.spec.type === 'object');
+    expect(bad.map((o) => `${o.event}.${o.key}`)).toEqual([]);
+  });
+
+  it('renders every offered uuid as a select (LOOKUP_FIELDS)', () => {
+    const bad = offered.filter((o) => o.spec.type === 'uuid' && !(o.key in LOOKUP_FIELDS));
+    expect(bad.map((o) => `${o.event}.${o.key}`)).toEqual([]);
+  });
+
+  it('declares options for every key whose description spells a closed set', () => {
+    const bad = offered.filter((o) => o.spec.description?.includes('|') && !o.spec.options?.length);
+    expect(bad.map((o) => `${o.event}.${o.key}`)).toEqual([]);
+  });
+
+  it.each(Object.keys(LOCALES))('%s labels every declared option value', (name) => {
+    const fields = fieldsOf(LOCALES[name]);
+    const missing: string[] = [];
+    for (const o of offered) {
+      for (const value of o.spec.options ?? []) {
+        const slug = value.replace(/[^A-Za-z0-9_]/g, '_');
+        if (!fields[o.key]?.options?.[slug]?.trim()) missing.push(`${o.key}.${slug}`);
+      }
+    }
+    expect([...new Set(missing)]).toEqual([]);
+  });
+});

--- a/src/components/journey/shared/EventPropertiesForm/filterFields.spec.ts
+++ b/src/components/journey/shared/EventPropertiesForm/filterFields.spec.ts
@@ -27,6 +27,22 @@ const offered = EVENT_NAMES.map((name) => getEvent(name))
 
 const offeredKeys = [...new Set(offered.map((o) => o.key))].sort();
 
+// The mirrored descriptions spell a closed set two ways: `a | b`, or a
+// parenthesised comma list — `Payment platform key (virtu, hotmart, kiwify,
+// cakto)`. Three items minimum, so `(e.g., Channel::Whatsapp)` is not read as
+// one. A two-value set in parentheses would still slip past; write those with
+// pipes.
+const BARE_TOKEN = /^[\w:.-]+$/;
+
+function spellsClosedSet(description?: string): boolean {
+  if (!description) return false;
+  if (description.includes('|')) return true;
+  return [...description.matchAll(/\(([^)]*)\)/g)].some(([, group]) => {
+    const items = group.split(',').map((item) => item.trim());
+    return items.length >= 3 && items.every((item) => BARE_TOKEN.test(item));
+  });
+}
+
 describe('trigger filter contract (CRM-519)', () => {
   it('offers at least one filter somewhere', () => {
     expect(offeredKeys.length).toBeGreaterThan(0);
@@ -61,7 +77,7 @@ describe('trigger filter contract (CRM-519)', () => {
   });
 
   it('declares options for every key whose description spells a closed set', () => {
-    const bad = offered.filter((o) => o.spec.description?.includes('|') && !o.spec.options?.length);
+    const bad = offered.filter((o) => spellsClosedSet(o.spec.description) && !o.spec.options?.length);
     expect(bad.map((o) => `${o.event}.${o.key}`)).toEqual([]);
   });
 

--- a/src/components/journey/shared/EventPropertiesForm/filterFields.ts
+++ b/src/components/journey/shared/EventPropertiesForm/filterFields.ts
@@ -1,0 +1,82 @@
+import type { EventCatalogEntry, FieldSpec } from '@/lib/events-manifest';
+
+// A catalog `required` key means "the producer always sends it", never "the
+// user must fill it": every schema key is an optional equality FILTER on the
+// trigger (evo-flow EventTrigger.matchesEventProperties). Identity keys are
+// ids of the very record the event announces, unknowable before it happens,
+// so they are not offered as filters. Persisted rows on those keys (legacy
+// journeys) stay visible so they can be removed.
+export const IDENTITY_FIELDS: ReadonlySet<string> = new Set([
+  'id',
+  'contact_id',
+  'conversation_id',
+  'message_id',
+  'purchase_id',
+  'pipeline_item_id',
+]);
+
+// Keys that never make sense as an equality filter: producer bookkeeping
+// (source), raw payload dumps, display names that duplicate an id with a
+// select, and an id the CRM emits as a free string.
+export const INTERNAL_FIELDS: ReadonlySet<string> = new Set([
+  'source',
+  'custom_fields',
+  'changes',
+  'inbox_name',
+  'labelName',
+  'pipeline_name',
+  'pipeline_stage_name',
+  'resolved_by_id',
+]);
+
+// Equality on a timestamp never matches and an object has no input.
+export const UNFILTERABLE_TYPES: ReadonlySet<FieldSpec['type']> = new Set(['date', 'object']);
+
+export type LookupKind =
+  | 'pipeline'
+  | 'pipeline_stage'
+  | 'inbox'
+  | 'label'
+  | 'agent'
+  | 'campaign'
+  | 'template';
+
+// Keys whose value is a CRM record id: rendered as a select fed by the CRM
+// list, since nobody types a UUID. `product` stays free text on purpose — on
+// purchase.approved it is the platform's product string, not a CRM product.
+export const LOOKUP_FIELDS: Readonly<Record<string, LookupKind>> = {
+  pipeline_id: 'pipeline',
+  pipeline_stage_id: 'pipeline_stage',
+  inbox_id: 'inbox',
+  labelId: 'label',
+  assigned_by_id: 'agent',
+  campaign_id: 'campaign',
+  template_id: 'template',
+};
+
+export function schemaFields(entry: EventCatalogEntry): Record<string, FieldSpec> {
+  return { ...entry.schema.required, ...entry.schema.optional };
+}
+
+export function filterableFields(entry: EventCatalogEntry): Record<string, FieldSpec> {
+  return Object.fromEntries(
+    Object.entries(schemaFields(entry)).filter(
+      ([key, spec]) =>
+        !IDENTITY_FIELDS.has(key) && !INTERNAL_FIELDS.has(key) && !UNFILTERABLE_TYPES.has(spec.type),
+    ),
+  );
+}
+
+// i18n keys cannot carry ':' or '.', so an option value is slugged for lookup
+// (Channel::Whatsapp -> Channel__Whatsapp) and falls back to the raw value.
+export function optionLabelKey(field: string, value: string): string {
+  return `fields.${field}.options.${value.replace(/[^A-Za-z0-9_]/g, '_')}`;
+}
+
+// An id and the type of the same object are one filter, not two: the inbox
+// list is narrowed by the chosen channel type, and once an inbox is chosen the
+// type is implied (dropped from the picker). A legacy pair that contradicts
+// itself is flagged inline so it can be removed.
+export const PAIRED_TYPE_FIELDS: Readonly<Record<string, string>> = {
+  inbox_id: 'channel_type',
+};

--- a/src/components/journey/shared/EventSelector/EventSelector.tsx
+++ b/src/components/journey/shared/EventSelector/EventSelector.tsx
@@ -109,7 +109,9 @@ export function EventSelector({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    // `modal`: inside the node Dialog the wheel dies on the dialog's scroll lock
+    // otherwise (Radix Popover-in-Dialog, CRM-519).
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <Button
           id={id}

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -86,6 +86,10 @@ export const COMMON_ALLOWED = new Set<string>([
 ]);
 
 export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
+  'events.json': new Set([
+    // CRM-519: channel brand names in the trigger filter option labels.
+    'SMS (Twilio)', 'X (Twitter)',
+  ]),
   'adminSettings.json': new Set([
     'Frontend Runtime', 'Google OAuth', 'Relay (Exim / Postfix / Qmail)',
   ]),

--- a/src/i18n/locales/_lib/allowlist.ts
+++ b/src/i18n/locales/_lib/allowlist.ts
@@ -87,8 +87,10 @@ export const COMMON_ALLOWED = new Set<string>([
 
 export const PER_FILE_ALLOWED: Record<string, Set<string>> = {
   'events.json': new Set([
-    // CRM-519: channel brand names in the trigger filter option labels.
+    // CRM-519: channel and payment-platform brand names in the trigger filter
+    // option labels.
     'SMS (Twilio)', 'X (Twitter)',
+    'Virtu', 'Hotmart', 'Kiwify', 'Cakto',
   ]),
   'adminSettings.json': new Set([
     'Frontend Runtime', 'Google OAuth', 'Relay (Exim / Postfix / Qmail)',

--- a/src/i18n/locales/en/events.json
+++ b/src/i18n/locales/en/events.json
@@ -15,17 +15,357 @@
     "custom": "Custom"
   },
   "propertiesForm": {
-    "requiredSectionLabel": "Required fields",
-    "optionalSectionLabel": "Optional fields",
-    "addFieldLabel": "+ Add field",
+    "optionalSectionLabel": "Filters (optional)",
+    "addFieldLabel": "+ Add filter",
     "customSectionLabel": "Custom properties",
     "customKeyPlaceholder": "key",
     "customValuePlaceholder": "value",
     "customAddLabel": "+ Add property",
-    "requiredFieldMissing": "Required field",
-    "customWarning": "Custom events are not schema-validated",
     "customRemoveAriaLabel": "Remove property",
-    "addFieldSearchPlaceholder": "Search field...",
-    "noResultsLabel": "No fields found"
+    "addFieldSearchPlaceholder": "Search filter...",
+    "noResultsLabel": "No filters found",
+    "filtersHint": "Without filters, the journey starts on every occurrence of the event.",
+    "removeFilterAriaLabel": "Remove filter",
+    "lookupLoading": "Loading...",
+    "lookupPlaceholder": "Select",
+    "lookupEmpty": "No options available",
+    "lookupError": "Could not load the list",
+    "lookupNeedsPipeline": "Choose the pipeline first",
+    "pairConflict": "The chosen channel is of type {{actual}}. This filter can never match; remove one of the two."
+  },
+  "fields": {
+    "inbox_id": {
+      "label": "Channel",
+      "help": "Only fires when the event comes from this channel."
+    },
+    "inbox_name": {
+      "label": "Channel name"
+    },
+    "channel_type": {
+      "label": "Channel type",
+      "help": "E.g. whatsapp, instagram, email.",
+      "options": {
+        "Channel__Whatsapp": "WhatsApp",
+        "Channel__Instagram": "Instagram",
+        "Channel__FacebookPage": "Facebook Messenger",
+        "Channel__Telegram": "Telegram",
+        "Channel__Email": "Email",
+        "Channel__Sms": "SMS",
+        "Channel__TwilioSms": "SMS (Twilio)",
+        "Channel__WebWidget": "Website chat",
+        "Channel__Api": "API",
+        "Channel__Line": "LINE",
+        "Channel__Sendgrid": "Email (SendGrid)",
+        "Channel__TwitterProfile": "X (Twitter)"
+      }
+    },
+    "pipeline_id": {
+      "label": "Pipeline",
+      "help": "Only fires for cards in this pipeline."
+    },
+    "pipeline_name": {
+      "label": "Pipeline name"
+    },
+    "pipeline_stage_id": {
+      "label": "Pipeline stage",
+      "help": "Choose the pipeline first to list its stages."
+    },
+    "pipeline_stage_name": {
+      "label": "Stage name"
+    },
+    "is_lead": {
+      "label": "Is lead",
+      "help": "Checked: only cards that entered as a lead."
+    },
+    "assigned_by_id": {
+      "label": "Assigned by (user id)",
+      "help": "Only fires when this agent made the assignment."
+    },
+    "labelId": {
+      "label": "Label",
+      "help": "Only fires for this label."
+    },
+    "labelName": {
+      "label": "Label name"
+    },
+    "attributeName": {
+      "label": "Attribute name",
+      "help": "The key of the custom attribute that changed."
+    },
+    "attributeValue": {
+      "label": "New attribute value",
+      "help": "The value the attribute now holds."
+    },
+    "oldValue": {
+      "label": "Previous value",
+      "help": "The value the attribute had before."
+    },
+    "changeType": {
+      "label": "Change type",
+      "help": "How the attribute changed (created, updated or removed)."
+    },
+    "activity_type": {
+      "label": "Activity type",
+      "help": "The type of the activity logged on the conversation."
+    },
+    "content": {
+      "label": "Content",
+      "help": "Exact text of the message or activity."
+    },
+    "content_type": {
+      "label": "Content type",
+      "help": "E.g. text, image, audio, file.",
+      "options": {
+        "text": "Text",
+        "input_text": "Text input",
+        "input_textarea": "Text area",
+        "input_email": "Email input",
+        "input_select": "Select",
+        "cards": "Cards",
+        "form": "Form",
+        "article": "Article",
+        "incoming_email": "Incoming email",
+        "input_csat": "CSAT survey",
+        "integrations": "Integration",
+        "sticker": "Sticker"
+      }
+    },
+    "message_type": {
+      "label": "Message direction",
+      "help": "incoming (from the contact) or outgoing (from the team).",
+      "options": {
+        "incoming": "Incoming (from the contact)",
+        "outgoing": "Outgoing (from the team)"
+      }
+    },
+    "status": {
+      "label": "Delivery status",
+      "options": {
+        "sent": "Sent",
+        "delivered": "Delivered",
+        "read": "Read",
+        "failed": "Failed"
+      },
+      "help": "The current message status."
+    },
+    "previous_status": {
+      "label": "Previous status",
+      "options": {
+        "sent": "Sent",
+        "delivered": "Delivered",
+        "read": "Read",
+        "failed": "Failed"
+      },
+      "help": "The message status before this change."
+    },
+    "external_error": {
+      "label": "Provider error",
+      "help": "The error message the provider returned."
+    },
+    "reason": {
+      "label": "Reason",
+      "help": "The reason given for the deletion or the handoff."
+    },
+    "resolved_by_id": {
+      "label": "Resolved by (id)"
+    },
+    "resolved_by_type": {
+      "label": "Resolved by (type)",
+      "help": "user, bot or system."
+    },
+    "resolution_time_seconds": {
+      "label": "Resolution time (s)",
+      "help": "Seconds between opening and resolution."
+    },
+    "response_time_seconds": {
+      "label": "Response time (s)",
+      "help": "Seconds until the team's first reply."
+    },
+    "reply_time_seconds": {
+      "label": "Reply time (s)",
+      "help": "Seconds until the team replied."
+    },
+    "replied_at": {
+      "label": "Replied at"
+    },
+    "measured_at": {
+      "label": "Measured at"
+    },
+    "handoff_at": {
+      "label": "Handed off at"
+    },
+    "resolved_at": {
+      "label": "Resolved at"
+    },
+    "deleted_at": {
+      "label": "Deleted at"
+    },
+    "opened_at": {
+      "label": "Opened at"
+    },
+    "clicked_at": {
+      "label": "Clicked at"
+    },
+    "campaign_id": {
+      "label": "Campaign (id)",
+      "help": "Only fires for messages of this campaign."
+    },
+    "template_id": {
+      "label": "Template (id)",
+      "help": "Only fires for messages sent with this template."
+    },
+    "url": {
+      "label": "Clicked URL",
+      "help": "The exact URL the contact clicked."
+    },
+    "provider": {
+      "label": "Payment platform",
+      "help": "virtu, hotmart, kiwify or cakto."
+    },
+    "product": {
+      "label": "Product",
+      "help": "The product name as the platform sends it."
+    },
+    "amount": {
+      "label": "Amount",
+      "help": "In the currency unit (e.g. 197.5), never cents."
+    },
+    "currency": {
+      "label": "Currency",
+      "help": "E.g. BRL, USD."
+    },
+    "platform_event": {
+      "label": "Platform event",
+      "help": "The event name as the platform sent it."
+    },
+    "outcome": {
+      "label": "CRM outcome",
+      "help": "created (new card) or already_in_pipeline (purchase appended to the open card)."
+    },
+    "new_contact": {
+      "label": "New contact",
+      "help": "Checked: the purchase created the contact."
+    },
+    "name": {
+      "label": "Name",
+      "help": "The contact's exact name."
+    },
+    "email": {
+      "label": "Email",
+      "help": "The contact's exact email."
+    },
+    "phone_number": {
+      "label": "Phone",
+      "help": "E.164 format, e.g. +5511999999999."
+    },
+    "identifier": {
+      "label": "External identifier",
+      "help": "The contact's identifier in another system."
+    },
+    "middle_name": {
+      "label": "Middle name",
+      "help": "The contact's exact middle name."
+    },
+    "last_name": {
+      "label": "Last name",
+      "help": "The contact's exact last name."
+    },
+    "location": {
+      "label": "Location",
+      "help": "The location stored on the contact."
+    },
+    "country_code": {
+      "label": "Country code",
+      "help": "E.g. BR, US."
+    },
+    "contact_type": {
+      "label": "Contact type",
+      "options": {
+        "visitor": "Visitor",
+        "lead": "Lead",
+        "customer": "Customer"
+      },
+      "help": "Visitor, lead or customer, as classified in the CRM."
+    },
+    "blocked": {
+      "label": "Blocked",
+      "help": "Checked: only blocked contacts."
+    },
+    "created_via": {
+      "label": "Created by",
+      "options": {
+        "agent": "Agent",
+        "system": "System"
+      },
+      "help": "Whether an agent or the system (channel, import, webhook) created the contact."
+    }
+  },
+  "events": {
+    "contact_created": {
+      "description": "A new contact was created in the CRM."
+    },
+    "contact_updated": {
+      "description": "A contact's data was changed."
+    },
+    "contact_deleted": {
+      "description": "A contact was deleted."
+    },
+    "contact_label_added": {
+      "description": "A label was applied to a contact."
+    },
+    "contact_label_removed": {
+      "description": "A label was removed from a contact."
+    },
+    "contact_custom_attribute_changed": {
+      "description": "A custom attribute of the contact changed value."
+    },
+    "conversation_created": {
+      "description": "A new conversation was opened on a channel."
+    },
+    "conversation_resolved": {
+      "description": "A conversation was marked as resolved."
+    },
+    "conversation_activity": {
+      "description": "An activity was logged on a conversation (note, assignment, status change)."
+    },
+    "conversation_first_reply": {
+      "description": "The team replied for the first time on a conversation."
+    },
+    "conversation_reply_time": {
+      "description": "The reply time of a conversation was measured."
+    },
+    "conversation_bot_handoff": {
+      "description": "The bot handed the conversation over to the team."
+    },
+    "conversation_bot_resolved": {
+      "description": "The bot resolved the conversation without the team."
+    },
+    "message_created": {
+      "description": "A message was sent or received on a conversation."
+    },
+    "message_delivered": {
+      "description": "A sent message was delivered to the contact."
+    },
+    "message_read": {
+      "description": "The contact read a sent message."
+    },
+    "message_failed": {
+      "description": "Sending a message failed at the provider."
+    },
+    "campaign_triggered": {
+      "description": "A contact entered a pipeline as a card (by lead, campaign or assignment)."
+    },
+    "campaign_message_sent": {
+      "description": "A campaign message was sent to a contact."
+    },
+    "campaign_message_opened": {
+      "description": "The contact opened a campaign message."
+    },
+    "campaign_message_clicked": {
+      "description": "The contact clicked a link in a campaign message."
+    },
+    "custom": {
+      "description": "An event you define, with free-form properties."
+    }
   }
 }

--- a/src/i18n/locales/en/events.json
+++ b/src/i18n/locales/en/events.json
@@ -43,7 +43,7 @@
     },
     "channel_type": {
       "label": "Channel type",
-      "help": "E.g. whatsapp, instagram, email.",
+      "help": "Only fires for conversations on this channel type.",
       "options": {
         "Channel__Whatsapp": "WhatsApp",
         "Channel__Instagram": "Instagram",
@@ -78,7 +78,7 @@
       "help": "Checked: only cards that entered as a lead."
     },
     "assigned_by_id": {
-      "label": "Assigned by (user id)",
+      "label": "Assigned by",
       "help": "Only fires when this agent made the assignment."
     },
     "labelId": {
@@ -240,7 +240,11 @@
     },
     "outcome": {
       "label": "CRM outcome",
-      "help": "created (new card) or already_in_pipeline (purchase appended to the open card)."
+      "help": "created (new card) or already_in_pipeline (purchase appended to the open card).",
+      "options": {
+        "created": "New card",
+        "already_in_pipeline": "Purchase appended to the open card"
+      }
     },
     "new_contact": {
       "label": "New contact",
@@ -366,6 +370,9 @@
     },
     "custom": {
       "description": "An event you define, with free-form properties."
+    },
+    "purchase_approved": {
+      "description": "A purchase was approved on a payment platform and captured as a lead in the CRM."
     }
   }
 }

--- a/src/i18n/locales/en/events.json
+++ b/src/i18n/locales/en/events.json
@@ -220,7 +220,13 @@
     },
     "provider": {
       "label": "Payment platform",
-      "help": "virtu, hotmart, kiwify or cakto."
+      "help": "Only fires for purchases from this platform.",
+      "options": {
+        "virtu": "Virtu",
+        "hotmart": "Hotmart",
+        "kiwify": "Kiwify",
+        "cakto": "Cakto"
+      }
     },
     "product": {
       "label": "Product",

--- a/src/i18n/locales/en/journey.json
+++ b/src/i18n/locales/en/journey.json
@@ -1809,7 +1809,7 @@
     }
   },
   "triggerComponents": {
-    "triggerType": "Trigger Type",
+    "triggerType": "How the journey starts",
     "selectType": "Select the type",
     "types": {
       "manual": "Manual Input",
@@ -1953,11 +1953,13 @@
       "customEventNamePlaceholder": "Type the custom event name (e.g. button_clicked)",
       "customEventWarning": "Custom events have no schema validation. Use only for cases not covered by canonical events.",
       "eventSwitch": {
-        "title": "Preserve compatible values?",
-        "body": "You changed the event. Keep the property values that also exist on the new event (same name and type), or clear them all?",
-        "preserve": "Preserve compatible",
-        "clear": "Clear all"
-      }
+        "dropped_one": "1 filter removed because it does not exist on {{event}}.",
+        "dropped_other": "{{count}} filters removed because they do not exist on {{event}}.",
+        "undo": "Undo"
+      },
+      "customEventNameLabel": "Custom event name",
+      "selectEventRequired": "Choose an event to save the trigger.",
+      "customEventNameRequired": "Type the custom event name to save."
     },
     "label": {
       "configuration": "Label Configuration",

--- a/src/i18n/locales/es/events.json
+++ b/src/i18n/locales/es/events.json
@@ -43,7 +43,7 @@
     },
     "channel_type": {
       "label": "Tipo de canal",
-      "help": "Ej.: whatsapp, instagram, email.",
+      "help": "Solo se dispara para conversaciones de este tipo de canal.",
       "options": {
         "Channel__Whatsapp": "WhatsApp",
         "Channel__Instagram": "Instagram",
@@ -78,7 +78,7 @@
       "help": "Marcado: solo tarjetas que entraron como lead."
     },
     "assigned_by_id": {
-      "label": "Asignado por (id de usuario)",
+      "label": "Asignado por",
       "help": "Solo se dispara cuando este agente hizo la asignación."
     },
     "labelId": {
@@ -240,7 +240,11 @@
     },
     "outcome": {
       "label": "Resultado en el CRM",
-      "help": "created (tarjeta nueva) o already_in_pipeline (compra añadida a la tarjeta abierta)."
+      "help": "created (tarjeta nueva) o already_in_pipeline (compra añadida a la tarjeta abierta).",
+      "options": {
+        "created": "Tarjeta nueva",
+        "already_in_pipeline": "Compra añadida a la tarjeta abierta"
+      }
     },
     "new_contact": {
       "label": "Contacto nuevo",
@@ -366,6 +370,9 @@
     },
     "custom": {
       "description": "Un evento definido por usted, con propiedades libres."
+    },
+    "purchase_approved": {
+      "description": "Una compra fue aprobada en una plataforma de pago y se convirtió en lead en el CRM."
     }
   }
 }

--- a/src/i18n/locales/es/events.json
+++ b/src/i18n/locales/es/events.json
@@ -15,17 +15,357 @@
     "custom": "Personalizado"
   },
   "propertiesForm": {
-    "requiredSectionLabel": "Campos obligatorios",
-    "optionalSectionLabel": "Campos opcionales",
-    "addFieldLabel": "+ Añadir campo",
+    "optionalSectionLabel": "Filtros (opcionales)",
+    "addFieldLabel": "+ Añadir filtro",
     "customSectionLabel": "Propiedades personalizadas",
     "customKeyPlaceholder": "clave",
     "customValuePlaceholder": "valor",
     "customAddLabel": "+ Añadir propiedad",
-    "requiredFieldMissing": "Campo obligatorio",
-    "customWarning": "Los eventos personalizados no se validan por schema",
     "customRemoveAriaLabel": "Eliminar propiedad",
-    "addFieldSearchPlaceholder": "Buscar campo...",
-    "noResultsLabel": "No se encontraron campos"
+    "addFieldSearchPlaceholder": "Buscar filtro...",
+    "noResultsLabel": "No se encontraron filtros",
+    "filtersHint": "Sin filtros, la jornada se inicia en cada ocurrencia del evento.",
+    "removeFilterAriaLabel": "Eliminar filtro",
+    "lookupLoading": "Cargando...",
+    "lookupPlaceholder": "Seleccione",
+    "lookupEmpty": "Ninguna opción disponible",
+    "lookupError": "No se pudo cargar la lista",
+    "lookupNeedsPipeline": "Elija primero el embudo",
+    "pairConflict": "El canal elegido es del tipo {{actual}}. Este filtro nunca coincidirá; elimine uno de los dos."
+  },
+  "fields": {
+    "inbox_id": {
+      "label": "Canal",
+      "help": "Solo se dispara cuando el evento viene de este canal."
+    },
+    "inbox_name": {
+      "label": "Nombre del canal"
+    },
+    "channel_type": {
+      "label": "Tipo de canal",
+      "help": "Ej.: whatsapp, instagram, email.",
+      "options": {
+        "Channel__Whatsapp": "WhatsApp",
+        "Channel__Instagram": "Instagram",
+        "Channel__FacebookPage": "Facebook Messenger",
+        "Channel__Telegram": "Telegram",
+        "Channel__Email": "Correo electrónico",
+        "Channel__Sms": "SMS",
+        "Channel__TwilioSms": "SMS (Twilio)",
+        "Channel__WebWidget": "Chat del sitio",
+        "Channel__Api": "API",
+        "Channel__Line": "LINE",
+        "Channel__Sendgrid": "Correo (SendGrid)",
+        "Channel__TwitterProfile": "X (Twitter)"
+      }
+    },
+    "pipeline_id": {
+      "label": "Embudo",
+      "help": "Solo se dispara para tarjetas de este embudo."
+    },
+    "pipeline_name": {
+      "label": "Nombre del embudo"
+    },
+    "pipeline_stage_id": {
+      "label": "Etapa del embudo",
+      "help": "Elija primero el embudo para ver las etapas."
+    },
+    "pipeline_stage_name": {
+      "label": "Nombre de la etapa"
+    },
+    "is_lead": {
+      "label": "Es lead",
+      "help": "Marcado: solo tarjetas que entraron como lead."
+    },
+    "assigned_by_id": {
+      "label": "Asignado por (id de usuario)",
+      "help": "Solo se dispara cuando este agente hizo la asignación."
+    },
+    "labelId": {
+      "label": "Etiqueta",
+      "help": "Solo se dispara para esta etiqueta."
+    },
+    "labelName": {
+      "label": "Nombre de la etiqueta"
+    },
+    "attributeName": {
+      "label": "Nombre del atributo",
+      "help": "La clave del atributo personalizado que cambió."
+    },
+    "attributeValue": {
+      "label": "Nuevo valor del atributo",
+      "help": "El valor que pasó a tener el atributo."
+    },
+    "oldValue": {
+      "label": "Valor anterior",
+      "help": "El valor que tenía antes el atributo."
+    },
+    "changeType": {
+      "label": "Tipo de cambio",
+      "help": "Cómo cambió el atributo (creado, modificado o eliminado)."
+    },
+    "activity_type": {
+      "label": "Tipo de actividad",
+      "help": "El tipo de actividad registrada en la conversación."
+    },
+    "content": {
+      "label": "Contenido",
+      "help": "Texto exacto del mensaje o actividad."
+    },
+    "content_type": {
+      "label": "Tipo de contenido",
+      "help": "Ej.: text, image, audio, file.",
+      "options": {
+        "text": "Texto",
+        "input_text": "Campo de texto",
+        "input_textarea": "Área de texto",
+        "input_email": "Campo de correo",
+        "input_select": "Selección",
+        "cards": "Tarjetas",
+        "form": "Formulario",
+        "article": "Artículo",
+        "incoming_email": "Correo recibido",
+        "input_csat": "Encuesta CSAT",
+        "integrations": "Integración",
+        "sticker": "Sticker"
+      }
+    },
+    "message_type": {
+      "label": "Dirección del mensaje",
+      "help": "incoming (del contacto) u outgoing (del equipo).",
+      "options": {
+        "incoming": "Recibida (del contacto)",
+        "outgoing": "Enviada (del equipo)"
+      }
+    },
+    "status": {
+      "label": "Estado de la entrega",
+      "options": {
+        "sent": "Enviada",
+        "delivered": "Entregada",
+        "read": "Leída",
+        "failed": "Falló"
+      },
+      "help": "El estado actual del mensaje."
+    },
+    "previous_status": {
+      "label": "Estado anterior",
+      "options": {
+        "sent": "Enviada",
+        "delivered": "Entregada",
+        "read": "Leída",
+        "failed": "Falló"
+      },
+      "help": "El estado del mensaje antes de este cambio."
+    },
+    "external_error": {
+      "label": "Error del proveedor",
+      "help": "El mensaje de error que devolvió el proveedor."
+    },
+    "reason": {
+      "label": "Motivo",
+      "help": "El motivo informado para la eliminación o la transferencia."
+    },
+    "resolved_by_id": {
+      "label": "Resuelto por (id)"
+    },
+    "resolved_by_type": {
+      "label": "Resuelto por (tipo)",
+      "help": "user, bot o system."
+    },
+    "resolution_time_seconds": {
+      "label": "Tiempo de resolución (s)",
+      "help": "Segundos entre la apertura y la resolución."
+    },
+    "response_time_seconds": {
+      "label": "Tiempo de respuesta (s)",
+      "help": "Segundos hasta la primera respuesta del equipo."
+    },
+    "reply_time_seconds": {
+      "label": "Tiempo hasta responder (s)",
+      "help": "Segundos hasta que el equipo respondió."
+    },
+    "replied_at": {
+      "label": "Respondido en"
+    },
+    "measured_at": {
+      "label": "Medido en"
+    },
+    "handoff_at": {
+      "label": "Transferido en"
+    },
+    "resolved_at": {
+      "label": "Resuelto en"
+    },
+    "deleted_at": {
+      "label": "Eliminado en"
+    },
+    "opened_at": {
+      "label": "Abierto en"
+    },
+    "clicked_at": {
+      "label": "Clic en"
+    },
+    "campaign_id": {
+      "label": "Campaña (id)",
+      "help": "Solo se dispara para mensajes de esta campaña."
+    },
+    "template_id": {
+      "label": "Plantilla (id)",
+      "help": "Solo se dispara para mensajes enviados con esta plantilla."
+    },
+    "url": {
+      "label": "URL clicada",
+      "help": "La URL exacta en la que hizo clic el contacto."
+    },
+    "provider": {
+      "label": "Plataforma de pago",
+      "help": "virtu, hotmart, kiwify o cakto."
+    },
+    "product": {
+      "label": "Producto",
+      "help": "El nombre del producto tal como lo envía la plataforma."
+    },
+    "amount": {
+      "label": "Importe",
+      "help": "En la unidad de la moneda (ej.: 197.5), nunca en centavos."
+    },
+    "currency": {
+      "label": "Moneda",
+      "help": "Ej.: BRL, USD."
+    },
+    "platform_event": {
+      "label": "Evento de la plataforma",
+      "help": "El nombre del evento tal como lo envió la plataforma."
+    },
+    "outcome": {
+      "label": "Resultado en el CRM",
+      "help": "created (tarjeta nueva) o already_in_pipeline (compra añadida a la tarjeta abierta)."
+    },
+    "new_contact": {
+      "label": "Contacto nuevo",
+      "help": "Marcado: la compra creó el contacto."
+    },
+    "name": {
+      "label": "Nombre",
+      "help": "El nombre exacto del contacto."
+    },
+    "email": {
+      "label": "Correo electrónico",
+      "help": "El correo exacto del contacto."
+    },
+    "phone_number": {
+      "label": "Teléfono",
+      "help": "Formato E.164, ej.: +5511999999999."
+    },
+    "identifier": {
+      "label": "Identificador externo",
+      "help": "El identificador del contacto en otro sistema."
+    },
+    "middle_name": {
+      "label": "Segundo nombre",
+      "help": "El segundo nombre exacto del contacto."
+    },
+    "last_name": {
+      "label": "Apellido",
+      "help": "El apellido exacto del contacto."
+    },
+    "location": {
+      "label": "Ubicación",
+      "help": "La ubicación registrada en el contacto."
+    },
+    "country_code": {
+      "label": "País (código)",
+      "help": "Ej.: BR, US."
+    },
+    "contact_type": {
+      "label": "Tipo de contacto",
+      "options": {
+        "visitor": "Visitante",
+        "lead": "Lead",
+        "customer": "Cliente"
+      },
+      "help": "Visitante, lead o cliente, según el CRM."
+    },
+    "blocked": {
+      "label": "Bloqueado",
+      "help": "Marcado: solo contactos bloqueados."
+    },
+    "created_via": {
+      "label": "Creado por",
+      "options": {
+        "agent": "Agente",
+        "system": "Sistema"
+      },
+      "help": "Si el contacto fue creado por un agente o por el sistema (canal, importación, webhook)."
+    }
+  },
+  "events": {
+    "contact_created": {
+      "description": "Se creó un contacto nuevo en el CRM."
+    },
+    "contact_updated": {
+      "description": "Se modificaron los datos de un contacto."
+    },
+    "contact_deleted": {
+      "description": "Se eliminó un contacto."
+    },
+    "contact_label_added": {
+      "description": "Se aplicó una etiqueta a un contacto."
+    },
+    "contact_label_removed": {
+      "description": "Se quitó una etiqueta de un contacto."
+    },
+    "contact_custom_attribute_changed": {
+      "description": "Un atributo personalizado del contacto cambió de valor."
+    },
+    "conversation_created": {
+      "description": "Se abrió una conversación nueva en un canal."
+    },
+    "conversation_resolved": {
+      "description": "Una conversación se marcó como resuelta."
+    },
+    "conversation_activity": {
+      "description": "Se registró una actividad en una conversación (nota, asignación, cambio de estado)."
+    },
+    "conversation_first_reply": {
+      "description": "El equipo respondió por primera vez en una conversación."
+    },
+    "conversation_reply_time": {
+      "description": "Se midió el tiempo de respuesta de una conversación."
+    },
+    "conversation_bot_handoff": {
+      "description": "El bot transfirió la conversación al equipo."
+    },
+    "conversation_bot_resolved": {
+      "description": "El bot resolvió la conversación sin el equipo."
+    },
+    "message_created": {
+      "description": "Se envió o recibió un mensaje en una conversación."
+    },
+    "message_delivered": {
+      "description": "Un mensaje enviado fue entregado al contacto."
+    },
+    "message_read": {
+      "description": "El contacto leyó un mensaje enviado."
+    },
+    "message_failed": {
+      "description": "El envío de un mensaje falló en el proveedor."
+    },
+    "campaign_triggered": {
+      "description": "Un contacto entró en un embudo como tarjeta (por lead, campaña o asignación)."
+    },
+    "campaign_message_sent": {
+      "description": "Se envió un mensaje de campaña a un contacto."
+    },
+    "campaign_message_opened": {
+      "description": "El contacto abrió un mensaje de campaña."
+    },
+    "campaign_message_clicked": {
+      "description": "El contacto hizo clic en un enlace de un mensaje de campaña."
+    },
+    "custom": {
+      "description": "Un evento definido por usted, con propiedades libres."
+    }
   }
 }

--- a/src/i18n/locales/es/events.json
+++ b/src/i18n/locales/es/events.json
@@ -220,7 +220,13 @@
     },
     "provider": {
       "label": "Plataforma de pago",
-      "help": "virtu, hotmart, kiwify o cakto."
+      "help": "Solo se dispara para compras de esta plataforma.",
+      "options": {
+        "virtu": "Virtu",
+        "hotmart": "Hotmart",
+        "kiwify": "Kiwify",
+        "cakto": "Cakto"
+      }
     },
     "product": {
       "label": "Producto",

--- a/src/i18n/locales/es/journey.json
+++ b/src/i18n/locales/es/journey.json
@@ -1776,7 +1776,7 @@
     }
   },
   "triggerComponents": {
-    "triggerType": "Tipo del Trigger",
+    "triggerType": "Cómo empieza la jornada",
     "selectType": "Seleccione el tipo",
     "types": {
       "manual": "Entrada Manual",
@@ -1918,11 +1918,15 @@
       "value": "Valor",
       "captureEventData": "Capturar Datos del Evento",
       "eventSwitch": {
-        "title": "¿Preservar valores compatibles?",
-        "body": "Cambiaste el evento. ¿Mantener los valores de propiedad que también existen en el nuevo evento (mismo nombre y tipo) o borrarlos todos?",
-        "preserve": "Preservar compatibles",
-        "clear": "Borrar todo"
-      }
+        "dropped_one": "1 filtro eliminado porque no existe en {{event}}.",
+        "dropped_other": "{{count}} filtros eliminados porque no existen en {{event}}.",
+        "undo": "Deshacer"
+      },
+      "customEventNameLabel": "Nombre del evento personalizado",
+      "customEventNamePlaceholder": "Escriba el nombre del evento custom (ej.: button_clicked)",
+      "customEventWarning": "Los eventos custom no tienen validación de schema. Úselos solo para casos que los eventos del catálogo no cubren.",
+      "selectEventRequired": "Elija un evento para guardar el disparador.",
+      "customEventNameRequired": "Escriba el nombre del evento personalizado para guardar."
     },
     "label": {
       "configuration": "Configuración de la Etiqueta",

--- a/src/i18n/locales/fr/events.json
+++ b/src/i18n/locales/fr/events.json
@@ -43,7 +43,7 @@
     },
     "channel_type": {
       "label": "Type de canal",
-      "help": "Ex. : whatsapp, instagram, email.",
+      "help": "Ne se déclenche que pour les conversations de ce type de canal.",
       "options": {
         "Channel__Whatsapp": "WhatsApp",
         "Channel__Instagram": "Instagram",
@@ -78,7 +78,7 @@
       "help": "Coché : uniquement les cartes entrées comme lead."
     },
     "assigned_by_id": {
-      "label": "Attribué par (id utilisateur)",
+      "label": "Attribué par",
       "help": "Ne se déclenche que si cet agent a fait l'attribution."
     },
     "labelId": {
@@ -240,7 +240,11 @@
     },
     "outcome": {
       "label": "Résultat dans le CRM",
-      "help": "created (nouvelle carte) ou already_in_pipeline (achat ajouté à la carte ouverte)."
+      "help": "created (nouvelle carte) ou already_in_pipeline (achat ajouté à la carte ouverte).",
+      "options": {
+        "created": "Nouvelle carte",
+        "already_in_pipeline": "Achat ajouté à la carte ouverte"
+      }
     },
     "new_contact": {
       "label": "Nouveau contact",
@@ -366,6 +370,9 @@
     },
     "custom": {
       "description": "Un événement que vous définissez, avec des propriétés libres."
+    },
+    "purchase_approved": {
+      "description": "Un achat a été approuvé sur une plateforme de paiement et capturé comme lead dans le CRM."
     }
   }
 }

--- a/src/i18n/locales/fr/events.json
+++ b/src/i18n/locales/fr/events.json
@@ -15,17 +15,357 @@
     "custom": "Personnalisé"
   },
   "propertiesForm": {
-    "requiredSectionLabel": "Champs obligatoires",
-    "optionalSectionLabel": "Champs optionnels",
-    "addFieldLabel": "+ Ajouter un champ",
+    "optionalSectionLabel": "Filtres (optionnels)",
+    "addFieldLabel": "+ Ajouter un filtre",
     "customSectionLabel": "Propriétés personnalisées",
     "customKeyPlaceholder": "clé",
     "customValuePlaceholder": "valeur",
     "customAddLabel": "+ Ajouter une propriété",
-    "requiredFieldMissing": "Champ obligatoire",
-    "customWarning": "Les événements personnalisés ne sont pas validés par schéma",
     "customRemoveAriaLabel": "Supprimer la propriété",
-    "addFieldSearchPlaceholder": "Rechercher un champ...",
-    "noResultsLabel": "Aucun champ trouvé"
+    "addFieldSearchPlaceholder": "Rechercher un filtre...",
+    "noResultsLabel": "Aucun filtre trouvé",
+    "filtersHint": "Sans filtres, le parcours démarre à chaque occurrence de l'événement.",
+    "removeFilterAriaLabel": "Supprimer le filtre",
+    "lookupLoading": "Chargement...",
+    "lookupPlaceholder": "Sélectionnez",
+    "lookupEmpty": "Aucune option disponible",
+    "lookupError": "Impossible de charger la liste",
+    "lookupNeedsPipeline": "Choisissez d'abord le pipeline",
+    "pairConflict": "Le canal choisi est de type {{actual}}. Ce filtre ne pourra jamais correspondre ; supprimez l'un des deux."
+  },
+  "fields": {
+    "inbox_id": {
+      "label": "Canal",
+      "help": "Ne se déclenche que si l'événement vient de ce canal."
+    },
+    "inbox_name": {
+      "label": "Nom du canal"
+    },
+    "channel_type": {
+      "label": "Type de canal",
+      "help": "Ex. : whatsapp, instagram, email.",
+      "options": {
+        "Channel__Whatsapp": "WhatsApp",
+        "Channel__Instagram": "Instagram",
+        "Channel__FacebookPage": "Facebook Messenger",
+        "Channel__Telegram": "Telegram",
+        "Channel__Email": "E-mail",
+        "Channel__Sms": "SMS",
+        "Channel__TwilioSms": "SMS (Twilio)",
+        "Channel__WebWidget": "Chat du site",
+        "Channel__Api": "API",
+        "Channel__Line": "LINE",
+        "Channel__Sendgrid": "E-mail (SendGrid)",
+        "Channel__TwitterProfile": "X (Twitter)"
+      }
+    },
+    "pipeline_id": {
+      "label": "Pipeline",
+      "help": "Ne se déclenche que pour les cartes de ce pipeline."
+    },
+    "pipeline_name": {
+      "label": "Nom du pipeline"
+    },
+    "pipeline_stage_id": {
+      "label": "Étape du pipeline",
+      "help": "Choisissez d'abord le pipeline pour voir ses étapes."
+    },
+    "pipeline_stage_name": {
+      "label": "Nom de l'étape"
+    },
+    "is_lead": {
+      "label": "Est un lead",
+      "help": "Coché : uniquement les cartes entrées comme lead."
+    },
+    "assigned_by_id": {
+      "label": "Attribué par (id utilisateur)",
+      "help": "Ne se déclenche que si cet agent a fait l'attribution."
+    },
+    "labelId": {
+      "label": "Étiquette",
+      "help": "Ne se déclenche que pour cette étiquette."
+    },
+    "labelName": {
+      "label": "Nom de l'étiquette"
+    },
+    "attributeName": {
+      "label": "Nom de l'attribut",
+      "help": "La clé de l'attribut personnalisé modifié."
+    },
+    "attributeValue": {
+      "label": "Nouvelle valeur de l'attribut",
+      "help": "La valeur que l'attribut a maintenant."
+    },
+    "oldValue": {
+      "label": "Valeur précédente",
+      "help": "La valeur que l'attribut avait avant."
+    },
+    "changeType": {
+      "label": "Type de changement",
+      "help": "Comment l'attribut a changé (créé, modifié ou supprimé)."
+    },
+    "activity_type": {
+      "label": "Type d'activité",
+      "help": "Le type d'activité enregistrée sur la conversation."
+    },
+    "content": {
+      "label": "Contenu",
+      "help": "Texte exact du message ou de l'activité."
+    },
+    "content_type": {
+      "label": "Type de contenu",
+      "help": "Ex. : text, image, audio, file.",
+      "options": {
+        "text": "Texte",
+        "input_text": "Champ texte",
+        "input_textarea": "Zone de texte",
+        "input_email": "Champ e-mail",
+        "input_select": "Sélection",
+        "cards": "Cartes",
+        "form": "Formulaire",
+        "article": "Article",
+        "incoming_email": "E-mail reçu",
+        "input_csat": "Enquête CSAT",
+        "integrations": "Intégration",
+        "sticker": "Sticker"
+      }
+    },
+    "message_type": {
+      "label": "Sens du message",
+      "help": "incoming (du contact) ou outgoing (de l'équipe).",
+      "options": {
+        "incoming": "Reçue (du contact)",
+        "outgoing": "Envoyée (de l'équipe)"
+      }
+    },
+    "status": {
+      "label": "Statut de livraison",
+      "options": {
+        "sent": "Envoyée",
+        "delivered": "Livrée",
+        "read": "Lue",
+        "failed": "Échouée"
+      },
+      "help": "Le statut actuel du message."
+    },
+    "previous_status": {
+      "label": "Statut précédent",
+      "options": {
+        "sent": "Envoyée",
+        "delivered": "Livrée",
+        "read": "Lue",
+        "failed": "Échouée"
+      },
+      "help": "Le statut du message avant ce changement."
+    },
+    "external_error": {
+      "label": "Erreur du fournisseur",
+      "help": "Le message d'erreur renvoyé par le fournisseur."
+    },
+    "reason": {
+      "label": "Motif",
+      "help": "Le motif donné pour la suppression ou le transfert."
+    },
+    "resolved_by_id": {
+      "label": "Résolu par (id)"
+    },
+    "resolved_by_type": {
+      "label": "Résolu par (type)",
+      "help": "user, bot ou system."
+    },
+    "resolution_time_seconds": {
+      "label": "Temps de résolution (s)",
+      "help": "Secondes entre l'ouverture et la résolution."
+    },
+    "response_time_seconds": {
+      "label": "Temps de réponse (s)",
+      "help": "Secondes avant la première réponse de l'équipe."
+    },
+    "reply_time_seconds": {
+      "label": "Délai de réponse (s)",
+      "help": "Secondes avant la réponse de l'équipe."
+    },
+    "replied_at": {
+      "label": "Répondu le"
+    },
+    "measured_at": {
+      "label": "Mesuré le"
+    },
+    "handoff_at": {
+      "label": "Transféré le"
+    },
+    "resolved_at": {
+      "label": "Résolu le"
+    },
+    "deleted_at": {
+      "label": "Supprimé le"
+    },
+    "opened_at": {
+      "label": "Ouvert le"
+    },
+    "clicked_at": {
+      "label": "Cliqué le"
+    },
+    "campaign_id": {
+      "label": "Campagne (id)",
+      "help": "Ne se déclenche que pour les messages de cette campagne."
+    },
+    "template_id": {
+      "label": "Modèle (id)",
+      "help": "Ne se déclenche que pour les messages envoyés avec ce modèle."
+    },
+    "url": {
+      "label": "URL cliquée",
+      "help": "L'URL exacte sur laquelle le contact a cliqué."
+    },
+    "provider": {
+      "label": "Plateforme de paiement",
+      "help": "virtu, hotmart, kiwify ou cakto."
+    },
+    "product": {
+      "label": "Produit",
+      "help": "Le nom du produit tel que la plateforme l'envoie."
+    },
+    "amount": {
+      "label": "Montant",
+      "help": "Dans l'unité de la devise (ex. : 197.5), jamais en centimes."
+    },
+    "currency": {
+      "label": "Devise",
+      "help": "Ex. : BRL, USD."
+    },
+    "platform_event": {
+      "label": "Événement de la plateforme",
+      "help": "Le nom de l'événement tel qu'envoyé par la plateforme."
+    },
+    "outcome": {
+      "label": "Résultat dans le CRM",
+      "help": "created (nouvelle carte) ou already_in_pipeline (achat ajouté à la carte ouverte)."
+    },
+    "new_contact": {
+      "label": "Nouveau contact",
+      "help": "Coché : l'achat a créé le contact."
+    },
+    "name": {
+      "label": "Nom",
+      "help": "Le nom exact du contact."
+    },
+    "email": {
+      "label": "E-mail",
+      "help": "L'e-mail exact du contact."
+    },
+    "phone_number": {
+      "label": "Téléphone",
+      "help": "Format E.164, ex. : +5511999999999."
+    },
+    "identifier": {
+      "label": "Identifiant externe",
+      "help": "L'identifiant du contact dans un autre système."
+    },
+    "middle_name": {
+      "label": "Deuxième prénom",
+      "help": "Le deuxième prénom exact du contact."
+    },
+    "last_name": {
+      "label": "Nom de famille",
+      "help": "Le nom de famille exact du contact."
+    },
+    "location": {
+      "label": "Localisation",
+      "help": "La localisation enregistrée sur le contact."
+    },
+    "country_code": {
+      "label": "Code pays",
+      "help": "Ex. : BR, US."
+    },
+    "contact_type": {
+      "label": "Type de contact",
+      "options": {
+        "visitor": "Visiteur",
+        "lead": "Lead",
+        "customer": "Client"
+      },
+      "help": "Visiteur, lead ou client, tel que classé dans le CRM."
+    },
+    "blocked": {
+      "label": "Bloqué",
+      "help": "Coché : uniquement les contacts bloqués."
+    },
+    "created_via": {
+      "label": "Créé par",
+      "options": {
+        "agent": "Agent",
+        "system": "Système"
+      },
+      "help": "Si le contact a été créé par un agent ou par le système (canal, import, webhook)."
+    }
+  },
+  "events": {
+    "contact_created": {
+      "description": "Un nouveau contact a été créé dans le CRM."
+    },
+    "contact_updated": {
+      "description": "Les données d'un contact ont été modifiées."
+    },
+    "contact_deleted": {
+      "description": "Un contact a été supprimé."
+    },
+    "contact_label_added": {
+      "description": "Une étiquette a été appliquée à un contact."
+    },
+    "contact_label_removed": {
+      "description": "Une étiquette a été retirée d'un contact."
+    },
+    "contact_custom_attribute_changed": {
+      "description": "Un attribut personnalisé du contact a changé de valeur."
+    },
+    "conversation_created": {
+      "description": "Une nouvelle conversation a été ouverte sur un canal."
+    },
+    "conversation_resolved": {
+      "description": "Une conversation a été marquée comme résolue."
+    },
+    "conversation_activity": {
+      "description": "Une activité a été enregistrée sur une conversation (note, attribution, changement de statut)."
+    },
+    "conversation_first_reply": {
+      "description": "L'équipe a répondu pour la première fois sur une conversation."
+    },
+    "conversation_reply_time": {
+      "description": "Le délai de réponse d'une conversation a été mesuré."
+    },
+    "conversation_bot_handoff": {
+      "description": "Le bot a transféré la conversation à l'équipe."
+    },
+    "conversation_bot_resolved": {
+      "description": "Le bot a résolu la conversation sans l'équipe."
+    },
+    "message_created": {
+      "description": "Un message a été envoyé ou reçu sur une conversation."
+    },
+    "message_delivered": {
+      "description": "Un message envoyé a été livré au contact."
+    },
+    "message_read": {
+      "description": "Le contact a lu un message envoyé."
+    },
+    "message_failed": {
+      "description": "L'envoi d'un message a échoué chez le fournisseur."
+    },
+    "campaign_triggered": {
+      "description": "Un contact est entré dans un pipeline comme carte (par lead, campagne ou attribution)."
+    },
+    "campaign_message_sent": {
+      "description": "Un message de campagne a été envoyé à un contact."
+    },
+    "campaign_message_opened": {
+      "description": "Le contact a ouvert un message de campagne."
+    },
+    "campaign_message_clicked": {
+      "description": "Le contact a cliqué sur un lien d'un message de campagne."
+    },
+    "custom": {
+      "description": "Un événement que vous définissez, avec des propriétés libres."
+    }
   }
 }

--- a/src/i18n/locales/fr/events.json
+++ b/src/i18n/locales/fr/events.json
@@ -220,7 +220,13 @@
     },
     "provider": {
       "label": "Plateforme de paiement",
-      "help": "virtu, hotmart, kiwify ou cakto."
+      "help": "Ne se déclenche que pour les achats de cette plateforme.",
+      "options": {
+        "virtu": "Virtu",
+        "hotmart": "Hotmart",
+        "kiwify": "Kiwify",
+        "cakto": "Cakto"
+      }
     },
     "product": {
       "label": "Produit",

--- a/src/i18n/locales/fr/journey.json
+++ b/src/i18n/locales/fr/journey.json
@@ -1776,7 +1776,7 @@
     }
   },
   "triggerComponents": {
-    "triggerType": "Type de déclencheur",
+    "triggerType": "Comment le parcours démarre",
     "selectType": "Sélectionnez le type",
     "types": {
       "manual": "Entrée manuelle",
@@ -1918,11 +1918,15 @@
       "value": "Valeur",
       "captureEventData": "Capturer les données de l'événement",
       "eventSwitch": {
-        "title": "Conserver les valeurs compatibles ?",
-        "body": "Vous avez changé d'événement. Conserver les valeurs de propriété qui existent aussi sur le nouvel événement (même nom et type) ou tout effacer ?",
-        "preserve": "Conserver compatibles",
-        "clear": "Tout effacer"
-      }
+        "dropped_one": "1 filtre supprimé car il n'existe pas sur {{event}}.",
+        "dropped_other": "{{count}} filtres supprimés car ils n'existent pas sur {{event}}.",
+        "undo": "Annuler"
+      },
+      "customEventNameLabel": "Nom de l'événement personnalisé",
+      "customEventNamePlaceholder": "Saisissez le nom de l'événement custom (ex. : button_clicked)",
+      "customEventWarning": "Les événements custom n'ont pas de validation de schéma. À utiliser seulement pour les cas non couverts par le catalogue.",
+      "selectEventRequired": "Choisissez un événement pour enregistrer le déclencheur.",
+      "customEventNameRequired": "Saisissez le nom de l'événement personnalisé pour enregistrer."
     },
     "label": {
       "configuration": "Configuration de l'étiquette",

--- a/src/i18n/locales/it/events.json
+++ b/src/i18n/locales/it/events.json
@@ -43,7 +43,7 @@
     },
     "channel_type": {
       "label": "Tipo di canale",
-      "help": "Es.: whatsapp, instagram, email.",
+      "help": "Scatta solo per le conversazioni di questo tipo di canale.",
       "options": {
         "Channel__Whatsapp": "WhatsApp",
         "Channel__Instagram": "Instagram",
@@ -78,7 +78,7 @@
       "help": "Selezionato: solo le card entrate come lead."
     },
     "assigned_by_id": {
-      "label": "Assegnato da (id utente)",
+      "label": "Assegnato da",
       "help": "Scatta solo quando questo agente ha fatto l'assegnazione."
     },
     "labelId": {
@@ -240,7 +240,11 @@
     },
     "outcome": {
       "label": "Esito nel CRM",
-      "help": "created (nuova card) o already_in_pipeline (acquisto aggiunto alla card aperta)."
+      "help": "created (nuova card) o already_in_pipeline (acquisto aggiunto alla card aperta).",
+      "options": {
+        "created": "Nuova card",
+        "already_in_pipeline": "Acquisto aggiunto alla card aperta"
+      }
     },
     "new_contact": {
       "label": "Nuovo contatto",
@@ -366,6 +370,9 @@
     },
     "custom": {
       "description": "Un evento definito da te, con proprietà libere."
+    },
+    "purchase_approved": {
+      "description": "Un acquisto è stato approvato su una piattaforma di pagamento ed è diventato lead nel CRM."
     }
   }
 }

--- a/src/i18n/locales/it/events.json
+++ b/src/i18n/locales/it/events.json
@@ -15,17 +15,357 @@
     "custom": "Personalizzato"
   },
   "propertiesForm": {
-    "requiredSectionLabel": "Campi obbligatori",
-    "optionalSectionLabel": "Campi opzionali",
-    "addFieldLabel": "+ Aggiungi campo",
+    "optionalSectionLabel": "Filtri (opzionali)",
+    "addFieldLabel": "+ Aggiungi filtro",
     "customSectionLabel": "Proprietà personalizzate",
     "customKeyPlaceholder": "chiave",
     "customValuePlaceholder": "valore",
     "customAddLabel": "+ Aggiungi proprietà",
-    "requiredFieldMissing": "Campo obbligatorio",
-    "customWarning": "Gli eventi personalizzati non sono validati dal schema",
     "customRemoveAriaLabel": "Rimuovi proprietà",
-    "addFieldSearchPlaceholder": "Cerca campo...",
-    "noResultsLabel": "Nessun campo trovato"
+    "addFieldSearchPlaceholder": "Cerca filtro...",
+    "noResultsLabel": "Nessun filtro trovato",
+    "filtersHint": "Senza filtri, il percorso parte a ogni occorrenza dell'evento.",
+    "removeFilterAriaLabel": "Rimuovi filtro",
+    "lookupLoading": "Caricamento...",
+    "lookupPlaceholder": "Seleziona",
+    "lookupEmpty": "Nessuna opzione disponibile",
+    "lookupError": "Impossibile caricare l'elenco",
+    "lookupNeedsPipeline": "Scegli prima la pipeline",
+    "pairConflict": "Il canale scelto è di tipo {{actual}}. Questo filtro non potrà mai corrispondere; rimuovi uno dei due."
+  },
+  "fields": {
+    "inbox_id": {
+      "label": "Canale",
+      "help": "Scatta solo quando l'evento arriva da questo canale."
+    },
+    "inbox_name": {
+      "label": "Nome del canale"
+    },
+    "channel_type": {
+      "label": "Tipo di canale",
+      "help": "Es.: whatsapp, instagram, email.",
+      "options": {
+        "Channel__Whatsapp": "WhatsApp",
+        "Channel__Instagram": "Instagram",
+        "Channel__FacebookPage": "Facebook Messenger",
+        "Channel__Telegram": "Telegram",
+        "Channel__Email": "E-mail",
+        "Channel__Sms": "SMS",
+        "Channel__TwilioSms": "SMS (Twilio)",
+        "Channel__WebWidget": "Chat del sito",
+        "Channel__Api": "API",
+        "Channel__Line": "LINE",
+        "Channel__Sendgrid": "E-mail (SendGrid)",
+        "Channel__TwitterProfile": "X (Twitter)"
+      }
+    },
+    "pipeline_id": {
+      "label": "Pipeline",
+      "help": "Scatta solo per le card di questa pipeline."
+    },
+    "pipeline_name": {
+      "label": "Nome della pipeline"
+    },
+    "pipeline_stage_id": {
+      "label": "Fase della pipeline",
+      "help": "Scegli prima la pipeline per vedere le fasi."
+    },
+    "pipeline_stage_name": {
+      "label": "Nome della fase"
+    },
+    "is_lead": {
+      "label": "È un lead",
+      "help": "Selezionato: solo le card entrate come lead."
+    },
+    "assigned_by_id": {
+      "label": "Assegnato da (id utente)",
+      "help": "Scatta solo quando questo agente ha fatto l'assegnazione."
+    },
+    "labelId": {
+      "label": "Etichetta",
+      "help": "Scatta solo per questa etichetta."
+    },
+    "labelName": {
+      "label": "Nome dell'etichetta"
+    },
+    "attributeName": {
+      "label": "Nome dell'attributo",
+      "help": "La chiave dell'attributo personalizzato cambiato."
+    },
+    "attributeValue": {
+      "label": "Nuovo valore dell'attributo",
+      "help": "Il valore che l'attributo ha assunto."
+    },
+    "oldValue": {
+      "label": "Valore precedente",
+      "help": "Il valore che l'attributo aveva prima."
+    },
+    "changeType": {
+      "label": "Tipo di modifica",
+      "help": "Come è cambiato l'attributo (creato, modificato o rimosso)."
+    },
+    "activity_type": {
+      "label": "Tipo di attività",
+      "help": "Il tipo di attività registrata nella conversazione."
+    },
+    "content": {
+      "label": "Contenuto",
+      "help": "Testo esatto del messaggio o dell'attività."
+    },
+    "content_type": {
+      "label": "Tipo di contenuto",
+      "help": "Es.: text, image, audio, file.",
+      "options": {
+        "text": "Testo",
+        "input_text": "Campo di testo",
+        "input_textarea": "Area di testo",
+        "input_email": "Campo e-mail",
+        "input_select": "Selezione",
+        "cards": "Card",
+        "form": "Modulo",
+        "article": "Articolo",
+        "incoming_email": "E-mail ricevuta",
+        "input_csat": "Sondaggio CSAT",
+        "integrations": "Integrazione",
+        "sticker": "Sticker"
+      }
+    },
+    "message_type": {
+      "label": "Direzione del messaggio",
+      "help": "incoming (dal contatto) o outgoing (dal team).",
+      "options": {
+        "incoming": "Ricevuta (dal contatto)",
+        "outgoing": "Inviata (dal team)"
+      }
+    },
+    "status": {
+      "label": "Stato della consegna",
+      "options": {
+        "sent": "Inviata",
+        "delivered": "Consegnata",
+        "read": "Letta",
+        "failed": "Fallita"
+      },
+      "help": "Lo stato attuale del messaggio."
+    },
+    "previous_status": {
+      "label": "Stato precedente",
+      "options": {
+        "sent": "Inviata",
+        "delivered": "Consegnata",
+        "read": "Letta",
+        "failed": "Fallita"
+      },
+      "help": "Lo stato del messaggio prima di questa modifica."
+    },
+    "external_error": {
+      "label": "Errore del provider",
+      "help": "Il messaggio di errore restituito dal provider."
+    },
+    "reason": {
+      "label": "Motivo",
+      "help": "Il motivo indicato per l'eliminazione o il trasferimento."
+    },
+    "resolved_by_id": {
+      "label": "Risolto da (id)"
+    },
+    "resolved_by_type": {
+      "label": "Risolto da (tipo)",
+      "help": "user, bot o system."
+    },
+    "resolution_time_seconds": {
+      "label": "Tempo di risoluzione (s)",
+      "help": "Secondi tra apertura e risoluzione."
+    },
+    "response_time_seconds": {
+      "label": "Tempo di risposta (s)",
+      "help": "Secondi fino alla prima risposta del team."
+    },
+    "reply_time_seconds": {
+      "label": "Tempo di replica (s)",
+      "help": "Secondi fino alla risposta del team."
+    },
+    "replied_at": {
+      "label": "Risposto il"
+    },
+    "measured_at": {
+      "label": "Misurato il"
+    },
+    "handoff_at": {
+      "label": "Trasferito il"
+    },
+    "resolved_at": {
+      "label": "Risolto il"
+    },
+    "deleted_at": {
+      "label": "Eliminato il"
+    },
+    "opened_at": {
+      "label": "Aperto il"
+    },
+    "clicked_at": {
+      "label": "Cliccato il"
+    },
+    "campaign_id": {
+      "label": "Campagna (id)",
+      "help": "Scatta solo per i messaggi di questa campagna."
+    },
+    "template_id": {
+      "label": "Template (id)",
+      "help": "Scatta solo per i messaggi inviati con questo template."
+    },
+    "url": {
+      "label": "URL cliccato",
+      "help": "L'URL esatto cliccato dal contatto."
+    },
+    "provider": {
+      "label": "Piattaforma di pagamento",
+      "help": "virtu, hotmart, kiwify o cakto."
+    },
+    "product": {
+      "label": "Prodotto",
+      "help": "Il nome del prodotto come lo invia la piattaforma."
+    },
+    "amount": {
+      "label": "Importo",
+      "help": "Nell'unità della valuta (es.: 197.5), mai in centesimi."
+    },
+    "currency": {
+      "label": "Valuta",
+      "help": "Es.: BRL, USD."
+    },
+    "platform_event": {
+      "label": "Evento della piattaforma",
+      "help": "Il nome dell'evento come inviato dalla piattaforma."
+    },
+    "outcome": {
+      "label": "Esito nel CRM",
+      "help": "created (nuova card) o already_in_pipeline (acquisto aggiunto alla card aperta)."
+    },
+    "new_contact": {
+      "label": "Nuovo contatto",
+      "help": "Selezionato: l'acquisto ha creato il contatto."
+    },
+    "name": {
+      "label": "Nome",
+      "help": "Il nome esatto del contatto."
+    },
+    "email": {
+      "label": "E-mail",
+      "help": "L'e-mail esatta del contatto."
+    },
+    "phone_number": {
+      "label": "Telefono",
+      "help": "Formato E.164, es.: +5511999999999."
+    },
+    "identifier": {
+      "label": "Identificatore esterno",
+      "help": "L'identificatore del contatto in un altro sistema."
+    },
+    "middle_name": {
+      "label": "Secondo nome",
+      "help": "Il secondo nome esatto del contatto."
+    },
+    "last_name": {
+      "label": "Cognome",
+      "help": "Il cognome esatto del contatto."
+    },
+    "location": {
+      "label": "Località",
+      "help": "La località registrata sul contatto."
+    },
+    "country_code": {
+      "label": "Codice paese",
+      "help": "Es.: BR, US."
+    },
+    "contact_type": {
+      "label": "Tipo di contatto",
+      "options": {
+        "visitor": "Visitatore",
+        "lead": "Lead",
+        "customer": "Cliente"
+      },
+      "help": "Visitatore, lead o cliente, come classificato nel CRM."
+    },
+    "blocked": {
+      "label": "Bloccato",
+      "help": "Selezionato: solo contatti bloccati."
+    },
+    "created_via": {
+      "label": "Creato da",
+      "options": {
+        "agent": "Agente",
+        "system": "Sistema"
+      },
+      "help": "Se il contatto è stato creato da un agente o dal sistema (canale, importazione, webhook)."
+    }
+  },
+  "events": {
+    "contact_created": {
+      "description": "Un nuovo contatto è stato creato nel CRM."
+    },
+    "contact_updated": {
+      "description": "I dati di un contatto sono stati modificati."
+    },
+    "contact_deleted": {
+      "description": "Un contatto è stato eliminato."
+    },
+    "contact_label_added": {
+      "description": "Un'etichetta è stata applicata a un contatto."
+    },
+    "contact_label_removed": {
+      "description": "Un'etichetta è stata rimossa da un contatto."
+    },
+    "contact_custom_attribute_changed": {
+      "description": "Un attributo personalizzato del contatto ha cambiato valore."
+    },
+    "conversation_created": {
+      "description": "Una nuova conversazione è stata aperta su un canale."
+    },
+    "conversation_resolved": {
+      "description": "Una conversazione è stata segnata come risolta."
+    },
+    "conversation_activity": {
+      "description": "Un'attività è stata registrata su una conversazione (nota, assegnazione, cambio di stato)."
+    },
+    "conversation_first_reply": {
+      "description": "Il team ha risposto per la prima volta in una conversazione."
+    },
+    "conversation_reply_time": {
+      "description": "Il tempo di risposta di una conversazione è stato misurato."
+    },
+    "conversation_bot_handoff": {
+      "description": "Il bot ha trasferito la conversazione al team."
+    },
+    "conversation_bot_resolved": {
+      "description": "Il bot ha risolto la conversazione senza il team."
+    },
+    "message_created": {
+      "description": "Un messaggio è stato inviato o ricevuto in una conversazione."
+    },
+    "message_delivered": {
+      "description": "Un messaggio inviato è stato consegnato al contatto."
+    },
+    "message_read": {
+      "description": "Il contatto ha letto un messaggio inviato."
+    },
+    "message_failed": {
+      "description": "L'invio di un messaggio è fallito presso il provider."
+    },
+    "campaign_triggered": {
+      "description": "Un contatto è entrato in una pipeline come card (per lead, campagna o assegnazione)."
+    },
+    "campaign_message_sent": {
+      "description": "Un messaggio di campagna è stato inviato a un contatto."
+    },
+    "campaign_message_opened": {
+      "description": "Il contatto ha aperto un messaggio di campagna."
+    },
+    "campaign_message_clicked": {
+      "description": "Il contatto ha cliccato un link in un messaggio di campagna."
+    },
+    "custom": {
+      "description": "Un evento definito da te, con proprietà libere."
+    }
   }
 }

--- a/src/i18n/locales/it/events.json
+++ b/src/i18n/locales/it/events.json
@@ -220,7 +220,13 @@
     },
     "provider": {
       "label": "Piattaforma di pagamento",
-      "help": "virtu, hotmart, kiwify o cakto."
+      "help": "Scatta solo per gli acquisti di questa piattaforma.",
+      "options": {
+        "virtu": "Virtu",
+        "hotmart": "Hotmart",
+        "kiwify": "Kiwify",
+        "cakto": "Cakto"
+      }
     },
     "product": {
       "label": "Prodotto",

--- a/src/i18n/locales/it/journey.json
+++ b/src/i18n/locales/it/journey.json
@@ -1788,7 +1788,7 @@
     }
   },
   "triggerComponents": {
-    "triggerType": "Tipo del Trigger",
+    "triggerType": "Come inizia il percorso",
     "selectType": "Seleziona il tipo",
     "types": {
       "manual": "Ingresso Manuale",
@@ -1930,11 +1930,15 @@
       "value": "Valore",
       "captureEventData": "Cattura Dati dell'Evento",
       "eventSwitch": {
-        "title": "Conservare i valori compatibili?",
-        "body": "Hai cambiato l'evento. Mantenere i valori delle proprietà che esistono anche nel nuovo evento (stesso nome e tipo) o cancellarli tutti?",
-        "preserve": "Conserva compatibili",
-        "clear": "Cancella tutto"
-      }
+        "dropped_one": "1 filtro rimosso perché non esiste su {{event}}.",
+        "dropped_other": "{{count}} filtri rimossi perché non esistono su {{event}}.",
+        "undo": "Annulla"
+      },
+      "customEventNameLabel": "Nome dell'evento personalizzato",
+      "customEventNamePlaceholder": "Digita il nome dell'evento custom (es.: button_clicked)",
+      "customEventWarning": "Gli eventi custom non hanno validazione di schema. Usali solo per casi non coperti dal catalogo.",
+      "selectEventRequired": "Scegli un evento per salvare il trigger.",
+      "customEventNameRequired": "Digita il nome dell'evento personalizzato per salvare."
     },
     "label": {
       "configuration": "Configurazione dell'Etichetta",

--- a/src/i18n/locales/journey-parity.spec.ts
+++ b/src/i18n/locales/journey-parity.spec.ts
@@ -68,15 +68,15 @@ describe('journey i18n parity (EVO-1260)', () => {
     expect(empties).toEqual([]);
   });
 
-  // EVO-1275: the event-switch confirm-modal keys were added to ALL six
-  // locales (the strict en↔pt-BR mirror would otherwise leave pt/es/fr/it
-  // unguarded against silent drift/removal). Assert presence + non-empty
+  // EVO-1275 / CRM-519: the event-switch keys were added to ALL six locales
+  // (the strict en↔pt-BR mirror would otherwise leave pt/es/fr/it unguarded
+  // against silent drift/removal). CRM-519 replaced the confirm modal with an
+  // inline "N filters removed" notice + Undo. Assert presence + non-empty
   // across every shipped locale, mirroring the EVO-1260 pattern above.
   const evo1275Keys = [
-    'triggerComponents.event.eventSwitch.title',
-    'triggerComponents.event.eventSwitch.body',
-    'triggerComponents.event.eventSwitch.preserve',
-    'triggerComponents.event.eventSwitch.clear',
+    'triggerComponents.event.eventSwitch.dropped_one',
+    'triggerComponents.event.eventSwitch.dropped_other',
+    'triggerComponents.event.eventSwitch.undo',
   ];
 
   it.each([

--- a/src/i18n/locales/pt-BR/events.json
+++ b/src/i18n/locales/pt-BR/events.json
@@ -43,7 +43,7 @@
     },
     "channel_type": {
       "label": "Tipo de canal",
-      "help": "Ex.: whatsapp, instagram, email.",
+      "help": "Só dispara para conversas deste tipo de canal.",
       "options": {
         "Channel__Whatsapp": "WhatsApp",
         "Channel__Instagram": "Instagram",
@@ -78,7 +78,7 @@
       "help": "Marcado: só cards que entraram como lead."
     },
     "assigned_by_id": {
-      "label": "Atribuído por (id do usuário)",
+      "label": "Atribuído por",
       "help": "Só dispara quando este agente fez a atribuição."
     },
     "labelId": {
@@ -240,7 +240,11 @@
     },
     "outcome": {
       "label": "Resultado no CRM",
-      "help": "created (card novo) ou already_in_pipeline (compra anexada ao card aberto)."
+      "help": "created (card novo) ou already_in_pipeline (compra anexada ao card aberto).",
+      "options": {
+        "created": "Card novo",
+        "already_in_pipeline": "Compra anexada ao card aberto"
+      }
     },
     "new_contact": {
       "label": "Contato novo",
@@ -366,6 +370,9 @@
     },
     "custom": {
       "description": "Evento definido por você, com propriedades livres."
+    },
+    "purchase_approved": {
+      "description": "Uma compra foi aprovada numa plataforma de pagamento e virou lead no CRM."
     }
   }
 }

--- a/src/i18n/locales/pt-BR/events.json
+++ b/src/i18n/locales/pt-BR/events.json
@@ -15,17 +15,357 @@
     "custom": "Personalizado"
   },
   "propertiesForm": {
-    "requiredSectionLabel": "Campos obrigatórios",
-    "optionalSectionLabel": "Campos opcionais",
-    "addFieldLabel": "+ Adicionar campo",
+    "optionalSectionLabel": "Filtros (opcionais)",
+    "addFieldLabel": "+ Adicionar filtro",
     "customSectionLabel": "Propriedades personalizadas",
     "customKeyPlaceholder": "chave",
     "customValuePlaceholder": "valor",
     "customAddLabel": "+ Adicionar propriedade",
-    "requiredFieldMissing": "Campo obrigatório",
-    "customWarning": "Eventos personalizados não são validados por schema",
     "customRemoveAriaLabel": "Remover propriedade",
-    "addFieldSearchPlaceholder": "Buscar campo...",
-    "noResultsLabel": "Nenhum campo encontrado"
+    "addFieldSearchPlaceholder": "Buscar filtro...",
+    "noResultsLabel": "Nenhum filtro encontrado",
+    "filtersHint": "Sem filtros, a jornada dispara em toda ocorrência do evento.",
+    "removeFilterAriaLabel": "Remover filtro",
+    "lookupLoading": "Carregando...",
+    "lookupPlaceholder": "Selecione",
+    "lookupEmpty": "Nenhuma opção disponível",
+    "lookupError": "Não foi possível carregar a lista",
+    "lookupNeedsPipeline": "Escolha o funil primeiro",
+    "pairConflict": "O canal escolhido é do tipo {{actual}}. Este filtro nunca vai casar; remova um dos dois."
+  },
+  "fields": {
+    "inbox_id": {
+      "label": "Canal",
+      "help": "Só dispara quando o evento vem deste canal."
+    },
+    "inbox_name": {
+      "label": "Nome do canal"
+    },
+    "channel_type": {
+      "label": "Tipo de canal",
+      "help": "Ex.: whatsapp, instagram, email.",
+      "options": {
+        "Channel__Whatsapp": "WhatsApp",
+        "Channel__Instagram": "Instagram",
+        "Channel__FacebookPage": "Facebook Messenger",
+        "Channel__Telegram": "Telegram",
+        "Channel__Email": "E-mail",
+        "Channel__Sms": "SMS",
+        "Channel__TwilioSms": "SMS (Twilio)",
+        "Channel__WebWidget": "Chat do site",
+        "Channel__Api": "API",
+        "Channel__Line": "LINE",
+        "Channel__Sendgrid": "E-mail (SendGrid)",
+        "Channel__TwitterProfile": "X (Twitter)"
+      }
+    },
+    "pipeline_id": {
+      "label": "Funil",
+      "help": "Só dispara para cards deste funil."
+    },
+    "pipeline_name": {
+      "label": "Nome do funil"
+    },
+    "pipeline_stage_id": {
+      "label": "Etapa do funil",
+      "help": "Escolha o funil primeiro para ver as etapas."
+    },
+    "pipeline_stage_name": {
+      "label": "Nome da etapa"
+    },
+    "is_lead": {
+      "label": "É lead",
+      "help": "Marcado: só cards que entraram como lead."
+    },
+    "assigned_by_id": {
+      "label": "Atribuído por (id do usuário)",
+      "help": "Só dispara quando este agente fez a atribuição."
+    },
+    "labelId": {
+      "label": "Etiqueta",
+      "help": "Só dispara para esta etiqueta."
+    },
+    "labelName": {
+      "label": "Nome da etiqueta"
+    },
+    "attributeName": {
+      "label": "Nome do atributo",
+      "help": "A chave do atributo personalizado que mudou."
+    },
+    "attributeValue": {
+      "label": "Novo valor do atributo",
+      "help": "O valor que o atributo passou a ter."
+    },
+    "oldValue": {
+      "label": "Valor anterior",
+      "help": "O valor que o atributo tinha antes."
+    },
+    "changeType": {
+      "label": "Tipo de mudança",
+      "help": "Como o atributo mudou (criado, alterado ou removido)."
+    },
+    "activity_type": {
+      "label": "Tipo de atividade",
+      "help": "O tipo da atividade registrada na conversa."
+    },
+    "content": {
+      "label": "Conteúdo",
+      "help": "Texto exato da mensagem ou atividade."
+    },
+    "content_type": {
+      "label": "Tipo de conteúdo",
+      "help": "Ex.: text, image, audio, file.",
+      "options": {
+        "text": "Texto",
+        "input_text": "Campo de texto",
+        "input_textarea": "Área de texto",
+        "input_email": "Campo de e-mail",
+        "input_select": "Seleção",
+        "cards": "Cartões",
+        "form": "Formulário",
+        "article": "Artigo",
+        "incoming_email": "E-mail recebido",
+        "input_csat": "Pesquisa CSAT",
+        "integrations": "Integração",
+        "sticker": "Figurinha"
+      }
+    },
+    "message_type": {
+      "label": "Direção da mensagem",
+      "help": "incoming (do contato) ou outgoing (da equipe).",
+      "options": {
+        "incoming": "Recebida (do contato)",
+        "outgoing": "Enviada (da equipe)"
+      }
+    },
+    "status": {
+      "label": "Status da entrega",
+      "options": {
+        "sent": "Enviada",
+        "delivered": "Entregue",
+        "read": "Lida",
+        "failed": "Falhou"
+      },
+      "help": "O status atual da mensagem."
+    },
+    "previous_status": {
+      "label": "Status anterior",
+      "options": {
+        "sent": "Enviada",
+        "delivered": "Entregue",
+        "read": "Lida",
+        "failed": "Falhou"
+      },
+      "help": "O status da mensagem antes desta mudança."
+    },
+    "external_error": {
+      "label": "Erro do provedor",
+      "help": "A mensagem de erro que o provedor devolveu."
+    },
+    "reason": {
+      "label": "Motivo",
+      "help": "O motivo informado para a exclusão ou a transferência."
+    },
+    "resolved_by_id": {
+      "label": "Resolvido por (id)"
+    },
+    "resolved_by_type": {
+      "label": "Resolvido por (tipo)",
+      "help": "user, bot ou system."
+    },
+    "resolution_time_seconds": {
+      "label": "Tempo de resolução (s)",
+      "help": "Segundos entre a abertura e a resolução."
+    },
+    "response_time_seconds": {
+      "label": "Tempo de resposta (s)",
+      "help": "Segundos até a primeira resposta da equipe."
+    },
+    "reply_time_seconds": {
+      "label": "Tempo até responder (s)",
+      "help": "Segundos até a equipe responder."
+    },
+    "replied_at": {
+      "label": "Respondido em"
+    },
+    "measured_at": {
+      "label": "Medido em"
+    },
+    "handoff_at": {
+      "label": "Transferido em"
+    },
+    "resolved_at": {
+      "label": "Resolvido em"
+    },
+    "deleted_at": {
+      "label": "Excluído em"
+    },
+    "opened_at": {
+      "label": "Aberto em"
+    },
+    "clicked_at": {
+      "label": "Clicado em"
+    },
+    "campaign_id": {
+      "label": "Campanha (id)",
+      "help": "Só dispara para mensagens desta campanha."
+    },
+    "template_id": {
+      "label": "Modelo (id)",
+      "help": "Só dispara para mensagens enviadas com este template."
+    },
+    "url": {
+      "label": "URL clicada",
+      "help": "A URL exata que o contato clicou."
+    },
+    "provider": {
+      "label": "Plataforma de pagamento",
+      "help": "virtu, hotmart, kiwify ou cakto."
+    },
+    "product": {
+      "label": "Produto",
+      "help": "O nome do produto como a plataforma envia."
+    },
+    "amount": {
+      "label": "Valor",
+      "help": "Na unidade da moeda (ex.: 197.5), nunca em centavos."
+    },
+    "currency": {
+      "label": "Moeda",
+      "help": "Ex.: BRL, USD."
+    },
+    "platform_event": {
+      "label": "Evento da plataforma",
+      "help": "O nome do evento como a plataforma enviou."
+    },
+    "outcome": {
+      "label": "Resultado no CRM",
+      "help": "created (card novo) ou already_in_pipeline (compra anexada ao card aberto)."
+    },
+    "new_contact": {
+      "label": "Contato novo",
+      "help": "Marcado: a compra criou o contato."
+    },
+    "name": {
+      "label": "Nome",
+      "help": "O nome exato do contato."
+    },
+    "email": {
+      "label": "E-mail",
+      "help": "O e-mail exato do contato."
+    },
+    "phone_number": {
+      "label": "Telefone",
+      "help": "Formato E.164, ex.: +5511999999999."
+    },
+    "identifier": {
+      "label": "Identificador externo",
+      "help": "O identificador do contato em outro sistema."
+    },
+    "middle_name": {
+      "label": "Nome do meio",
+      "help": "O nome do meio exato do contato."
+    },
+    "last_name": {
+      "label": "Sobrenome",
+      "help": "O sobrenome exato do contato."
+    },
+    "location": {
+      "label": "Localização",
+      "help": "A localização registrada no contato."
+    },
+    "country_code": {
+      "label": "País (código)",
+      "help": "Ex.: BR, US."
+    },
+    "contact_type": {
+      "label": "Tipo de contato",
+      "options": {
+        "visitor": "Visitante",
+        "lead": "Lead",
+        "customer": "Cliente"
+      },
+      "help": "Visitante, lead ou cliente, como classificado no CRM."
+    },
+    "blocked": {
+      "label": "Bloqueado",
+      "help": "Marcado: só contatos bloqueados."
+    },
+    "created_via": {
+      "label": "Criado por",
+      "options": {
+        "agent": "Agente",
+        "system": "Sistema"
+      },
+      "help": "Se o contato foi criado por um agente ou pelo sistema (canal, importação, webhook)."
+    }
+  },
+  "events": {
+    "contact_created": {
+      "description": "Um contato novo foi criado no CRM."
+    },
+    "contact_updated": {
+      "description": "Os dados de um contato foram alterados."
+    },
+    "contact_deleted": {
+      "description": "Um contato foi excluído."
+    },
+    "contact_label_added": {
+      "description": "Uma etiqueta foi aplicada a um contato."
+    },
+    "contact_label_removed": {
+      "description": "Uma etiqueta foi removida de um contato."
+    },
+    "contact_custom_attribute_changed": {
+      "description": "Um atributo personalizado do contato mudou de valor."
+    },
+    "conversation_created": {
+      "description": "Uma conversa nova foi aberta em um canal."
+    },
+    "conversation_resolved": {
+      "description": "Uma conversa foi marcada como resolvida."
+    },
+    "conversation_activity": {
+      "description": "Uma atividade foi registrada em uma conversa (nota, atribuição, mudança de status)."
+    },
+    "conversation_first_reply": {
+      "description": "A equipe respondeu pela primeira vez em uma conversa."
+    },
+    "conversation_reply_time": {
+      "description": "O tempo de resposta de uma conversa foi medido."
+    },
+    "conversation_bot_handoff": {
+      "description": "O bot transferiu a conversa para a equipe."
+    },
+    "conversation_bot_resolved": {
+      "description": "O bot resolveu a conversa sem a equipe."
+    },
+    "message_created": {
+      "description": "Uma mensagem foi enviada ou recebida em uma conversa."
+    },
+    "message_delivered": {
+      "description": "Uma mensagem enviada foi entregue ao contato."
+    },
+    "message_read": {
+      "description": "O contato leu uma mensagem enviada."
+    },
+    "message_failed": {
+      "description": "O envio de uma mensagem falhou no provedor."
+    },
+    "campaign_triggered": {
+      "description": "Um contato entrou em um funil como card (por lead, campanha ou atribuição)."
+    },
+    "campaign_message_sent": {
+      "description": "Uma mensagem de campanha foi enviada a um contato."
+    },
+    "campaign_message_opened": {
+      "description": "O contato abriu uma mensagem de campanha."
+    },
+    "campaign_message_clicked": {
+      "description": "O contato clicou em um link de uma mensagem de campanha."
+    },
+    "custom": {
+      "description": "Evento definido por você, com propriedades livres."
+    }
   }
 }

--- a/src/i18n/locales/pt-BR/events.json
+++ b/src/i18n/locales/pt-BR/events.json
@@ -220,7 +220,13 @@
     },
     "provider": {
       "label": "Plataforma de pagamento",
-      "help": "virtu, hotmart, kiwify ou cakto."
+      "help": "Só dispara para compras vindas desta plataforma.",
+      "options": {
+        "virtu": "Virtu",
+        "hotmart": "Hotmart",
+        "kiwify": "Kiwify",
+        "cakto": "Cakto"
+      }
     },
     "product": {
       "label": "Produto",

--- a/src/i18n/locales/pt-BR/journey.json
+++ b/src/i18n/locales/pt-BR/journey.json
@@ -1809,7 +1809,7 @@
     }
   },
   "triggerComponents": {
-    "triggerType": "Tipo do Trigger",
+    "triggerType": "Como a jornada começa",
     "selectType": "Selecione o tipo",
     "types": {
       "manual": "Entrada Manual",
@@ -1953,11 +1953,13 @@
       "customEventNamePlaceholder": "Digite o nome do evento custom (ex: button_clicked)",
       "customEventWarning": "Eventos custom não têm validação de schema. Use apenas para casos não cobertos pelos eventos canônicos.",
       "eventSwitch": {
-        "title": "Preservar valores compatíveis?",
-        "body": "Você alterou o evento. Manter os valores de propriedade que também existem no novo evento (mesmo nome e tipo) ou limpar todos?",
-        "preserve": "Preservar compatíveis",
-        "clear": "Limpar tudo"
-      }
+        "dropped_one": "1 filtro removido porque não existe em {{event}}.",
+        "dropped_other": "{{count}} filtros removidos porque não existem em {{event}}.",
+        "undo": "Desfazer"
+      },
+      "customEventNameLabel": "Nome do evento personalizado",
+      "selectEventRequired": "Escolha um evento para salvar o gatilho.",
+      "customEventNameRequired": "Digite o nome do evento personalizado para salvar."
     },
     "label": {
       "configuration": "Configuração da Etiqueta",

--- a/src/i18n/locales/pt/events.json
+++ b/src/i18n/locales/pt/events.json
@@ -43,7 +43,7 @@
     },
     "channel_type": {
       "label": "Tipo de canal",
-      "help": "Ex.: whatsapp, instagram, email.",
+      "help": "Só dispara para conversas deste tipo de canal.",
       "options": {
         "Channel__Whatsapp": "WhatsApp",
         "Channel__Instagram": "Instagram",
@@ -78,7 +78,7 @@
       "help": "Marcado: só cards que entraram como lead."
     },
     "assigned_by_id": {
-      "label": "Atribuído por (id do usuário)",
+      "label": "Atribuído por",
       "help": "Só dispara quando este agente fez a atribuição."
     },
     "labelId": {
@@ -240,7 +240,11 @@
     },
     "outcome": {
       "label": "Resultado no CRM",
-      "help": "created (card novo) ou already_in_pipeline (compra anexada ao card aberto)."
+      "help": "created (card novo) ou already_in_pipeline (compra anexada ao card aberto).",
+      "options": {
+        "created": "Card novo",
+        "already_in_pipeline": "Compra anexada ao card aberto"
+      }
     },
     "new_contact": {
       "label": "Contato novo",
@@ -366,6 +370,9 @@
     },
     "custom": {
       "description": "Evento definido por você, com propriedades livres."
+    },
+    "purchase_approved": {
+      "description": "Uma compra foi aprovada numa plataforma de pagamento e virou lead no CRM."
     }
   }
 }

--- a/src/i18n/locales/pt/events.json
+++ b/src/i18n/locales/pt/events.json
@@ -15,17 +15,357 @@
     "custom": "Personalizado"
   },
   "propertiesForm": {
-    "requiredSectionLabel": "Campos obrigatórios",
-    "optionalSectionLabel": "Campos opcionais",
-    "addFieldLabel": "+ Adicionar campo",
+    "optionalSectionLabel": "Filtros (opcionais)",
+    "addFieldLabel": "+ Adicionar filtro",
     "customSectionLabel": "Propriedades personalizadas",
     "customKeyPlaceholder": "chave",
     "customValuePlaceholder": "valor",
     "customAddLabel": "+ Adicionar propriedade",
-    "requiredFieldMissing": "Campo obrigatório",
-    "customWarning": "Eventos personalizados não são validados por schema",
     "customRemoveAriaLabel": "Remover propriedade",
-    "addFieldSearchPlaceholder": "Buscar campo...",
-    "noResultsLabel": "Nenhum campo encontrado"
+    "addFieldSearchPlaceholder": "Buscar filtro...",
+    "noResultsLabel": "Nenhum filtro encontrado",
+    "filtersHint": "Sem filtros, a jornada dispara em toda ocorrência do evento.",
+    "removeFilterAriaLabel": "Remover filtro",
+    "lookupLoading": "Carregando...",
+    "lookupPlaceholder": "Selecione",
+    "lookupEmpty": "Nenhuma opção disponível",
+    "lookupError": "Não foi possível carregar a lista",
+    "lookupNeedsPipeline": "Escolha o funil primeiro",
+    "pairConflict": "O canal escolhido é do tipo {{actual}}. Este filtro nunca vai casar; remova um dos dois."
+  },
+  "fields": {
+    "inbox_id": {
+      "label": "Canal",
+      "help": "Só dispara quando o evento vem deste canal."
+    },
+    "inbox_name": {
+      "label": "Nome do canal"
+    },
+    "channel_type": {
+      "label": "Tipo de canal",
+      "help": "Ex.: whatsapp, instagram, email.",
+      "options": {
+        "Channel__Whatsapp": "WhatsApp",
+        "Channel__Instagram": "Instagram",
+        "Channel__FacebookPage": "Facebook Messenger",
+        "Channel__Telegram": "Telegram",
+        "Channel__Email": "E-mail",
+        "Channel__Sms": "SMS",
+        "Channel__TwilioSms": "SMS (Twilio)",
+        "Channel__WebWidget": "Chat do site",
+        "Channel__Api": "API",
+        "Channel__Line": "LINE",
+        "Channel__Sendgrid": "E-mail (SendGrid)",
+        "Channel__TwitterProfile": "X (Twitter)"
+      }
+    },
+    "pipeline_id": {
+      "label": "Funil",
+      "help": "Só dispara para cards deste funil."
+    },
+    "pipeline_name": {
+      "label": "Nome do funil"
+    },
+    "pipeline_stage_id": {
+      "label": "Etapa do funil",
+      "help": "Escolha o funil primeiro para ver as etapas."
+    },
+    "pipeline_stage_name": {
+      "label": "Nome da etapa"
+    },
+    "is_lead": {
+      "label": "É lead",
+      "help": "Marcado: só cards que entraram como lead."
+    },
+    "assigned_by_id": {
+      "label": "Atribuído por (id do usuário)",
+      "help": "Só dispara quando este agente fez a atribuição."
+    },
+    "labelId": {
+      "label": "Etiqueta",
+      "help": "Só dispara para esta etiqueta."
+    },
+    "labelName": {
+      "label": "Nome da etiqueta"
+    },
+    "attributeName": {
+      "label": "Nome do atributo",
+      "help": "A chave do atributo personalizado que mudou."
+    },
+    "attributeValue": {
+      "label": "Novo valor do atributo",
+      "help": "O valor que o atributo passou a ter."
+    },
+    "oldValue": {
+      "label": "Valor anterior",
+      "help": "O valor que o atributo tinha antes."
+    },
+    "changeType": {
+      "label": "Tipo de mudança",
+      "help": "Como o atributo mudou (criado, alterado ou removido)."
+    },
+    "activity_type": {
+      "label": "Tipo de atividade",
+      "help": "O tipo da atividade registrada na conversa."
+    },
+    "content": {
+      "label": "Conteúdo",
+      "help": "Texto exato da mensagem ou atividade."
+    },
+    "content_type": {
+      "label": "Tipo de conteúdo",
+      "help": "Ex.: text, image, audio, file.",
+      "options": {
+        "text": "Texto",
+        "input_text": "Campo de texto",
+        "input_textarea": "Área de texto",
+        "input_email": "Campo de e-mail",
+        "input_select": "Seleção",
+        "cards": "Cartões",
+        "form": "Formulário",
+        "article": "Artigo",
+        "incoming_email": "E-mail recebido",
+        "input_csat": "Pesquisa CSAT",
+        "integrations": "Integração",
+        "sticker": "Figurinha"
+      }
+    },
+    "message_type": {
+      "label": "Direção da mensagem",
+      "help": "incoming (do contato) ou outgoing (da equipe).",
+      "options": {
+        "incoming": "Recebida (do contato)",
+        "outgoing": "Enviada (da equipe)"
+      }
+    },
+    "status": {
+      "label": "Status da entrega",
+      "options": {
+        "sent": "Enviada",
+        "delivered": "Entregue",
+        "read": "Lida",
+        "failed": "Falhou"
+      },
+      "help": "O status atual da mensagem."
+    },
+    "previous_status": {
+      "label": "Status anterior",
+      "options": {
+        "sent": "Enviada",
+        "delivered": "Entregue",
+        "read": "Lida",
+        "failed": "Falhou"
+      },
+      "help": "O status da mensagem antes desta mudança."
+    },
+    "external_error": {
+      "label": "Erro do provedor",
+      "help": "A mensagem de erro que o provedor devolveu."
+    },
+    "reason": {
+      "label": "Motivo",
+      "help": "O motivo informado para a exclusão ou a transferência."
+    },
+    "resolved_by_id": {
+      "label": "Resolvido por (id)"
+    },
+    "resolved_by_type": {
+      "label": "Resolvido por (tipo)",
+      "help": "user, bot ou system."
+    },
+    "resolution_time_seconds": {
+      "label": "Tempo de resolução (s)",
+      "help": "Segundos entre a abertura e a resolução."
+    },
+    "response_time_seconds": {
+      "label": "Tempo de resposta (s)",
+      "help": "Segundos até a primeira resposta da equipe."
+    },
+    "reply_time_seconds": {
+      "label": "Tempo até responder (s)",
+      "help": "Segundos até a equipe responder."
+    },
+    "replied_at": {
+      "label": "Respondido em"
+    },
+    "measured_at": {
+      "label": "Medido em"
+    },
+    "handoff_at": {
+      "label": "Transferido em"
+    },
+    "resolved_at": {
+      "label": "Resolvido em"
+    },
+    "deleted_at": {
+      "label": "Excluído em"
+    },
+    "opened_at": {
+      "label": "Aberto em"
+    },
+    "clicked_at": {
+      "label": "Clicado em"
+    },
+    "campaign_id": {
+      "label": "Campanha (id)",
+      "help": "Só dispara para mensagens desta campanha."
+    },
+    "template_id": {
+      "label": "Modelo (id)",
+      "help": "Só dispara para mensagens enviadas com este template."
+    },
+    "url": {
+      "label": "URL clicada",
+      "help": "A URL exata que o contato clicou."
+    },
+    "provider": {
+      "label": "Plataforma de pagamento",
+      "help": "virtu, hotmart, kiwify ou cakto."
+    },
+    "product": {
+      "label": "Produto",
+      "help": "O nome do produto como a plataforma envia."
+    },
+    "amount": {
+      "label": "Valor",
+      "help": "Na unidade da moeda (ex.: 197.5), nunca em centavos."
+    },
+    "currency": {
+      "label": "Moeda",
+      "help": "Ex.: BRL, USD."
+    },
+    "platform_event": {
+      "label": "Evento da plataforma",
+      "help": "O nome do evento como a plataforma enviou."
+    },
+    "outcome": {
+      "label": "Resultado no CRM",
+      "help": "created (card novo) ou already_in_pipeline (compra anexada ao card aberto)."
+    },
+    "new_contact": {
+      "label": "Contato novo",
+      "help": "Marcado: a compra criou o contato."
+    },
+    "name": {
+      "label": "Nome",
+      "help": "O nome exato do contato."
+    },
+    "email": {
+      "label": "E-mail",
+      "help": "O e-mail exato do contato."
+    },
+    "phone_number": {
+      "label": "Telefone",
+      "help": "Formato E.164, ex.: +5511999999999."
+    },
+    "identifier": {
+      "label": "Identificador externo",
+      "help": "O identificador do contato em outro sistema."
+    },
+    "middle_name": {
+      "label": "Nome do meio",
+      "help": "O nome do meio exato do contato."
+    },
+    "last_name": {
+      "label": "Sobrenome",
+      "help": "O sobrenome exato do contato."
+    },
+    "location": {
+      "label": "Localização",
+      "help": "A localização registrada no contato."
+    },
+    "country_code": {
+      "label": "País (código)",
+      "help": "Ex.: BR, US."
+    },
+    "contact_type": {
+      "label": "Tipo de contato",
+      "options": {
+        "visitor": "Visitante",
+        "lead": "Lead",
+        "customer": "Cliente"
+      },
+      "help": "Visitante, lead ou cliente, como classificado no CRM."
+    },
+    "blocked": {
+      "label": "Bloqueado",
+      "help": "Marcado: só contatos bloqueados."
+    },
+    "created_via": {
+      "label": "Criado por",
+      "options": {
+        "agent": "Agente",
+        "system": "Sistema"
+      },
+      "help": "Se o contato foi criado por um agente ou pelo sistema (canal, importação, webhook)."
+    }
+  },
+  "events": {
+    "contact_created": {
+      "description": "Um contato novo foi criado no CRM."
+    },
+    "contact_updated": {
+      "description": "Os dados de um contato foram alterados."
+    },
+    "contact_deleted": {
+      "description": "Um contato foi excluído."
+    },
+    "contact_label_added": {
+      "description": "Uma etiqueta foi aplicada a um contato."
+    },
+    "contact_label_removed": {
+      "description": "Uma etiqueta foi removida de um contato."
+    },
+    "contact_custom_attribute_changed": {
+      "description": "Um atributo personalizado do contato mudou de valor."
+    },
+    "conversation_created": {
+      "description": "Uma conversa nova foi aberta em um canal."
+    },
+    "conversation_resolved": {
+      "description": "Uma conversa foi marcada como resolvida."
+    },
+    "conversation_activity": {
+      "description": "Uma atividade foi registrada em uma conversa (nota, atribuição, mudança de status)."
+    },
+    "conversation_first_reply": {
+      "description": "A equipe respondeu pela primeira vez em uma conversa."
+    },
+    "conversation_reply_time": {
+      "description": "O tempo de resposta de uma conversa foi medido."
+    },
+    "conversation_bot_handoff": {
+      "description": "O bot transferiu a conversa para a equipe."
+    },
+    "conversation_bot_resolved": {
+      "description": "O bot resolveu a conversa sem a equipe."
+    },
+    "message_created": {
+      "description": "Uma mensagem foi enviada ou recebida em uma conversa."
+    },
+    "message_delivered": {
+      "description": "Uma mensagem enviada foi entregue ao contato."
+    },
+    "message_read": {
+      "description": "O contato leu uma mensagem enviada."
+    },
+    "message_failed": {
+      "description": "O envio de uma mensagem falhou no provedor."
+    },
+    "campaign_triggered": {
+      "description": "Um contato entrou em um funil como card (por lead, campanha ou atribuição)."
+    },
+    "campaign_message_sent": {
+      "description": "Uma mensagem de campanha foi enviada a um contato."
+    },
+    "campaign_message_opened": {
+      "description": "O contato abriu uma mensagem de campanha."
+    },
+    "campaign_message_clicked": {
+      "description": "O contato clicou em um link de uma mensagem de campanha."
+    },
+    "custom": {
+      "description": "Evento definido por você, com propriedades livres."
+    }
   }
 }

--- a/src/i18n/locales/pt/events.json
+++ b/src/i18n/locales/pt/events.json
@@ -220,7 +220,13 @@
     },
     "provider": {
       "label": "Plataforma de pagamento",
-      "help": "virtu, hotmart, kiwify ou cakto."
+      "help": "Só dispara para compras vindas desta plataforma.",
+      "options": {
+        "virtu": "Virtu",
+        "hotmart": "Hotmart",
+        "kiwify": "Kiwify",
+        "cakto": "Cakto"
+      }
     },
     "product": {
       "label": "Produto",

--- a/src/i18n/locales/pt/journey.json
+++ b/src/i18n/locales/pt/journey.json
@@ -1776,7 +1776,7 @@
     }
   },
   "triggerComponents": {
-    "triggerType": "Tipo do Trigger",
+    "triggerType": "Como a jornada começa",
     "selectType": "Selecione o tipo",
     "types": {
       "manual": "Entrada Manual",
@@ -1918,11 +1918,15 @@
       "value": "Valor",
       "captureEventData": "Capturar Dados do Evento",
       "eventSwitch": {
-        "title": "Preservar valores compatíveis?",
-        "body": "Você alterou o evento. Manter os valores de propriedade que também existem no novo evento (mesmo nome e tipo) ou limpar todos?",
-        "preserve": "Preservar compatíveis",
-        "clear": "Limpar tudo"
-      }
+        "dropped_one": "1 filtro removido porque não existe em {{event}}.",
+        "dropped_other": "{{count}} filtros removidos porque não existem em {{event}}.",
+        "undo": "Desfazer"
+      },
+      "customEventNameLabel": "Nome do evento personalizado",
+      "customEventNamePlaceholder": "Digite o nome do evento custom (ex.: button_clicked)",
+      "customEventWarning": "Eventos custom não têm validação de schema. Use só para casos que os eventos do catálogo não cobrem.",
+      "selectEventRequired": "Escolha um evento para salvar o gatilho.",
+      "customEventNameRequired": "Digite o nome do evento personalizado para salvar."
     },
     "label": {
       "configuration": "Configuração da Etiqueta",

--- a/src/lib/events-manifest/catalog.ts
+++ b/src/lib/events-manifest/catalog.ts
@@ -1,7 +1,46 @@
 import { EVENT_NAMES } from './event-names';
 import type { EventCatalogEntry, EventCategory, FieldSpec } from './types';
 
-const f = (type: FieldSpec['type'], description?: string): FieldSpec => ({ type, description });
+const f = (
+  type: FieldSpec['type'],
+  description?: string,
+  options?: readonly string[],
+): FieldSpec => (options ? { type, description, options } : { type, description });
+
+// CRM-519: values the CRM actually emits (Inbox#channel_type class names,
+// Message enums, Contact#contact_type, ContactEventsListener#created_via).
+const CHANNEL_TYPES = [
+  'Channel::Whatsapp',
+  'Channel::Instagram',
+  'Channel::FacebookPage',
+  'Channel::Telegram',
+  'Channel::Email',
+  'Channel::Sms',
+  'Channel::TwilioSms',
+  'Channel::WebWidget',
+  'Channel::Api',
+  'Channel::Line',
+  'Channel::Sendgrid',
+  'Channel::TwitterProfile',
+] as const;
+const MESSAGE_TYPES = ['incoming', 'outgoing'] as const;
+const MESSAGE_STATUSES = ['sent', 'delivered', 'read', 'failed'] as const;
+const CONTENT_TYPES = [
+  'text',
+  'input_text',
+  'input_textarea',
+  'input_email',
+  'input_select',
+  'cards',
+  'form',
+  'article',
+  'incoming_email',
+  'input_csat',
+  'integrations',
+  'sticker',
+] as const;
+const CONTACT_TYPES = ['visitor', 'lead', 'customer'] as const;
+const CREATED_VIA = ['agent', 'system'] as const;
 
 const contactIdentityOptionalFields: Record<string, FieldSpec> = {
   name: f('string'),
@@ -12,25 +51,25 @@ const contactIdentityOptionalFields: Record<string, FieldSpec> = {
   last_name: f('string'),
   location: f('string'),
   country_code: f('string'),
-  contact_type: f('string'),
+  contact_type: f('string', undefined, CONTACT_TYPES),
   blocked: f('boolean'),
   created_at: f('date'),
   updated_at: f('date'),
   customAttributes: f('object'),
   additionalAttributes: f('object'),
-  created_via: f('string'),
+  created_via: f('string', undefined, CREATED_VIA),
 };
 
 const messageCommonRequired: Record<string, FieldSpec> = {
   message_id: f('uuid', 'Message UUID'),
-  channel_type: f('string', 'Channel identifier (e.g., Channel::Whatsapp)'),
+  channel_type: f('string', 'Channel identifier (e.g., Channel::Whatsapp)', CHANNEL_TYPES),
   conversation_id: f('uuid'),
   source: f('string'),
 };
 
 const messageCommonOptional: Record<string, FieldSpec> = {
-  message_type: f('string', 'incoming | outgoing'),
-  content_type: f('string'),
+  message_type: f('string', 'incoming | outgoing', MESSAGE_TYPES),
+  content_type: f('string', undefined, CONTENT_TYPES),
   content: f('string', 'Truncated to 2000 chars; absent when EVO_FLOW_MESSAGE_CONTENT_DISABLED=true'),
 };
 
@@ -113,7 +152,7 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'A new conversation was opened with a contact.',
     schema: {
       required: { conversation_id: f('uuid'), inbox_id: f('uuid'), source: f('string') },
-      optional: { inbox_name: f('string'), channel_type: f('string') },
+      optional: { inbox_name: f('string'), channel_type: f('string', 'Channel identifier (e.g., Channel::Whatsapp)', CHANNEL_TYPES) },
     },
   },
   {
@@ -127,7 +166,7 @@ const ENTRIES: EventCatalogEntry[] = [
       required: { conversation_id: f('uuid'), inbox_id: f('uuid'), source: f('string') },
       optional: {
         inbox_name: f('string'),
-        channel_type: f('string'),
+        channel_type: f('string', 'Channel identifier (e.g., Channel::Whatsapp)', CHANNEL_TYPES),
         resolved_by_id: f('string'),
         resolved_by_type: f('string'),
         resolution_time_seconds: f('number'),
@@ -202,8 +241,8 @@ const ENTRIES: EventCatalogEntry[] = [
     labelEn: 'Message created',
     description: 'A new incoming or outgoing message was recorded.',
     schema: {
-      required: { ...messageCommonRequired, message_type: f('string') },
-      optional: { content_type: f('string'), content: f('string') },
+      required: { ...messageCommonRequired, message_type: f('string', 'incoming | outgoing', MESSAGE_TYPES) },
+      optional: { content_type: f('string', undefined, CONTENT_TYPES), content: f('string') },
     },
   },
   {
@@ -215,7 +254,7 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'A message reached the recipient device.',
     schema: {
       required: messageCommonRequired,
-      optional: { ...messageCommonOptional, previous_status: f('string'), status: f('string'), external_error: f('string') },
+      optional: { ...messageCommonOptional, previous_status: f('string', undefined, MESSAGE_STATUSES), status: f('string', undefined, MESSAGE_STATUSES), external_error: f('string') },
     },
   },
   {
@@ -227,7 +266,7 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'A message was read by the recipient.',
     schema: {
       required: messageCommonRequired,
-      optional: { ...messageCommonOptional, previous_status: f('string'), status: f('string'), external_error: f('string') },
+      optional: { ...messageCommonOptional, previous_status: f('string', undefined, MESSAGE_STATUSES), status: f('string', undefined, MESSAGE_STATUSES), external_error: f('string') },
     },
   },
   {
@@ -239,7 +278,7 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'A message delivery attempt failed.',
     schema: {
       required: messageCommonRequired,
-      optional: { ...messageCommonOptional, previous_status: f('string'), status: f('string'), external_error: f('string') },
+      optional: { ...messageCommonOptional, previous_status: f('string', undefined, MESSAGE_STATUSES), status: f('string', undefined, MESSAGE_STATUSES), external_error: f('string') },
     },
   },
   {
@@ -272,7 +311,7 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'A campaign sent a message to a contact.',
     schema: {
       required: { campaign_id: f('uuid'), message_id: f('uuid'), source: f('string') },
-      optional: { contact_id: f('uuid'), channel_type: f('string'), template_id: f('uuid') },
+      optional: { contact_id: f('uuid'), channel_type: f('string', 'Channel identifier (e.g., Channel::Whatsapp)', CHANNEL_TYPES), template_id: f('uuid') },
     },
   },
   {

--- a/src/lib/events-manifest/catalog.ts
+++ b/src/lib/events-manifest/catalog.ts
@@ -41,6 +41,8 @@ const CONTENT_TYPES = [
 ] as const;
 const CONTACT_TYPES = ['visitor', 'lead', 'customer'] as const;
 const CREATED_VIA = ['agent', 'system'] as const;
+// Webhooks::Purchases::LeadCaptureService outcomes that emit purchase.approved.
+const PURCHASE_OUTCOMES = ['created', 'already_in_pipeline'] as const;
 
 const contactIdentityOptionalFields: Record<string, FieldSpec> = {
   name: f('string'),
@@ -369,7 +371,7 @@ const ENTRIES: EventCatalogEntry[] = [
         amount: f('number', 'Currency major unit (e.g. 197.5 reais), never cents'),
         currency: f('string'),
         platform_event: f('string', 'Event name as the platform sent it'),
-        outcome: f('string', 'created | already_in_pipeline'),
+        outcome: f('string', 'created | already_in_pipeline', PURCHASE_OUTCOMES),
         new_contact: f('boolean', 'Whether the purchase created the contact'),
         contact_id: f('uuid'),
         pipeline_name: f('string'),

--- a/src/lib/events-manifest/catalog.ts
+++ b/src/lib/events-manifest/catalog.ts
@@ -43,6 +43,8 @@ const CONTACT_TYPES = ['visitor', 'lead', 'customer'] as const;
 const CREATED_VIA = ['agent', 'system'] as const;
 // Webhooks::Purchases::LeadCaptureService outcomes that emit purchase.approved.
 const PURCHASE_OUTCOMES = ['created', 'already_in_pipeline'] as const;
+// The adapters registered in config/initializers/purchase_adapters.rb.
+const PURCHASE_PROVIDERS = ['virtu', 'hotmart', 'kiwify', 'cakto'] as const;
 
 const contactIdentityOptionalFields: Record<string, FieldSpec> = {
   name: f('string'),
@@ -360,7 +362,7 @@ const ENTRIES: EventCatalogEntry[] = [
     description: 'A purchase was approved on a payment platform and captured as a lead in the CRM.',
     schema: {
       required: {
-        provider: f('string', 'Payment platform key (virtu, hotmart, kiwify, cakto)'),
+        provider: f('string', 'Payment platform key (virtu, hotmart, kiwify, cakto)', PURCHASE_PROVIDERS),
         purchase_id: f('string', 'Purchase/order id on the platform'),
         pipeline_id: f('uuid'),
         pipeline_item_id: f('uuid', 'Card that holds the purchase'),

--- a/src/lib/events-manifest/event-properties-bridge.spec.ts
+++ b/src/lib/events-manifest/event-properties-bridge.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   propertiesToRecord,
   recordToProperties,
-  validateEventProperties,
   preserveCompatibleValues,
   type EventProperty,
 } from './event-properties-bridge';
@@ -77,32 +76,6 @@ describe('propertiesToRecord / recordToProperties round-trip', () => {
     expect(recordToProperties({ a: '1' })).toEqual([
       { path: 'a', operator: { type: 'Equals', value: '1' } },
     ]);
-  });
-});
-
-describe('validateEventProperties', () => {
-  it('flags missing required fields', () => {
-    expect(validateEventProperties('message.delivered', {})).toEqual({
-      valid: false,
-      missing: ['message_id'],
-    });
-  });
-
-  it('treats empty-string / null / undefined as missing', () => {
-    expect(validateEventProperties('message.delivered', { message_id: '' }).valid).toBe(false);
-    expect(validateEventProperties('message.delivered', { message_id: null }).valid).toBe(false);
-  });
-
-  it('is valid when all required fields are filled', () => {
-    expect(validateEventProperties('message.delivered', { message_id: 'uuid-1' })).toEqual({
-      valid: true,
-      missing: [],
-    });
-  });
-
-  it('is always valid for custom or unknown events', () => {
-    expect(validateEventProperties('custom', {}).valid).toBe(true);
-    expect(validateEventProperties('does.not.exist', {}).valid).toBe(true);
   });
 });
 

--- a/src/lib/events-manifest/event-properties-bridge.ts
+++ b/src/lib/events-manifest/event-properties-bridge.ts
@@ -71,25 +71,6 @@ export function recordToProperties(
   });
 }
 
-/**
- * Required-field validation for the structured form. Custom or unknown events
- * have no schema → always valid. For canonical events, every key in the
- * event's `schema.required` must be present with a non-empty value.
- */
-export function validateEventProperties(
-  eventName: string,
-  record: Record<string, unknown>,
-): { valid: boolean; missing: string[] } {
-  const entry = getEvent(eventName);
-  if (!entry || isCustomEvent(eventName)) return { valid: true, missing: [] };
-
-  const missing = Object.keys(entry.schema.required).filter((key) => {
-    const value = record[key];
-    return value === undefined || value === null || value === '';
-  });
-  return { valid: missing.length === 0, missing };
-}
-
 function fieldType(eventName: string, key: string): FieldSpec['type'] | undefined {
   const entry = getEvent(eventName);
   if (!entry) return undefined;

--- a/src/lib/events-manifest/index.ts
+++ b/src/lib/events-manifest/index.ts
@@ -47,7 +47,6 @@ export type { ResolvedLegacyEventName } from './legacy';
 export {
   propertiesToRecord,
   recordToProperties,
-  validateEventProperties,
   preserveCompatibleValues,
 } from './event-properties-bridge';
 export type { EventProperty } from './event-properties-bridge';

--- a/src/lib/events-manifest/types.ts
+++ b/src/lib/events-manifest/types.ts
@@ -3,6 +3,9 @@ export type FieldType = 'string' | 'number' | 'boolean' | 'date' | 'uuid' | 'obj
 export interface FieldSpec {
   type: FieldType;
   description?: string;
+  // Closed set of values the producer emits (rendered as a select). Frontend
+  // extension over the evo-flow mirror; absent means free text.
+  options?: readonly string[];
 }
 
 export interface EventSchema {

--- a/src/services/channels/inboxesService.ts
+++ b/src/services/channels/inboxesService.ts
@@ -34,8 +34,8 @@ const appendFormDataValue = (formData: FormData, key: string, value: unknown): v
 // Inbox service aligned with Evolution API
 // Only endpoints needed for the Channels page are implemented initially.
 const InboxesService = {
-  async list(): Promise<InboxesResponse> {
-    const response = await api.get('/inboxes');
+  async list(params?: { page?: number; per_page?: number }): Promise<InboxesResponse> {
+    const response = await api.get('/inboxes', { params });
     return extractResponse<Inbox>(response) as InboxesResponse;
   },
 


### PR DESCRIPTION
## Summary
- O gatilho por evento de jornada tratava os campos `required` do catálogo como inputs obrigatórios do usuário (asterisco em `purchase_id`, `conversation_id`, `message_id`). No catálogo, `required` é "o produtor sempre envia"; no evo-flow, as propriedades do gatilho são um filtro opcional por igualdade. O gatilho era inutilizável pela tela.
- Todo campo do schema vira filtro opcional atrás de "+ Adicionar filtro", com remoção por linha e a dica de que sem filtro a jornada dispara em toda ocorrência. Ids de identidade, chaves internas (`source`, dumps), nomes que duplicam um id e campos `date`/`object` não são oferecidos. Linha legada persistida continua visível e removível.
- Ids do CRM viram `Select` alimentado pelos services (funil, etapa dependente do funil, canal, etiqueta, agente, campanha, template). Conjuntos fechados viram `Select` via `options` no `FieldSpec`, com os valores que o CRM emite de fato (`Channel::*`, `incoming`/`outgoing`, `sent`/`delivered`/`read`/`failed`, `contact_type`, `created_via`, `content_type`).
- Canal e tipo de canal são um filtro só: a lista de canais segue o tipo escolhido, o tipo some do picker quando há canal, e um par legado contraditório ganha aviso inline com o botão de remover.
- Rótulo humano e ajuda para cada campo, e descrição de cada evento, nos 6 locales. Sem fallback para o texto em inglês do catálogo.
- Troca de evento sem diálogo: mantém os filtros compatíveis (mesma chave e tipo), avisa quantos saíram e oferece Desfazer. Salvar fica desabilitado sem evento ou com personalizado sem nome, com a mensagem sob o campo.
- Modal: sem separador colado no título, "Como a jornada começa", descrição como texto simples, um aviso e um título no modo personalizado, roda do mouse nos dropdowns (Popover `modal` dentro do Dialog).

## Security
- Só front: sem rota nova, sem mudança de contrato com o evo-flow (a forma persistida `{path, operator: {type: 'Equals', value}}` é a mesma).
- Os selects usam os services já existentes da conta; nenhum dado novo é exposto.

## Test plan
- `npx vitest run src/components/journey/nodes/trigger src/components/journey/shared src/lib/events-manifest src/i18n src/services/channels` (488 passed, na branch rebaseada no `develop` atual)
- `npx tsc --noEmit` e `eslint` nos arquivos tocados (limpos); `vite build` do shell OK
- Tela (camada conta, Jornadas → nova jornada → gatilho por evento): sem asterisco; "Conversa criada" → "Tipo de canal" abre select e "Canal" lista os canais do tipo escolhido; "Contato criado" sem `created_at`/`customAttributes`/`id`, com E-mail, Telefone e Tipo de contato; troca de evento com filtro incompatível mostra "1 filtro removido…" com Desfazer; personalizado sem nome não salva e diz o motivo; roda do mouse rola os dropdowns.

## Rodada 2 (review de 04/09)
- Branch rebaseada no `develop`: só o `test.yml` conflitou (lanes de lista fechada), mantidos os dois lados.
- `purchase.approved` entrou no `develop` pela PR #369 depois desta branch: descrição do evento nos 6 locales, `outcome` com `options` (`created` | `already_in_pipeline`) e rótulos, e 3 specs cobrindo o evento (ids escondidos, `product` texto livre e `amount` numérico, `outcome` select).
- Lookups pedem o mesmo tamanho de página que os filtros do CRM já usam: etiquetas e canais 200, agentes 100, templates -1. O index de canais pagina, então `InboxesService.list` ganhou o parâmetro opcional; os outros chamadores seguem sem argumento.
- **Exceção declarada:** `product` fica em texto livre. No `purchase.approved` ele é a string do produto que a plataforma de pagamento envia (virtu, hotmart, kiwify, cakto), não um `Product` do CRM; um dropdown de produtos do CRM geraria filtro que nunca casa.
- Comentários que o diff tornou falsos corrigidos (diálogo de troca de evento, campos obrigatórios), justificativa verdadeira no `eslint-disable`, fragmento vazio removido, ajuda do tipo de canal e rótulo "Atribuído por" condizentes com selects.
- Limite conhecido: conta com mais de 200 etiquetas ou 100 agentes ainda trunca a lista; busca no select fica para o card de UX.

## Fora do escopo
- Aba Avançado (`EventAdvancedConfig` + `VariableMapping`): não foi tocada; estouro horizontal, caixa fixa e copy ficam para cards próprios.
- Chaves ainda em texto livre por não terem conjunto verificado no CRM: `activity_type`, `changeType`, `resolved_by_type`, `reason`.
- Select de lookup com valor persistido que já não existe na lista mostra o placeholder e mantém o valor gravado (só exibição).

## Changed Files
- `src/components/journey/shared/EventPropertiesForm/{EventPropertiesForm.tsx,filterFields.ts,filterFields.spec.ts,EventPropertiesForm.spec.tsx,EventPropertiesForm.stories.tsx}`
- `src/components/journey/shared/EventSelector/EventSelector.tsx`
- `src/components/journey/nodes/trigger/{JourneyTriggerPanel.tsx,JourneyTriggerPanel.spec.tsx}`
- `src/components/journey/nodes/trigger/components/{EventBasicConfig.tsx,EventBasicConfig.spec.tsx,EventConfiguration.tsx,EventConfiguration.spec.tsx,EventConfiguration.both-contexts.spec.tsx,TriggerDescription.tsx}`
- `src/lib/events-manifest/{catalog.ts,types.ts,index.ts,event-properties-bridge.ts,event-properties-bridge.spec.ts}`
- `src/services/channels/inboxesService.ts`
- `src/i18n/locales/{pt,pt-BR,en,es,fr,it}/{events.json,journey.json}`, `src/i18n/locales/_lib/allowlist.ts`, `src/i18n/locales/journey-parity.spec.ts`
- `.github/workflows/test.yml`

## Linked Issue
- CRM-519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxYjUwr2vV69kYddiXJHRo

## Summary by Sourcery

Make journey event triggers usable with optional, localized, and CRM-aware filters while preserving compatibility with existing saved configurations.

New Features:
- Offer event-trigger properties as optional equality filters with add/remove controls and guidance for unfiltered triggers.
- Provide CRM-backed selects and closed-set options for supported filter values, including dependent pipeline stages and channel-aware inbox selection.
- Localize event descriptions, field labels, help text, and option labels across all supported locales.

Bug Fixes:
- Stop treating catalog-producer-required fields and event identity IDs as user-required trigger inputs.
- Prevent incompatible filters from remaining after event changes by retaining compatible filters and offering inline Undo for removed filters.
- Prevent incomplete event configurations from being saved and improve dropdown scrolling within the trigger dialog.

Enhancements:
- Hide timestamps, objects, internal fields, and redundant display names from the filter picker while preserving legacy persisted filters for removal.
- Add inline warnings for contradictory legacy channel and inbox filters and retain the existing persisted filter contract.
- Extend lookup loading to request appropriate page sizes for complete CRM select options.

CI:
- Expand the focused CI test gate to cover event filter, trigger configuration, and locale parity regressions.

Documentation:
- Update component guidance to describe optional event filters and CRM-backed filter controls.

Tests:
- Replace required-field validation coverage with tests for optional filters, event switching, lookup selects, closed-set options, localization parity, legacy filters, and lookup pagination.

Chores:
- Remove obsolete required-property validation and event-switch confirmation-dialog behavior.