### PR TITLE
perf(layout): não remontar a página quando só o parâmetro da rota muda

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -26,6 +26,12 @@ import { injectDashboardAppsIntoMenu } from '@/utils/injectDashboardApps';
 import { WelcomeTourModal } from '@/components/WelcomeTourModal';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
+// A path segment that is a record id rather than part of the page's identity:
+// a UUID (/conversations/:conversationId, /pipelines/:pipelineId, ...) or a
+// numeric id (/settings/roles/:id, ...).
+const ROUTE_PARAM_SEGMENT =
+  /^(?:[0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
 interface MainLayoutProps {
   children: React.ReactNode;
 }
@@ -37,6 +43,21 @@ export default function MainLayout({ children }: MainLayoutProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const pathname = location.pathname;
+
+  // Identifies the *page*, not the exact URL: route params are dropped so that
+  // /conversations/<id-A> and /conversations/<id-B> produce the same key.
+  // Keying the ErrorBoundary below by the raw pathname made every param change
+  // a full remount of the page subtree — picking another conversation threw
+  // away all chat state, re-ran every mount fetch and loaded the messages twice
+  // (the second load is what made the list flash back to its skeleton).
+  const pageKey = useMemo(
+    () =>
+      pathname
+        .split('/')
+        .filter(segment => !ROUTE_PARAM_SEGMENT.test(segment))
+        .join('/'),
+    [pathname],
+  );
 
   // Estados do layout
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -141,9 +162,9 @@ export default function MainLayout({ children }: MainLayoutProps) {
 
         {/* Main Content */}
         <main className="flex-1 min-h-0 overflow-auto bg-background transition-colors duration-150 ease-in-out">
-          {/* Keyed by path so a crashed page does not keep the fallback up after navigating away */}
+          {/* Keyed by page so a crashed page does not keep the fallback up after navigating away */}
           <div className="h-full">
-            <ErrorBoundary key={pathname}>{children}</ErrorBoundary>
+            <ErrorBoundary key={pageKey}>{children}</ErrorBoundary>
           </div>
         </main>
 


### PR DESCRIPTION
# Troca de conversa remonta a página inteira (ErrorBoundary com `key={pathname}`)

## Resumo

`MainLayout` envolve a página em `<ErrorBoundary key={pathname}>`. Como a `key` é o
pathname **completo**, qualquer mudança de parâmetro de rota gera uma `key` nova e o
React **destrói e recria toda a subárvore da página**.

Na prática, trocar de conversa (`/conversations/A` → `/conversations/B`) desmonta
`ChatPage` → `ChatProvider` → `Chat` e monta tudo de novo 1ms depois. Isso zera o
estado do chat, re-executa todos os efeitos de mount e **carrega as mensagens duas
vezes** — a lista pisca de volta para o skeleton, o que o usuário percebe como
"a página recarregou".

## Como reproduzir

1. Abrir `/conversations` e selecionar uma conversa
2. Selecionar outra conversa na lista
3. Observar a aba Network e a lista de mensagens

Esperado: uma requisição de mensagens, um skeleton.
Observado: duas requisições, o skeleton aparece → conteúdo renderiza → **skeleton
volta** → conteúdo renderiza de novo.

## Medições

Instrumentando o DOM a cada 40ms durante uma troca de conversa:

| t | evento |
|---|---|
| 2967ms | skeleton aparece (35 elementos) |
| 3602ms | conteúdo renderiza |
| **3722ms** | **skeleton volta** (17 elementos) |
| 4204ms | conteúdo renderiza de novo |

O conteúdo fica visível por ~120ms antes de sumir de novo.

Ciclo de vida do componente `Chat` (id por instância, via o objeto do ref):

```
t=7592  loadMessages  (instância pmgmg)
t=7602  UNMOUNT pmgmg
t=7603  MOUNT   44oer      <- 1ms depois: mesma commit do React
t=8318  loadMessages  (instância 44oer)
```

E o log de URL confirma o gatilho:

```
t=44873  replaceState -> /conversations/b78e4c5d…
t=44904  UNMOUNT + MOUNT          <- 31ms depois da URL mudar
```

Requisições por troca de conversa:

| endpoint | vezes |
|---|---|
| `GET /conversations/{id}/messages` | **2** |
| `POST /conversations/{id}/update_last_seen` | **4** |
| `GET /conversations` | 1 |
| `GET /pipelines` | 1 |
| `GET /canned_responses` | 1 |
| `GET /integrations/apps/openai` | 1 |
| `GET /custom_attribute_definitions` | 1 |
| **total** | **11** (~1678ms de janela de rede) |

As quatro últimas são efeitos de mount: só aparecem porque a subárvore remontou.

## Causa raiz

`src/components/layout/MainLayout.tsx`:

```jsx
{/* Keyed by path so a crashed page does not keep the fallback up after navigating away */}
<div className="h-full">
  <ErrorBoundary key={pathname}>{children}</ErrorBoundary>
</div>
```

A intenção documentada é legítima — resetar o boundary ao sair de uma página que
quebrou. O problema é usar o pathname cru: ele também muda quando só o parâmetro
muda.

Vale notar que a trava existente em `Chat.tsx` não protege contra isso:

```js
if (lastLoadedConversationRef.current === conversations.state.selectedConversationId) {
  return;
}
```

É um ref **por instância do componente**. A remontagem cria uma instância nova com o
ref zerado, então a trava nunca vê o carregamento anterior.

## Correção sugerida

Derivar a `key` da *página*, descartando segmentos que são identificadores de
registro. Assim as duas conversas produzem a mesma key, mas páginas distintas
continuam com keys distintas e o reset em caso de crash é preservado.

```js
const ROUTE_PARAM_SEGMENT =
  /^(?:[0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;

const pageKey = useMemo(
  () =>
    pathname
      .split('/')
      .filter(segment => !ROUTE_PARAM_SEGMENT.test(segment))
      .join('/'),
  [pathname],
);

// <ErrorBoundary key={pageKey}>{children}</ErrorBoundary>
```

## Resultado depois da correção

Mesma medição, mesmo ambiente:

| métrica | antes | depois |
|---|---|---|
| chamadas de API por troca | 11 | **3** |
| `GET messages` | 2x | **1x** |
| `update_last_seen` | 4x | **2x** |
| janela de rede | 1678ms | **617ms** |
| renders do skeleton | 2x | **1x** (o flash sumiu) |

`pipelines`, `canned_responses`, `integrations/apps/openai` e
`custom_attribute_definitions` deixam de ser requisitados na troca.

Suíte completa rodada antes e depois: mesmo conjunto de falhas (78 arquivos,
pré-existentes), nenhuma regressão.

## Observações

- O `update_last_seen` continua sendo chamado 2x mesmo depois da correção. Há
  caminhos redundantes de marcar-como-lida (`chatService.markConversationAsRead` e
  `conversationService.markAsRead`, acionados por `ChatSidebar`, `ChatContext` e
  `ConversationsContext`). Fica como item separado.
- A correção beneficia todas as rotas com parâmetro, não só conversas — por exemplo
  `/agents/:id/edit`, `/pipelines/:pipelineId` e `/settings/roles/:id`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Derive the main error-boundary key from the page route rather than the full pathname to avoid unnecessary remounts when switching records.

Bug Fixes:
- Prevent page subtrees from remounting when only numeric or UUID route parameters change, eliminating duplicate message loads and skeleton flashes during navigation.

Enhancements:
- Preserve error-boundary resets when navigating between distinct pages while keeping component state across changes to record-specific routes.