### PR TITLE
fix(widget): embed com origem única, cable sob host embutido e SDK com autocura (CRM-605)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,10 +140,8 @@ jobs:
       #     which is the ONLY thing that tells the auth which account to bind the token
       #     to. Dropping the header is invisible here and shows up as a 401 on every CRM
       #     call the customer's automations make.
-      #   - website widget embed + cable (CRM-605): the two embeds point SDK and
-      #     widget at the origin the agency is on (never the backend's FRONTEND_URL),
-      #     the cable URL resolves from a path-only API base instead of throwing, and
-      #     the subscription carries website_token so the server can route the stream.
+      #   - website widget embed + cable: both embeds point at the agency's origin, the
+      #     cable URL resolves from a path-only API base, and the subscription carries website_token.
       #   - account people directory (CRM-539): every agent selector reads
       #     usersService.getAccountUsers, which asks the auth for full pages and walks
       #     them all (the default page is 20, and a truncated list looks complete);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,10 @@ jobs:
       #     which is the ONLY thing that tells the auth which account to bind the token
       #     to. Dropping the header is invisible here and shows up as a 401 on every CRM
       #     call the customer's automations make.
+      #   - website widget embed + cable (CRM-605): the two embeds point SDK and
+      #     widget at the origin the agency is on (never the backend's FRONTEND_URL),
+      #     the cable URL resolves from a path-only API base instead of throwing, and
+      #     the subscription carries website_token so the server can route the stream.
       #   - account people directory (CRM-539): every agent selector reads
       #     usersService.getAccountUsers, which asks the auth for full pages and walks
       #     them all (the default page is 20, and a truncated list looks complete);
@@ -227,7 +231,9 @@ jobs:
             src/pages/Customer/Campaigns/NewCampaign/wizard/Step4_Settings.spreadWindow.spec.tsx \
             src/services/auth/accessTokensService.spec.ts \
             src/services/users/usersService.spec.ts \
-            src/components/channels/settings/CollaboratorsForm.spec.tsx
+            src/components/channels/settings/CollaboratorsForm.spec.tsx \
+            src/components/channels/settings/helpers/widgetHelpers.spec.ts \
+            src/services/widget/widgetCable.spec.ts
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/public/widget-sdk/sdk.min.js
+++ b/public/widget-sdk/sdk.min.js
@@ -1,7 +1,6 @@
 (function(){
-  // The origin this file was loaded from: lets an embed that lost its
-  // baseUrl still open the widget on the right host instead of a relative
-  // "/widget" on the customer's own site.
+  // Origin this file was loaded from: an embed without baseUrl opens the widget
+  // here, not at a relative "/widget" on the customer's site.
   var SCRIPT_ORIGIN = (function(){
     try{
       // currentScript is null for type=module: fall back to the tag by its src.

--- a/public/widget-sdk/sdk.min.js
+++ b/public/widget-sdk/sdk.min.js
@@ -1,4 +1,15 @@
 (function(){
+  // The origin this file was loaded from: lets an embed that lost its
+  // baseUrl still open the widget on the right host instead of a relative
+  // "/widget" on the customer's own site.
+  var SCRIPT_ORIGIN = (function(){
+    try{
+      var s = document.currentScript;
+      if(s && s.src){ return new URL(s.src, window.location.href).origin; }
+    }catch(e){}
+    return '';
+  })();
+
   function escapeHtml(s){
     return String(s || '')
       .replace(/&/g, '&amp;')
@@ -141,7 +152,7 @@
         var settings = window.evoChatSettings || {};
         var widgetColor = (settings && settings.widgetColor) || '#00d4aa';
         createStyles(widgetColor);
-        var baseUrl = (opts && opts.baseUrl) || '';
+        var baseUrl = (opts && opts.baseUrl) || SCRIPT_ORIGIN || '';
         var token = (opts && opts.websiteToken) || '';
         var pos = settings.position === 'left' ? 'left' : 'right';
 

--- a/public/widget-sdk/sdk.min.js
+++ b/public/widget-sdk/sdk.min.js
@@ -4,7 +4,8 @@
   // "/widget" on the customer's own site.
   var SCRIPT_ORIGIN = (function(){
     try{
-      var s = document.currentScript;
+      // currentScript is null for type=module: fall back to the tag by its src.
+      var s = document.currentScript || document.querySelector('script[src*="/widget-sdk/sdk.min.js"]');
       if(s && s.src){ return new URL(s.src, window.location.href).origin; }
     }catch(e){}
     return '';

--- a/src/components/channels/settings/helpers/widgetHelpers.spec.ts
+++ b/src/components/channels/settings/helpers/widgetHelpers.spec.ts
@@ -27,8 +27,6 @@ const BACKEND_SCRIPT = `
 
 const CONFIG = { position: 'right', type: 'standard', launcherTitle: 'Fale conosco' };
 
-// CRM-605: the embeds point at the origin the agency is on, never at the
-// platform the backend script names. A whitelabel host must not leak the portal.
 describe('widgetHelpers — one origin for SDK and widget', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_API_URL', '/crm-api');

--- a/src/components/channels/settings/helpers/widgetHelpers.spec.ts
+++ b/src/components/channels/settings/helpers/widgetHelpers.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/i18n/config', () => ({ default: { t: (k: string) => k } }));
+
+import {
+  extractWebsiteToken,
+  generateWidgetScript,
+  generateWidgetIframeEmbed,
+  widgetOrigin,
+} from './widgetHelpers';
+
+// The script the backend generates: BASE_URL is the platform's FRONTEND_URL.
+const BACKEND_SCRIPT = `
+<script>
+  (function(d,t) {
+    var BASE_URL="https://portal.example.com";
+    var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+    g.src=BASE_URL+"/packs/js/sdk.js";
+    g.onload=function(){
+      window.evolutionSDK.run({
+        websiteToken: 'wt-abc123',
+        baseUrl: BASE_URL
+      })
+    }
+  })(document,"script");
+</script>`;
+
+const CONFIG = { position: 'right', type: 'standard', launcherTitle: 'Fale conosco' };
+
+// CRM-605: the embeds point at the origin the agency is on, never at the
+// platform the backend script names. A whitelabel host must not leak the portal.
+describe('widgetHelpers — one origin for SDK and widget', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_API_URL', '/crm-api');
+    vi.stubGlobal('location', { ...window.location, origin: 'https://crm.agencia.com' });
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('reads the website token out of the backend script', () => {
+    expect(extractWebsiteToken(BACKEND_SCRIPT)).toBe('wt-abc123');
+    expect(extractWebsiteToken('')).toBe('');
+  });
+
+  it('script embed: SDK and widget share the current origin, the platform URL never appears', () => {
+    const out = generateWidgetScript(BACKEND_SCRIPT, CONFIG);
+
+    expect(out).toContain("var SDK_BASE = 'https://crm.agencia.com'");
+    expect(out).toContain("var WIDGET_BASE = 'https://crm.agencia.com'");
+    expect(out).toContain("SDK_BASE + '/widget-sdk/sdk.min.js'");
+    expect(out).toContain("websiteToken: 'wt-abc123'");
+    expect(out).not.toContain('portal.example.com');
+    expect(out).not.toContain('/packs/js/sdk.js');
+  });
+
+  it('script embed: apiBase is the API base the host runs on', () => {
+    const out = generateWidgetScript(BACKEND_SCRIPT, CONFIG);
+    expect(out).toContain('"apiBase":"/crm-api"');
+  });
+
+  it('iframe embed: same origin, token and api_base in the query', () => {
+    const out = generateWidgetIframeEmbed(BACKEND_SCRIPT);
+
+    expect(out).toContain('src="https://crm.agencia.com/widget?website_token=wt-abc123&api_base=%2Fcrm-api"');
+    expect(out).not.toContain('portal.example.com');
+  });
+
+  it('falls back to a placeholder token when the backend script has none', () => {
+    expect(generateWidgetIframeEmbed('<script></script>')).toContain('website_token=REPLACE_WITH_WEBSITE_TOKEN');
+    expect(generateWidgetScript('', CONFIG)).toContain("websiteToken: 'REPLACE_WITH_WEBSITE_TOKEN'");
+  });
+
+  it('widgetOrigin is the browser origin', () => {
+    expect(widgetOrigin()).toBe('https://crm.agencia.com');
+  });
+});

--- a/src/components/channels/settings/helpers/widgetHelpers.ts
+++ b/src/components/channels/settings/helpers/widgetHelpers.ts
@@ -110,6 +110,10 @@ export const getDefaultWidgetConfig = (): WidgetConfig => ({
   widgetBubbleType: 'standard',
 });
 
+/** The origin the embeds point at: where the agency is, never the backend's FRONTEND_URL. */
+export const widgetOrigin = (): string =>
+  typeof window !== 'undefined' ? window.location.origin : '';
+
 // Generate widget script
 export const extractWebsiteToken = (originalScript: string): string => {
   try {
@@ -129,20 +133,12 @@ export const generateWidgetScript = (
 ): string => {
   const token = extractWebsiteToken(originalScript);
 
-  // SDK and widget page are served from frontend origin (/widget route).
-  const SDK_BASE = typeof window !== 'undefined' ? window.location.origin : '';
-  let WIDGET_BASE = SDK_BASE;
+  // SDK and widget page are both served from the origin the agency is on: the
+  // backend script carries FRONTEND_URL (the platform), which on a whitelabel
+  // host would put the platform inside the client's site. One origin only.
+  const SDK_BASE = widgetOrigin();
+  const WIDGET_BASE = SDK_BASE;
   const ENV_API_BASE = import.meta.env.VITE_API_URL || '';
-
-  // Keep compatibility with legacy scripts that already point widget page to frontend host.
-  try {
-    const fm = originalScript?.match(
-      /(SDK_BASE|FRONTEND_URL|BASE_URL|WIDGET_BASE)\s*=\s*['\"]([^'\"]+)['\"]/i,
-    );
-    if (fm && fm[2]) WIDGET_BASE = fm[2];
-  } catch (_) {}
-
-  if (!WIDGET_BASE) WIDGET_BASE = SDK_BASE;
 
   const opts = JSON.stringify({
     position: config.position,
@@ -159,7 +155,7 @@ export const generateWidgetScript = (
 // Generate iframe embed code (without SDK bubble)
 export const generateWidgetIframeEmbed = (originalScript: string): string => {
   const token = extractWebsiteToken(originalScript) || 'REPLACE_WITH_WEBSITE_TOKEN';
-  const widgetBase = typeof window !== 'undefined' ? window.location.origin : '';
+  const widgetBase = widgetOrigin();
   const envApiBase = import.meta.env.VITE_API_URL || '';
   const src = envApiBase
     ? `${widgetBase}/widget?website_token=${token}&api_base=${encodeURIComponent(envApiBase)}`

--- a/src/components/channels/settings/helpers/widgetHelpers.ts
+++ b/src/components/channels/settings/helpers/widgetHelpers.ts
@@ -133,9 +133,8 @@ export const generateWidgetScript = (
 ): string => {
   const token = extractWebsiteToken(originalScript);
 
-  // SDK and widget page are both served from the origin the agency is on: the
-  // backend script carries FRONTEND_URL (the platform), which on a whitelabel
-  // host would put the platform inside the client's site. One origin only.
+  // Both served from the agency's origin: the backend script carries the platform's
+  // FRONTEND_URL, which on a whitelabel host would leak into the client's site.
   const SDK_BASE = widgetOrigin();
   const WIDGET_BASE = SDK_BASE;
   const ENV_API_BASE = import.meta.env.VITE_API_URL || '';

--- a/src/pages/Widget/index.tsx
+++ b/src/pages/Widget/index.tsx
@@ -993,7 +993,7 @@ export default function Widget() {
                 console.error('❌ Widget: Error processing message', e);
               }
             },
-          });
+          }, { websiteToken: token });
         }
         // Only load messages if we haven't already started (for identified users)
         if (!hasStarted) {

--- a/src/services/widget/widgetCable.spec.ts
+++ b/src/services/widget/widgetCable.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const created = vi.hoisted(() => ({ urls: [] as string[], subscriptions: [] as unknown[] }));
+vi.mock('@rails/actioncable', () => ({
+  createConsumer: (url: string) => {
+    created.urls.push(url);
+    return {
+      subscriptions: {
+        create: (params: unknown) => {
+          created.subscriptions.push(params);
+          return { unsubscribe: vi.fn(), perform: vi.fn(), send: vi.fn() };
+        },
+      },
+      disconnect: vi.fn(),
+    };
+  },
+}));
+
+import { WidgetCable, resolveCableUrl } from './widgetCable';
+
+// CRM-605: under an embedding host VITE_API_URL is a path ("/crm-api"), which
+// `new URL(path)` rejects — the widget lost realtime silently. The subscription
+// also carries website_token so the server can route the stream to the account.
+describe('resolveCableUrl', () => {
+  it('turns a path-only API base into an absolute cable URL under the current origin', () => {
+    expect(resolveCableUrl('/crm-api', 'https://crm.agencia.com')).toBe('https://crm.agencia.com/crm-api/cable');
+    expect(resolveCableUrl('/crm-api/', 'https://crm.agencia.com')).toBe('https://crm.agencia.com/crm-api/cable');
+  });
+
+  it('keeps an absolute API base as is (standalone community)', () => {
+    expect(resolveCableUrl('http://localhost:3000', 'http://localhost:5173')).toBe('http://localhost:3000/cable');
+  });
+
+  it('falls back to the origin when the env is empty', () => {
+    expect(resolveCableUrl(undefined, 'https://crm.agencia.com')).toBe('https://crm.agencia.com/cable');
+  });
+});
+
+describe('WidgetCable', () => {
+  beforeEach(() => {
+    created.urls.length = 0;
+    created.subscriptions.length = 0;
+    vi.stubEnv('VITE_API_URL', '/crm-api');
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('connects to the resolved cable URL and subscribes with pubsub_token AND website_token', () => {
+    new WidgetCable('pub-1', {}, { websiteToken: 'wt-abc123' });
+
+    expect(created.urls).toEqual([`${window.location.origin}/crm-api/cable`]);
+    expect(created.subscriptions).toEqual([
+      { channel: 'RoomChannel', pubsub_token: 'pub-1', website_token: 'wt-abc123' },
+    ]);
+  });
+
+  it('omits website_token when not given (community parity)', () => {
+    new WidgetCable('pub-1');
+    expect(created.subscriptions).toEqual([{ channel: 'RoomChannel', pubsub_token: 'pub-1' }]);
+  });
+
+  it('honours an explicit cableUrl', () => {
+    new WidgetCable('pub-1', {}, { cableUrl: 'wss://x.example/cable' });
+    expect(created.urls).toEqual(['wss://x.example/cable']);
+  });
+});

--- a/src/services/widget/widgetCable.spec.ts
+++ b/src/services/widget/widgetCable.spec.ts
@@ -18,9 +18,7 @@ vi.mock('@rails/actioncable', () => ({
 
 import { WidgetCable, resolveCableUrl } from './widgetCable';
 
-// CRM-605: under an embedding host VITE_API_URL is a path ("/crm-api"), which
-// `new URL(path)` rejects — the widget lost realtime silently. The subscription
-// also carries website_token so the server can route the stream to the account.
+// Under an embedding host VITE_API_URL is a path ("/crm-api"), which `new URL(path)` rejects.
 describe('resolveCableUrl', () => {
   it('turns a path-only API base into an absolute cable URL under the current origin', () => {
     expect(resolveCableUrl('/crm-api', 'https://crm.agencia.com')).toBe('https://crm.agencia.com/crm-api/cable');

--- a/src/services/widget/widgetCable.ts
+++ b/src/services/widget/widgetCable.ts
@@ -3,8 +3,7 @@ import { createConsumer, Consumer, Subscription } from '@rails/actioncable';
 
 export interface CableOptions {
   cableUrl?: string; // optional custom cable URL, defaults to VITE_API_URL + /cable
-  // Sent with the subscription so the server can route the stream to the
-  // widget's account before it looks the contact up (CRM-605).
+  // Lets the server route the stream to the widget's account before the contact lookup.
   websiteToken?: string;
 }
 

--- a/src/services/widget/widgetCable.ts
+++ b/src/services/widget/widgetCable.ts
@@ -2,7 +2,18 @@
 import { createConsumer, Consumer, Subscription } from '@rails/actioncable';
 
 export interface CableOptions {
-  cableUrl?: string; // optional custom cable URL, defaults to VITE_API_URL origin + /cable
+  cableUrl?: string; // optional custom cable URL, defaults to VITE_API_URL + /cable
+  // Sent with the subscription so the server can route the stream to the
+  // widget's account before it looks the contact up (CRM-605).
+  websiteToken?: string;
+}
+
+// VITE_API_URL may be absolute (standalone) or a path under the current origin
+// (embedded host); a bare path would throw in `new URL`.
+export function resolveCableUrl(apiUrl: string | undefined, origin: string): string {
+  const base = new URL(apiUrl || '/', origin);
+  const path = base.pathname.replace(/\/+$/, '');
+  return `${base.origin}${path}/cable`;
 }
 
 export interface CableHandlers {
@@ -17,13 +28,16 @@ export class WidgetCable {
   private handlers: CableHandlers;
 
   constructor(pubsubToken: string, handlers: CableHandlers = {}, opts: CableOptions = {}) {
-    const base = new URL(import.meta.env.VITE_API_URL);
-    const cableUrl = opts.cableUrl || `${base.origin}/cable`;
+    const cableUrl = opts.cableUrl || resolveCableUrl(import.meta.env.VITE_API_URL, window.location.origin);
     this.consumer = createConsumer(cableUrl);
     this.handlers = handlers;
 
     this.subscription = this.consumer.subscriptions.create(
-      { channel: 'RoomChannel', pubsub_token: pubsubToken },
+      {
+        channel: 'RoomChannel',
+        pubsub_token: pubsubToken,
+        ...(opts.websiteToken ? { website_token: opts.websiteToken } : {}),
+      },
       {
         received: (msg: any) => {
           if (!msg) return;


### PR DESCRIPTION
## Summary
- **Gerador do embed** (`widgetHelpers.ts`): SDK e página do widget apontam para a origem em que a tela está aberta (`window.location.origin`). O `BASE_URL`/`FRONTEND_URL` do script que o backend gera não é mais herdado, então um embed gerado num domínio próprio não referencia outro host.
- **`widgetCable.ts`**: quando `VITE_API_URL` é um caminho (`/crm-api`, caso de host embutido), `new URL(...)` lançava `TypeError` e o realtime do widget morria em silêncio. A URL do cable resolve contra a origem atual (`resolveCableUrl`). A assinatura do `RoomChannel` passa `website_token` junto do `pubsub_token`, para o servidor saber a qual canal o stream pertence.
- **`public/widget-sdk/sdk.min.js`**: sem `baseUrl` no snippet, o iframe virava `/widget?…` relativo ao site do cliente. O SDK cai para a origem do próprio `<script>` (`document.currentScript`, com fallback pela tag `src` para `type=module`).

## Security
- Nenhum endpoint novo. O `website_token` já viaja na URL do widget; passá-lo na assinatura do cable não expõe nada a mais. `postMessage('*')` do SDK é pré-existente e fica registrado.

## Test plan
- `npx vitest run src/components/channels/settings/helpers/widgetHelpers.spec.ts src/services/widget/widgetCable.spec.ts` → 12 testes (origem única nos dois embeds sem o host do backend, token extraído, `api_base` na query; cable com base relativa/absoluta/vazia, `website_token` na assinatura, `cableUrl` explícito)
- `npx tsc --noEmit` · `npx vite build` (`dist/widget-sdk/sdk.min.js` presente)
- Prova ao vivo num site externo com os dois embeds: bolha abre o iframe, mensagem enviada, resposta do atendente chega pelo cable com a assinatura confirmada.
- Os dois specs entram na lane fechada do `test.yml`.

## Changed Files
- `src/components/channels/settings/helpers/widgetHelpers.ts` (+ `.spec.ts`)
- `src/services/widget/widgetCable.ts` (+ `.spec.ts`)
- `src/pages/Widget/index.tsx`
- `public/widget-sdk/sdk.min.js`
- `.github/workflows/test.yml`

## Related PRs
- shell (rotas públicas + publicação do SDK): https://github.com/evolution-foundation/evolution-ecosystem-frontend/pull/158

## Linked Issue
- CRM-605

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rZkGCmqXE3uuFW8po7TBZ

## Summary by Sourcery

Make widget embeds and realtime connections work reliably on custom hosts while preserving correct account and stream routing.

New Features:
- Support widget embeds on custom or embedded hosts by using the host origin for the SDK, iframe, and widget page.
- Pass the website token during cable subscription so realtime messages can be routed to the correct widget stream.

Bug Fixes:
- Fix realtime connections when the API base is a relative path instead of an absolute URL.
- Prevent generated embeds from referencing the backend frontend host instead of the host where the widget is embedded.

Enhancements:
- Centralize cable URL resolution for absolute, relative, empty, and explicitly configured API bases.

CI:
- Add widget embed and cable tests to the scoped test workflow.

Tests:
- Add coverage for single-origin embed generation, API base query parameters, token extraction, cable URL resolution, subscription parameters, and custom cable URLs.