### PR TITLE
fix(i18n): registra o catálogo survey e a avaliação pública deixa de mostrar chave crua (CRM-606)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,7 +231,8 @@ jobs:
             src/services/users/usersService.spec.ts \
             src/components/channels/settings/CollaboratorsForm.spec.tsx \
             src/components/channels/settings/helpers/widgetHelpers.spec.ts \
-            src/services/widget/widgetCable.spec.ts
+            src/services/widget/widgetCable.spec.ts \
+            src/pages/Public/Survey/SurveyResponse.spec.tsx
 
   # Lint gate scoped to the files the PR touched.
   eslint:

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -338,6 +338,15 @@ import frTours from './locales/fr/tours.json';
 import itTours from './locales/it/tours.json'
 import itTutorials from './locales/it/tutorials.json';
 
+// Public CSAT survey page (no session, no layout — it renders for the contact
+// who clicked the link in the survey e-mail).
+import ptBRSurvey from './locales/pt-BR/survey.json';
+import ptSurvey from './locales/pt/survey.json';
+import enSurvey from './locales/en/survey.json';
+import esSurvey from './locales/es/survey.json';
+import frSurvey from './locales/fr/survey.json';
+import itSurvey from './locales/it/survey.json';
+
 // Segments / Journey / Campaigns namespaces
 import ptBRSegments from './locales/pt-BR/segments.json';
 import ptBRJourney from './locales/pt-BR/journey.json';
@@ -455,6 +464,7 @@ const resources = {
     roles: ptBRRoles,
     tours: ptBRTours,
     tutorials: ptBRTutorials,
+    survey: ptBRSurvey,
     segments: ptBRSegments,
     journey: ptBRJourney,
     campaigns: ptBRCampaigns,
@@ -517,6 +527,7 @@ const resources = {
     roles: ptRoles,
     tours: ptTours,
     tutorials: ptTutorials,
+    survey: ptSurvey,
     segments: ptSegments,
     journey: ptJourney,
     campaigns: ptCampaigns,
@@ -579,6 +590,7 @@ const resources = {
     roles: enRoles,
     tours: enTours,
     tutorials: enTutorials,
+    survey: enSurvey,
     segments: enSegments,
     journey: enJourney,
     campaigns: enCampaigns,
@@ -641,6 +653,7 @@ const resources = {
     roles: esRoles,
     tours: esTours,
     tutorials: esTutorials,
+    survey: esSurvey,
     segments: esSegments,
     journey: esJourney,
     campaigns: esCampaigns,
@@ -703,6 +716,7 @@ const resources = {
     roles: frRoles,
     tours: frTours,
     tutorials: frTutorials,
+    survey: frSurvey,
     segments: frSegments,
     journey: frJourney,
     campaigns: frCampaigns,
@@ -765,6 +779,7 @@ const resources = {
     roles: itRoles,
     tours: itTours,
     tutorials: itTutorials,
+    survey: itSurvey,
     segments: itSegments,
     journey: itJourney,
     campaigns: itCampaigns,

--- a/src/i18n/locales/en/survey.json
+++ b/src/i18n/locales/en/survey.json
@@ -1,0 +1,24 @@
+{
+  "survey": {
+    "description": "How would you rate the support you received from {{inboxName}}?",
+    "rating": {
+      "label": "Your rating",
+      "veryDissatisfied": "Very dissatisfied",
+      "dissatisfied": "Dissatisfied",
+      "neutral": "Neutral",
+      "satisfied": "Satisfied",
+      "verySatisfied": "Very satisfied",
+      "successMessage": "Thanks for your rating! It helps us improve."
+    },
+    "feedback": {
+      "label": "Would you like to tell us more?",
+      "placeholder": "Write your comment here",
+      "buttonText": "Send comment"
+    },
+    "api": {
+      "errorMessage": "We could not load this survey. The link may have expired.",
+      "successMessage": "Comment sent. Thank you!",
+      "submitting": "Sending..."
+    }
+  }
+}

--- a/src/i18n/locales/es/survey.json
+++ b/src/i18n/locales/es/survey.json
@@ -1,0 +1,24 @@
+{
+  "survey": {
+    "description": "¿Cómo calificas la atención que recibiste de {{inboxName}}?",
+    "rating": {
+      "label": "Tu calificación",
+      "veryDissatisfied": "Muy insatisfecho",
+      "dissatisfied": "Insatisfecho",
+      "neutral": "Neutral",
+      "satisfied": "Satisfecho",
+      "verySatisfied": "Muy satisfecho",
+      "successMessage": "¡Gracias por tu calificación! Nos ayuda a mejorar."
+    },
+    "feedback": {
+      "label": "¿Quieres contarnos algo más?",
+      "placeholder": "Escribe tu comentario aquí",
+      "buttonText": "Enviar comentario"
+    },
+    "api": {
+      "errorMessage": "No pudimos cargar esta encuesta. Es posible que el enlace haya caducado.",
+      "successMessage": "Comentario enviado. ¡Gracias!",
+      "submitting": "Enviando..."
+    }
+  }
+}

--- a/src/i18n/locales/fr/survey.json
+++ b/src/i18n/locales/fr/survey.json
@@ -1,0 +1,24 @@
+{
+  "survey": {
+    "description": "Comment évaluez-vous l'assistance reçue de {{inboxName}} ?",
+    "rating": {
+      "label": "Votre note",
+      "veryDissatisfied": "Très insatisfait",
+      "dissatisfied": "Insatisfait",
+      "neutral": "Neutre",
+      "satisfied": "Satisfait",
+      "verySatisfied": "Très satisfait",
+      "successMessage": "Merci pour votre note ! Elle nous aide à nous améliorer."
+    },
+    "feedback": {
+      "label": "Souhaitez-vous nous en dire plus ?",
+      "placeholder": "Écrivez votre commentaire ici",
+      "buttonText": "Envoyer le commentaire"
+    },
+    "api": {
+      "errorMessage": "Impossible de charger cette enquête. Le lien a peut-être expiré.",
+      "successMessage": "Commentaire envoyé. Merci !",
+      "submitting": "Envoi en cours..."
+    }
+  }
+}

--- a/src/i18n/locales/it/survey.json
+++ b/src/i18n/locales/it/survey.json
@@ -1,0 +1,24 @@
+{
+  "survey": {
+    "description": "Come valuti l'assistenza ricevuta da {{inboxName}}?",
+    "rating": {
+      "label": "Il tuo voto",
+      "veryDissatisfied": "Molto insoddisfatto",
+      "dissatisfied": "Insoddisfatto",
+      "neutral": "Neutro",
+      "satisfied": "Soddisfatto",
+      "verySatisfied": "Molto soddisfatto",
+      "successMessage": "Grazie per il tuo voto! Ci aiuta a migliorare."
+    },
+    "feedback": {
+      "label": "Vuoi raccontarci qualcosa in più?",
+      "placeholder": "Scrivi qui il tuo commento",
+      "buttonText": "Invia commento"
+    },
+    "api": {
+      "errorMessage": "Non è stato possibile caricare questo sondaggio. Il link potrebbe essere scaduto.",
+      "successMessage": "Commento inviato. Grazie!",
+      "submitting": "Invio in corso..."
+    }
+  }
+}

--- a/src/i18n/locales/pt-BR/survey.json
+++ b/src/i18n/locales/pt-BR/survey.json
@@ -1,0 +1,24 @@
+{
+  "survey": {
+    "description": "Como você avalia o atendimento que recebeu de {{inboxName}}?",
+    "rating": {
+      "label": "Sua nota",
+      "veryDissatisfied": "Muito insatisfeito",
+      "dissatisfied": "Insatisfeito",
+      "neutral": "Neutro",
+      "satisfied": "Satisfeito",
+      "verySatisfied": "Muito satisfeito",
+      "successMessage": "Obrigado pela sua nota! Ela nos ajuda a melhorar."
+    },
+    "feedback": {
+      "label": "Quer contar mais alguma coisa?",
+      "placeholder": "Escreva seu comentário aqui",
+      "buttonText": "Enviar comentário"
+    },
+    "api": {
+      "errorMessage": "Não foi possível carregar esta avaliação. O link pode ter expirado.",
+      "successMessage": "Comentário enviado. Obrigado!",
+      "submitting": "Enviando..."
+    }
+  }
+}

--- a/src/i18n/locales/pt/survey.json
+++ b/src/i18n/locales/pt/survey.json
@@ -1,0 +1,24 @@
+{
+  "survey": {
+    "description": "Como você avalia o atendimento que recebeu de {{inboxName}}?",
+    "rating": {
+      "label": "Sua nota",
+      "veryDissatisfied": "Muito insatisfeito",
+      "dissatisfied": "Insatisfeito",
+      "neutral": "Neutro",
+      "satisfied": "Satisfeito",
+      "verySatisfied": "Muito satisfeito",
+      "successMessage": "Obrigado pela sua nota! Ela nos ajuda a melhorar."
+    },
+    "feedback": {
+      "label": "Quer contar mais alguma coisa?",
+      "placeholder": "Escreva seu comentário aqui",
+      "buttonText": "Enviar comentário"
+    },
+    "api": {
+      "errorMessage": "Não foi possível carregar esta avaliação. O link pode ter expirado.",
+      "successMessage": "Comentário enviado. Obrigado!",
+      "submitting": "Enviando..."
+    }
+  }
+}

--- a/src/pages/Public/Survey/SurveyResponse.spec.tsx
+++ b/src/pages/Public/Survey/SurveyResponse.spec.tsx
@@ -63,6 +63,10 @@ describe('Public CSAT survey page (CRM-606)', () => {
     expect(screen.getByTitle('Muito satisfeito')).toBeInTheDocument();
   });
 
+  // The reachable branch, not a defensive one: the endpoint sends `content` only
+  // when the account configured its own prompt, and omits it otherwise, because an
+  // anonymous public endpoint has no reader locale to render a default in and this
+  // page does. That is what makes this the single owner of the phrase.
   it('falls back to the translated prompt when the backend sends no content', async () => {
     getSurveyDetails.mockResolvedValue(surveyDetails());
 
@@ -83,16 +87,6 @@ describe('Public CSAT survey page (CRM-606)', () => {
     await waitFor(() =>
       expect(updateSurvey).toHaveBeenCalledWith('3f1b6a0e-6f2a-4f4d-9a1e-0a7c3b2d5e81', 5, ''),
     );
-  });
-
-  // A null response is what tells the page the survey is still open; an object
-  // carrying `rating: null` would read as answered and hide the widget.
-  it('keeps the rating widget open while csat_survey_response is null', async () => {
-    getSurveyDetails.mockResolvedValue(surveyDetails());
-
-    render(<SurveyResponse />);
-
-    expect(await screen.findByText('Sua nota')).toBeInTheDocument();
   });
 
   it('shows the translated thank-you once a rating is already stored', async () => {

--- a/src/pages/Public/Survey/SurveyResponse.spec.tsx
+++ b/src/pages/Public/Survey/SurveyResponse.spec.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import i18n from '@/i18n/config';
+import SurveyResponse from './SurveyResponse';
+import type { SurveyDetails } from '@/types/core/survey';
+
+// CRM-606: the public CSAT page is reached from the survey e-mail with NO session
+// and NO layout, so it is the only screen whose copy depends on the `survey`
+// namespace being registered in i18n/config.ts. It was not, and the contact saw
+// the raw keys. These tests run the REAL i18n config on purpose — mocking
+// useTranslation here would assert nothing about the wiring that was broken.
+
+const getSurveyDetails = vi.fn();
+const updateSurvey = vi.fn();
+
+vi.mock('@/services/public/surveyService', () => ({
+  surveyService: {
+    getSurveyDetails: (...args: unknown[]) => getSurveyDetails(...args),
+    updateSurvey: (...args: unknown[]) => updateSurvey(...args),
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ uuid: '3f1b6a0e-6f2a-4f4d-9a1e-0a7c3b2d5e81' }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const surveyDetails = (overrides: Partial<SurveyDetails> = {}): SurveyDetails => ({
+  inbox_name: 'Suporte',
+  inbox_avatar_url: '',
+  csat_survey_response: null,
+  display_type: 'emoji',
+  ...overrides,
+});
+
+describe('Public CSAT survey page (CRM-606)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    updateSurvey.mockResolvedValue(undefined);
+    await i18n.changeLanguage('pt-BR');
+  });
+
+  it('renders the rating copy translated instead of the raw i18n keys', async () => {
+    getSurveyDetails.mockResolvedValue(surveyDetails());
+
+    render(<SurveyResponse />);
+
+    expect(await screen.findByText('Sua nota')).toBeInTheDocument();
+    expect(screen.queryByText('survey.rating.label')).not.toBeInTheDocument();
+  });
+
+  it('renders the emoji labels translated, not resolved a second time', async () => {
+    getSurveyDetails.mockResolvedValue(surveyDetails());
+
+    render(<SurveyResponse />);
+
+    await screen.findByText('Sua nota');
+    expect(screen.getByTitle('Muito insatisfeito')).toBeInTheDocument();
+    expect(screen.getByTitle('Muito satisfeito')).toBeInTheDocument();
+  });
+
+  it('falls back to the translated prompt when the backend sends no content', async () => {
+    getSurveyDetails.mockResolvedValue(surveyDetails());
+
+    render(<SurveyResponse />);
+
+    expect(
+      await screen.findByText('Como você avalia o atendimento que recebeu de Suporte?'),
+    ).toBeInTheDocument();
+  });
+
+  it('submits the chosen rating for the conversation in the link', async () => {
+    getSurveyDetails.mockResolvedValue(surveyDetails());
+
+    render(<SurveyResponse />);
+    await screen.findByText('Sua nota');
+    await userEvent.click(screen.getByTitle('Muito satisfeito'));
+
+    await waitFor(() =>
+      expect(updateSurvey).toHaveBeenCalledWith('3f1b6a0e-6f2a-4f4d-9a1e-0a7c3b2d5e81', 5, ''),
+    );
+  });
+
+  // A null response is what tells the page the survey is still open; an object
+  // carrying `rating: null` would read as answered and hide the widget.
+  it('keeps the rating widget open while csat_survey_response is null', async () => {
+    getSurveyDetails.mockResolvedValue(surveyDetails());
+
+    render(<SurveyResponse />);
+
+    expect(await screen.findByText('Sua nota')).toBeInTheDocument();
+  });
+
+  it('shows the translated thank-you once a rating is already stored', async () => {
+    getSurveyDetails.mockResolvedValue(
+      surveyDetails({ csat_survey_response: { rating: 4, feedback_message: '' } }),
+    );
+
+    render(<SurveyResponse />);
+
+    expect(
+      await screen.findByText('Obrigado pela sua nota! Ela nos ajuda a melhorar.'),
+    ).toBeInTheDocument();
+  });
+
+  it('translates the failure message when the survey cannot be loaded', async () => {
+    getSurveyDetails.mockRejectedValue(new Error('boom'));
+
+    render(<SurveyResponse />);
+
+    expect(
+      await screen.findByText('Não foi possível carregar esta avaliação. O link pode ter expirado.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/Public/Survey/SurveyResponse.tsx
+++ b/src/pages/Public/Survey/SurveyResponse.tsx
@@ -7,12 +7,15 @@ import { surveyService } from '@/services/public/surveyService';
 import { SurveyDetails } from '@/types/core/survey';
 import { Button } from '@evoapi/design-system';
 
+// `label` is already the translated string, not a key: passing it back through
+// t() would resolve a second time, and a label carrying the ':' separator would
+// come back with everything before it stripped as a namespace.
 const getEmojiRatings = (t: any) => [
-  { value: 1, icon: Frown, labelKey: t('survey.rating.veryDissatisfied'), color: 'text-red-500' },
-  { value: 2, icon: Frown, labelKey: t('survey.rating.dissatisfied'), color: 'text-orange-400' },
-  { value: 3, icon: Meh, labelKey: t('survey.rating.neutral'), color: 'text-yellow-500' },
-  { value: 4, icon: Smile, labelKey: t('survey.rating.satisfied'), color: 'text-green-400' },
-  { value: 5, icon: Smile, labelKey: t('survey.rating.verySatisfied'), color: 'text-green-500' },
+  { value: 1, icon: Frown, label: t('survey.rating.veryDissatisfied'), color: 'text-red-500' },
+  { value: 2, icon: Frown, label: t('survey.rating.dissatisfied'), color: 'text-orange-400' },
+  { value: 3, icon: Meh, label: t('survey.rating.neutral'), color: 'text-yellow-500' },
+  { value: 4, icon: Smile, label: t('survey.rating.satisfied'), color: 'text-green-400' },
+  { value: 5, icon: Smile, label: t('survey.rating.verySatisfied'), color: 'text-green-500' },
 ];
 
 const SurveyResponse = () => {
@@ -166,7 +169,7 @@ const SurveyResponse = () => {
                 {t('survey.rating.label')}
               </label>
               <div className="flex justify-between gap-2">
-                {getEmojiRatings(t).map(({ value, icon: Icon, labelKey, color }) => (
+                {getEmojiRatings(t).map(({ value, icon: Icon, label, color }) => (
                   <button
                     key={value}
                     onClick={() => handleRatingSelect(value)}
@@ -176,7 +179,7 @@ const SurveyResponse = () => {
                         ? 'border-primary bg-primary/10'
                         : 'border-border hover:border-primary/50'
                     } ${isUpdating ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
-                    title={t(labelKey)}
+                    title={label}
                   >
                     <Icon
                       className={`w-8 h-8 ${


### PR DESCRIPTION
> **Um de três PRs do CRM-606, e este deve entrar PRIMEIRO** (ou junto do backend). Ver *Ordem de entrega* no fim.

## A causa, e ela é maior do que o card diz

O card diz que o namespace i18n `survey` "não é registrado". Medido: `grep -n survey src/i18n/config.ts` devolve **zero** linhas, e **não existe `survey.json` em nenhuma das 6 línguas** registradas (pt-BR, pt, en, es, fr, it). Não é só faltar registrar — o catálogo precisava ser **autorado**. São 14 chaves que a tela usa.

Resultado hoje: a página pública de avaliação mostra `survey.description` cru.

## O detalhe de forma que morde

`SurveyResponse.tsx` faz `useTranslation('survey')` e depois chama `t('survey.description')`. Como o `config.ts` usa `nsSeparator: ':'`, o ponto **não** separa namespace: a busca é `ns='survey'` + chave `'survey.description'`. O JSON precisa de um objeto `survey` no topo, **prefixo duplicado**.

Isso não é suposição — medi com i18next 25.10.10 real: com o prefixo duplicado, `t('survey.rating.label')` devolve "Sua nota"; sem ele, devolve a chave crua. O formato "estranho" do `survey.json` é exigido pelos 50 call sites `t('survey.` do arquivo, não é descuido.

## O guard de paridade cria trabalho sozinho, e isso é bom

`src/i18n/locales/i18n-parity.spec.ts` faz `import.meta.glob('./en/*.json')`. No instante em que `en/survey.json` existe, ele monta **sozinho** um bloco `describe.each` para o arquivo, com quatro asserções de forma exata: arquivo ausente em qualquer língua reprova; chave faltando reprova; valor vazio reprova; chave sobrando (leak) reprova.

Por isso os seis arquivos entram juntos e completos, com paridade de chave a chave. O contador da suíte sai de 178 para 181.

## Prova

| | |
|---|---|
| lane `test.yml`, job vitest, lista inteira de 74 arquivos | **74 passed, 1018 tests**, exit 0 (baseline: 73 arquivos, 1008 testes) |
| `npx tsc -b` | exit 0 |
| `i18n-parity.spec.ts` | **181 passed** (base 178) |
| `SurveyResponse.spec.tsx` | **6 passed** |
| lane `no-enterprise-guard` | exit 0, "no forbidden identifiers" |

**Desvio de ambiente, declarado:** node local 24.14.0 contra node 22 da CI. É a única divergência de versão em qualquer camada deste card.

## Um teste foi apagado, de propósito

O exemplo `keeps the rating widget open while csat_survey_response is null` renderizava `surveyDetails()`, cujo default **já é** `csat_survey_response: null`, e afirmava o **mesmo** `findByText('Sua nota')` do primeiro exemplo do arquivo. Nunca alimentava `{rating: null}`, que é o contrato que o próprio comentário dele dizia guardar. Passava dos dois lados. Esse contrato está guardado no backend, onde há exemplo específico. O arquivo vai de 7 para 6 exemplos.

## Ordem de entrega, e ela não é opcional

O PR do backend (`evo-ai-crm-community`) passa a **omitir** a chave `content` quando a caixa não configurou prompt próprio, justamente para o fallback `surveyDetails?.content || t('survey.description')` virar alcançável. Sem **este** PR, esse fallback resolve para a chave crua: a página imprime `survey.description` para toda caixa sem prompt configurado.

**Este primeiro, ou os dois juntos.** Mergear só o backend troca uma página em branco por uma chave crua na cara do cliente.

E, para o **ecosystem**: o ponteiro do `vendor/crm` no superprojeto precisa subir para pegar este commit. Sem o bump, o catálogo não chega ao shell.

## O que este PR não resolve

**Correção desta descrição.** Uma versão anterior deste texto afirmava que o **shell** não serve `/survey/responses/:uuid` e que `FRONTEND_URL` estaria **vazia** no cluster. **As duas afirmações são falsas.** O shell serve a rota desde o **CRM-605** (merge `3a1088d`, evolution-ecosystem-frontend#158): há `src/pages/PublicSurveyRoute.tsx`, o despacho no `App.tsx`, a entrada em `PUBLIC_PREFIXES` de `src/lib/publicRoutes.ts` e um guard de CI (`publicRoutes.test.mts`, lane `ui-guardrails`). E `FRONTEND_URL` está preenchida em `k8s/base/configmap.yaml:15`, nos dois overlays de staging e nos 3 serviços do compose — lida de dentro do container, vale `http://evo.localtest.me`. As duas medições erradas vieram de um checkout local do front preso em `1be1647` (base anterior ao CRM-605) e de uma expansão de `$FRONTEND_URL` consumida pelo shell externo no encadeamento Git Bash → wsl → container; nenhuma das duas falhou em voz alta.

O que de fato falta no ecosystem é **defasagem de ponteiro**, não código: o superprojeto fixa um front anterior ao CRM-605 nos dois refs (`develop` → `1be1647`, `main` → `6e22371`), e por isso o link ainda cai no login no cloud. É o **CRM-610**, reescrito para essa causa — ele não tem código a escrever e **depende deste PR**, porque bumpar o ponteiro antes de mergear o catálogo `survey` publica a tela com as chaves cruas.

## Summary by Sourcery

Register and cover the public survey translations so CSAT respondents receive localized text throughout the rating flow.

Bug Fixes:
- Restore translated copy on the public CSAT survey page instead of exposing raw i18n keys.
- Translate expired-survey errors and preserve localized fallback messages for survey failures.

Enhancements:
- Register the survey i18n namespace with complete, synchronized catalogs for all supported locales.
- Correct emoji rating labels to use their translated values directly.

CI:
- Add the public survey component tests to the Vitest CI test list.

Tests:
- Add coverage for localized survey rendering, fallback copy, rating submission, thank-you state, expired links, and load failures.