### PR TITLE
fix(journey): telas de flow seguem o tema escuro (CRM-520)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,9 @@ jobs:
       #     a legacy string is repaired on edit, and a nameless row is flagged
       #     instead of dropped in silence. The three specs shipped green but
       #     outside this list, so nothing here ran them.
+      #   - theme tokens on journey/segment screens (CRM-520): a fixed
+      #     gray/white/black class only looks right in one theme; the guard
+      #     fails on any new one, with no baseline.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -193,7 +196,8 @@ jobs:
             src/lib/events-manifest/catalog.spec.ts \
             src/components/ai_agents/shared/BodyParamsEditor.spec.tsx \
             src/components/customTools/CustomToolForm.spec.tsx \
-            src/components/customTools/CustomToolWizardModal.spec.tsx
+            src/components/customTools/CustomToolWizardModal.spec.tsx \
+            src/components/journey/theme-tokens.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/base/BaseDefaultEdge.tsx
+++ b/src/components/base/BaseDefaultEdge.tsx
@@ -87,7 +87,7 @@ export default function BaseDefaultEdge({
             className="nodrag nopan"
           >
             <button
-              className="rounded-full bg-white p-1 shadow-md"
+              className="rounded-full bg-background p-1 shadow-md"
               onClick={onEdgeClick}
             >
               <Trash2 className="text-red-500" size={16} />

--- a/src/components/base/BaseFlow.css
+++ b/src/components/base/BaseFlow.css
@@ -309,3 +309,45 @@
  * `.react-flow.dark { ... }` defaults — driven by the colorMode prop
  * (EVO-1270 C7) — handle the dark variant correctly.
  */
+
+/*
+ * React Flow theming bridge (EVO-1270).
+ *
+ * React Flow ships its own `--xy-*` design tokens with light defaults
+ * scoped to `.react-flow {}` and dark defaults scoped to
+ * `.react-flow.dark {}`. The CRM theme toggle drives that `.dark` class
+ * on the React Flow wrapper via the `colorMode` prop on <ReactFlow>
+ * (set in BaseFlowCanvas from the `useDarkMode()` hook), so the
+ * package's own dark switching now works correctly out of the box.
+ *
+ * We still want the chrome (Controls, MiniMap internals, edges,
+ * attribution, handle) to look like the rest of the CRM, so this block
+ * remaps the relevant `--xy-*-default` tokens onto the shadcn semantic
+ * tokens (--color-card, --color-foreground, --color-border, etc.).
+ * Each shadcn token has its own light/dark resolution in @evoapi/
+ * design-system/styles, so the chrome tracks the global theme via the
+ * shadcn cascade.
+ *
+ * Specificity is bumped to `.react-flow.react-flow` (and `.react-flow.react-flow.dark`
+ * for the dark colorMode) so this block beats the package's `.react-flow {}` /
+ * `.react-flow.dark {}` selectors whatever the CSS load order in the host.
+ *
+ * Lives here, next to BaseFlowCanvas, because this file is imported by the
+ * component and therefore reaches every host of the canvas — globals.css
+ * does not (the shell that embeds the CRM never loads it).
+ */
+.react-flow.react-flow,
+.react-flow.react-flow.dark {
+  --xy-controls-button-background-color-default: var(--color-card);
+  --xy-controls-button-background-color-hover-default: var(--color-accent);
+  --xy-controls-button-color-default: var(--color-foreground);
+  --xy-controls-button-color-hover-default: var(--color-foreground);
+  --xy-controls-button-border-color-default: var(--color-border);
+  --xy-minimap-background-color-default: var(--color-flow-palette-bg);
+  --xy-edge-stroke-default: var(--color-flow-edge-default);
+  --xy-edge-stroke-selected-default: var(--color-flow-edge-active);
+  --xy-connectionline-stroke-default: var(--color-flow-edge-active);
+  --xy-attribution-background-color-default: color-mix(in srgb, var(--color-card) 50%, transparent);
+  --xy-handle-background-color-default: var(--color-muted-foreground);
+  --xy-handle-border-color-default: var(--color-foreground);
+}

--- a/src/components/base/BaseFlow.css
+++ b/src/components/base/BaseFlow.css
@@ -317,8 +317,9 @@
  * scoped to `.react-flow {}` and dark defaults scoped to
  * `.react-flow.dark {}`. The CRM theme toggle drives that `.dark` class
  * on the React Flow wrapper via the `colorMode` prop on <ReactFlow>
- * (set in BaseFlowCanvas from the `useDarkMode()` hook), so the
- * package's own dark switching now works correctly out of the box.
+ * (BaseFlowCanvas reads `DarkModeContext` directly — not `useDarkMode()`,
+ * which throws without a provider), so the package's own dark switching
+ * works out of the box.
  *
  * We still want the chrome (Controls, MiniMap internals, edges,
  * attribution, handle) to look like the rest of the CRM, so this block
@@ -334,7 +335,10 @@
  *
  * Lives here, next to BaseFlowCanvas, because this file is imported by the
  * component and therefore reaches every host of the canvas — globals.css
- * does not (the shell that embeds the CRM never loads it).
+ * does not (the shell that embeds the CRM never loads it). The host must
+ * therefore define the `--color-flow-*` aliases used below: an undefined
+ * one makes the whole `--xy-*` declaration invalid, and the chrome falls
+ * back to `none`/transparent instead of the package default (CRM-520).
  */
 .react-flow.react-flow,
 .react-flow.react-flow.dark {

--- a/src/components/base/BaseFlowCanvas.tsx
+++ b/src/components/base/BaseFlowCanvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useRef } from 'react';
+import React, { useCallback, useContext, useState, useRef } from 'react';
 import {
   ReactFlow,
   Controls,
@@ -25,6 +25,7 @@ import './BaseFlow.css';
 import { Button } from '@evoapi/design-system';
 import { PanelRightOpen, PanelRightClose } from 'lucide-react';
 import { useDnD } from '@/contexts/DnDContext';
+import { DarkModeContext } from '@/contexts/ThemeContext';
 import { BaseFlowContextMenu } from './BaseFlowContextMenu';
 import { BaseFlowHelperLines } from './BaseFlowHelperLines';
 import BaseDefaultEdge from './BaseDefaultEdge';
@@ -168,6 +169,7 @@ export function BaseFlowCanvas({
   canvasClassName,
   style,
 }: BaseFlowCanvasProps) {
+  const colorMode = useContext(DarkModeContext)?.theme === 'dark' ? 'dark' : 'light';
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { screenToFlowPosition } = useReactFlow();
   const { type, setPointerEvents, setType } = useDnD();
@@ -572,8 +574,10 @@ export function BaseFlowCanvas({
       ref={reactFlowWrapper}
       style={style}
     >
-      {/* colorMode="light" keeps the ReactFlow chrome light and stops RF from
-          injecting .dark into .react-flow, which would darken the cards. */}
+      {/* colorMode follows the app theme (CRM-520): a forced "light" left the
+          canvas chrome and the cards as a light island inside the dark page.
+          Read the context directly so a host without DarkModeProvider (tests,
+          previews) falls back to light instead of throwing. */}
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -594,7 +598,7 @@ export function BaseFlowCanvas({
         snapToGrid={snapToGrid}
         snapGrid={snapGrid}
         proOptions={proOptions}
-        colorMode="light"
+        colorMode={colorMode}
         deleteKeyCode={['Backspace', 'Delete']}
         multiSelectionKeyCode={['Meta', 'Ctrl']}
         panOnDrag={true}

--- a/src/components/base/BaseFlowContextMenu.tsx
+++ b/src/components/base/BaseFlowContextMenu.tsx
@@ -94,7 +94,7 @@ export function BaseFlowContextMenu({
         id: 'edit',
         label: t('base.flow.node.edit'),
         icon: Settings,
-        color: 'text-gray-400',
+        color: 'text-muted-foreground',
         onClick: editNode,
       });
     }

--- a/src/components/base/BaseFlowNode.tsx
+++ b/src/components/base/BaseFlowNode.tsx
@@ -108,8 +108,8 @@ const colorStyles = {
     handle: "bg-yellow-500 border-yellow-400"
   },
   slate: {
-    border: "border-slate-300 hover:border-slate-500 dark:border-slate-700/70 dark:hover:border-slate-500",
-    gradient: "bg-gradient-to-br from-slate-50 to-card dark:from-slate-800/40 dark:to-neutral-900/90",
+    border: "border-border hover:border-muted-foreground/60",
+    gradient: "bg-gradient-to-br from-muted to-card",
     glow: "shadow-[0_0_15px_rgba(100,116,139,0.15)]",
     selectedGlow: "shadow-[0_0_25px_rgba(100,116,139,0.3)]",
     handle: "bg-yellow-500 border-yellow-400"
@@ -261,7 +261,7 @@ export function BaseFlowNode({
           <Handle
             className={cn(
               "!w-3 !h-3 !rounded-full !border-2 transition-all duration-300 hover:scale-110",
-              isSourceHandleConnected ? "!bg-yellow-500 !border-yellow-400" : "!bg-neutral-400 !border-neutral-500",
+              isSourceHandleConnected ? "!bg-yellow-500 !border-yellow-400" : "!bg-muted-foreground !border-muted-foreground",
               selected && isSourceHandleConnected && "!bg-yellow-400 !border-yellow-300"
             )}
             style={{

--- a/src/components/base/BaseStatsCard.tsx
+++ b/src/components/base/BaseStatsCard.tsx
@@ -64,8 +64,8 @@ const colorVariants = {
     text: 'text-indigo-600 dark:text-indigo-400',
   },
   gray: {
-    bg: 'bg-gray-100 dark:bg-gray-900/50',
-    text: 'text-gray-600 dark:text-gray-400',
+    bg: 'bg-muted',
+    text: 'text-muted-foreground',
   },
 };
 

--- a/src/components/base/BaseStatusBadge.tsx
+++ b/src/components/base/BaseStatusBadge.tsx
@@ -14,9 +14,9 @@ const statusConfig = {
     borderClassName: 'border-emerald-600 dark:border-[#26533D]',
   },
   inactive: {
-    bgClassName: 'bg-gray-500',
-    textClassName: 'text-white',
-    borderClassName: 'border-gray-500',
+    bgClassName: 'bg-muted',
+    textClassName: 'text-foreground',
+    borderClassName: 'border-border',
   },
   blocked: {
     bgClassName: 'bg-red-600 dark:bg-[#6A231D]',

--- a/src/components/base/BaseStatusBadge.tsx
+++ b/src/components/base/BaseStatusBadge.tsx
@@ -14,9 +14,11 @@ const statusConfig = {
     borderClassName: 'border-emerald-600 dark:border-[#26533D]',
   },
   inactive: {
-    bgClassName: 'bg-muted',
-    textClassName: 'text-foreground',
-    borderClassName: 'border-border',
+    // Solid pill like every other status: bg-muted sits at 1.09:1 against the
+    // card in light theme, so the badge disappears where it used to read.
+    bgClassName: 'bg-muted-foreground',
+    textClassName: 'text-background',
+    borderClassName: 'border-muted-foreground',
   },
   blocked: {
     bgClassName: 'bg-red-600 dark:bg-[#6A231D]',

--- a/src/components/journey/SessionsViewer.tsx
+++ b/src/components/journey/SessionsViewer.tsx
@@ -107,7 +107,7 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
     cancelled: {
       label: t('sessions.viewer.status.cancelled'),
       icon: Ban,
-      color: 'text-gray-500',
+      color: 'text-muted-foreground',
       bgColor: 'bg-gray-500/10',
       borderColor: 'border-gray-500/20',
     },
@@ -293,7 +293,7 @@ export function SessionsViewer({ journeyId, journeyName, onClose }: SessionsView
               </Card>
               <Card className="bg-gray-500/10 border-gray-500/20" data-testid="sessions-stat-cancelled">
                 <CardContent className="p-4">
-                  <div className="text-2xl font-bold text-gray-500">{stats.byStatus?.cancelled ?? 0}</div>
+                  <div className="text-2xl font-bold text-muted-foreground">{stats.byStatus?.cancelled ?? 0}</div>
                   <div className="text-xs text-sidebar-foreground/60 mt-1">{t('sessions.viewer.stats.cancelled')}</div>
                 </CardContent>
               </Card>

--- a/src/components/journey/environment-manager/VariableMapping.tsx
+++ b/src/components/journey/environment-manager/VariableMapping.tsx
@@ -91,7 +91,7 @@ export function VariableMapping({
       <div className="flex items-center justify-between">
         <div>
           <Label className="text-sm font-medium">{t('environmentManager.title')}</Label>
-          <p className="text-xs text-gray-500 mt-1">{t('environmentManager.description')}</p>
+          <p className="text-xs text-muted-foreground mt-1">{t('environmentManager.description')}</p>
         </div>
         <Button
           type="button"
@@ -139,8 +139,8 @@ export function VariableMapping({
       )}
 
       {mappings.length === 0 ? (
-        <div className="text-center py-8 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg">
-          <p className="text-sm text-gray-500">
+        <div className="text-center py-8 border-2 border-dashed border-border rounded-lg">
+          <p className="text-sm text-muted-foreground">
             {t('environmentManager.customVariables.empty.title')}
           </p>
           <Button
@@ -158,14 +158,14 @@ export function VariableMapping({
           {mappings.map(mapping => (
             <div
               key={mapping.id}
-              className="p-3 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50"
+              className="p-3 border border-border rounded-lg bg-muted"
             >
               <div className="flex items-end gap-2">
                 {/* Caminho de origem */}
                 <div className="flex-1 space-y-1">
                   <Label
                     htmlFor={`variable-mapping-source-${mapping.id}`}
-                    className="text-xs text-gray-600 font-medium"
+                    className="text-xs text-muted-foreground font-medium"
                   >
                     {t('environmentManager.mapping.sourcePathLabel')}
                   </Label>
@@ -189,16 +189,16 @@ export function VariableMapping({
                     >
                       <SelectTrigger
                         id={`variable-mapping-source-${mapping.id}`}
-                        className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 w-full"
+                        className="bg-background border-input h-8 w-full"
                       >
                         <SelectValue placeholder={t('environmentManager.searchPlaceholder')} />
                       </SelectTrigger>
-                      <SelectContent className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 max-h-[200px]">
+                      <SelectContent className="bg-background border-input max-h-[200px]">
                         {paths.map(path => (
                           <SelectItem
                             key={path}
                             value={path}
-                            className="text-gray-900 dark:text-gray-100"
+                            className="text-foreground"
                           >
                             <span className="font-mono text-xs">{path}</span>
                           </SelectItem>
@@ -219,7 +219,7 @@ export function VariableMapping({
                       placeholder={t('environmentManager.form.fields.name.placeholder')}
                       value={mapping.sourcePath || ''}
                       onChange={e => updateMapping(mapping.id, 'sourcePath', e.target.value)}
-                      className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 font-mono text-xs h-8"
+                      className="bg-background border-input font-mono text-xs h-8"
                     />
                   )}
                 </div>
@@ -229,7 +229,7 @@ export function VariableMapping({
                   <div className="flex-1 space-y-1">
                     <Label
                       htmlFor={`variable-mapping-custom-path-${mapping.id}`}
-                      className="text-xs text-gray-600 font-medium"
+                      className="text-xs text-muted-foreground font-medium"
                     >
                       {t('environmentManager.mapping.customPathLabel')}
                     </Label>
@@ -246,7 +246,7 @@ export function VariableMapping({
                           updateMapping(mapping.id, 'sourcePath', '');
                         }
                       }}
-                      className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 font-mono text-xs h-8"
+                      className="bg-background border-input font-mono text-xs h-8"
                       autoFocus
                     />
                   </div>
@@ -254,14 +254,14 @@ export function VariableMapping({
 
                 {/* Seta visual */}
                 <div className="pb-2">
-                  <ArrowRight className="w-4 h-4 text-gray-400" />
+                  <ArrowRight className="w-4 h-4 text-muted-foreground" />
                 </div>
 
                 {/* Variável destino */}
                 <div className="flex-1 space-y-1">
                   <Label
                     htmlFor={`variable-mapping-variable-${mapping.id}`}
-                    className="text-xs text-gray-600 font-medium"
+                    className="text-xs text-muted-foreground font-medium"
                   >
                     {t('environmentManager.mapping.variableLabel')}
                   </Label>
@@ -273,7 +273,7 @@ export function VariableMapping({
                     placeholder={t('environmentManager.searchPlaceholder')}
                     showCreateOption={true}
                     showSystemVariables={false}
-                    className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 text-xs w-full"
+                    className="bg-background border-input h-8 text-xs w-full"
                   />
                 </div>
 
@@ -281,7 +281,7 @@ export function VariableMapping({
                 <div className="w-24 space-y-1">
                   <Label
                     htmlFor={`variable-mapping-transform-${mapping.id}`}
-                    className="text-xs text-gray-600 font-medium"
+                    className="text-xs text-muted-foreground font-medium"
                   >
                     {t('environmentManager.mapping.transformLabel')}
                   </Label>
@@ -291,7 +291,7 @@ export function VariableMapping({
                   >
                     <SelectTrigger
                       id={`variable-mapping-transform-${mapping.id}`}
-                      className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600 h-8 w-full"
+                      className="bg-background border-input h-8 w-full"
                     >
                       <SelectValue>
                         {mapping.transform && (
@@ -307,7 +307,7 @@ export function VariableMapping({
                         )}
                       </SelectValue>
                     </SelectTrigger>
-                    <SelectContent className="bg-white dark:bg-gray-900 border-gray-300 dark:border-gray-600">
+                    <SelectContent className="bg-background border-input">
                       {TRANSFORM_OPTIONS.map(option => (
                         <SelectItem key={option.value} value={option.value} className="text-xs">
                           {option.value === 'none' ? 'None' : option.label}
@@ -337,7 +337,7 @@ export function VariableMapping({
 
       {/* Informação adicional */}
       {mappings.length > 0 && (
-        <div className="text-xs text-gray-500 dark:text-gray-400 bg-gray-50 dark:bg-gray-900/30 p-3 rounded border border-dashed">
+        <div className="text-xs text-muted-foreground bg-muted p-3 rounded border border-dashed">
           <p>{t('environmentManager.footer.tip')}</p>
         </div>
       )}

--- a/src/components/journey/environment-manager/VariableSelect.tsx
+++ b/src/components/journey/environment-manager/VariableSelect.tsx
@@ -192,7 +192,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
             {/* Variáveis do Sistema */}
             {showSystemVariables && (
               <>
-                <div className="px-2 py-1 text-xs font-medium text-gray-500">
+                <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
                   {t('environmentManager.tabs.system')}
                 </div>
                 {[
@@ -236,7 +236,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                 {showSystemVariables && variables.length === 0 && (
                   <Separator className="my-2" />
                 )}
-                <div className="px-2 py-1 text-xs font-medium text-gray-500">
+                <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
                   {t('environmentManager.categories.contactAttributes')}
                 </div>
                 {contactAttributes
@@ -265,7 +265,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
             {/* Variáveis Personalizadas */}
             {variables.length > 0 && (
               <>
-                <div className="px-2 py-1 text-xs font-medium text-gray-500">
+                <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
                   {t('environmentManager.tabs.custom', { count: variables.length })}
                 </div>
                 {variables.map(variable => (
@@ -284,7 +284,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
 
             {/* Estado vazio */}
             {variables.length === 0 && !showSystemVariables && !showCreateOption && (
-              <div className="px-2 py-4 text-center text-sm text-gray-500">
+              <div className="px-2 py-4 text-center text-sm text-muted-foreground">
                 {t('environmentManager.customVariables.empty.title')}
               </div>
             )}
@@ -315,7 +315,7 @@ const VariableSelect = forwardRef<HTMLButtonElement, VariableSelectProps>(
                   placeholder={t('environmentManager.form.fields.name.placeholder')}
                   className="mt-1"
                 />
-                <p className="text-xs text-gray-500 mt-1">
+                <p className="text-xs text-muted-foreground mt-1">
                   {t('environmentManager.form.fields.name.help')}
                 </p>
               </div>

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx
@@ -47,9 +47,9 @@ describe('ConditionalNode — handle connectivity (EVO-1902)', () => {
 
     const handle = container.querySelector('[data-handleid="path-p1"]');
     expect(handle).not.toBeNull();
-    // connected => green; disconnected => neutral-400 (gray).
+    // connected => green; disconnected => muted-foreground (gray).
     expect(handle!.className).toContain('!bg-green-500');
-    expect(handle!.className).not.toContain('!bg-neutral-400');
+    expect(handle!.className).not.toContain('!bg-muted-foreground');
   });
 
   it('renders the branch handle as disconnected (gray) when no edge matches', () => {
@@ -57,7 +57,7 @@ describe('ConditionalNode — handle connectivity (EVO-1902)', () => {
 
     const handle = container.querySelector('[data-handleid="path-p1"]');
     expect(handle).not.toBeNull();
-    expect(handle!.className).toContain('!bg-neutral-400');
+    expect(handle!.className).toContain('!bg-muted-foreground');
     expect(handle!.className).not.toContain('!bg-green-500');
   });
 
@@ -70,6 +70,6 @@ describe('ConditionalNode — handle connectivity (EVO-1902)', () => {
 
     const handle = container.querySelector('[data-handleid="path-p1"]');
     expect(handle).not.toBeNull();
-    expect(handle!.className).toContain('!bg-neutral-400');
+    expect(handle!.className).toContain('!bg-muted-foreground');
   });
 });

--- a/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
+++ b/src/components/journey/nodes/actions/conditional/ConditionalNode.tsx
@@ -192,7 +192,7 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
                 '!rounded-full transition-all duration-300',
                 isConnected
                   ? '!bg-green-500 !border-green-400'
-                  : '!bg-neutral-400 !border-neutral-500',
+                  : '!bg-muted-foreground !border-muted-foreground',
               )}
               style={{
                 top: '50%',
@@ -258,7 +258,7 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
               '!rounded-full transition-all duration-300',
               isConnected
                 ? '!bg-green-500 !border-green-400'
-                : '!bg-neutral-400 !border-neutral-500',
+                : '!bg-muted-foreground !border-muted-foreground',
             )}
             style={{
               top: '50%',
@@ -340,7 +340,7 @@ export function ConditionalNode({ selected, data, id }: ConditionalNodeProps) {
                 '!rounded-full transition-all duration-300',
                 isHandleConnected('else')
                   ? '!bg-green-500 !border-green-400'
-                  : '!bg-neutral-400 !border-neutral-500',
+                  : '!bg-muted-foreground !border-muted-foreground',
               )}
               style={{
                 top: '50%',

--- a/src/components/journey/nodes/actions/send-webhook/SendWebhookNode.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/SendWebhookNode.tsx
@@ -144,7 +144,7 @@ export function SendWebhookNode({ selected, data, id }: SendWebhookNodeProps) {
                 data.method === 'PUT' ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200' :
                 data.method === 'PATCH' ? 'bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200' :
                 data.method === 'DELETE' ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' :
-                'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200'
+                'bg-muted text-foreground'
               }`}>
                 {data.method || 'POST'}
               </span>

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookAuthConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookAuthConfig.tsx
@@ -108,7 +108,7 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
                   )}
                 </Button>
               </div>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 {t('panels.sendWebhook.auth.bearerDescription')}
               </p>
             </div>
@@ -161,7 +161,7 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
                 </div>
               </div>
             </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-muted-foreground">
               {t('panels.sendWebhook.auth.basicDescription')}
             </p>
           </div>
@@ -182,7 +182,7 @@ export function WebhookAuthConfig({ data, onChange, journeyId }: WebhookAuthConf
                 className="bg-sidebar border-sidebar-border text-sidebar-foreground"
                 journeyId={journeyId}
               />
-              <p className="text-xs text-gray-500 dark:text-gray-400">
+              <p className="text-xs text-muted-foreground">
                 {t('panels.sendWebhook.auth.headerNameDescription')}
               </p>
             </div>

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBasicConfig.tsx
@@ -62,7 +62,7 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
           className="w-full bg-sidebar border-sidebar-border text-sidebar-foreground"
           journeyId={journeyId}
         />
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-muted-foreground">
           {t('panels.sendWebhook.basic.urlDescription')}
         </p>
       </div>
@@ -111,7 +111,7 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
             onChange={e => handleTimeoutChange(e.target.value)}
             className="bg-sidebar border-sidebar-border text-sidebar-foreground"
           />
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-muted-foreground">
             {t('panels.sendWebhook.basic.timeoutDescription')}
           </p>
         </div>
@@ -129,7 +129,7 @@ export function WebhookBasicConfig({ data, onChange, journeyId }: WebhookBasicCo
             onChange={e => handleRetryChange(e.target.value)}
             className="bg-sidebar border-sidebar-border text-sidebar-foreground"
           />
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-muted-foreground">
             {t('panels.sendWebhook.basic.retryDescription')}
           </p>
         </div>

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyBuilder.tsx
@@ -47,8 +47,8 @@ export function WebhookBodyBuilder({ fields, bodyType, onChange, journeyId }: We
 
       <div className="space-y-3" role="group" aria-labelledby="send-webhook-body-fields-label">
         {fields.length === 0 ? (
-          <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
-            <p className="text-sm text-gray-500">{t('panels.sendWebhook.body.builder.noFields')}</p>
+          <div className="p-4 rounded-lg border-2 border-dashed border-border bg-muted text-center">
+            <p className="text-sm text-muted-foreground">{t('panels.sendWebhook.body.builder.noFields')}</p>
           </div>
         ) : (
           fields.map(field => (

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookBodyConfig.tsx
@@ -163,9 +163,9 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
 
   if (!shouldShowBody()) {
     return (
-      <div className="p-4 rounded-lg bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800/30 text-center">
-        <Code className="h-6 w-6 text-gray-400 mx-auto mb-2" />
-        <p className="text-sm text-gray-600 dark:text-gray-400">
+      <div className="p-4 rounded-lg bg-muted border border-border text-center">
+        <Code className="h-6 w-6 text-muted-foreground mx-auto mb-2" />
+        <p className="text-sm text-muted-foreground">
           {t('panels.sendWebhook.body.methodNotSupported', { method: data.method || 'GET' })}
         </p>
       </div>
@@ -302,7 +302,7 @@ export function WebhookBodyConfig({ data, onChange, journeyId }: WebhookBodyConf
                 journeyId={journeyId}
               />
             </div>
-            <div className="text-xs text-gray-500 dark:text-gray-400">
+            <div className="text-xs text-muted-foreground">
               {t('panels.sendWebhook.body.useVariables')}
             </div>
           </div>

--- a/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.tsx
+++ b/src/components/journey/nodes/actions/send-webhook/components/WebhookHeadersConfig.tsx
@@ -91,9 +91,9 @@ export function WebhookHeadersConfig({ data, onChange, journeyId }: WebhookHeade
           : {})}
       >
         {headers.length === 0 ? (
-          <div className="p-4 rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 dark:bg-gray-950/20 text-center">
-            <p className="text-sm text-gray-500">{t('panels.sendWebhook.headers.noHeadersConfigured')}</p>
-            <p className="text-xs text-gray-400 mt-1">
+          <div className="p-4 rounded-lg border-2 border-dashed border-border bg-muted text-center">
+            <p className="text-sm text-muted-foreground">{t('panels.sendWebhook.headers.noHeadersConfigured')}</p>
+            <p className="text-xs text-muted-foreground mt-1">
               {t('panels.sendWebhook.headers.headersOptional')}
             </p>
           </div>

--- a/src/components/journey/nodes/actions/set-variable/SetVariableNode.tsx
+++ b/src/components/journey/nodes/actions/set-variable/SetVariableNode.tsx
@@ -46,7 +46,7 @@ export function SetVariableNode({ selected, data, id }: SetVariableNodeProps) {
   const getOperationColor = () => {
     switch (data.operation) {
       case 'set': return 'text-purple-600';
-      case 'clear': return 'text-gray-600';
+      case 'clear': return 'text-muted-foreground';
       case 'increase': return 'text-green-600';
       case 'decrease': return 'text-red-600';
       case 'now':

--- a/src/components/journey/nodes/actions/split/SplitNode.tsx
+++ b/src/components/journey/nodes/actions/split/SplitNode.tsx
@@ -125,7 +125,7 @@ export function SplitNode({ selected, data, id }: SplitNodeProps) {
               '!rounded-full transition-all duration-300',
               isConnected
                 ? '!bg-green-500 !border-green-400'
-                : '!bg-neutral-400 !border-neutral-500',
+                : '!bg-muted-foreground !border-muted-foreground',
             )}
             style={{
               top: '50%',

--- a/src/components/journey/nodes/actions/wait/WaitNode.tsx
+++ b/src/components/journey/nodes/actions/wait/WaitNode.tsx
@@ -334,7 +334,7 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
                     '!rounded-full transition-all duration-300',
                     isHandleConnected('wait-success')
                       ? '!bg-green-500 !border-green-400'
-                      : '!bg-neutral-400 !border-neutral-500',
+                      : '!bg-muted-foreground !border-muted-foreground',
                   )}
                   style={{
                     top: '50%',
@@ -376,7 +376,7 @@ export function WaitNode({ selected, data, id }: WaitNodeProps) {
                     '!rounded-full transition-all duration-300',
                     isHandleConnected('wait-otherwise')
                       ? '!bg-green-500 !border-green-400'
-                      : '!bg-neutral-400 !border-neutral-500',
+                      : '!bg-muted-foreground !border-muted-foreground',
                   )}
                   style={{
                     top: '50%',

--- a/src/components/journey/nodes/actions/wait/components/WaitConditionConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitConditionConfig.tsx
@@ -197,7 +197,7 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
         <Label htmlFor="wait-condition-variable" className="text-sm font-medium">
           {t('panels.waitComponents.condition.variableLabel')}
         </Label>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-muted-foreground">
           {t('panels.waitComponents.condition.variableDescription')}
         </p>
         <VariableSelect
@@ -223,7 +223,7 @@ export function WaitConditionConfig({ data, onChange, journeyId }: WaitCondition
           </Label>
         </div>
 
-        <p className="text-xs text-gray-500 dark:text-gray-400 pl-6">
+        <p className="text-xs text-muted-foreground pl-6">
           {t('panels.waitComponents.condition.fallbackDescription')}
         </p>
 

--- a/src/components/journey/nodes/actions/wait/components/WaitEventConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitEventConfig.tsx
@@ -261,7 +261,7 @@ export function WaitEventConfig({ data, onChange, journeyId }: WaitEventConfigPr
           </Label>
         </div>
 
-        <p className="text-xs text-gray-500 dark:text-gray-400 pl-6">
+        <p className="text-xs text-muted-foreground pl-6">
           {t('panels.waitComponents.event.fallbackDescription')}
         </p>
 

--- a/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.tsx
+++ b/src/components/journey/nodes/actions/wait/components/WaitTimeConfig.tsx
@@ -79,7 +79,7 @@ export function WaitTimeConfig({ data, onChange, journeyId }: WaitTimeConfigProp
             console.log('Variable inserted in wait duration:', variable);
           }}
         />
-        <p className="text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-xs text-muted-foreground">
           {t('panels.waitComponents.time.variableHint')}
         </p>
       </div>

--- a/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/ContactConfiguration.tsx
@@ -246,7 +246,7 @@ export function ContactConfiguration({
                           console.log('Variable inserted in contact field value:', variable);
                         }}
                       />
-                      <p className="text-xs text-gray-500 dark:text-gray-400">
+                      <p className="text-xs text-muted-foreground">
                         {t('triggerComponents.contact.useVariablesHint')}
                       </p>
                     </div>
@@ -312,7 +312,7 @@ export function ContactConfiguration({
                   onMappingsChange={onVariableMappingsChange}
                   paths={generateContactPaths()}
                   journeyId={journeyId}
-                  className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+                  className="bg-background p-4 rounded-lg border"
                 />
               </div>
             </div>

--- a/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/CustomAttributeConfiguration.tsx
@@ -261,7 +261,7 @@ export function CustomAttributeConfiguration({
                 console.log('Variable inserted in custom attribute value:', variable);
               }}
             />
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-muted-foreground">
               {t('triggerComponents.customAttribute.useVariablesHint')}
             </p>
           </div>
@@ -338,7 +338,7 @@ export function CustomAttributeConfiguration({
                   onMappingsChange={onVariableMappingsChange}
                   paths={generateCustomAttributePaths()}
                   journeyId={journeyId}
-                  className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+                  className="bg-background p-4 rounded-lg border"
                 />
               </div>
             </div>

--- a/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
+++ b/src/components/journey/nodes/trigger/components/EventAdvancedConfig.tsx
@@ -46,7 +46,7 @@ export function EventAdvancedConfig({
             onMappingsChange={onVariableMappingsChange}
             paths={paths}
             journeyId={journeyId}
-            className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+            className="bg-background p-4 rounded-lg border"
           />
         </div>
       </div>

--- a/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
+++ b/src/components/journey/nodes/trigger/components/WebhookConfiguration.tsx
@@ -266,11 +266,11 @@ export function WebhookConfiguration({
               </span>
             )}
           </p>
-          <div className="mt-3 p-3 bg-gray-100 dark:bg-gray-800 rounded-md">
-            <Label className="text-xs font-medium text-gray-700 dark:text-gray-300 block mb-2">
+          <div className="mt-3 p-3 bg-muted rounded-md">
+            <Label className="text-xs font-medium text-foreground block mb-2">
               {t('triggerComponents.webhook.curlExample')}:
             </Label>
-            <pre className="text-xs text-gray-600 dark:text-gray-400 overflow-x-auto">
+            <pre className="text-xs text-muted-foreground overflow-x-auto">
               {`curl --location '${
                 import.meta.env.VITE_CAMPAIGN_API_URL || 'http://localhost:3000'
               }/api/v1/journeys/trigger/5286fd5c-7ed9-4c0c-ae3e-479e35047fb8' \\
@@ -314,7 +314,7 @@ export function WebhookConfiguration({
                   onMappingsChange={onVariableMappingsChange}
                   paths={webhookPaths}
                   journeyId={journeyId}
-                  className="bg-white dark:bg-gray-900/50 p-4 rounded-lg border"
+                  className="bg-background p-4 rounded-lg border"
                 />
               </div>
             </div>

--- a/src/components/journey/theme-tokens.spec.ts
+++ b/src/components/journey/theme-tokens.spec.ts
@@ -1,0 +1,51 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// CRM-520 regression guard: journey/segment screens and the flow canvas must paint with the
+// theme tokens (bg-background, bg-muted, text-muted-foreground, border-border…)
+// so the dark theme stays legible. A fixed gray/white/black class only looks
+// right in one theme. Translucent tints (`bg-gray-500/10`), `text-white` on a
+// coloured button and `bg-black/50` overlays are theme-neutral and allowed.
+const ROOTS = [
+  'src/components/journey',
+  'src/components/segments',
+  'src/components/base',
+  'src/pages/Customer/Journey',
+];
+
+// No baseline: every file under ROOTS is expected clean (CRM-520 closed the debt).
+
+// `(?<!dark:)`: a `dark:` variant is the theme-aware half of a pair, not a fixed
+// colour. `(?![\w/-])`: a translucent `bg-gray-500/10` must not match as `bg-gray`.
+const FIXED_COLOR =
+  /(?<!dark:)\b(?:bg|text|border|from|to|via|ring|fill|stroke|divide|outline|placeholder)-(?:white|black|gray|slate|zinc|neutral)(?:-\d+)?(?![\w/-])/g;
+const ALLOWED = new Set(['text-white']);
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(name) && !/\.(spec|stories)\.tsx?$/.test(name)) out.push(full);
+  }
+  return out;
+}
+
+function offenders(): Record<string, string[]> {
+  const found: Record<string, string[]> = {};
+  for (const root of ROOTS) {
+    for (const file of walk(root)) {
+      const hits = (readFileSync(file, 'utf8').match(FIXED_COLOR) ?? []).filter((c) => !ALLOWED.has(c));
+      if (hits.length > 0) found[relative(process.cwd(), file)] = [...new Set(hits)];
+    }
+  }
+  return found;
+}
+
+describe('journey/segment screens use theme tokens (CRM-520)', () => {
+  const found = offenders();
+
+  it('has no fixed gray/white/black class anywhere', () => {
+    expect(found).toEqual({});
+  });
+});

--- a/src/components/segments/SegmentModal.tsx
+++ b/src/components/segments/SegmentModal.tsx
@@ -175,7 +175,7 @@ export default function SegmentModal({
 
           <div className="grid gap-6 py-4 max-h-[60vh] overflow-y-auto">
             {/* Nome do Segmento */}
-            <div className="bg-gray-50 p-4 rounded-lg">
+            <div className="bg-muted p-4 rounded-lg">
               <Label htmlFor="name" className="text-sm font-medium mb-2">
                 {t('modal.segmentName')} <span className="text-red-500">*</span>
               </Label>
@@ -192,7 +192,7 @@ export default function SegmentModal({
             </div>
 
             {/* Tipo de Combinação */}
-            <div className="bg-gray-50 p-4 rounded-lg">
+            <div className="bg-muted p-4 rounded-lg">
               <Label className="text-sm font-medium mb-3">{t('modal.combinationType')}</Label>
               <RadioGroup value={definitionType} onValueChange={handleDefinitionTypeChange}>
                 <div className="flex items-center space-x-2 mb-2">
@@ -270,7 +270,7 @@ export default function SegmentModal({
             <Button type="submit" disabled={loading}>
               {loading ? (
                 <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current mr-2"></div>
                   {isNew ? t('modal.creating') : t('modal.saving')}
                 </>
               ) : (

--- a/src/components/segments/SegmentsTable.tsx
+++ b/src/components/segments/SegmentsTable.tsx
@@ -85,8 +85,8 @@ export default function SegmentsTable({
       sortable: true,
       render: (segment: Segment) => (
         <div>
-          <div className="font-medium text-gray-200">{segment.name}</div>
-          <div className="text-sm text-gray-500">ID: {segment.id}</div>
+          <div className="font-medium text-foreground">{segment.name}</div>
+          <div className="text-sm text-muted-foreground">ID: {segment.id}</div>
         </div>
       ),
     },
@@ -104,7 +104,7 @@ export default function SegmentsTable({
       key: 'lastComputedAt',
       label: t('table.columns.lastComputed'),
       render: (segment: Segment) => (
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-muted-foreground">
           {segment.lastComputedAt ? formatDate(segment.lastComputedAt) : t('table.never')}
         </div>
       ),
@@ -114,7 +114,7 @@ export default function SegmentsTable({
       label: t('table.columns.createdAt'),
       sortable: true,
       render: (segment: Segment) => (
-        <div className="text-sm text-gray-500">{formatDate(segment.created_at)}</div>
+        <div className="text-sm text-muted-foreground">{formatDate(segment.created_at)}</div>
       ),
     },
   ];

--- a/src/components/segments/canvas/SegmentCanvasNode.tsx
+++ b/src/components/segments/canvas/SegmentCanvasNode.tsx
@@ -27,8 +27,8 @@ function SegmentCanvasNodeComponent({ type, selected }: NodeProps) {
       <div className="flex items-start gap-2">
         <Icon className="h-4 w-4 mt-0.5" />
         <div className="min-w-0">
-          <p className="text-sm font-medium text-neutral-100">{label}</p>
-          <p className="truncate text-xs text-neutral-400">{description}</p>
+          <p className="text-sm font-medium text-foreground">{label}</p>
+          <p className="truncate text-xs text-muted-foreground">{description}</p>
         </div>
       </div>
     </BaseFlowNode>

--- a/src/components/segments/editors/CustomAttributeEditor.tsx
+++ b/src/components/segments/editors/CustomAttributeEditor.tsx
@@ -102,7 +102,7 @@ export default function CustomAttributeEditor({
           </SelectTrigger>
           <SelectContent>
             {availableCustomAttributes.length === 0 && !loadingCustomAttributes && (
-              <div className="p-2 text-sm text-gray-500">
+              <div className="p-2 text-sm text-muted-foreground">
                 {t('customAttributeEditor.noAttributes')}
               </div>
             )}

--- a/src/components/segments/editors/LabelConditionEditor.tsx
+++ b/src/components/segments/editors/LabelConditionEditor.tsx
@@ -72,7 +72,7 @@ export default function LabelConditionEditor({
           </SelectTrigger>
           <SelectContent>
             {availableLabels.length === 0 && !loadingLabels && (
-              <div className="p-2 text-sm text-gray-500">
+              <div className="p-2 text-sm text-muted-foreground">
                 {t('labelEditor.noLabels')}
               </div>
             )}

--- a/src/components/segments/editors/UserPropertyEditor.tsx
+++ b/src/components/segments/editors/UserPropertyEditor.tsx
@@ -75,7 +75,7 @@ export default function UserPropertyEditor({
             <SelectValue placeholder={t('userPropertyEditor.selectProperty')} />
           </SelectTrigger>
           <SelectContent>
-            <div className="font-medium p-2 text-sm text-gray-500 border-b">
+            <div className="font-medium p-2 text-sm text-muted-foreground border-b">
               {t('userPropertyEditor.categories.basicInfo')}
             </div>
             {userProperties.slice(0, 6).map((prop) => (
@@ -84,7 +84,7 @@ export default function UserPropertyEditor({
               </SelectItem>
             ))}
             
-            <div className="font-medium p-2 text-sm text-gray-500 border-b">
+            <div className="font-medium p-2 text-sm text-muted-foreground border-b">
               {t('userPropertyEditor.categories.metadata')}
             </div>
             {userProperties.slice(6).map((prop) => (

--- a/src/components/segments/ui/TimeWindowSelector.tsx
+++ b/src/components/segments/ui/TimeWindowSelector.tsx
@@ -42,7 +42,7 @@ export default function TimeWindowSelector({
           type="button"
           onClick={() => onToggleShow(!show)}
           className={`w-4 h-4 rounded border ${
-            show ? 'bg-blue-500 border-blue-500' : 'border-gray-300'
+            show ? 'bg-blue-500 border-blue-500' : 'border-input'
           }`}
         />
       </div>

--- a/src/pages/Customer/Journey/JourneyFlowEditor.tsx
+++ b/src/pages/Customer/Journey/JourneyFlowEditor.tsx
@@ -473,7 +473,7 @@ function JourneyFlowEditor() {
         id: 'mute-conversation-node',
         name: t('flowEditor.nodes.muteConversation.name'),
         icon: Volume2,
-        color: 'text-gray-400',
+        color: 'text-muted-foreground',
         category: 'conversation',
         description: t('flowEditor.nodes.muteConversation.description'),
         searchKeywords: ['mute', 'silence', 'quiet', 'hide', 'suppress'],

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -430,40 +430,6 @@
   }
 }
 
-/*
- * React Flow theming bridge (EVO-1270).
- *
- * React Flow ships its own `--xy-*` design tokens with light defaults
- * scoped to `.react-flow {}` and dark defaults scoped to
- * `.react-flow.dark {}`. The CRM theme toggle drives that `.dark` class
- * on the React Flow wrapper via the `colorMode` prop on <ReactFlow>
- * (set in BaseFlowCanvas from the `useDarkMode()` hook), so the
- * package's own dark switching now works correctly out of the box.
- *
- * We still want the chrome (Controls, MiniMap internals, edges,
- * attribution, handle) to look like the rest of the CRM, so this block
- * remaps the relevant `--xy-*-default` tokens onto the shadcn semantic
- * tokens (--color-card, --color-foreground, --color-border, etc.).
- * Each shadcn token has its own light/dark resolution in @evoapi/
- * design-system/styles, so the chrome tracks the global theme via the
- * shadcn cascade.
- *
- * Specificity is bumped to `.react-flow.react-flow` so this block beats
- * the package's `.react-flow.dark {}` selector when both load (the
- * package CSS is imported in main.tsx before globals.css so cascade
- * order also favours this file).
- */
-.react-flow.react-flow {
-  --xy-controls-button-background-color-default: var(--color-card);
-  --xy-controls-button-background-color-hover-default: var(--color-accent);
-  --xy-controls-button-color-default: var(--color-foreground);
-  --xy-controls-button-color-hover-default: var(--color-foreground);
-  --xy-controls-button-border-color-default: var(--color-border);
-  --xy-minimap-background-color-default: var(--color-flow-palette-bg);
-  --xy-edge-stroke-default: var(--color-flow-edge-default);
-  --xy-edge-stroke-selected-default: var(--color-flow-edge-active);
-  --xy-connectionline-stroke-default: var(--color-flow-edge-active);
-  --xy-attribution-background-color-default: color-mix(in srgb, var(--color-card) 50%, transparent);
-  --xy-handle-background-color-default: var(--color-muted-foreground);
-  --xy-handle-border-color-default: var(--color-foreground);
-}
+/* React Flow theming bridge (EVO-1270) moved to components/base/BaseFlow.css,
+ * which BaseFlowCanvas imports: the shell embeds the CRM without this file and
+ * was left with React Flow's white chrome (CRM-520). */


### PR DESCRIPTION
## Summary
- As telas de jornada (gatilho, nós, webhook, sessões, variáveis), o modal de segmento e o canvas usavam cor fixa (`bg-white`, `gray-*`, `slate-*`) com par `dark:` manual, e o React Flow estava travado em `colorMode="light"`. No tema escuro sobrava uma ilha clara.
- 33 arquivos (`journey`, `segments`, `base` do canvas e a página do editor) trocam cor fixa por token do tema (`bg-background`, `bg-muted`, `text-foreground`, `text-muted-foreground`, `border-border`, `border-input`). Tintas translúcidas, overlays e `text-white` sobre botão colorido ficam.
- React Flow segue o tema: `colorMode` lido do `DarkModeContext`, com fallback claro sem provider. O bloco que mapeia controles, minimapa, arestas e handles para os tokens sai do `globals.css` e vai para `BaseFlow.css`, importado pelo próprio `BaseFlowCanvas`, então chega a qualquer host do canvas; o seletor cobre `.react-flow.dark` do pacote em qualquer ordem de carga.
- Guarda `theme-tokens.spec.ts`: falha em classe `gray|white|black|slate|zinc|neutral` fixa (`bg`, `text`, `border`, `from`, `to`, `ring`, `fill`, `stroke`…) nas quatro raízes, ignorando a metade `dark:` de um par. Sem baseline. Na lane do Vitest.

## Security
- Só classes, CSS e um prop do React Flow. Sem rota, sem dado novo.

## Test plan
- `npx vitest run src/components/base src/components/journey src/components/segments src/pages/Customer/Journey src/lib/events-manifest` (367 passed; `_ui/tokens.contrast.spec.ts` só não carrega em máquina sem `colorjs.io` instalado, fora da lane)
- `npx tsc --noEmit` e `eslint` nos arquivos do diff (limpos)
- Tela, nos dois temas: editor de jornada (cabeçalho, paleta, nós, controles de zoom, minimapa), gatilho por evento/contato/atributo/webhook, nó Enviar webhook, Sessões, aba Avançado, modal de Segmentos. Trocar o tema com o editor aberto acompanha na hora.

## Nota
- O host que embute o CRM precisa definir os tokens `--flow-*` no nível raiz (`:root`/`.dark`/`.light`), porque o modal do gatilho renderiza em portal fora do wrapper do CRM. Ver a PR irmã.

## Changed Files
- `src/components/base/{BaseFlowCanvas.tsx,BaseFlow.css,BaseFlowNode.tsx,BaseStatsCard.tsx,BaseStatusBadge.tsx,BaseDefaultEdge.tsx,BaseFlowContextMenu.tsx}`
- `src/styles/globals.css`
- `src/components/journey/**` (25 arquivos), `src/components/segments/**` (7), `src/pages/Customer/Journey/JourneyFlowEditor.tsx`
- `src/components/journey/theme-tokens.spec.ts` (novo), `src/components/journey/nodes/actions/conditional/ConditionalNode.spec.tsx`
- `.github/workflows/test.yml`

## Related PRs
- vendor/crm (evo-ai-frontend-community): https://github.com/evolution-foundation/evo-ai-frontend-community/pull/374
- shell (evolution-ecosystem-frontend): https://github.com/evolution-foundation/evolution-ecosystem-frontend/pull/140
Independentes entre si; qualquer ordem de deploy.

## Linked Issue
- CRM-520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxYjUwr2vV69kYddiXJHRo

## Summary by Sourcery

Ensure journey and segment experiences remain visually consistent across light and dark themes.

Bug Fixes:
- Make journey and segment screens, including the flow canvas and React Flow controls, correctly follow the active light or dark theme instead of showing fixed light-colored areas.

Enhancements:
- Replace fixed grayscale styling across journey, segment, canvas, and editor components with semantic theme tokens.
- Centralize React Flow theme integration with the base canvas so it works in embedded hosts and follows runtime theme changes.
- Add a regression guard preventing new fixed grayscale color classes in the affected component and page roots.

CI:
- Run the new theme-token regression test in the scoped Vitest workflow.

Deployment:
- Document the need for embedded CRM hosts to provide root-level flow theme tokens for portal-rendered content.

Tests:
- Update conditional-node assertions for semantic muted foreground styling.