### PR TITLE
fix(channels): make Evolution connection tests read-only and translate feedback

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,6 +153,7 @@ jobs:
             src/pages/Customer/Settings/Users/Users.spec.tsx \
             src/utils/apiHelpers.spec.ts \
             src/hooks/channels/useChannelSubmission.spec.ts \
+            src/services/channels/evolutionService.spec.ts \
             src/hooks/channels/useChannelValidation.spec.ts \
             src/hooks/channels/useLiveChannelStatus.spec.ts \
             src/utils/channelStatus.spec.ts \

--- a/src/hooks/channels/useChannelSubmission.spec.ts
+++ b/src/hooks/channels/useChannelSubmission.spec.ts
@@ -5,6 +5,7 @@ import { useChannelSubmission } from './useChannelSubmission';
 import InboxesService from '@/services/channels/inboxesService';
 import EvolutionService from '@/services/channels/evolutionService';
 import EvolutionGoService from '@/services/channels/evolutionGoService';
+import i18n from '@/i18n/config';
 
 vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
@@ -55,7 +56,8 @@ const submit = async (channelType: string, providerId: string, form: Record<stri
 };
 
 describe('useChannelSubmission.submitCreate', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
     vi.clearAllMocks();
     createChannelMock.mockResolvedValue({ data: { id: 'inbox-1' } } as never);
   });
@@ -140,10 +142,49 @@ describe('useChannelSubmission.submitCreate', () => {
     });
   });
 
+  it('uses read-only tests before creating the Evolution channel once with the same instance name', async () => {
+    vi.mocked(EvolutionService.verifyConnection).mockResolvedValue({} as never);
+    const form = { name: 'Display label', instance_name: 'shimon', phone_number: '+333' };
+    const channel = { type: 'whatsapp' } as never;
+    const provider = { id: 'evolution' } as never;
+    const config = { hasEvolutionConfig: true, hasEvolutionGoConfig: false };
+    const { result } = renderHook(() => useChannelSubmission(form as never));
+
+    await act(async () => {
+      await result.current.testConnection(channel, provider, form as never, config);
+      await result.current.testConnection(channel, provider, form as never, config);
+    });
+    expect(createChannelMock).not.toHaveBeenCalled();
+    expect(EvolutionService.verifyConnection).toHaveBeenNthCalledWith(1, expect.objectContaining({ mode: 'test', instanceName: 'shimon' }));
+    expect(EvolutionService.verifyConnection).toHaveBeenNthCalledWith(2, expect.objectContaining({ mode: 'test', instanceName: 'shimon' }));
+    expect(toast.success).toHaveBeenCalledWith('Connection verified successfully');
+
+    await act(async () => {
+      await result.current.submitCreate(channel, provider, form as never, config);
+    });
+    expect(EvolutionService.verifyConnection).toHaveBeenNthCalledWith(3, expect.objectContaining({ mode: 'create', instanceName: 'shimon' }));
+    expect(createChannelMock).toHaveBeenCalledTimes(1);
+    expect(createChannelMock).toHaveBeenCalledWith(expect.objectContaining({
+      channel: expect.objectContaining({ provider_config: expect.objectContaining({ instance_name: 'shimon' }) }),
+    }));
+  });
+
+  it('keeps the connection confirmation translated in Portuguese', async () => {
+    await i18n.changeLanguage('pt-BR');
+    vi.mocked(EvolutionService.verifyConnection).mockResolvedValue({} as never);
+    const { result } = renderHook(() => useChannelSubmission());
+
+    await act(async () => {
+      await result.current.testConnection({ type: 'whatsapp' } as never, { id: 'evolution' } as never,
+        { name: 'test', phone_number: '+333' } as never, { hasEvolutionConfig: true, hasEvolutionGoConfig: false });
+    });
+    expect(toast.success).toHaveBeenCalledWith('Conexão verificada com sucesso');
+  });
+
   it('confirms the creation on screen', async () => {
     await submit('api', 'api', { name: 'api-inbox', webhook_url: 'https://hook' });
 
-    expect(toast.success).toHaveBeenCalledWith('Canal criado com sucesso');
+    expect(toast.success).toHaveBeenCalledWith('Channel created successfully');
   });
 
   it('shows the reason the backend gave for refusing the create', async () => {

--- a/src/hooks/channels/useChannelSubmission.ts
+++ b/src/hooks/channels/useChannelSubmission.ts
@@ -28,9 +28,11 @@ import { ChannelType, FormData } from '@/hooks/channels/useChannelForm';
 import { useChannelValidation } from '@/hooks/channels/useChannelValidation';
 import { useAppDataStore } from '@/store/appDataStore';
 import { apiErrorMessage } from '@/utils/apiHelpers';
+import { useLanguage } from '@/hooks/useLanguage';
 
 export const useChannelSubmission = (form?: FormData) => {
   const navigate = useNavigate();
+  const { t } = useLanguage('channels');
   const { validateByChannelAndProvider, getStr } = useChannelValidation();
   const { addInbox } = useAppDataStore();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -92,6 +94,7 @@ export const useChannelSubmission = (form?: FormData) => {
         try {
           // Build verify payload
           const verifyPayload: any = {
+            mode: 'test',
             instanceName: getStr(form, 'instance_name') || getStr(form, 'name'),
             phoneNumber: getStr(form, 'phone_number'),
             proxySettings: form.proxy_enabled
@@ -120,7 +123,7 @@ export const useChannelSubmission = (form?: FormData) => {
           if (!useGlobalConfig) {
             const apiUrl = getStr(form, 'api_url');
             if (!apiUrl) {
-              toast.error('URL da API é obrigatória');
+              toast.error(t('newChannel.messages.apiUrlRequired'));
               setIsTesting(false);
               return;
             }
@@ -131,7 +134,7 @@ export const useChannelSubmission = (form?: FormData) => {
               result = {
                 success: false,
                 error:
-                  'Health check falhou. Verifique se a URL da Evolution API está correta e acessível.',
+                  t('newChannel.messages.evolutionHealthFailed'),
               };
               setHealthCheckPassed(false);
               setIsTesting(false);
@@ -145,7 +148,7 @@ export const useChannelSubmission = (form?: FormData) => {
 
           // Backend will run health check if using global config
           await EvolutionService.verifyConnection(verifyPayload);
-          result = { success: true, message: 'Conexão verificada com sucesso' };
+          result = { success: true, message: t('newChannel.messages.connectionVerified') };
           setHealthCheckPassed(true);
         } catch (error) {
           result = { success: false, error: apiErrorMessage(error) || (error as Error).message };
@@ -174,7 +177,7 @@ export const useChannelSubmission = (form?: FormData) => {
           if (!useGlobalConfig) {
             const apiUrl = getStr(form, 'api_url');
             if (!apiUrl) {
-              toast.error('URL da API é obrigatória');
+              toast.error(t('newChannel.messages.apiUrlRequired'));
               setIsTesting(false);
               return;
             }
@@ -199,7 +202,7 @@ export const useChannelSubmission = (form?: FormData) => {
 
           // Backend will run health check if using global config
           await EvolutionGoService.verifyConnection(verifyPayload);
-          result = { success: true, message: 'Conexão verificada com sucesso' };
+          result = { success: true, message: t('newChannel.messages.connectionVerified') };
           setHealthCheckPassed(true);
         } catch (error) {
           result = { success: false, error: apiErrorMessage(error) || (error as Error).message };
@@ -233,14 +236,14 @@ export const useChannelSubmission = (form?: FormData) => {
 
       if (result) {
         if (result.success) {
-          toast.success(result.message || 'Conexão testada com sucesso');
+          toast.success(result.message || t('newChannel.messages.connectionVerified'));
         } else {
-          toast.error(result.error || 'Falha no teste de conexão');
+          toast.error(result.error || t('newChannel.messages.connectionTestFailed'));
         }
       }
     } catch (error) {
       toast.error(
-        apiErrorMessage(error) || (error as Error).message || 'Erro no teste de conexão',
+        apiErrorMessage(error) || (error as Error).message || t('newChannel.messages.connectionTestFailed'),
       );
     } finally {
       setIsTesting(false);
@@ -500,13 +503,13 @@ export const useChannelSubmission = (form?: FormData) => {
             if (!useGlobalConfig) {
               const apiUrl = getStr(form, 'api_url');
               if (!apiUrl) {
-                throw new Error('URL da API é obrigatória');
+                throw new Error(t('newChannel.messages.apiUrlRequired'));
               }
 
               const healthOk = await EvolutionService.healthCheck(apiUrl);
               if (!healthOk) {
                 throw new Error(
-                  'Health check falhou. Verifique se a URL da Evolution API está correta e acessível.',
+                  t('newChannel.messages.evolutionHealthFailed'),
                 );
               }
             }
@@ -543,11 +546,12 @@ export const useChannelSubmission = (form?: FormData) => {
               verifyPayload.adminToken = getStr(form, 'admin_token');
             }
 
+            verifyPayload.mode = 'create';
             await EvolutionService.verifyConnection(verifyPayload);
 
             // Build final payload
             const providerConfig: any = {
-              instance_name: getStr(form, 'name'),
+              instance_name: getStr(form, 'instance_name') || getStr(form, 'name'),
               proxy_settings: form.proxy_enabled
                 ? {
                     enabled: true,
@@ -595,7 +599,7 @@ export const useChannelSubmission = (form?: FormData) => {
             if (!useGlobalConfig) {
               const apiUrl = getStr(form, 'api_url');
               if (!apiUrl) {
-                throw new Error('URL da API é obrigatória');
+                throw new Error(t('newChannel.messages.apiUrlRequired'));
               }
 
               const healthOk = await EvolutionGoService.healthCheck(apiUrl);
@@ -713,7 +717,7 @@ export const useChannelSubmission = (form?: FormData) => {
         addInbox(data as Inbox);
       }
 
-      toast.success('Canal criado com sucesso');
+      toast.success(t('newChannel.messages.channelCreated'));
       if (onCreated) {
         onCreated(createdId);
       } else {
@@ -721,7 +725,7 @@ export const useChannelSubmission = (form?: FormData) => {
       }
     } catch (e: unknown) {
       const err = e as Error;
-      toast.error(apiErrorMessage(e) || err?.message || 'Falha ao criar canal');
+      toast.error(apiErrorMessage(e) || err?.message || t('newChannel.messages.channelCreateFailed'));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/i18n/locales/en/channels.json
+++ b/src/i18n/locales/en/channels.json
@@ -220,7 +220,13 @@
       "selectProvider": "Select a provider to continue",
       "selectEmailProvider": "Select an email provider to continue",
       "selectSmsProvider": "Select an SMS provider to continue",
-      "testConnectionFirst": "You must test the connection before saving"
+      "testConnectionFirst": "You must test the connection before saving",
+      "apiUrlRequired": "API URL is required",
+      "evolutionHealthFailed": "Connection check failed. Verify that the Evolution API URL is correct and reachable.",
+      "connectionVerified": "Connection verified successfully",
+      "connectionTestFailed": "Connection test failed",
+      "channelCreated": "Channel created successfully",
+      "channelCreateFailed": "Failed to create channel"
     },
     "success": {
       "channelCreated": "Channel created successfully!",

--- a/src/i18n/locales/pt-BR/channels.json
+++ b/src/i18n/locales/pt-BR/channels.json
@@ -220,7 +220,13 @@
       "selectProvider": "Selecione um provedor para continuar",
       "selectEmailProvider": "Selecione um provedor de email para continuar",
       "selectSmsProvider": "Selecione um provedor de SMS para continuar",
-      "testConnectionFirst": "É necessário testar a conexão antes de salvar"
+      "testConnectionFirst": "É necessário testar a conexão antes de salvar",
+      "apiUrlRequired": "URL da API é obrigatória",
+      "evolutionHealthFailed": "Health check falhou. Verifique se a URL da Evolution API está correta e acessível.",
+      "connectionVerified": "Conexão verificada com sucesso",
+      "connectionTestFailed": "Falha no teste de conexão",
+      "channelCreated": "Canal criado com sucesso",
+      "channelCreateFailed": "Falha ao criar canal"
     },
     "success": {
       "channelCreated": "Canal criado com sucesso!",

--- a/src/services/channels/evolutionService.spec.ts
+++ b/src/services/channels/evolutionService.spec.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import api from '@/services/core/api';
+import EvolutionService from './evolutionService';
+
+vi.mock('@/services/core/api', () => ({ default: { post: vi.fn() } }));
+
+describe('EvolutionService.verifyConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.post).mockResolvedValue({ data: { success: true, data: {} } });
+  });
+
+  it.each(['test', 'create'] as const)('forwards %s mode to the backend', async mode => {
+    await EvolutionService.verifyConnection({
+      apiUrl: 'https://evolution.example.com', adminToken: 'synthetic-token',
+      instanceName: 'shimon', phoneNumber: '+333', mode,
+    });
+    expect(api.post).toHaveBeenCalledWith('/evolution/authorization', {
+      authorization: expect.objectContaining({ mode, instance_name: 'shimon' }),
+    });
+  });
+});

--- a/src/services/channels/evolutionService.ts
+++ b/src/services/channels/evolutionService.ts
@@ -34,6 +34,7 @@ const EvolutionService = {
         admin_token: params.adminToken,
         instance_name: params.instanceName,
         phone_number: params.phoneNumber,
+        mode: params.mode,
         proxy_settings: params.proxySettings,
         instance_settings: params.instanceSettings,
       },

--- a/src/types/channels/inbox.ts
+++ b/src/types/channels/inbox.ts
@@ -544,6 +544,7 @@ export interface WhatsappChannel {
 // ============================================
 
 export interface EvolutionConnectionParams {
+  mode?: 'test' | 'create';
   apiUrl: string;
   adminToken: string;
   instanceName: string;


### PR DESCRIPTION
The Evolution channel wizard calls the provisioning endpoint for both “Test connection” and “Create channel.” Testing therefore creates an instance before the inbox exists; saving repeats creation and either replaces that instance or fails with “Instance already exists” once CRM #348 is applied.

Send `mode: test` when testing and `mode: create` when saving, preserving the selected instance name in the inbox payload. The backend read-only test mode is implemented in https://github.com/evolution-foundation/evo-ai-crm-community/pull/348; deploy that backend change before this frontend change.

Move connection-test and channel-creation feedback into the existing channels translations, with English and Brazilian Portuguese strings, so English users no longer see Portuguese success messages.

Validation: 13 focused hook/service tests pass, including repeated tests followed by one create, mode forwarding, matching instance names, and English/Portuguese confirmations. TypeScript and changed-file ESLint pass. The new service spec is included in CI. On the patched v1.1.0 demo, two real connection tests return HTTP 200 without changing the provider's instance IDs.

## Summary by Sourcery

Prevent Evolution connection tests from creating channels and provide correctly localized feedback during testing and creation.

Bug Fixes:
- Make Evolution connection tests read-only by forwarding test mode and reserve creation mode for channel saves.
- Preserve the selected Evolution instance name across connection verification and inbox creation.
- Translate channel connection and creation feedback through the English and Brazilian Portuguese channel locales.

CI:
- Include Evolution service tests in the CI test suite.

Tests:
- Add coverage for repeated read-only connection tests, mode forwarding, instance-name consistency, and localized confirmations.