### PR TITLE
fix(css): tokens de cor do host só pelos aliases --color-* no CSS de componente (CRM-547)

### DIFF
--- a/src/components/base/BaseFlow.css
+++ b/src/components/base/BaseFlow.css
@@ -95,12 +95,12 @@
 
 /* Edges styling */
 .react-flow__edge-path {
-  stroke: var(--primary); /* Use primary color for edges */
+  stroke: var(--color-primary);
   stroke-width: 2;
 }
 
 .react-flow__edge.selected .react-flow__edge-path {
-  stroke: var(--primary); /* Use primary color for selected edges */
+  stroke: var(--color-primary);
   stroke-width: 3;
 }
 
@@ -109,14 +109,14 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: var(--primary);
-  border: 2px solid var(--primary);
+  background-color: var(--color-primary);
+  border: 2px solid var(--color-primary);
   opacity: 0.8;
 }
 
 .react-flow__handle:hover {
-  background-color: var(--primary);
-  border-color: var(--primary);
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
   opacity: 1;
 }
 
@@ -188,16 +188,16 @@
 
 /* Base Flow Panel styles */
 .base-flow-panel {
-  background: hsl(var(--sidebar));
-  border: 1px solid hsl(var(--sidebar-border));
+  background: var(--color-sidebar);
+  border: 1px solid var(--color-sidebar-border);
   border-radius: 8px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
 .base-flow-panel-header {
   padding: 16px;
-  border-bottom: 1px solid hsl(var(--sidebar-border));
-  background: hsl(var(--sidebar-accent));
+  border-bottom: 1px solid var(--color-sidebar-border);
+  background: var(--color-sidebar-accent);
 }
 
 .base-flow-panel-content {
@@ -209,16 +209,16 @@
 /* Base Node Panel styles */
 .base-node-panel {
   width: 420px;
-  background: hsl(var(--sidebar));
-  border: 1px solid hsl(var(--sidebar-border));
+  background: var(--color-sidebar);
+  border: 1px solid var(--color-sidebar-border);
   border-radius: 8px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
 }
 
 .base-node-panel-header {
   padding: 16px;
-  border-bottom: 1px solid hsl(var(--sidebar-border));
-  background: hsl(var(--sidebar-accent));
+  border-bottom: 1px solid var(--color-sidebar-border);
+  background: var(--color-sidebar-accent);
 }
 
 .base-node-panel-content {
@@ -236,8 +236,8 @@
 
 /* Context menu styles */
 .base-flow-context-menu {
-  background: hsl(var(--sidebar));
-  border: 1px solid hsl(var(--sidebar-border));
+  background: var(--color-sidebar);
+  border: 1px solid var(--color-sidebar-border);
   border-radius: 8px;
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
   padding: 4px;
@@ -253,19 +253,19 @@
   border-radius: 4px;
   cursor: pointer;
   transition: background-color 0.2s ease;
-  color: hsl(var(--sidebar-foreground));
+  color: var(--color-sidebar-foreground);
 }
 
 .base-flow-context-menu-item:hover {
-  background: hsl(var(--sidebar-accent));
+  background: var(--color-sidebar-accent);
 }
 
 .base-flow-context-menu-item.destructive {
-  color: hsl(var(--destructive));
+  color: var(--color-destructive);
 }
 
 .base-flow-context-menu-item.destructive:hover {
-  background: hsl(var(--destructive) / 0.1);
+  background: color-mix(in srgb, var(--color-destructive) 10%, transparent);
 }
 
 /* Helper lines styles */

--- a/src/components/chat/rich-text-editor/RichTextEditor.css
+++ b/src/components/chat/rich-text-editor/RichTextEditor.css
@@ -32,7 +32,7 @@
 .prosemirror-editor:empty:before,
 .prosemirror-editor:has(> p:only-child > br.ProseMirror-trailingBreak:only-child):before {
   content: attr(data-placeholder);
-  color: hsl(var(--muted-foreground));
+  color: var(--color-muted-foreground);
   position: absolute;
   pointer-events: none;
   /* EVO-2234: keep the placeholder on one line and cut it with an ellipsis
@@ -58,8 +58,8 @@
 }
 
 .prosemirror-editor code {
-  background-color: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
+  background-color: var(--color-muted);
+  color: var(--color-muted-foreground);
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
   font-size: 0.875rem;
@@ -105,8 +105,8 @@
 }
 
 .rich-content code {
-  background-color: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
+  background-color: var(--color-muted);
+  color: var(--color-muted-foreground);
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
   font-size: 0.875rem;

--- a/src/components/shared/PhoneInput.css
+++ b/src/components/shared/PhoneInput.css
@@ -35,11 +35,11 @@
 
 /* Error state */
 .phone-input-error .PhoneInputInput {
-  border-color: hsl(var(--destructive));
+  border-color: var(--color-destructive);
 }
 
 .phone-input-error .PhoneInputInput:focus-visible {
-  ring-color: hsl(var(--destructive));
+  ring-color: var(--color-destructive);
 }
 
 /* Disabled state */
@@ -51,6 +51,6 @@
 /* Dark mode support */
 @media (prefers-color-scheme: dark) {
   .phone-input .PhoneInputCountrySelect {
-    color: hsl(var(--foreground));
+    color: var(--color-foreground);
   }
 }

--- a/src/components/shared/PhoneInput.css
+++ b/src/components/shared/PhoneInput.css
@@ -38,10 +38,6 @@
   border-color: var(--color-destructive);
 }
 
-.phone-input-error .PhoneInputInput:focus-visible {
-  ring-color: var(--color-destructive);
-}
-
 /* Disabled state */
 .phone-input .PhoneInputInput:disabled {
   cursor: not-allowed;


### PR DESCRIPTION
## Summary
- CSS de componente passa a consumir os tokens de cor do host **só pelos aliases `--color-*`**. Os hosts definem os tokens em formatos diferentes (tripla HSL num, cor completa no outro); só os aliases são cor completa nos dois.
- `BaseFlow.css`: `var(--primary)` cru deixava as **arestas do editor de jornada sem `stroke`** no shell; `hsl(var(--sidebar…))`/`hsl(var(--destructive))` deixavam painel, cabeçalho e menu de contexto sem cor no standalone.
- A regra `.react-flow__handle` **não é inerte** (correção do que esta descrição dizia antes): no bundle ela vem depois da do xyflow e vence, então os handles também estavam sem cor no shell (`background-color: rgba(0,0,0,0)`) e passam a ser pintados com o primário.
- `RichTextEditor.css` e `PhoneInput.css`: mesma troca `hsl(var(--x))` → `var(--color-x)`.
- `hsl(var(--destructive) / 0.1)` → `color-mix(in srgb, var(--color-destructive) 10%, transparent)` (padrão já usado no arquivo).
- **Review:** removida a regra `ring-color` do estado de erro do PhoneInput — `ring-color` não é propriedade CSS (`CSS.supports('ring-color','red')` é `false`), nunca pintou nada. O anel destrutivo que o input com erro exibe vem da utility `focus-visible:ring-destructive` no elemento, medido idêntico antes e depois da remoção nos dois hosts e nos dois temas.

## Test plan
- `npx tsc --noEmit` · `npx vite build` (standalone) OK
- Computed styles medidos no Chromium sobre o CSS do `vite build`, com `.dark`/`.light` na raiz, nos dois hosts, antes e depois:
  - shell — aresta normal e selecionada: `none` → `rgb(31,168,113)` (light) / `rgb(54,196,137)` (dark); handle: `rgba(0,0,0,0)` → mesmo primário
  - standalone — arestas inalteradas; painel, cabeçalho, menu destrutivo, `code` do editor e borda de erro do PhoneInput saem de transparente/`currentColor` para os tokens reais (nenhuma regressão)
- Sem token cru restante nos três arquivos (a guarda do shell #151 fica verde contra este branch).

## Changed Files
- `src/components/base/BaseFlow.css`
- `src/components/chat/rich-text-editor/RichTextEditor.css`
- `src/components/shared/PhoneInput.css`

## Related PRs
- evolution-ecosystem-frontend (guarda): https://github.com/evolution-foundation/evolution-ecosystem-frontend/pull/151

## Linked Issue
- CRM-547
