### PR TITLE
fix(users): seletores de pessoas leem o diretório da conta por uma fonte única (CRM-539)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,12 @@ jobs:
       #     which is the ONLY thing that tells the auth which account to bind the token
       #     to. Dropping the header is invisible here and shows up as a 401 on every CRM
       #     call the customer's automations make.
+      #   - account people directory (CRM-539): every agent selector reads
+      #     usersService.getAccountUsers, which asks the auth for full pages and walks
+      #     them all (the default page is 20, and a truncated list looks complete);
+      #     the channel "Atendentes" total is the size of that list and the current
+      #     inbox members are the ones marked. The account scope itself is the host's
+      #     request context — a caller-side filter here would only mask its absence.
       # The whole list runs in ~40s and is deterministic.
       #
       # Running the whole suite here was tried and reverted: 160 jsdom files in
@@ -219,7 +225,9 @@ jobs:
             src/components/journey/nodes/trigger/components/EventBasicConfig.spec.tsx \
             src/i18n/locales/journey-parity.spec.ts \
             src/pages/Customer/Campaigns/NewCampaign/wizard/Step4_Settings.spreadWindow.spec.tsx \
-            src/services/auth/accessTokensService.spec.ts
+            src/services/auth/accessTokensService.spec.ts \
+            src/services/users/usersService.spec.ts \
+            src/components/channels/settings/CollaboratorsForm.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/components/channels/settings/CollaboratorsForm.spec.tsx
+++ b/src/components/channels/settings/CollaboratorsForm.spec.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// A stable `t`, as the real i18n gives: the component re-loads when `t` changes.
+const t = (key: string, opts?: Record<string, unknown>) =>
+  opts && 'count' in opts ? `${key}:${opts.count}` : key;
+vi.mock('@/hooks/useLanguage', () => ({ useLanguage: () => ({ t }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@evoapi/design-system', () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  return { Card: Passthrough, CardContent: Passthrough, Switch: () => <input type="checkbox" /> };
+});
+
+const getAccountUsersMock = vi.fn();
+vi.mock('@/services/users/usersService', () => ({
+  default: { getAccountUsers: (...args: unknown[]) => getAccountUsersMock(...args) },
+}));
+const inboxMembersGetMock = vi.fn();
+vi.mock('@/services/channels/inboxMembersService', () => ({
+  default: { get: (...args: unknown[]) => inboxMembersGetMock(...args), update: vi.fn() },
+}));
+
+import CollaboratorsForm from './CollaboratorsForm';
+
+const person = (id: number, name: string) => ({
+  id,
+  name,
+  email: `${name.toLowerCase()}@example.com`,
+  role: { key: 'agent', name: 'agent' },
+  availability_status: 'online',
+});
+
+// CRM-539: "Atendentes" lists the account directory (single scoped source),
+// marks the current inbox members, and the total is the size of that list —
+// not of a cross-account union, not of the auth's default page.
+describe('CollaboratorsForm — account-scoped agents (CRM-539)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAccountUsersMock.mockResolvedValue([person(1, 'Ana'), person(2, 'Bia'), person(3, 'Caio')]);
+    inboxMembersGetMock.mockResolvedValue([person(2, 'Bia')]);
+  });
+
+  it('reads the universe from the account directory, once, for the inbox', async () => {
+    render(<CollaboratorsForm inboxId="inbox-9" />);
+
+    await waitFor(() => expect(screen.getByText('Ana')).toBeInTheDocument());
+    expect(getAccountUsersMock).toHaveBeenCalledTimes(1);
+    expect(inboxMembersGetMock).toHaveBeenCalledWith('inbox-9');
+  });
+
+  it('shows the total of the directory and the count of current members', async () => {
+    render(<CollaboratorsForm inboxId="inbox-9" />);
+
+    await waitFor(() => expect(screen.getByText('Caio')).toBeInTheDocument());
+    expect(screen.getByText(/settings\.collaborators\.agents\.selectedCount:1/)).toBeInTheDocument();
+    expect(screen.getByText(/\(3 settings\.collaborators\.agents\.total\)/)).toBeInTheDocument();
+  });
+
+  it('marks only the users who are already inbox members', async () => {
+    render(<CollaboratorsForm inboxId="inbox-9" />);
+
+    await waitFor(() => expect(screen.getByText('Bia')).toBeInTheDocument());
+    const rowOf = (name: string) => screen.getByText(name).closest('[class*="cursor-pointer"]') as HTMLElement;
+    expect(rowOf('Bia').className).toContain('border-primary');
+    expect(rowOf('Ana').className).not.toContain('ring-2');
+    expect(rowOf('Caio').className).not.toContain('ring-2');
+  });
+
+  it('renders the empty state when the directory is empty', async () => {
+    getAccountUsersMock.mockResolvedValue([]);
+    inboxMembersGetMock.mockResolvedValue([]);
+    render(<CollaboratorsForm inboxId="inbox-9" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('settings.collaborators.agents.noAgents.title')).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/\(0 settings\.collaborators\.agents\.total\)/)).toBeInTheDocument();
+  });
+});

--- a/src/components/channels/settings/CollaboratorsForm.spec.tsx
+++ b/src/components/channels/settings/CollaboratorsForm.spec.tsx
@@ -67,6 +67,14 @@ describe('CollaboratorsForm — account-scoped agents (CRM-539)', () => {
     expect(rowOf('Caio').className).not.toContain('ring-2');
   });
 
+  it('reports a failed directory load instead of showing "no agents"', async () => {
+    const { toast } = await import('sonner');
+    getAccountUsersMock.mockRejectedValue(new Error('403'));
+    render(<CollaboratorsForm inboxId="inbox-9" />);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('settings.collaborators.errors.loadError'));
+  });
+
   it('renders the empty state when the directory is empty', async () => {
     getAccountUsersMock.mockResolvedValue([]);
     inboxMembersGetMock.mockResolvedValue([]);

--- a/src/components/channels/settings/CollaboratorsForm.spec.tsx
+++ b/src/components/channels/settings/CollaboratorsForm.spec.tsx
@@ -62,7 +62,8 @@ describe('CollaboratorsForm — account-scoped agents (CRM-539)', () => {
 
     await waitFor(() => expect(screen.getByText('Bia')).toBeInTheDocument());
     const rowOf = (name: string) => screen.getByText(name).closest('[class*="cursor-pointer"]') as HTMLElement;
-    expect(rowOf('Bia').className).toContain('border-primary');
+    // ring-2 is the selected-only class; border-primary also matches the hover of unselected rows.
+    expect(rowOf('Bia').className).toContain('ring-2');
     expect(rowOf('Ana').className).not.toContain('ring-2');
     expect(rowOf('Caio').className).not.toContain('ring-2');
   });

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx
@@ -15,7 +15,7 @@ vi.mock('@/services/contacts/labelsService', () => ({
   labelsService: { getLabels: vi.fn() },
 }));
 vi.mock('@/services/users/usersService', () => ({
-  default: { getUsers: vi.fn() },
+  default: { getUsers: vi.fn(), getAccountUsers: vi.fn() },
 }));
 vi.mock('@/services/campaigns/campaignsService', () => ({
   campaignsService: { getCampaigns: vi.fn() },
@@ -395,8 +395,6 @@ describe('EventPropertiesForm — lookup page sizes', () => {
   const cases: Array<[string, string, () => ReturnType<typeof vi.fn>, unknown]> = [
     ['conversation.created', 'inbox_id', () => asMock(InboxesService.list), { per_page: 200 }],
     ['contact.label.added', 'labelId', () => asMock(labelsService.getLabels), { per_page: 200 }],
-    // The auth service caps page_size at MAX_PAGE_SIZE = 100.
-    ['campaign.triggered', 'assigned_by_id', () => asMock(UsersService.getUsers), { per_page: 100 }],
     // evo-flow's CampaignQueryDto rejects anything over 100.
     ['campaign.message.sent', 'campaign_id', () => asMock(campaignsService.getCampaigns), { per_page: 100 }],
     // message_templates has an explicit unpaginated branch for -1.
@@ -418,6 +416,21 @@ describe('EventPropertiesForm — lookup page sizes', () => {
     await user.click(within(listbox).getByText(key));
 
     await waitFor(() => expect(mock).toHaveBeenCalledWith(expected));
+  });
+
+  // CRM-539: people come from the account directory, which walks every page
+  // itself, so the lookup no longer pins a page size.
+  it('campaign.triggered → assigned_by_id reads the account directory', async () => {
+    const mock = asMock(UsersService.getAccountUsers);
+    mock.mockResolvedValue([{ id: 7, name: 'Ana' }]);
+    const user = userEvent.setup();
+    render(<Harness eventName="campaign.triggered" />);
+
+    const listbox = await openPicker(user);
+    await user.click(within(listbox).getByText('assigned_by_id'));
+
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
+    expect(asMock(UsersService.getUsers)).not.toHaveBeenCalled();
   });
 
   it('asks the pipeline endpoints for nothing — they do not paginate', async () => {

--- a/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
+++ b/src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx
@@ -368,8 +368,8 @@ async function loadLookup(kind: LookupKind, pipelineId?: string): Promise<Lookup
       return (response?.data || []).map((l) => ({ id: String(l.id), name: l.title }));
     }
     case 'agent': {
-      const response = await UsersService.getUsers({ per_page: 100 });
-      return (response?.data || []).map((u) => ({ id: String(u.id), name: u.name }));
+      const users = await UsersService.getAccountUsers();
+      return users.map((u) => ({ id: String(u.id), name: u.name }));
     }
     case 'campaign': {
       const response = await campaignsService.getCampaigns({ per_page: 100 });

--- a/src/hooks/chat/useFilterOptions.ts
+++ b/src/hooks/chat/useFilterOptions.ts
@@ -72,7 +72,7 @@ export const useFilterOptions = (params: UseFilterOptionsParams = {}): FilterOpt
           contactsService.getContacts({ per_page: 100, sort: 'last_activity_at', order: 'desc' }),
           labelsService.getLabels({ per_page: 200 }),
           chatService.getAvailableTeams(),
-          usersService.getUsers({ per_page: 100 }),
+          usersService.getAccountUsers(),
         ]);
 
         // ✅ Processar inboxes
@@ -156,7 +156,7 @@ export const useFilterOptions = (params: UseFilterOptionsParams = {}): FilterOpt
 
         const users: FilterOption[] = [];
         if (usersResponse.status === 'fulfilled') {
-          const usersData = usersResponse.value?.data ?? [];
+          const usersData = usersResponse.value ?? [];
           if (Array.isArray(usersData)) {
             users.push(
               ...usersData.map((user: User) => ({

--- a/src/hooks/useAccountUsers.ts
+++ b/src/hooks/useAccountUsers.ts
@@ -12,14 +12,7 @@ export function useAccountUsers() {
     setError(null);
 
     try {
-      const response = await usersService.getUsers();
-
-      if (response.data) {
-        // Normalizar dados
-        const userData = Array.isArray(response.data) ? response.data : [];
-
-        setUsers(userData);
-      }
+      setUsers(await usersService.getAccountUsers());
     } catch (err) {
       console.error('Error loading account users:', err);
       setError(err instanceof Error ? err.message : 'Erro ao carregar usuários');

--- a/src/pages/Customer/Agents/Agent/AgentEditPage.tsx
+++ b/src/pages/Customer/Agents/Agent/AgentEditPage.tsx
@@ -261,8 +261,7 @@ const AgentEditPage = () => {
 
   const loadUsers = useCallback(async () => {
     try {
-      const response = await usersService.getUsers();
-      const users = response.data || [];
+      const users = await usersService.getAccountUsers();
 
       const transformedUsers = users.map(user => ({
         id: user.id,

--- a/src/pages/Customer/Dashboard/index.tsx
+++ b/src/pages/Customer/Dashboard/index.tsx
@@ -124,13 +124,13 @@ const CustomerDashboardPage = () => {
           pipelinesService.getPipelines({ page: 1, per_page: 100, sort: 'name', order: 'asc' }),
           TeamsService.getTeams({ page: 1, per_page: 100, sort: 'name', order: 'asc' }),
           InboxesService.list(),
-          usersService.getUsers({ page: 1, per_page: 100, sort: 'name', order: 'asc' }),
+          usersService.getAccountUsers({ sort: 'name', order: 'asc' }),
         ]);
 
         setPipelines((pipelinesResponse.data || []).map(item => ({ id: item.id, name: item.name })));
         setTeams((teamsResponse.data || []).map(item => ({ id: item.id, name: item.name })));
         setInboxes((inboxesResponse.data || []).map(item => ({ id: item.id, name: item.name })));
-        setUsers((usersResponse.data || []).map(item => ({ id: item.id, name: item.available_name || item.name })));
+        setUsers(usersResponse.map(item => ({ id: item.id, name: item.available_name || item.name })));
       } catch (err) {
         console.error('Error loading dashboard filter options:', err);
       }

--- a/src/pages/Customer/Settings/Teams/AddUsers.tsx
+++ b/src/pages/Customer/Settings/Teams/AddUsers.tsx
@@ -44,12 +44,12 @@ const AddUsers: React.FC = () => {
       setIsLoading(true);
       const [teamResponse, usersResponse, membersResponse] = await Promise.all([
         TeamsService.getTeam(teamId),
-        usersService.getUsers(),
+        usersService.getAccountUsers(),
         TeamsService.getTeamMembers(teamId),
       ]);
 
       setTeam(teamResponse);
-      setUsers(usersResponse.data || []);
+      setUsers(usersResponse);
       const existingMemberIds = (membersResponse as unknown as TeamMembershipRow[])
         .map(extractMemberId)
         .filter((id): id is string => Boolean(id));

--- a/src/services/account/accountService.ts
+++ b/src/services/account/accountService.ts
@@ -4,6 +4,7 @@ import { extractData } from '@/utils/apiHelpers';
 import type { Account, UpdateAccount, FormDataOptions, AccountUpdateResponse } from '@/types/settings';
 import { extractError } from '@/utils/apiHelpers';
 import { fetchGlobalConfig } from '@/contexts/GlobalConfigContext';
+import usersService from '@/services/users/usersService';
 
 class AccountService {
   async getAccount(): Promise<Account> {
@@ -32,18 +33,14 @@ class AccountService {
     try {
       const [inboxesRes, agentsRes, teamsRes, labelsRes] = await Promise.allSettled([
         api.get('/inboxes'),
-        authApi.get('/users'),
+        usersService.getAccountUsers(),
         api.get('/teams'),
         api.get('/labels'),
       ]);
 
-      const getResultData = (result: PromiseSettledResult<any>, isAuthService = false) => {
+      const getResultData = (result: PromiseSettledResult<any>) => {
         if (result.status === 'fulfilled') {
           const data = extractData(result.value);
-          if (isAuthService) {
-            // Auth service may return { users: [...] }
-            return (data as any)?.users || data || [];
-          }
           return Array.isArray(data) ? data : [];
         }
         return [];
@@ -51,7 +48,7 @@ class AccountService {
 
       return {
         inboxes: getResultData(inboxesRes),
-        agents: getResultData(agentsRes, true), // true = isAuthService
+        agents: agentsRes.status === 'fulfilled' ? agentsRes.value : [],
         teams: getResultData(teamsRes),
         labels: getResultData(labelsRes),
       };

--- a/src/services/automation/automationService.ts
+++ b/src/services/automation/automationService.ts
@@ -1,6 +1,6 @@
 import { extractData, extractResponse } from '@/utils/apiHelpers';
 import api from '../core/api';
-import authApi from '@/services/core/apiAuth';
+import usersService from '@/services/users/usersService';
 import type {
   AutomationRule,
   AutomationRuleRun,
@@ -174,20 +174,14 @@ class AutomationService {
     try {
       const [inboxesRes, agentsRes, teamsRes, labelsRes] = await Promise.allSettled([
         api.get('/inboxes'),
-        authApi.get('/users'),
+        usersService.getAccountUsers(),
         api.get('/teams'),
         api.get('/labels'),
       ]);
 
-      const getResultData = (result: PromiseSettledResult<any>, isAuthService = false): any[] => {
+      const getResultData = (result: PromiseSettledResult<any>): any[] => {
         if (result.status === 'fulfilled') {
-          const data = extractData<{ users?: any[] } | any[]>(result.value);
-          if (isAuthService) {
-            if (data && typeof data === 'object' && 'users' in data && Array.isArray(data.users)) {
-              return data.users;
-            }
-            return Array.isArray(data) ? data : [];
-          }
+          const data = extractData<any[]>(result.value);
           return Array.isArray(data) ? data : [];
         }
         return [];
@@ -195,7 +189,7 @@ class AutomationService {
 
       return {
         inboxes: getResultData(inboxesRes),
-        agents: getResultData(agentsRes, true), // true = isAuthService
+        agents: agentsRes.status === 'fulfilled' ? agentsRes.value : [],
         teams: getResultData(teamsRes),
         labels: getResultData(labelsRes),
         campaigns: [],

--- a/src/services/channels/agentsService.ts
+++ b/src/services/channels/agentsService.ts
@@ -12,13 +12,9 @@ const AgentsService = {
    * Endpoint: GET /api/v1/users
    */
   async getAll(): Promise<AgentChannel[]> {
-    try {
-      // Single account-scoped source (CRM-539); the auth pages at 20 otherwise.
-      return (await usersService.getAccountUsers()) as unknown as AgentChannel[];
-    } catch (error) {
-      console.error('AgentsService.getAll error:', error);
-      return []; // Return empty array on error
-    }
+    // Single account-scoped source (CRM-539); the auth pages at 20 otherwise.
+    // Errors propagate: an empty list must mean "no one", not "the request failed".
+    return (await usersService.getAccountUsers()) as unknown as AgentChannel[];
   },
 
   /**

--- a/src/services/channels/agentsService.ts
+++ b/src/services/channels/agentsService.ts
@@ -1,4 +1,5 @@
 import authApi from '@/services/core/apiAuth';
+import usersService from '@/services/users/usersService';
 import { extractData } from '@/utils/apiHelpers';
 import type { AgentChannel } from '@/types/channels/inbox';
 import type { AgentDeleteResponse } from '@/types/agents';
@@ -12,21 +13,8 @@ const AgentsService = {
    */
   async getAll(): Promise<AgentChannel[]> {
     try {
-      const response = await authApi.get('/users');
-      const data = extractData<{ users?: AgentChannel[] } | AgentChannel[]>(response);
-
-      // Handle different response structures
-      // For auth-service response: { users: [...] } or direct array
-      if (Array.isArray(data)) {
-        return data;
-      }
-
-      if (data && typeof data === 'object' && 'users' in data && Array.isArray(data.users)) {
-        return data.users;
-      }
-
-      console.warn('AgentsService.getAll: Unexpected response structure:', data);
-      return [];
+      // Single account-scoped source (CRM-539); the auth pages at 20 otherwise.
+      return (await usersService.getAccountUsers()) as unknown as AgentChannel[];
     } catch (error) {
       console.error('AgentsService.getAll error:', error);
       return []; // Return empty array on error

--- a/src/services/macros/macrosService.ts
+++ b/src/services/macros/macrosService.ts
@@ -1,7 +1,7 @@
 import type { AxiosResponse } from 'axios';
 import api from '@/services/core/api';
 import { extractData, extractResponse } from '@/utils/apiHelpers';
-import authApi from '@/services/core/apiAuth';
+import usersService from '@/services/users/usersService';
 import type {
   Macro,
   MacrosResponse,
@@ -83,7 +83,7 @@ class MacrosService {
   async getFormData(): Promise<MacroFormData> {
     const [inboxesRes, agentsRes, teamsRes, labelsRes] = await Promise.allSettled([
       api.get('/inboxes'),
-      authApi.get('/users'),
+      usersService.getAccountUsers(),
       api.get('/teams'),
       api.get('/labels'),
     ]);
@@ -94,7 +94,7 @@ class MacrosService {
     // one, so the failing source has to be reported instead of swallowed.
     const getResultData = (
       source: MacroFormDataSource,
-      result: PromiseSettledResult<AxiosResponse>,
+      result: PromiseSettledResult<AxiosResponse | MacroFormOption[]>,
       isAuthService = false,
     ): MacroFormOption[] => {
       if (result.status === 'rejected') {
@@ -105,11 +105,10 @@ class MacrosService {
 
       try {
         if (isAuthService) {
-          // Auth services return {data, meta} structure
-          const response = extractResponse<MacroFormOption>(result.value);
-          return response.data || [];
+          // Already the account directory, resolved by usersService.
+          return Array.isArray(result.value) ? result.value : [];
         }
-        const data = extractData<MacroFormOption[]>(result.value);
+        const data = extractData<MacroFormOption[]>(result.value as AxiosResponse);
         return Array.isArray(data) ? data : [];
       } catch (error) {
         console.error(`Failed to parse ${source} for the macro form:`, error);

--- a/src/services/macros/macrosService.ts
+++ b/src/services/macros/macrosService.ts
@@ -95,7 +95,6 @@ class MacrosService {
     const getResultData = (
       source: MacroFormDataSource,
       result: PromiseSettledResult<AxiosResponse | MacroFormOption[]>,
-      isAuthService = false,
     ): MacroFormOption[] => {
       if (result.status === 'rejected') {
         console.error(`Failed to load ${source} for the macro form:`, result.reason);
@@ -104,11 +103,9 @@ class MacrosService {
       }
 
       try {
-        if (isAuthService) {
-          // Already the account directory, resolved by usersService.
-          return Array.isArray(result.value) ? result.value : [];
-        }
-        const data = extractData<MacroFormOption[]>(result.value as AxiosResponse);
+        // The account directory arrives already resolved by usersService.
+        if (Array.isArray(result.value)) return result.value;
+        const data = extractData<MacroFormOption[]>(result.value);
         return Array.isArray(data) ? data : [];
       } catch (error) {
         console.error(`Failed to parse ${source} for the macro form:`, error);
@@ -119,7 +116,7 @@ class MacrosService {
 
     return {
       inboxes: getResultData('inboxes', inboxesRes),
-      agents: getResultData('agents', agentsRes, true),
+      agents: getResultData('agents', agentsRes),
       teams: getResultData('teams', teamsRes),
       labels: getResultData('labels', labelsRes),
       campaigns: [],

--- a/src/services/users/usersService.spec.ts
+++ b/src/services/users/usersService.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/core/apiAuth', () => ({
+  default: { get: vi.fn() },
+}));
+
+import apiAuth from '@/services/core/apiAuth';
+import usersService from './usersService';
+
+const mockedGet = apiAuth.get as unknown as ReturnType<typeof vi.fn>;
+
+const page = (ids: number[], pageNo: number, totalPages: number) => ({
+  data: {
+    success: true,
+    data: ids.map(id => ({ id, name: `User ${id}`, email: `u${id}@example.com` })),
+    meta: { pagination: { page: pageNo, page_size: 100, total: 0, total_pages: totalPages } },
+  },
+});
+
+// CRM-539: the account directory is the single people source. The auth pages
+// at 20 by default and caps at 100, so the source asks for full pages and
+// walks all of them; the account scope itself is applied by the auth from the
+// request context, never by a caller-side filter.
+describe('usersService.getAccountUsers', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('asks /users for full pages and walks every page', async () => {
+    mockedGet
+      .mockResolvedValueOnce(page([1, 2], 1, 3))
+      .mockResolvedValueOnce(page([3], 2, 3))
+      .mockResolvedValueOnce(page([4], 3, 3));
+
+    const users = await usersService.getAccountUsers();
+
+    expect(users.map(u => u.id)).toEqual([1, 2, 3, 4]);
+    expect(mockedGet).toHaveBeenCalledTimes(3);
+    expect(mockedGet.mock.calls.map(c => c[0])).toEqual(['/users', '/users', '/users']);
+    expect(mockedGet.mock.calls.map(c => c[1].params)).toEqual([
+      { page: 1, per_page: 100 },
+      { page: 2, per_page: 100 },
+      { page: 3, per_page: 100 },
+    ]);
+  });
+
+  it('forwards sort/order/q and stops after a single page when that is all there is', async () => {
+    mockedGet.mockResolvedValueOnce(page([9], 1, 1));
+
+    const users = await usersService.getAccountUsers({ sort: 'name', order: 'asc' });
+
+    expect(users).toHaveLength(1);
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedGet.mock.calls[0][1].params).toEqual({ sort: 'name', order: 'asc', page: 1, per_page: 100 });
+  });
+
+  it('treats a response without pagination meta as a single page', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { success: true, data: [{ id: 1 }] } });
+
+    const users = await usersService.getAccountUsers();
+
+    expect(users).toHaveLength(1);
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('never sends a tenant filter itself — scoping belongs to the request context', async () => {
+    mockedGet.mockResolvedValueOnce(page([1], 1, 1));
+
+    await usersService.getAccountUsers();
+
+    const [, config] = mockedGet.mock.calls[0];
+    expect(config.headers).toBeUndefined();
+    expect(Object.keys(config.params)).not.toContain('tenant_id');
+  });
+});

--- a/src/services/users/usersService.ts
+++ b/src/services/users/usersService.ts
@@ -10,6 +10,10 @@ import type {
   User,
 } from '@/types/users';
 
+// The auth caps page_size at 100; the page ceiling only bounds a runaway meta.
+const ACCOUNT_USERS_PAGE_SIZE = 100;
+const ACCOUNT_USERS_MAX_PAGES = 50;
+
 class UsersService {
   // List users with pagination and filters
   async getUsers(params?: UsersListParams): Promise<UsersResponse> {
@@ -18,6 +22,29 @@ class UsersService {
     });
 
     return extractResponse<User>(response) as UsersResponse;
+  }
+
+  // The people directory of the current account, complete. Every selector
+  // that lists agents (channel collaborators, assignee, automation/macro
+  // forms, ...) reads from here, never from GET /users directly: the auth
+  // pages at 20 by default, and the account scope is applied by the auth
+  // from the request context — so one call site keeps the behaviour uniform.
+  async getAccountUsers(params: Pick<UsersListParams, 'sort' | 'order' | 'q'> = {}): Promise<User[]> {
+    const users: User[] = [];
+    let page = 1;
+    let totalPages = 1;
+
+    do {
+      const response = await apiAuth.get('/users', {
+        params: { ...params, page, per_page: ACCOUNT_USERS_PAGE_SIZE },
+      });
+      const { data, meta } = extractResponse<User>(response);
+      users.push(...(Array.isArray(data) ? data : []));
+      totalPages = Number(meta?.pagination?.total_pages) || 1;
+      page += 1;
+    } while (page <= totalPages && page <= ACCOUNT_USERS_MAX_PAGES);
+
+    return users;
   }
 
   // Get single user

--- a/src/store/appDataStore.ts
+++ b/src/store/appDataStore.ts
@@ -116,9 +116,9 @@ export const useAppDataStore = create<AppDataState>((set, get) => ({
 
     set({ isLoadingAgents: true });
     try {
-      const response = await usersService.getUsers();
+      const agents = await usersService.getAccountUsers();
       set({
-        agents: response.data,
+        agents,
         isLoadingAgents: false,
         lastFetchTimestamps: { ...state.lastFetchTimestamps, agents: now }
       });


### PR DESCRIPTION
## Summary
- Catorze pontos do front montavam listas de atendentes/responsáveis chamando `GET /users` do auth direto, cada um do seu jeito, e sete deles sem paginação. O auth pagina em 20 por padrão, então a lista truncava e o total de "Atendentes" do canal era o da primeira página.
- `usersService.getAccountUsers()` vira a fonte única: pede páginas de 100 e percorre todas (`meta.pagination.total_pages`); aceita `sort`/`order`/`q`. O escopo por conta vem do contexto da request do host, nunca de filtro no cliente.
- Todos os seletores passam por ela: atendentes do canal (`channels/agentsService`), responsável e filtro do chat (`appDataStore`, `useFilterOptions`), formulários de automação, macros e conta (`getFormData`), membros de time, dashboard, edição de agente, formulário de jornada, `useAccountUsers`. A tabela paginada de Configurações → Usuários mantém `getUsers(params)`.
- `AgentsService.getAll` deixa de engolir erro: um 403/500 vira o toast que o `CollaboratorsForm` já tinha, em vez de "nenhum atendente (0 total)".
- `CollaboratorsForm` não muda lógica: universo completo e escopado, membros do inbox marcados por id, total = tamanho da lista.

## Security
- Só consolidação de chamadas de leitura já existentes; nenhum endpoint novo, nenhum filtro de conta no cliente.

## Test plan
- `npx vitest run src/services/users/usersService.spec.ts src/components/channels/settings/CollaboratorsForm.spec.tsx src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.spec.tsx` (percorre páginas com `per_page=100`, fonte única no canal, membros marcados, total, erro vira toast)
- Lane fechada do CI rodada local: 71 arquivos, 996 testes; os dois specs novos entraram na lista
- `npx tsc --noEmit` · `npx vite build` · eslint nos arquivos tocados

## Changed Files
- `src/services/users/usersService.ts` (+ `usersService.spec.ts`)
- `src/services/channels/agentsService.ts`
- `src/services/automation/automationService.ts`, `src/services/macros/macrosService.ts`, `src/services/account/accountService.ts`
- `src/store/appDataStore.ts`, `src/hooks/useAccountUsers.ts`, `src/hooks/chat/useFilterOptions.ts`
- `src/pages/Customer/Settings/Teams/AddUsers.tsx`, `src/pages/Customer/Dashboard/index.tsx`, `src/pages/Customer/Agents/Agent/AgentEditPage.tsx`
- `src/components/journey/shared/EventPropertiesForm/EventPropertiesForm.tsx` (+ spec)
- `src/components/channels/settings/CollaboratorsForm.spec.tsx`
- `.github/workflows/test.yml`

## Related PRs
- shell (header da conta ativa no cliente do auth): https://github.com/evolution-foundation/evolution-ecosystem-frontend/pull/153

## Linked Issue
- CRM-539

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw788PPGZwaVtkLX69JZUi

## Summary by Sourcery

Centralize account user selection on a complete, account-scoped directory to prevent truncated people lists and expose loading failures.

Bug Fixes:
- Ensure all account people selectors load the complete account directory instead of truncated default user pages.
- Surface user-directory request failures so collaborator views show an error rather than an empty agent list.

Enhancements:
- Centralize account-scoped user lookups through a paginated users service while preserving direct pagination for the Settings → Users table.
- Update channel, chat, automation, macro, dashboard, team, journey, agent-edit, and account data flows to use the shared account directory.

CI:
- Add the new user-directory and collaborator coverage to the scoped CI test lane.

Tests:
- Add coverage for multi-page account-user retrieval, query options, missing pagination metadata, account scoping, collaborator selection totals, membership marking, empty states, and load errors.