### PR TITLE
fix(channels): prevent business-hours render loop when hours are omitted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,7 @@ jobs:
             src/utils/apiHelpers.spec.ts \
             src/hooks/channels/useChannelSubmission.spec.ts \
             src/hooks/channels/useChannelValidation.spec.ts \
+            src/components/channels/settings/BusinessHoursForm.spec.tsx \
             src/hooks/channels/useLiveChannelStatus.spec.ts \
             src/utils/channelStatus.spec.ts \
             src/components/channels/ChannelTypeHub.spec.tsx \

--- a/src/components/channels/settings/BusinessHoursForm.tsx
+++ b/src/components/channels/settings/BusinessHoursForm.tsx
@@ -46,11 +46,13 @@ interface BusinessHoursFormProps {
   }) => Promise<void>;
 }
 
+const EMPTY_WORKING_HOURS: unknown[] = [];
+
 export default function BusinessHoursForm({
   workingHoursEnabled = false,
   outOfOfficeMessage = '',
   outOfOfficeMessageTemplateId = null,
-  workingHours = [],
+  workingHours = EMPTY_WORKING_HOURS,
   timezone,
   registerSave,
   onUpdate,


### PR DESCRIPTION
Rendering BusinessHoursForm without a workingHours prop creates a fresh default array on every render. The initialization effect depends on that array and sets a fresh timezone object, causing a repeated render/effect cycle. Running the existing BusinessHoursForm specs can spin indefinitely and exhaust worker memory.

Use a stable empty-array default and include the four existing BusinessHoursForm tests in the CI test list.

Validation: the four tests pass after the fix, along with TypeScript checking and ESLint for the changed component. During a full-suite run on the original code, the Node inspector identified the stuck worker as BusinessHoursForm.spec.tsx in React commit processing; the worker had to be terminated. Other full-suite failures remain outside this change.

## Summary by Sourcery

Prevent BusinessHoursForm render loops when working hours are omitted and run its tests in CI.

Bug Fixes:
- Prevent BusinessHoursForm from entering a render/effect loop when working hours are omitted by using a stable default value.

CI:
- Add BusinessHoursForm component tests to the CI test suite.