### PR TITLE
fix(channels): rótulo e cor próprios para a sessão QR estabelecendo (CRM-490)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,7 @@ jobs:
             src/utils/apiHelpers.spec.ts \
             src/hooks/channels/useChannelSubmission.spec.ts \
             src/hooks/channels/useChannelValidation.spec.ts \
+            src/hooks/channels/useLiveChannelStatus.spec.ts \
             src/utils/channelStatus.spec.ts \
             src/components/channels/ChannelTypeHub.spec.tsx \
             src/components/inbox/HubConnectButton.spec.tsx \

--- a/src/components/channels/ChannelConnectionsPopover.tsx
+++ b/src/components/channels/ChannelConnectionsPopover.tsx
@@ -18,6 +18,7 @@ import { Inbox, InboxConnectionState } from '@/types/channels/inbox';
 const stateDotClasses: Record<InboxConnectionState, string> = {
   connected: 'bg-emerald-500',
   pending: 'bg-amber-500',
+  connecting: 'bg-blue-500',
   disconnected: 'bg-red-500',
   error: 'bg-red-500',
   unknown: 'bg-muted-foreground/40',

--- a/src/components/channels/ChannelTypeHub.spec.tsx
+++ b/src/components/channels/ChannelTypeHub.spec.tsx
@@ -375,6 +375,33 @@ describe('ChannelConnectionsPopover', () => {
     expect(screen.getByText('overview.statusMeta.live')).toBeInTheDocument();
   });
 
+  it('gives the QR session establishing its own label and dot color, not the shared pending one (CRM-490)', async () => {
+    const user = userEvent.setup();
+    const connecting = inbox({
+      id: 'w-connecting',
+      name: 'Connecting WA',
+      channel_type: 'whatsapp',
+      connection_state: 'connecting',
+    });
+    render(
+      <ChannelConnectionsPopover
+        typeStatus={statusFor('whatsapp', [connecting])}
+        onAdd={noop}
+        onOpenInbox={noop}
+        onDelete={noop}
+      >
+        <button>open</button>
+      </ChannelConnectionsPopover>,
+    );
+    await user.click(screen.getByRole('button', { name: 'open' }));
+    expect(await screen.findByText(/overview\.inboxState\.connecting/)).toBeInTheDocument();
+    expect(screen.queryByText(/overview\.inboxState\.pending/)).toBeNull();
+    // The popover content portals to document.body, outside the render root — query it directly.
+    const dot = document.body.querySelector('.rounded-full[aria-hidden="true"]');
+    expect(dot).toHaveClass('bg-blue-500');
+    expect(dot).not.toHaveClass('bg-amber-500');
+  });
+
   it('drops the unmonitored label once the probe confirms the inbox', async () => {
     const user = userEvent.setup();
     const target = inbox({

--- a/src/hooks/channels/useLiveChannelStatus.spec.ts
+++ b/src/hooks/channels/useLiveChannelStatus.spec.ts
@@ -52,6 +52,25 @@ describe('useLiveChannelStatus', () => {
     });
   });
 
+  // The overlay outranks the API state, so every value has to land where the
+  // backend's CONNECTION_MAP lands — `connecting` above all (CRM-490).
+  it.each([
+    ['open', 'connected'],
+    ['connected', 'connected'],
+    ['connecting', 'connecting'],
+    ['close', 'disconnected'],
+    ['closed', 'disconnected'],
+    ['disconnected', 'disconnected'],
+  ])('overlays the provider state %s as %s, mirroring the backend map (CRM-490)', async (raw, expected) => {
+    mockedGet.mockResolvedValueOnce({
+      data: { success: true, data: { instance: { instanceName: 'inst-1', state: raw } } },
+    });
+
+    const { result } = renderHook(() => useLiveChannelStatus([evolutionInbox()]));
+
+    await waitFor(() => expect(result.current.states.w1).toBe(expected));
+  });
+
   it('marks the inbox as failed when the probe errors, keeping the stored state authoritative', async () => {
     mockedGet.mockRejectedValueOnce(new Error('proxy down'));
 

--- a/src/hooks/channels/useLiveChannelStatus.ts
+++ b/src/hooks/channels/useLiveChannelStatus.ts
@@ -4,11 +4,12 @@ import { Inbox, InboxConnectionState } from '@/types/channels/inbox';
 import { normalizeChannelTypeId, LiveStatusOverlay } from '@/utils/channelStatus';
 
 // connectionState values reported by the Evolution API (v2 uses `state`,
-// older payloads use `status`).
+// older payloads use `status`). Values mirror the backend CONNECTION_MAP:
+// the overlay outranks the API state, so drift here silently overrides it.
 const EVOLUTION_STATE_MAP: Record<string, InboxConnectionState> = {
   open: 'connected',
   connected: 'connected',
-  connecting: 'pending',
+  connecting: 'connecting',
   close: 'disconnected',
   closed: 'disconnected',
   disconnected: 'disconnected',

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -1750,6 +1750,7 @@
       "connected": "Connected",
       "disconnected": "Disconnected",
       "pending": "Awaiting confirmation",
+      "connecting": "Connecting...",
       "error": "Error",
       "unknown": "Unknown",
       "unmonitored": "Not monitored",

--- a/src/i18n/locales/es/channels.json
+++ b/src/i18n/locales/es/channels.json
@@ -1671,6 +1671,7 @@
       "connected": "Conectado",
       "disconnected": "Desconectado",
       "pending": "Esperando confirmación",
+      "connecting": "Conectando...",
       "error": "Error",
       "unknown": "Desconocido",
       "unmonitored": "Sin monitoreo",

--- a/src/i18n/locales/fr/channels.json
+++ b/src/i18n/locales/fr/channels.json
@@ -1690,6 +1690,7 @@
       "connected": "Connecté",
       "disconnected": "Déconnecté",
       "pending": "En attente de confirmation",
+      "connecting": "Connexion...",
       "error": "Erreur",
       "unknown": "Inconnu",
       "unmonitored": "Non surveillé",

--- a/src/i18n/locales/it/channels.json
+++ b/src/i18n/locales/it/channels.json
@@ -1629,6 +1629,7 @@
       "connected": "Connesso",
       "disconnected": "Disconnesso",
       "pending": "In attesa di conferma",
+      "connecting": "Connessione in corso...",
       "error": "Errore",
       "unknown": "Sconosciuto",
       "unmonitored": "Non monitorato",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -1750,6 +1750,7 @@
       "connected": "Conectado",
       "disconnected": "Desconectado",
       "pending": "Aguardando confirmação",
+      "connecting": "Conectando...",
       "error": "Erro",
       "unknown": "Desconhecido",
       "unmonitored": "Sem monitoramento",

--- a/src/i18n/locales/pt/channels.json
+++ b/src/i18n/locales/pt/channels.json
@@ -1688,6 +1688,7 @@
       "connected": "Conectado",
       "disconnected": "Desconectado",
       "pending": "A aguardar confirmação",
+      "connecting": "A conectar...",
       "error": "Erro",
       "unknown": "Desconhecido",
       "unmonitored": "Sem monitorização",

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -7,7 +7,7 @@ import type { PaginatedResponse, PaginationMeta, StandardResponse } from '@/type
 // ============================================
 
 /** Live connection state exposed by /inboxes (EVO-1674). */
-export type InboxConnectionState = 'connected' | 'disconnected' | 'pending' | 'error' | 'unknown';
+export type InboxConnectionState = 'connected' | 'disconnected' | 'pending' | 'connecting' | 'error' | 'unknown';
 
 /**
  * How trustworthy the connection state is: event-fed by the provider,

--- a/src/utils/channelStatus.spec.ts
+++ b/src/utils/channelStatus.spec.ts
@@ -63,6 +63,10 @@ describe('deriveInboxStatus', () => {
     expect(deriveInboxStatus(inbox({ connection_state: 'error' }))).toBe('error');
   });
 
+  it('rolls a QR session establishing up into attention, same as pending (CRM-490)', () => {
+    expect(deriveInboxStatus(inbox({ connection_state: 'connecting' }))).toBe('attention');
+  });
+
   it('treats unmonitored (unknown) channels as active — explicit degrade, not broken', () => {
     expect(deriveInboxStatus(inbox({ connection_state: 'unknown', health_source: 'none' }))).toBe('active');
   });

--- a/src/utils/channelStatus.ts
+++ b/src/utils/channelStatus.ts
@@ -91,7 +91,7 @@ export function deriveInboxStatus(
 ): Exclude<ChannelHealthStatus, 'available' | 'unmonitored'> {
   const state = resolveInboxConnectionState(inbox, live);
   if (state === 'error' || state === 'disconnected') return 'error';
-  if (state === 'pending') return 'attention';
+  if (state === 'pending' || state === 'connecting') return 'attention';
   if (state === 'unknown' && inbox.health_source && inbox.health_source !== 'none') return 'attention';
   return 'active';
 }


### PR DESCRIPTION
## Resumo

Companion do fix no backend (evo-ai-crm-community). `connecting` entra na união `InboxConnectionState`, com dot azul distinto do âmbar de `pending` em `ChannelConnectionsPopover` e a chave `overview.inboxState.connecting` nas seis locales. `deriveInboxStatus` mantém o roll-up de hoje — `connecting` joga em `attention`, igual `pending` — então o selo agregado do card do tipo não muda de comportamento.

## Test plan

- `npx vitest run src/utils/channelStatus.spec.ts src/components/channels/ChannelTypeHub.spec.tsx` — 52 exemplos, 0 falhas
- `npx tsc -b` — sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014d7g7Qr1S1jwvpmwZoz6FZ

## Summary by Sourcery

Distinguish QR sessions establishing from pending connections across inbox state handling and channel connection displays.

New Features:
- Add a distinct `connecting` inbox connection state with a localized label and blue indicator for QR sessions establishing.

Bug Fixes:
- Preserve the aggregated channel status behavior by treating `connecting` as attention alongside `pending`.
- Map live provider connection states to the dedicated `connecting` state instead of collapsing them into `pending`.

CI:
- Include live channel status tests in the GitHub Actions test workflow.

Tests:
- Add coverage for provider-state mapping and the QR session label and indicator.