### PR TITLE
fix(custom-tools): parâmetro de body sem nome deixa de sumir calado (CRM-527)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,11 @@ jobs:
       #     here. The bedrock lifecycle spec stays out: it reaches the network.
       #   - events manifest catalog (CRM-316): mirror of the evo-flow catalog the
       #     journey trigger and segment editor read; a drift only shows in the UI.
+      #   - custom-tool body params (CRM-527): body_params stay the
+      #     {type, required, description} schema the tool-execution engine reads,
+      #     a legacy string is repaired on edit, and a nameless row is flagged
+      #     instead of dropped in silence. The three specs shipped green but
+      #     outside this list, so nothing here ran them.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -183,7 +188,10 @@ jobs:
             src/components/ai_agents/__tests__/ModelSelector.availableModels.spec.ts \
             src/components/ai_agents/__tests__/ModelSelector.retirement.spec.ts \
             src/components/ai_agents/__tests__/ModelSelector.retiredValue.spec.tsx \
-            src/lib/events-manifest/catalog.spec.ts
+            src/lib/events-manifest/catalog.spec.ts \
+            src/components/ai_agents/shared/BodyParamsEditor.spec.tsx \
+            src/components/customTools/CustomToolForm.spec.tsx \
+            src/components/customTools/CustomToolWizardModal.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/ai_agents/shared/BodyParamsEditor.spec.tsx
+++ b/src/components/ai_agents/shared/BodyParamsEditor.spec.tsx
@@ -80,6 +80,25 @@ describe('BodyParamsEditor', () => {
     ).toBe('the query');
   });
 
+  it('flags a filled row whose name is blank instead of dropping it silently', () => {
+    const onChange = vi.fn();
+    render(<BodyParamsEditor value={{}} onChange={onChange} label="Body" />);
+    fireEvent.click(screen.getByText('form.fields.bodyParams.addParam'));
+    fireEvent.change(screen.getByLabelText('Body description'), {
+      target: { value: 'the search query' },
+    });
+
+    expect(onChange.mock.calls.at(-1)![0]).toEqual({});
+    expect(screen.getByText('keyValueEditor.errors.emptyKey')).toBeTruthy();
+  });
+
+  it('leaves an untouched new row alone', () => {
+    render(<BodyParamsEditor value={{}} onChange={vi.fn()} label="Body" />);
+    fireEvent.click(screen.getByText('form.fields.bodyParams.addParam'));
+
+    expect(screen.queryByText('keyValueEditor.errors.emptyKey')).toBeNull();
+  });
+
   it('coerces a legacy string value on load', () => {
     render(
       <BodyParamsEditor

--- a/src/components/ai_agents/shared/BodyParamsEditor.tsx
+++ b/src/components/ai_agents/shared/BodyParamsEditor.tsx
@@ -42,6 +42,14 @@ const objectToRows = (obj: Record<string, unknown>): Row[] =>
     schema: coerceBodyParam(raw),
   }));
 
+/** A row nobody filled in is just an empty slot; one carrying a type, a
+ * description or an optional flag is a param the user meant to keep. Only the
+ * second kind is worth an error when the name is missing. */
+const rowHasContent = (row: Row): boolean =>
+  row.schema.description.trim().length > 0 ||
+  row.schema.type !== 'string' ||
+  !row.schema.required;
+
 const rowsToObject = (rows: Row[]): Record<string, BodyParamSchema> => {
   const out: Record<string, BodyParamSchema> = {};
   for (const row of rows) {
@@ -89,7 +97,12 @@ export default function BodyParamsEditor({
     const keys = new Map<string, number>();
     rows.forEach(row => {
       const trimmed = row.key.trim();
-      if (!trimmed) return;
+      if (!trimmed) {
+        // rowsToObject drops a nameless row: without this the param the user
+        // filled in vanishes on save with nothing on screen to explain it.
+        if (rowHasContent(row)) errs[row.id] = t('keyValueEditor.errors.emptyKey');
+        return;
+      }
       if (keys.has(trimmed)) {
         errs[row.id] = t('keyValueEditor.errors.duplicateKey');
       } else {

--- a/src/i18n/locales/en/customTools.json
+++ b/src/i18n/locales/en/customTools.json
@@ -90,7 +90,6 @@
         "labelKv": "Body Parameters",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Field name",
-        "valuePlaceholder": "Value",
         "hint": "Body fields sent with POST/PUT/PATCH requests",
         "descriptionPlaceholder": "What this field is for",
         "required": "Required",

--- a/src/i18n/locales/es/customTools.json
+++ b/src/i18n/locales/es/customTools.json
@@ -90,7 +90,6 @@
         "labelKv": "Parámetros del Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nombre del campo",
-        "valuePlaceholder": "Valor",
         "hint": "Campos del cuerpo enviados en solicitudes POST/PUT/PATCH",
         "descriptionPlaceholder": "Para qué sirve este campo",
         "required": "Obligatorio",

--- a/src/i18n/locales/fr/customTools.json
+++ b/src/i18n/locales/fr/customTools.json
@@ -90,7 +90,6 @@
         "labelKv": "Paramètres du Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nom du champ",
-        "valuePlaceholder": "Valeur",
         "hint": "Champs du corps envoyés avec les requêtes POST/PUT/PATCH",
         "descriptionPlaceholder": "À quoi sert ce champ",
         "required": "Obligatoire",

--- a/src/i18n/locales/it/customTools.json
+++ b/src/i18n/locales/it/customTools.json
@@ -90,7 +90,6 @@
         "labelKv": "Parametri del Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nome campo",
-        "valuePlaceholder": "Valore",
         "hint": "Campi del corpo inviati con richieste POST/PUT/PATCH",
         "descriptionPlaceholder": "A cosa serve questo campo",
         "required": "Obbligatorio",

--- a/src/i18n/locales/pt-BR/customTools.json
+++ b/src/i18n/locales/pt-BR/customTools.json
@@ -90,7 +90,6 @@
         "labelKv": "Parâmetros do Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nome do campo",
-        "valuePlaceholder": "Valor",
         "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH",
         "descriptionPlaceholder": "Para que serve este campo",
         "required": "Obrigatório",

--- a/src/i18n/locales/pt/customTools.json
+++ b/src/i18n/locales/pt/customTools.json
@@ -90,7 +90,6 @@
         "labelKv": "Parâmetros do Body",
         "placeholder": "{\"key\": \"value\", \"nested\": {\"field\": \"data\"}}",
         "keyPlaceholder": "Nome do campo",
-        "valuePlaceholder": "Valor",
         "hint": "Campos do corpo enviados em requisições POST/PUT/PATCH",
         "descriptionPlaceholder": "Para que serve este campo",
         "required": "Obrigatório",


### PR DESCRIPTION
## Problema

Achados **M1**, **M2** e **L3** do review do CRM-527.

**M1 — parâmetro sem nome some calado.** `rowsToObject` pula a linha cujo nome está em branco, e o memo de erros do `BodyParamsEditor` só checa duplicata. Resultado: o usuário preenche tipo, descrição e obrigatoriedade, esquece o nome, salva — e o parâmetro desaparece sem nada na tela. O `KeyValueEditor`, irmão em que este editor foi espelhado, já levanta `errors.emptyKey` exatamente nesse caso (`KeyValueEditor.tsx:104`).

**M2 — o check verde do Vitest na PR #370 não rodou os testes novos.** O `test.yml` roda uma allowlist explícita de specs e nenhum dos três arquivos de custom tools estava nela.

**L3 — `form.fields.bodyParams.valuePlaceholder`** ficou morto nos seis locales: o editor não tem mais campo de valor e nenhum consumidor referencia a chave.

## Correção

- `rowHasContent` + o ramo de nome vazio no memo de erros: linha com conteúdo e sem nome agora mostra `errors.emptyKey` e marca o input como inválido. Linha recém-adicionada e intocada continua sem erro — mesmo critério do `KeyValueEditor`.
- `BodyParamsEditor.spec.tsx`, `CustomToolForm.spec.tsx` e `CustomToolWizardModal.spec.tsx` entram na allowlist do `test.yml`, com a justificativa no bloco de comentários que já documenta as outras entradas.
- `valuePlaceholder` removido do bloco `bodyParams` nos seis locales (paridade preservada).

## Testes

Dois testes novos no `BodyParamsEditor.spec.tsx`: a linha preenchida sem nome levanta o erro, e a linha nova intocada não. **Falsificado:** removendo o ramo do erro, o primeiro fica vermelho.

241 testes passando entre `customTools`, `ai_agents/shared` e as duas specs de paridade de i18n; `tsc -b` limpo; eslint limpo nos arquivos tocados.

https://claude.ai/code/session_019CSZZDzLqvHC19nybzcHtV

## Summary by Sourcery

Prevent populated nameless body parameters from being silently dropped and ensure the related custom tool tests run in CI.

Bug Fixes:
- Report validation errors for body parameter rows that contain user-entered data but have no name, preventing them from disappearing silently.
- Keep newly added, untouched body parameter rows free of validation errors.

Enhancements:
- Remove the unused body parameter value placeholder from all supported locales.

CI:
- Add the custom tool and body parameter editor specs to the explicit Vitest CI allowlist.

Tests:
- Add coverage for nameless populated rows and untouched new rows in the body parameter editor.