### PR TITLE
fix(users): painel de usuários não oferece account_owner nem super_admin (CRM-524)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,7 @@ jobs:
             src/pages/Admin/Roles/RolesList.spec.tsx \
             src/services/campaigns/campaignsService.spec.ts \
             src/pages/Customer/Settings/Users/Users.spec.tsx \
+            src/components/users/UserFormModal.spec.tsx \
             src/utils/apiHelpers.spec.ts \
             src/hooks/channels/useChannelSubmission.spec.ts \
             src/hooks/channels/useChannelValidation.spec.ts \

--- a/src/components/users/UserFormModal.spec.tsx
+++ b/src/components/users/UserFormModal.spec.tsx
@@ -121,11 +121,9 @@ describe('UserFormModal — account roles in the create-agent modal (AC8)', () =
   });
 });
 
-// CRM-524: the panel never hands out the user-global roles. account_owner is no
-// longer a base role, and super_admin (type:user) is dropped even when the API
-// lists it. Editing someone who already holds one keeps it visible but locked,
-// and a save that does not change the role omits it from the PATCH.
-describe('UserFormModal — non-assignable roles (CRM-524)', () => {
+// The panel never hands out the user-global roles: editing someone who holds
+// one keeps it visible but locked, and an unchanged role stays out of the PATCH.
+describe('UserFormModal — non-assignable roles', () => {
   const ownerUser = {
     id: 'u-owner',
     name: 'Dona',

--- a/src/components/users/UserFormModal.spec.tsx
+++ b/src/components/users/UserFormModal.spec.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import type { Role } from '@/types/auth/rbac';
+import type { User } from '@/types/users';
 
 vi.mock('@/hooks/useLanguage', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
@@ -36,6 +37,10 @@ const accountRole: Role = {
   updated_at: '',
 };
 
+// type:user like the seeded system role, so the panel filter (not the type
+// filter) is what keeps it out of the list.
+const superAdminRole: Role = { ...userRole, id: 'role-super-admin', key: 'super_admin', name: 'Super Admin', system: true };
+
 vi.mock('@/hooks/useRoles', () => ({
   default: (options?: { type?: 'user' | 'account' }) => {
     if (options?.type === 'account') {
@@ -43,7 +48,7 @@ vi.mock('@/hooks/useRoles', () => ({
     }
     // Default call (no type) — the "system" roles list. Include only a user
     // role here so we prove the account role comes from the dedicated fetch.
-    return { roles: [userRole], loading: false, error: null, refetch: vi.fn() };
+    return { roles: [userRole, superAdminRole], loading: false, error: null, refetch: vi.fn() };
   },
 }));
 
@@ -64,8 +69,16 @@ vi.mock('@evoapi/design-system', () => {
     ),
     Select: Passthrough,
     SelectContent: Passthrough,
-    SelectItem: ({ children, value }: { children?: React.ReactNode; value?: string }) => (
-      <div data-testid="select-item" data-value={value}>
+    SelectItem: ({
+      children,
+      value,
+      disabled,
+    }: {
+      children?: React.ReactNode;
+      value?: string;
+      disabled?: boolean;
+    }) => (
+      <div data-testid="select-item" data-value={value} data-disabled={disabled ? 'true' : undefined}>
         {children}
       </div>
     ),
@@ -94,18 +107,68 @@ describe('UserFormModal — account roles in the create-agent modal (AC8)', () =
     expect(screen.getByText('Converse')).toBeInTheDocument();
   });
 
-  it('still includes the base roles and the type:user roles, deduped by key', () => {
+  it('still includes the agent base role and the type:user roles, deduped by key', () => {
     renderModal();
 
     const items = screen.getAllByTestId('select-item');
     const values = items.map(el => el.getAttribute('data-value'));
 
-    // base roles always present
     expect(values).toContain('agent');
-    expect(values).toContain('account_owner');
     // type:user system role merged in
     expect(values).toContain('gerente');
     // no duplicate keys
     expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+// CRM-524: the panel never hands out the user-global roles. account_owner is no
+// longer a base role, and super_admin (type:user) is dropped even when the API
+// lists it. Editing someone who already holds one keeps it visible but locked,
+// and a save that does not change the role omits it from the PATCH.
+describe('UserFormModal — non-assignable roles (CRM-524)', () => {
+  const ownerUser = {
+    id: 'u-owner',
+    name: 'Dona',
+    email: 'dona@example.com',
+    role: { id: 'role-owner', key: 'account_owner', name: 'Account Owner' },
+    availability: 'online',
+  } as unknown as User;
+
+  const values = () =>
+    screen.getAllByTestId('select-item').map(el => el.getAttribute('data-value'));
+
+  it('offers neither account_owner nor super_admin when creating', () => {
+    render(<UserFormModal isOpen user={null} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    expect(values()).not.toContain('account_owner');
+    expect(values()).not.toContain('super_admin');
+    expect(values()).toContain('agent');
+  });
+
+  it('shows the current non-assignable role locked when editing', () => {
+    render(<UserFormModal isOpen user={ownerUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    const locked = screen
+      .getAllByTestId('select-item')
+      .find(el => el.getAttribute('data-value') === 'account_owner');
+    expect(locked).toBeDefined();
+    expect(locked?.getAttribute('data-disabled')).toBe('true');
+    expect(values().filter(v => v === 'account_owner')).toHaveLength(1);
+  });
+
+  it('omits role from the PATCH when the role did not change', async () => {
+    const { default: usersService } = await import('@/services/users/usersService');
+    vi.mocked(usersService.updateUser).mockResolvedValue(ownerUser);
+    const { container } = render(
+      <UserFormModal isOpen user={ownerUser} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+
+    fireEvent.change(screen.getByDisplayValue('Dona'), { target: { value: 'Dona Renomeada' } });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => expect(usersService.updateUser).toHaveBeenCalledTimes(1));
+    const [, payload] = vi.mocked(usersService.updateUser).mock.calls[0];
+    expect(payload).not.toHaveProperty('role');
+    expect(payload.name).toBe('Dona Renomeada');
   });
 });

--- a/src/components/users/UserFormModal.tsx
+++ b/src/components/users/UserFormModal.tsx
@@ -19,6 +19,7 @@ import useRoles from '@/hooks/useRoles';
 import type { User, UserFormData, UserUpdateData } from '@/types/users';
 import { Loader2 } from 'lucide-react';
 import { useLanguage } from '@/hooks/useLanguage';
+import { isPanelAssignableRole } from '@/constants/roles';
 
 
 interface UserFormModalProps {
@@ -31,36 +32,39 @@ interface UserFormModalProps {
 export default function UserFormModal({ isOpen, onClose, user, onSuccess }: UserFormModalProps) {
   const { t } = useLanguage('users');
 
-  // Buscar system roles (todos os tipos) + roles customizadas type:'account'.
-  // Atendentes podem receber tanto as roles base (agent/account_owner) quanto
-  // roles customizadas type:'account' (ex.: "Converse"). O backend passou a
-  // retornar essas roles account em account_user_roles (RBAC split).
+  // System roles (all types) + custom type:'account' roles. The panel hands out
+  // `agent` and the account roles (e.g. "Converse"); super_admin and
+  // account_owner are never offered (CRM-524) — the auth refuses them from
+  // this caller anyway.
   const { roles: systemRoles, error: rolesError } = useRoles();
   const { roles: accountRoles } = useRoles({ type: 'account' });
 
-  // Deduplicar roles por chave para evitar que apareçam duplicados ou que a seleção marque múltiplos
   const uniqueRoles = useMemo(() => {
-    // Definimos os papéis básicos que devem estar sempre disponíveis
-    const baseRoles = [
-      { id: 'role-agent', key: 'agent', name: 'Agent', type: 'user' },
-      { id: 'role-account-owner', key: 'account_owner', name: 'Account Owner', type: 'user' },
-    ];
+    const baseRoles = [{ id: 'role-agent', key: 'agent', name: 'Agent', type: 'user' }];
 
-    // Roles atribuíveis a atendentes: type 'user' (compat legado), 'account'
-    // (atendentes customizados) ou sem type definido.
+    // type 'user' (legacy), 'account' (custom attendants) or untyped.
     const assignableRoleTypes = ['user', 'account', null, undefined];
     const filteredSystemRoles = [...systemRoles, ...accountRoles].filter(
-      role => !!role.key && (assignableRoleTypes.includes(role.type as any) || !role.type)
+      role =>
+        !!role.key &&
+        isPanelAssignableRole(role.key) &&
+        (assignableRoleTypes.includes(role.type as any) || !role.type)
     );
 
-    // Combinamos e removemos duplicatas por key (dando preferência ao que vem
-    // do sistema/account se existir).
     return Array.from(
       new Map(
         [...baseRoles, ...filteredSystemRoles].map(role => [role.key, role])
       ).values()
     );
   }, [systemRoles, accountRoles]);
+
+  // Editing someone who already holds a non-assignable role: show it, locked,
+  // so the field is not blank and the save does not re-grant it.
+  const currentRoleKey = user?.role?.key;
+  const lockedCurrentRole =
+    currentRoleKey && !isPanelAssignableRole(currentRoleKey)
+      ? { id: `role-current-${currentRoleKey}`, key: currentRoleKey, name: user?.role?.name || currentRoleKey }
+      : null;
 
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState<UserFormData>({
@@ -161,10 +165,12 @@ export default function UserFormModal({ isOpen, onClose, user, onSuccess }: User
     try {
       if (user) {
         // Atualizar usuário
+        // `role` only travels when it changed: resubmitting the current one is
+        // a role-set rewrite on the auth side, which the guard may refuse.
         const updateData: UserUpdateData = {
           name: formData.name,
-          role: formData.role,
           availability: formData.availability,
+          ...(formData.role !== user.role?.key ? { role: formData.role } : {}),
         };
 
         await usersService.updateUser(user.id, updateData);
@@ -272,6 +278,11 @@ export default function UserFormModal({ isOpen, onClose, user, onSuccess }: User
                   <div className="px-2 py-4 text-sm text-center text-sidebar-foreground/60">
                     {rolesError ? rolesError : t('form.messages.loading')}
                   </div>
+                )}
+                {lockedCurrentRole && (
+                  <SelectItem key={lockedCurrentRole.id} value={lockedCurrentRole.key} disabled>
+                    {lockedCurrentRole.name}
+                  </SelectItem>
                 )}
                 {uniqueRoles.map(role => (
                   <SelectItem key={role.id} value={role.key}>

--- a/src/components/users/UserFormModal.tsx
+++ b/src/components/users/UserFormModal.tsx
@@ -33,9 +33,8 @@ export default function UserFormModal({ isOpen, onClose, user, onSuccess }: User
   const { t } = useLanguage('users');
 
   // System roles (all types) + custom type:'account' roles. The panel hands out
-  // `agent` and the account roles (e.g. "Converse"); super_admin and
-  // account_owner are never offered (CRM-524) — the auth refuses them from
-  // this caller anyway.
+  // `agent` and the account roles; super_admin and account_owner are never
+  // offered (the auth refuses them from this caller anyway).
   const { roles: systemRoles, error: rolesError } = useRoles();
   const { roles: accountRoles } = useRoles({ type: 'account' });
 

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -17,3 +17,14 @@ export type RoleKey = (typeof ROLE_KEYS)[keyof typeof ROLE_KEYS];
 
 export const isAdminRole = (key: string): boolean =>
   (ADMIN_ROLE_KEYS as readonly string[]).includes(key);
+
+// Roles the Settings > Users panel never hands out (CRM-524): super_admin is
+// the installation owner and account_owner is user-global in the auth. Account
+// admins come from the enterprise membership roles, not from here.
+export const PANEL_NON_ASSIGNABLE_ROLE_KEYS = [
+  ROLE_KEYS.SUPER_ADMIN,
+  ROLE_KEYS.ACCOUNT_OWNER,
+] as const;
+
+export const isPanelAssignableRole = (key: string): boolean =>
+  !(PANEL_NON_ASSIGNABLE_ROLE_KEYS as readonly string[]).includes(key);

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -18,9 +18,8 @@ export type RoleKey = (typeof ROLE_KEYS)[keyof typeof ROLE_KEYS];
 export const isAdminRole = (key: string): boolean =>
   (ADMIN_ROLE_KEYS as readonly string[]).includes(key);
 
-// Roles the Settings > Users panel never hands out (CRM-524): super_admin is
-// the installation owner and account_owner is user-global in the auth. Account
-// admins come from the enterprise membership roles, not from here.
+// Roles the Settings > Users panel never hands out: super_admin is the
+// installation owner, account_owner is user-global in the auth.
 export const PANEL_NON_ASSIGNABLE_ROLE_KEYS = [
   ROLE_KEYS.SUPER_ADMIN,
   ROLE_KEYS.ACCOUNT_OWNER,


### PR DESCRIPTION
## Summary
- O modal de usuário (Configurações → Usuários) listava `account_owner` como papel base e deixaria passar `super_admin` se a API o devolvesse (é `type: user`). Os dois saem da lista: o painel atribui `agent` e os papéis de conta customizados.
- `PANEL_NON_ASSIGNABLE_ROLE_KEYS` em `constants/roles.ts` + filtro por chave no merge de papéis.
- Ao editar quem já tem um desses papéis, ele aparece travado no select, para o campo não ficar em branco.
- O PATCH só manda `role` quando o papel mudou: um rename não reescreve o papel (o auth trata reenvio como troca e pode recusar).

## Security
- Só apresentação; a recusa de verdade é do auth (`users#update`/`#create`). O painel deixa de oferecer o que o backend nega.

## Test plan
- `npx vitest run src/components/users` → 22 testes (5 no modal: sem as duas chaves na criação, papel atual travado na edição, PATCH sem `role` quando inalterado)
- `npx tsc --noEmit`
- `npx vite build`

## Changed Files
- `src/constants/roles.ts`
- `src/components/users/UserFormModal.tsx`
- `src/components/users/UserFormModal.spec.tsx`

## Linked Issue
- CRM-524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw788PPGZwaVtkLX69JZUi

## Summary by Sourcery

Restrict user-role assignment in the Users panel to supported roles while preserving existing protected roles during edits.

Bug Fixes:
- Prevent the Users panel from offering the globally managed `account_owner` and `super_admin` roles for assignment.
- Avoid resubmitting an unchanged role during user updates, preventing rejected role rewrites.

Enhancements:
- Keep an existing non-assignable role visible and locked when editing a user.

CI:
- Add the UserFormModal test suite to the GitHub Actions test workflow.

Tests:
- Add coverage for role filtering, locked current roles, and omitting unchanged roles from update requests.