### PR TITLE
fix(access-tokens): envia a conta ativa ao criar um token de acesso (CRM-561)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,10 @@ jobs:
       #     persists, and 9 stays selectable. The "10 Horas" row shipped bound to 9, and
       #     dropping 9 now would blank the trigger on campaigns that hold it — Radix shows
       #     the placeholder only for an empty value, so the window reads as "no interval".
+      #   - access-token creation (CRM-561): the POST carries the host's active account,
+      #     which is the ONLY thing that tells the auth which account to bind the token
+      #     to. Dropping the header is invisible here and shows up as a 401 on every CRM
+      #     call the customer's automations make.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -213,7 +217,8 @@ jobs:
             src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx \
             src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx \
             src/i18n/locales/journey-parity.spec.ts \
-            src/pages/Customer/Campaigns/NewCampaign/wizard/Step4_Settings.spreadWindow.spec.tsx
+            src/pages/Customer/Campaigns/NewCampaign/wizard/Step4_Settings.spreadWindow.spec.tsx \
+            src/services/auth/accessTokensService.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/services/auth/accessTokensService.spec.ts
+++ b/src/services/auth/accessTokensService.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createAccessToken, activeAccountHeaders } from './accessTokensService';
+
+const post = vi.fn();
+
+vi.mock('@/services/core/apiAuth', () => ({
+  default: { post: (...args: unknown[]) => post(...args) },
+}));
+
+const created = { data: { data: { access_token: { id: 't-1', token: 'secret' } } } };
+
+// CRM-561: the auth binds a new token to the account it was minted in, and it
+// learns that account only from this header. Without it an agency owner's token
+// resolves to no account and every CRM call answers 401.
+describe('createAccessToken', () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue(created);
+    localStorage.clear();
+  });
+
+  it('sends the active account the host persisted', async () => {
+    localStorage.setItem('evo_active_tenant_id', 'acc-1');
+
+    await createAccessToken({ name: 'CI', scopes: 'contacts.read' } as never);
+
+    expect(post).toHaveBeenCalledWith(
+      '/access_tokens',
+      { access_token: { name: 'CI', scopes: 'contacts.read' } },
+      { headers: { 'X-Evo-Tenant-Id': 'acc-1' } },
+    );
+  });
+
+  it('sends no account header on a standalone install', async () => {
+    await createAccessToken({ name: 'CI', scopes: 'contacts.read' } as never);
+
+    expect(post).toHaveBeenCalledWith('/access_tokens', expect.anything(), { headers: {} });
+  });
+
+  it('never throws when storage is unavailable', () => {
+    const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+
+    expect(activeAccountHeaders()).toEqual({});
+    getItem.mockRestore();
+  });
+});

--- a/src/services/auth/accessTokensService.ts
+++ b/src/services/auth/accessTokensService.ts
@@ -1,11 +1,27 @@
 import apiAuth from '@/services/core/apiAuth';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
+
 import type {
   AccessToken,
   AccessTokenFormData,
   AccessTokensResponse,
   AccessTokenResponse,
 } from '@/types/auth';
+
+// When embedded, the host persists the active account under this key (same
+// channel as `access_token`). The auth binds a new token to that account so API
+// calls made with it resolve their account without any further header. A
+// standalone install has no host and no header; the auth keeps its fallback.
+const ACTIVE_ACCOUNT_KEY = 'evo_active_tenant_id';
+
+export const activeAccountHeaders = (): Record<string, string> => {
+  try {
+    const accountId = localStorage.getItem(ACTIVE_ACCOUNT_KEY);
+    return accountId ? { 'X-Evo-Tenant-Id': accountId } : {};
+  } catch {
+    return {};
+  }
+};
 
 /**
  * Get all Access Tokens for an account
@@ -35,9 +51,11 @@ export const getAccessToken = async (id: string): Promise<AccessTokenResponse> =
 export const createAccessToken = async (
   data: AccessTokenFormData,
 ): Promise<AccessTokenResponse> => {
-  const response = await apiAuth.post('/access_tokens', {
-    access_token: data,
-  });
+  const response = await apiAuth.post(
+    '/access_tokens',
+    { access_token: data },
+    { headers: activeAccountHeaders() },
+  );
   return extractData<any>(response);
 };
 


### PR DESCRIPTION
## Summary
- `createAccessToken` manda `X-Evo-Tenant-Id` com a conta ativa que o host persiste em `localStorage` (`evo_active_tenant_id`, mesmo canal do `access_token`). Sem isso um token criado pela tela não fica associado à conta e as chamadas de API feitas com ele não resolvem a conta.
- Standalone (sem host) não tem a chave → sem header, comportamento atual.

## Correções do code review (2º commit)
- O job Vitest roda uma **allowlist explícita** de specs e o spec novo não estava nela: o guard era real (derrubar o header deixa vermelho localmente) mas uma regressão mergearia verde — a mesma falha que o comentário da própria lista registra para o CRM-527. Spec adicionado à lista.

## Test plan
- `npx vitest run --reporter=basic src/services/auth/accessTokensService.spec.ts` (3 verdes: header presente com a chave, ausente sem ela, storage indisponível não quebra) — agora pelo comando que o CI roda.
- Mutação: `activeAccountHeaders()` retornando `{}` deixa o spec vermelho.
- `npx tsc --noEmit -p tsconfig.json`, `npx eslint` no arquivo.

## Changed Files
- `src/services/auth/accessTokensService.ts`
- `src/services/auth/accessTokensService.spec.ts`
- `.github/workflows/test.yml`

## Linked Issue
- CRM-561
