### PR TITLE
fix(contacts): salvar contato mostra a mensagem do backend no lugar do erro genérico (CRM-132)

### DIFF
--- a/src/pages/Customer/Contacts/Contacts.tsx
+++ b/src/pages/Customer/Contacts/Contacts.tsx
@@ -20,6 +20,7 @@ import { Contact, ContactsState, ContactsListParams, ContactFormData } from '@/t
 import { BaseFilter, AppliedFilter, CONTACT_FILTER_TYPES } from '@/types/core';
 import { useContactFilterOptions } from '@/hooks/contacts/useContactFilterOptions';
 import { DEFAULT_PAGE_SIZE } from '@/constants/pagination';
+import { apiErrorMessage } from '@/utils/apiHelpers';
 
 import ContactsHeader from '@/components/contacts/ContactsHeader';
 import ContactsTable from '@/components/contacts/ContactsTable';
@@ -768,7 +769,10 @@ export default function Contacts() {
       }
     } catch (error) {
       console.error('Error saving contact:', error);
-      toast.error(editingContactId ? t('messages.updateError') : t('messages.createError'));
+      toast.error(
+        apiErrorMessage(error) ||
+          (editingContactId ? t('messages.updateError') : t('messages.createError')),
+      );
     } finally {
       setFormLoading(false);
     }


### PR DESCRIPTION
## O problema

Criar um contato numa conta que já está no teto de contatos do plano devolve **422 `QUOTA_EXCEEDED`** com a mensagem pronta para o usuário (`Limite do plano excedido (N/M) para contacts`). O erro chegava intacto ao `catch` de `handleContactFormSubmit`, que descartava o envelope e mostrava sempre `messages.createError`. O operador não ficava sabendo que tinha batido no teto nem qual era o limite.

## O que mudou

O `catch` passa a exibir `apiErrorMessage(error)` e mantém o texto localizado como fallback, o mesmo padrão já usado na criação de canais. O helper ignora respostas 5xx e envelopes sem mensagem, então nesses casos a tela continua igual.

O ramo de edição usa o mesmo `catch` e passa a mostrar também os erros de validação do backend (ex.: e-mail já em uso) no lugar de `messages.updateError`.

## Verificação

`npx tsc -p tsconfig.app.json --noEmit` e `npx eslint` limpos no arquivo tocado. `apiHelpers.spec.ts`: 12 passando, inclusive o caso `QUOTA_EXCEEDED` com e sem mensagem. A página de contatos não tem spec própria.

## Summary by Sourcery

Bug Fixes:
- Exiba as mensagens de erro retornadas pelo backend ao criar ou editar contatos, mantendo as mensagens localizadas como fallback para erros sem mensagem utilizável.