### PR TITLE
fix(credentials): a tela nomeia quem segura a credencial no 409 do delete (CRM-207)

### DIFF
--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -59,6 +59,10 @@
     "title": "Delete credential",
     "description": "Are you sure you want to delete the credential \"{{name}}\"? This action cannot be undone.",
     "inUseWarning": "This credential is referenced by {{count}} consumer(s): {{consumers}}. They will fall back to their inline value while it exists.",
+    "conflict": {
+      "title": "The credential could not be deleted because it is still in use by:",
+      "help": "Remove the credential from each of them and try again."
+    },
     "cancel": "Cancel",
     "confirm": "Delete"
   },

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -59,6 +59,10 @@
     "title": "Eliminar credencial",
     "description": "¿Está seguro de que desea eliminar la credencial \"{{name}}\"? Esta acción no se puede deshacer.",
     "inUseWarning": "Esta credencial es referenciada por {{count}} consumidor(es): {{consumers}}. Volverán al valor incorporado mientras exista.",
+    "conflict": {
+      "title": "No se pudo eliminar la credencial porque todavía la usan:",
+      "help": "Quita la credencial de cada uno de ellos e inténtalo de nuevo."
+    },
     "cancel": "Cancelar",
     "confirm": "Eliminar"
   },

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -59,6 +59,10 @@
     "title": "Supprimer l'identifiant",
     "description": "Voulez-vous vraiment supprimer l'identifiant \"{{name}}\" ? Cette action est irréversible.",
     "inUseWarning": "Cet identifiant est référencé par {{count}} consommateur(s) : {{consumers}}. Ils reviendront à la valeur intégrée tant qu'elle existe.",
+    "conflict": {
+      "title": "L'identifiant n'a pas pu être supprimé car il est encore utilisé par :",
+      "help": "Retirez l'identifiant de chacun d'eux, puis réessayez."
+    },
     "cancel": "Annuler",
     "confirm": "Supprimer"
   },

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -59,6 +59,10 @@
     "title": "Elimina credenziale",
     "description": "Vuoi davvero eliminare la credenziale \"{{name}}\"? Questa azione non può essere annullata.",
     "inUseWarning": "Questa credenziale è referenziata da {{count}} consumatore/i: {{consumers}}. Torneranno al valore incorporato finché esiste.",
+    "conflict": {
+      "title": "Non è stato possibile eliminare la credenziale perché è ancora usata da:",
+      "help": "Rimuovi la credenziale da ciascuno di essi e riprova."
+    },
     "cancel": "Annulla",
     "confirm": "Elimina"
   },

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -59,6 +59,10 @@
     "title": "Excluir credencial",
     "description": "Tem certeza de que deseja excluir a credencial \"{{name}}\"? Esta ação não pode ser desfeita.",
     "inUseWarning": "Esta credencial é referenciada por {{count}} consumidor(es): {{consumers}}. Eles voltarão ao valor embutido enquanto ele existir.",
+    "conflict": {
+      "title": "A credencial não pôde ser excluída porque ainda está em uso por:",
+      "help": "Remova a credencial de cada um deles e tente novamente."
+    },
     "cancel": "Cancelar",
     "confirm": "Excluir"
   },

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -59,6 +59,10 @@
     "title": "Excluir credencial",
     "description": "Tem certeza de que deseja excluir a credencial \"{{name}}\"? Esta ação não pode ser desfeita.",
     "inUseWarning": "Esta credencial é referenciada por {{count}} consumidor(es): {{consumers}}. Eles voltarão ao valor embutido enquanto ele existir.",
+    "conflict": {
+      "title": "A credencial não pôde ser excluída porque ainda está em uso por:",
+      "help": "Remova a credencial de cada um deles e tente novamente."
+    },
     "cancel": "Cancelar",
     "confirm": "Excluir"
   },

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -5,6 +5,7 @@ import IntegrationCredentials from './IntegrationCredentials';
 import { parseOwnerTimestamp } from './ownerTimestamp';
 import { maskKey } from '@/constants/aiProviders';
 import type { IntegrationCredential } from '@/types/agents';
+import { toast } from 'sonner';
 
 // EVO-2250 story 2.1: the vault page reads the new registry only, never
 // returns the value to the browser, gates every action on
@@ -31,14 +32,23 @@ const listCustomTools = vi.fn();
 const listCustomMcpServers = vi.fn();
 const listAgentBots = vi.fn();
 
-vi.mock('@/services/agents', () => ({
-  listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
-  createIntegrationCredential: (...args: unknown[]) => createIntegrationCredential(...args),
-  updateIntegrationCredential: (...args: unknown[]) => updateIntegrationCredential(...args),
-  deleteIntegrationCredential: (...args: unknown[]) => deleteIntegrationCredential(...args),
-  listCustomTools: (...args: unknown[]) => listCustomTools(...args),
-  listCustomMcpServers: (...args: unknown[]) => listCustomMcpServers(...args),
-}));
+// deleteConflictConsumers is NOT stubbed: it is the contract reader under test,
+// so the 409 cases below exercise the real payload check.
+vi.mock('@/services/agents', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/agents/integrationCredentialService')
+  >('@/services/agents/integrationCredentialService');
+
+  return {
+    deleteConflictConsumers: actual.deleteConflictConsumers,
+    listIntegrationCredentials: (...args: unknown[]) => listIntegrationCredentials(...args),
+    createIntegrationCredential: (...args: unknown[]) => createIntegrationCredential(...args),
+    updateIntegrationCredential: (...args: unknown[]) => updateIntegrationCredential(...args),
+    deleteIntegrationCredential: (...args: unknown[]) => deleteIntegrationCredential(...args),
+    listCustomTools: (...args: unknown[]) => listCustomTools(...args),
+    listCustomMcpServers: (...args: unknown[]) => listCustomMcpServers(...args),
+  };
+});
 
 vi.mock('@/services/channels/agentBotsService', () => ({
   default: {
@@ -669,5 +679,141 @@ describe('IntegrationCredentials — deleting (AC6)', () => {
     await user.click(await screen.findByText('deleteDialog.confirm'));
 
     await waitFor(() => expect(deleteIntegrationCredential).toHaveBeenCalledWith('cred-dify'));
+  });
+});
+
+// The core refuses the delete with 409 while a consumer still points at the
+// credential, and names each holder in `details.consumers` (CRM-191, PR #29).
+describe('IntegrationCredentials — the 409 names who holds the credential (CRM-207)', () => {
+  const conflictError = (
+    consumers: unknown,
+    { status = 409, code = 'CONFLICT' }: { status?: number; code?: string } = {},
+  ) => ({
+    response: {
+      status,
+      data: {
+        success: false,
+        error: {
+          code,
+          message: 'integration credential is still in use by 2 consumer(s)',
+          details: { consumers },
+        },
+      },
+    },
+  });
+
+  const confirmDelete = async () => {
+    const user = userEvent.setup();
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    await user.click(screen.getAllByLabelText('actions.delete')[0]);
+    await user.click(await screen.findByText('deleteDialog.confirm'));
+
+    return user;
+  };
+
+  it('lists every consumer as its own item and drops the generic toast', async () => {
+    deleteIntegrationCredential.mockRejectedValue(
+      conflictError(['Bot de canal (whatsapp)', 'Ferramenta Busca [Authorization]']),
+    );
+    await confirmDelete();
+
+    const alert = await screen.findByRole('alert');
+    expect(within(alert).getByText('deleteDialog.conflict.title')).toBeInTheDocument();
+    expect(within(alert).getByText('deleteDialog.conflict.help')).toBeInTheDocument();
+
+    const items = within(alert).getAllByRole('listitem').map(item => item.textContent);
+    expect(items).toEqual(['Bot de canal (whatsapp)', 'Ferramenta Busca [Authorization]']);
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(screen.getByText('deleteDialog.confirm')).toBeInTheDocument();
+  });
+
+  it('replaces the pre-flight warning, which is a tolerant snapshot of the listing', async () => {
+    listIntegrationCredentials.mockResolvedValue([
+      { ...DIFY_CREDENTIAL, referenced_by: ['Agente Dify'] },
+    ]);
+    deleteIntegrationCredential.mockRejectedValue(conflictError(['Bot de canal (whatsapp)']));
+    await confirmDelete();
+
+    const alert = await screen.findByRole('alert');
+    expect(within(alert).getByText('deleteDialog.conflict.title')).toBeInTheDocument();
+    expect(screen.queryByText('deleteDialog.inUseWarning')).not.toBeInTheDocument();
+  });
+
+  it('names the holders even when the listing reported none', async () => {
+    deleteIntegrationCredential.mockRejectedValue(conflictError(['Integração github']));
+    await confirmDelete();
+
+    const alert = await screen.findByRole('alert');
+    expect(within(alert).getAllByRole('listitem').map(item => item.textContent)).toEqual([
+      'Integração github',
+    ]);
+    expect(screen.queryByText('deleteDialog.inUseWarning')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['a 500', { response: { status: 500, data: { error: { code: 'INTERNAL_ERROR' } } } }],
+    ['a 409 with no details', { response: { status: 409, data: { error: { code: 'CONFLICT' } } } }],
+    ['an empty consumer list', conflictError([])],
+    ['a consumer list that is not strings', conflictError([{ name: 'Bot' }])],
+    ['a 400 carrying a same-named field', conflictError(['Bot'], { status: 400 })],
+    [
+      'a 409 that is not this conflict',
+      conflictError(['Bot'], { code: 'RESOURCE_ALREADY_EXISTS' }),
+    ],
+  ])('falls back to the generic message for %s', async (_label, error) => {
+    deleteIntegrationCredential.mockRejectedValue(error);
+    await confirmDelete();
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.deleteError'));
+    expect(screen.queryByText('deleteDialog.conflict.title')).not.toBeInTheDocument();
+    expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+  });
+
+  it('clears the previous holders when the delete is retried', async () => {
+    deleteIntegrationCredential.mockRejectedValueOnce(conflictError(['Bot de canal (whatsapp)']));
+    const user = await confirmDelete();
+
+    await screen.findByText('deleteDialog.conflict.title');
+
+    deleteIntegrationCredential.mockResolvedValueOnce({ message: 'ok' });
+    await user.click(screen.getByText('deleteDialog.confirm'));
+
+    await waitFor(() =>
+      expect(screen.queryByText('deleteDialog.conflict.title')).not.toBeInTheDocument(),
+    );
+    expect(toast.success).toHaveBeenCalledWith('messages.deleteSuccess');
+  });
+
+  it('does not keep the old holders on screen when the retry fails for another reason', async () => {
+    deleteIntegrationCredential.mockRejectedValueOnce(conflictError(['Bot de canal (whatsapp)']));
+    const user = await confirmDelete();
+
+    await screen.findByText('deleteDialog.conflict.title');
+
+    deleteIntegrationCredential.mockRejectedValueOnce({ response: { status: 500, data: {} } });
+    await user.click(screen.getByText('deleteDialog.confirm'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('messages.deleteError'));
+    expect(screen.queryByText('deleteDialog.conflict.title')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bot de canal (whatsapp)')).not.toBeInTheDocument();
+  });
+
+  // Cancel closes the dialog by flipping the open prop, which does not run
+  // onOpenChange — so opening another credential is a distinct entry point.
+  it('does not carry the holders over to another credential', async () => {
+    deleteIntegrationCredential.mockRejectedValueOnce(conflictError(['Bot de canal (whatsapp)']));
+    const user = await confirmDelete();
+
+    await screen.findByText('deleteDialog.conflict.title');
+    await user.click(screen.getByText('deleteDialog.cancel'));
+
+    await user.click(screen.getAllByLabelText('actions.delete')[1]);
+
+    expect(await screen.findByText('deleteDialog.confirm')).toBeInTheDocument();
+    expect(screen.queryByText('deleteDialog.conflict.title')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bot de canal (whatsapp)')).not.toBeInTheDocument();
   });
 });

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -19,6 +19,7 @@ import EmptyState from '@/components/base/EmptyState';
 import { maskKey } from '@/constants/aiProviders';
 import {
   createIntegrationCredential,
+  deleteConflictConsumers,
   deleteIntegrationCredential,
   listCustomMcpServers,
   listCustomTools,
@@ -84,6 +85,7 @@ export default function IntegrationCredentials() {
   const [formOpen, setFormOpen] = useState(false);
   const [draft, setDraft] = useState<CredentialDraft>(EMPTY_DRAFT);
   const [credentialToDelete, setCredentialToDelete] = useState<IntegrationCredential | null>(null);
+  const [deleteConflict, setDeleteConflict] = useState<string[] | null>(null);
   const [connectionToDisconnect, setConnectionToDisconnect] =
     useState<IntegrationCredential | null>(null);
   const [consumersInUse, setConsumersInUse] = useState<ConsumerInUse[]>([]);
@@ -344,12 +346,22 @@ export default function IntegrationCredentials() {
 
     try {
       setSaving(true);
+      setDeleteConflict(null);
       await deleteIntegrationCredential(credentialToDelete.id);
       toast.success(t('messages.deleteSuccess'));
       setCredentialToDelete(null);
       loadCredentials();
     } catch (error) {
       console.error('Error deleting integration credential:', error);
+
+      // The refusal names its holders, so the dialog stays open and says who
+      // they are; a generic toast on top would compete with that answer.
+      const consumers = deleteConflictConsumers(error);
+      if (consumers) {
+        setDeleteConflict(consumers);
+        return;
+      }
+
       toast.error(t('messages.deleteError'));
     } finally {
       setSaving(false);
@@ -431,7 +443,10 @@ export default function IntegrationCredentials() {
                         variant="ghost"
                         size="sm"
                         aria-label={t('actions.delete')}
-                        onClick={() => setCredentialToDelete(credential)}
+                        onClick={() => {
+                          setDeleteConflict(null);
+                          setCredentialToDelete(credential);
+                        }}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
@@ -697,7 +712,12 @@ export default function IntegrationCredentials() {
 
       <Dialog
         open={Boolean(credentialToDelete)}
-        onOpenChange={open => !open && setCredentialToDelete(null)}
+        onOpenChange={open => {
+          if (!open) {
+            setCredentialToDelete(null);
+            setDeleteConflict(null);
+          }
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -707,14 +727,35 @@ export default function IntegrationCredentials() {
             </DialogDescription>
           </DialogHeader>
 
-          {(credentialToDelete?.referenced_by?.length ?? 0) > 0 && (
-            <p role="alert" className="flex gap-2 text-sm text-amber-600">
-              <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-              {t('deleteDialog.inUseWarning', {
-                count: credentialToDelete?.referenced_by?.length,
-                consumers: credentialToDelete?.referenced_by?.join(', '),
-              })}
-            </p>
+          {deleteConflict ? (
+            // The server just answered failing closed; `referenced_by` is a
+            // tolerant snapshot taken at listing time. Showing both would hand
+            // the reader two lists of who holds this and no way to choose.
+            <div
+              role="alert"
+              className="rounded border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive"
+            >
+              <p className="flex gap-2 font-medium">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                {t('deleteDialog.conflict.title')}
+              </p>
+              <ul className="list-disc pl-10 mt-2 space-y-1">
+                {deleteConflict.map((consumer, index) => (
+                  <li key={`${consumer}-${index}`}>{consumer}</li>
+                ))}
+              </ul>
+              <p className="pl-6 mt-2">{t('deleteDialog.conflict.help')}</p>
+            </div>
+          ) : (
+            (credentialToDelete?.referenced_by?.length ?? 0) > 0 && (
+              <p role="alert" className="flex gap-2 text-sm text-amber-600">
+                <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                {t('deleteDialog.inUseWarning', {
+                  count: credentialToDelete?.referenced_by?.length,
+                  consumers: credentialToDelete?.referenced_by?.join(', '),
+                })}
+              </p>
+            )
           )}
 
           <DialogFooter>

--- a/src/services/agents/integrationCredentialService.ts
+++ b/src/services/agents/integrationCredentialService.ts
@@ -1,5 +1,5 @@
 import evoaiApi from '@/services/core/apiEvoAI';
-import { extractData, buildPaginationParams } from '@/utils/apiHelpers';
+import { apiErrorCode, extractData, buildPaginationParams } from '@/utils/apiHelpers';
 import type {
   IntegrationCredential,
   IntegrationCredentialCreate,
@@ -42,6 +42,27 @@ export const deleteIntegrationCredential = async (
 ): Promise<IntegrationCredentialDeleteResponse> => {
   const response = await evoaiApi.delete(`/integration-credentials/${credentialId}`);
   return extractData<IntegrationCredentialDeleteResponse>(response);
+};
+
+// The delete refuses with 409 while a consumer still points at the credential,
+// naming each holder in `details.consumers` as a ready-to-display string. The
+// whole shape is required, not just the status: a conflict without consumers
+// would render a list asserting that somebody holds it and showing nobody.
+export const deleteConflictConsumers = (error: unknown): string[] | null => {
+  if (!error || typeof error !== 'object') return null;
+
+  const response = (error as { response?: { status?: number; data?: unknown } }).response;
+  if (response?.status !== 409 || apiErrorCode(error) !== 'CONFLICT') return null;
+
+  const data = response.data;
+  if (!data || typeof data !== 'object') return null;
+
+  const consumers = (data as { error?: { details?: { consumers?: unknown } } }).error?.details
+    ?.consumers;
+  if (!Array.isArray(consumers) || consumers.length === 0) return null;
+  if (!consumers.every(entry => typeof entry === 'string' && entry.trim() !== '')) return null;
+
+  return consumers as string[];
 };
 
 // EVO-2250 story 2.7: the retirement guard, per consumer. A consumer only


### PR DESCRIPTION
## O problema

O `DELETE /integration-credentials/:id` do core recusa com **409** enquanto algum consumidor ainda referencia a credencial, e nomeia cada um em `error.details.consumers` como string pronta para exibição (`Ferramenta Busca [Authorization]`, `Bot de canal (whatsapp)`).

O array chegava íntegro ao navegador — o interceptor do axios só trata 401 — e era descartado pela tela. O `catch` de `handleDeleteConfirm` era único para todos os erros e terminava em `toast.error(t('messages.deleteError'))`. O usuário lia "Falha ao excluir a credencial", sem nenhuma pista de qual ferramenta, MCP, agente, integração ou bot mexer para conseguir excluir.

## O que mudou

O 409 passa a manter o diálogo aberto (o `setCredentialToDelete(null)` já estava dentro do `try`) e a listar os consumidores **item a item**, com o texto do caminho a seguir. O toast genérico não dispara nesse caminho: o motivo passa a estar na tela, e um aviso por cima competiria com ele. Os demais erros seguem exatamente como antes.

O bloco **substitui** o aviso pré-flight (`deleteDialog.inUseWarning`) em vez de somar a ele. Os dois respondem a mesma pergunta com origens diferentes e divergem de verdade: `referenced_by` vem agregado no momento da listagem pelo `ReferencesByCredential`, que descarta em silêncio o store que falhar ("the column is decoration"), enquanto o `ConsumersOf` que alimenta o 409 falha fechado. Três caminhos chegam ao 409 com o diálogo sem aviso nenhum — credencial `oauth` com conexão viva (que por construção nunca entra no `referenced_by`), store que falhou na listagem, e o caso mais banal: alguém criou o consumidor depois que a página carregou. Mostrar as duas listas entregaria ao leitor dois conjuntos de "quem segura isto" e nenhuma forma de escolher.

A comporta é a **forma do payload**, não só o status: 409 com `code: CONFLICT` e `details.consumers` sendo array não vazio de strings. Qualquer outra forma cai no toast de antes — degradar para o comportamento atual, nunca para uma lista vazia afirmando que alguém segura a credencial. A leitura mora no `integrationCredentialService.ts`, ao lado da chamada que produz o erro.

As labels vêm prontas em pt-BR do servidor (`CONCAT('Ferramenta ', t.name, ...)` em SQL) e são exibidas verbatim; só o título e a instrução passam por i18n, nos seis locales. Traduzi-las exigiria o core devolver `{kind, name, key}` estruturado — mudança de contrato em dois repos, fora deste escopo.

## Verificação

`IntegrationCredentials.spec.tsx` + `i18n-parity.spec.ts`: 225 passando (47 no spec da tela, era 40). `npx tsc -b` e `npx eslint` limpos nos arquivos tocados. O spec já estava na lista opt-in do job Vitest, então não houve mudança em `test.yml`.

Cada guarda foi provada por mutação, uma a uma — não checar o status, não checar o `code`, aceitar lista vazia, aceitar item não-string, manter o toast no 409, trocar a lista por `join(', ')`, deixar o pré-flight aparecer junto, não limpar o estado ao reter, não limpar ao abrir outra credencial. Duas dessas mutações passavam ilesas na primeira rodada e acharam buraco de teste: o caso de retentativa só provava que o sucesso fecha o diálogo (troquei por uma retentativa que falha com 500, onde manter a lista antiga seria mentira na tela), e a limpeza ao abrir outra credencial parecia redundante até eu conferir que o **Cancelar** fecha o diálogo virando a prop `open`, o que não dispara `onOpenChange`.

Sem mudança no `evo-ai-core-service-community`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GhdzpEL9Pscew5Q5kTon2

## Summary by Sourcery

Show users which consumers still reference an integration credential when the server prevents its deletion.

New Features:
- Display the credential consumers named by the server when deletion is rejected by a qualifying 409 conflict.

Bug Fixes:
- Preserve the delete dialog and suppress the generic error toast when the server provides valid consumer details, while retaining the existing fallback for other errors.

Enhancements:
- Replace the stale pre-flight usage warning with the server-authoritative conflict details and clear conflict state between deletion attempts and credentials.

Documentation:
- Add localized titles and guidance for credential deletion conflicts across all supported locales.

Tests:
- Expand integration credential UI coverage for consumer rendering, payload validation, fallback behavior, retry handling, and state cleanup.