### PR TITLE
fix(credentials): linha OAuth órfã oferece excluir no lugar de um Desconectar morto (CRM-208)

### DIFF
--- a/src/i18n/locales/en/integrationCredentials.json
+++ b/src/i18n/locales/en/integrationCredentials.json
@@ -96,7 +96,8 @@
     "status": {
       "connected": "Connected",
       "expiring": "Expiring soon",
-      "expired": "Expired"
+      "expired": "Expired",
+      "disconnected": "Disconnected"
     },
     "actions": {
       "disconnect": "Disconnect"

--- a/src/i18n/locales/es/integrationCredentials.json
+++ b/src/i18n/locales/es/integrationCredentials.json
@@ -96,7 +96,8 @@
     "status": {
       "connected": "Conectada",
       "expiring": "Expira pronto",
-      "expired": "Expirada"
+      "expired": "Expirada",
+      "disconnected": "Desconectada"
     },
     "actions": {
       "disconnect": "Desconectar"

--- a/src/i18n/locales/fr/integrationCredentials.json
+++ b/src/i18n/locales/fr/integrationCredentials.json
@@ -96,7 +96,8 @@
     "status": {
       "connected": "Connectée",
       "expiring": "Expire bientôt",
-      "expired": "Expirée"
+      "expired": "Expirée",
+      "disconnected": "Déconnectée"
     },
     "actions": {
       "disconnect": "Déconnecter"

--- a/src/i18n/locales/it/integrationCredentials.json
+++ b/src/i18n/locales/it/integrationCredentials.json
@@ -96,7 +96,8 @@
     "status": {
       "connected": "Connessa",
       "expiring": "In scadenza",
-      "expired": "Scaduta"
+      "expired": "Scaduta",
+      "disconnected": "Disconnessa"
     },
     "actions": {
       "disconnect": "Disconnetti"

--- a/src/i18n/locales/pt-BR/integrationCredentials.json
+++ b/src/i18n/locales/pt-BR/integrationCredentials.json
@@ -96,7 +96,8 @@
     "status": {
       "connected": "Conectada",
       "expiring": "Expirando em breve",
-      "expired": "Expirada"
+      "expired": "Expirada",
+      "disconnected": "Desconectada"
     },
     "actions": {
       "disconnect": "Desconectar"

--- a/src/i18n/locales/pt/integrationCredentials.json
+++ b/src/i18n/locales/pt/integrationCredentials.json
@@ -96,7 +96,8 @@
     "status": {
       "connected": "Conectada",
       "expiring": "Expirando em breve",
-      "expired": "Expirada"
+      "expired": "Expirada",
+      "disconnected": "Desconectada"
     },
     "actions": {
       "disconnect": "Desconectar"

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -123,6 +123,18 @@ const OAUTH_EXPIRED: IntegrationCredential = {
   connection_status: 'expired',
 };
 
+// The connection left the owner store: the listing sync deactivated the row
+// and the backend decorates it without an agent (CRM-208).
+const OAUTH_ORPHANED: IntegrationCredential = {
+  ...OAUTH_CREDENTIAL,
+  id: 'cred-oauth-slack',
+  provider: 'slack',
+  agent_id: undefined,
+  agent_name: undefined,
+  connection_status: 'expired',
+  is_active: false,
+};
+
 const ALL_PERMISSIONS = [
   'ai_integration_credentials.read',
   'ai_integration_credentials.create',
@@ -383,6 +395,63 @@ describe('IntegrationCredentials — OAuth connections section (2.5 AC1, AC2, AC
 
     await findAccountRow();
     expect(within(oauthSection()).getByText('oauthSection.empty')).toBeInTheDocument();
+  });
+
+  // CRM-208: a row whose connection is gone has nothing to disconnect and the
+  // vault delete no longer conflicts, so delete is offered there and only there.
+  it('offers delete, not disconnect, on an oauth row whose connection is gone', async () => {
+    const user = userEvent.setup();
+    deleteIntegrationCredential.mockResolvedValue({ message: 'ok' });
+    listIntegrationCredentials.mockResolvedValue([
+      DIFY_CREDENTIAL,
+      OAUTH_CREDENTIAL,
+      OAUTH_ORPHANED,
+    ]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const section = oauthSection();
+    expect(within(section).getByText('oauthSection.status.disconnected')).toBeInTheDocument();
+    // One delete for the orphaned row, one disconnect for the live one.
+    expect(within(section).getAllByLabelText('actions.delete')).toHaveLength(1);
+    expect(within(section).getAllByLabelText('oauthSection.actions.disconnect')).toHaveLength(1);
+
+    await user.click(within(section).getByLabelText('actions.delete'));
+    await user.click(await screen.findByText('deleteDialog.confirm'));
+
+    await waitFor(() =>
+      expect(deleteIntegrationCredential).toHaveBeenCalledWith('cred-oauth-slack'),
+    );
+    expect(deleteIntegration).not.toHaveBeenCalled();
+  });
+
+  it('keeps disconnect and no delete on a live connection whose token expired (negative proof)', async () => {
+    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, OAUTH_EXPIRED]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const section = oauthSection();
+    // Token expiry is the backend's word; only a deactivated row is orphaned.
+    expect(within(section).getByText('oauthSection.status.expired')).toBeInTheDocument();
+    expect(within(section).queryByText('oauthSection.status.disconnected')).not.toBeInTheDocument();
+    expect(within(section).getByLabelText('oauthSection.actions.disconnect')).toBeInTheDocument();
+    expect(within(section).queryByLabelText('actions.delete')).not.toBeInTheDocument();
+  });
+
+  it('hides the orphaned row delete without ai_integration_credentials.delete', async () => {
+    granted = ALL_PERMISSIONS.filter(
+      permission => permission !== 'ai_integration_credentials.delete',
+    );
+    listIntegrationCredentials.mockResolvedValue([DIFY_CREDENTIAL, OAUTH_ORPHANED]);
+    render(<IntegrationCredentials />);
+
+    await findAccountRow();
+    const section = oauthSection();
+    expect(within(section).getByText('oauthSection.status.disconnected')).toBeInTheDocument();
+    expect(within(section).queryByLabelText('actions.delete')).not.toBeInTheDocument();
+    expect(
+      within(section).queryByLabelText('oauthSection.actions.disconnect'),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.spec.tsx
@@ -123,8 +123,7 @@ const OAUTH_EXPIRED: IntegrationCredential = {
   connection_status: 'expired',
 };
 
-// The connection left the owner store: the listing sync deactivated the row
-// and the backend decorates it without an agent (CRM-208).
+// Deactivated by the listing sync: the backend decorates it without an agent.
 const OAUTH_ORPHANED: IntegrationCredential = {
   ...OAUTH_CREDENTIAL,
   id: 'cred-oauth-slack',
@@ -397,8 +396,6 @@ describe('IntegrationCredentials — OAuth connections section (2.5 AC1, AC2, AC
     expect(within(oauthSection()).getByText('oauthSection.empty')).toBeInTheDocument();
   });
 
-  // CRM-208: a row whose connection is gone has nothing to disconnect and the
-  // vault delete no longer conflicts, so delete is offered there and only there.
   it('offers delete, not disconnect, on an oauth row whose connection is gone', async () => {
     const user = userEvent.setup();
     deleteIntegrationCredential.mockResolvedValue({ message: 'ok' });
@@ -412,7 +409,6 @@ describe('IntegrationCredentials — OAuth connections section (2.5 AC1, AC2, AC
     await findAccountRow();
     const section = oauthSection();
     expect(within(section).getByText('oauthSection.status.disconnected')).toBeInTheDocument();
-    // One delete for the orphaned row, one disconnect for the live one.
     expect(within(section).getAllByLabelText('actions.delete')).toHaveLength(1);
     expect(within(section).getAllByLabelText('oauthSection.actions.disconnect')).toHaveLength(1);
 

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -560,10 +560,8 @@ export default function IntegrationCredentials() {
               </thead>
               <tbody>
                 {oauthConnections.map(connection => {
-                  // The listing sync deactivates an oauth row whose connection
-                  // left the owner store. There is no agent left to disconnect
-                  // and the vault delete no longer conflicts, so delete is the
-                  // way out (CRM-208).
+                  // The listing sync deactivates a row whose connection left the
+                  // owner store: nothing to disconnect, so delete is the way out.
                   const orphaned = !connection.is_active;
 
                   return (

--- a/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
+++ b/src/pages/Customer/Settings/IntegrationCredentials/IntegrationCredentials.tsx
@@ -317,6 +317,7 @@ export default function IntegrationCredentials() {
   // token is touched — and the provider-side grant is NOT revoked.
   const handleDisconnectConfirm = async () => {
     if (!connectionToDisconnect?.agent_id) {
+      toast.error(t('oauthSection.disconnectError'));
       return;
     }
 
@@ -558,42 +559,67 @@ export default function IntegrationCredentials() {
                 </tr>
               </thead>
               <tbody>
-                {oauthConnections.map(connection => (
-                  <tr key={connection.id} className="border-t">
-                    <td className="p-3">
-                      <Badge variant="outline">{connection.provider}</Badge>
-                    </td>
-                    <td className="p-3">{connection.agent_name ?? connection.owner_ref}</td>
-                    <td className="p-3">
-                      <Badge
-                        variant={
-                          connection.connection_status === 'connected' ? 'default' : 'secondary'
-                        }
-                      >
-                        {t(`oauthSection.status.${connection.connection_status ?? 'connected'}`)}
-                      </Badge>
-                    </td>
-                    <td className="p-3">
-                      {connection.connection_expires_at
-                        ? parseOwnerTimestamp(connection.connection_expires_at).toLocaleString()
-                        : t('oauthSection.noExpiry')}
-                    </td>
-                    <td className="p-3">
-                      <div className="flex justify-end gap-2">
-                        {canDisconnect && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            aria-label={t('oauthSection.actions.disconnect')}
-                            onClick={() => setConnectionToDisconnect(connection)}
-                          >
-                            {t('oauthSection.actions.disconnect')}
-                          </Button>
-                        )}
-                      </div>
-                    </td>
-                  </tr>
-                ))}
+                {oauthConnections.map(connection => {
+                  // The listing sync deactivates an oauth row whose connection
+                  // left the owner store. There is no agent left to disconnect
+                  // and the vault delete no longer conflicts, so delete is the
+                  // way out (CRM-208).
+                  const orphaned = !connection.is_active;
+
+                  return (
+                    <tr key={connection.id} className="border-t">
+                      <td className="p-3">
+                        <Badge variant="outline">{connection.provider}</Badge>
+                      </td>
+                      <td className="p-3">{connection.agent_name ?? connection.owner_ref}</td>
+                      <td className="p-3">
+                        <Badge
+                          variant={
+                            connection.connection_status === 'connected' && !orphaned
+                              ? 'default'
+                              : 'secondary'
+                          }
+                        >
+                          {orphaned
+                            ? t('oauthSection.status.disconnected')
+                            : t(
+                                `oauthSection.status.${connection.connection_status ?? 'connected'}`,
+                              )}
+                        </Badge>
+                      </td>
+                      <td className="p-3">
+                        {connection.connection_expires_at
+                          ? parseOwnerTimestamp(connection.connection_expires_at).toLocaleString()
+                          : t('oauthSection.noExpiry')}
+                      </td>
+                      <td className="p-3">
+                        <div className="flex justify-end gap-2">
+                          {orphaned
+                            ? canDeleteInScope(connection.scope ?? 'account') && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  aria-label={t('actions.delete')}
+                                  onClick={() => setCredentialToDelete(connection)}
+                                >
+                                  <Trash2 className="h-4 w-4" />
+                                </Button>
+                              )
+                            : canDisconnect && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  aria-label={t('oauthSection.actions.disconnect')}
+                                  onClick={() => setConnectionToDisconnect(connection)}
+                                >
+                                  {t('oauthSection.actions.disconnect')}
+                                </Button>
+                              )}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Contexto

O pedido do CRM-208 (não oferecer excluir em linha `kind='oauth'` com conexão ativa, apontar para Desconectar, manter excluir em `static`) já estava na `develop` desde o `a05c7221`, e a prova negativa da spec passa 35/35. O que o review encontrou foi o caso inverso, levantado no comentário do card: quando a conexão some do owner store, o sync do core **desativa** a linha em vez de apagar (`oauth_sync.go:80-90`), a listagem continua devolvendo ela e o `Decorate` a marca `expired` sem `agent_id`. A tela mostrava Desconectar nessa linha (o handler retornava cedo, sem toast) e nunca oferecia excluir em linha oauth. Sobrava uma linha morta que o usuário não conseguia remover, com o mesmo badge "Expirada" de uma conexão viva com token vencido.

## O que muda

- Linha oauth **inativa** (`is_active=false`, que após o sync significa "sem conexão viva") passa a mostrar o estado **Desconectada** e o botão de excluir, gated por `ai_integration_credentials.delete`. O `refuseIfConnected` do core deixa esse DELETE passar, porque não há conexão que o recrie.
- Linha oauth **ativa** segue como antes: só Desconectar, nunca excluir. A prova negativa nova cobre a conexão viva com token expirado.
- `handleDisconnectConfirm` sem `agent_id` agora dispara o toast de erro em vez de retornar em silêncio.
- Chave i18n `oauthSection.status.disconnected` nas 6 locales.

## Verificação

- `IntegrationCredentials.spec.tsx`: 38/38 (3 casos novos). Mutar `orphaned` para `false` derruba o caso novo.
- `i18n-parity.spec.ts`: 178/178.
- `tsc -p tsconfig.app.json --noEmit` e eslint limpos.

## Relação com a #382 (CRM-207)

Toca o mesmo arquivo, em hunks diferentes (linha oauth e guard do Desconectar aqui; diálogo de exclusão e catch do delete lá). Sem sobreposição textual.

## Summary by Sourcery

Allow users to remove orphaned OAuth credentials while preserving disconnect-only behavior for active connections.

New Features:
- Allow deleting inactive orphaned OAuth credential rows when the required permission is granted.

Bug Fixes:
- Show orphaned OAuth rows as disconnected instead of offering an unusable disconnect action.
- Display an error toast when disconnect is attempted without an agent connection.

Enhancements:
- Keep active OAuth rows, including those with expired tokens, restricted to the disconnect action.

Tests:
- Add coverage for orphaned-row deletion, expired live connections, and permission-gated deletion.